### PR TITLE
Retry on Rate Limit Error

### DIFF
--- a/pr_agent/algo/ai_handler.py
+++ b/pr_agent/algo/ai_handler.py
@@ -72,6 +72,9 @@ class AiHandler:
         except (RateLimitError) as e:
             logging.error("Rate limit error during OpenAI inference: ", e)
             raise
+        except (Exception) as e:
+            logging.error("Unknown error during OpenAI inference: ", e)
+            raise TryAgain from e
         if response is None or len(response.choices) == 0:
             raise TryAgain
         resp = response.choices[0]['message']['content']


### PR DESCRIPTION
PR Type:
**Bug fix**

___
PR Description:
**This PR increases the number of retries for OpenAI API calls and adds handling for rate limit errors. It also includes logging for unknown errors during OpenAI inference.**

___
PR Main Files Walkthrough:
- `pr_agent/algo/ai_handler.py`: The number of retries for OpenAI API calls has been increased from 2 to 5. The `retry` decorator on the `chat_completion` method now includes `RateLimitError` in its list of exceptions to retry on. Additional exception handling has been added for `RateLimitError` and unknown exceptions, both of which log the error and re-raise it.
