### PR TITLE
Add functionality to preserve existing labels in PRs

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -27,7 +27,7 @@ class BitbucketProvider:
             self.set_pr(pr_url)
 
     def is_supported(self, capability: str) -> bool:
-        if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments']:
+        if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments', 'get_labels']:
             return False
         return True
 

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -61,6 +61,10 @@ class GitProvider(ABC):
         pass
 
     @abstractmethod
+    def get_labels(self):
+        pass
+
+    @abstractmethod
     def remove_initial_comment(self):
         pass
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -322,5 +322,12 @@ class GithubProvider(GitProvider):
             headers, data = self.pr._requester.requestJsonAndCheck(
                 "PUT", f"{self.pr.issue_url}/labels", input=post_parameters
             )
-        except:
-            logging.exception("Failed to publish labels")
+        except Exception as e:
+            logging.exception(f"Failed to publish labels, error: {e}")
+
+    def get_labels(self):
+        try:
+            return [label.name for label in self.pr.labels]
+        except Exception as e:
+            logging.exception(f"Failed to get labels, error: {e}")
+            return []

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -35,7 +35,7 @@ class GitLabProvider(GitProvider):
         self.incremental = incremental
 
     def is_supported(self, capability: str) -> bool:
-        if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments']:
+        if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments', 'get_labels']:
             return False
         return True
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -46,7 +46,9 @@ class PRDescription:
                 self.git_provider.publish_comment(markdown_text)
             else:
                 self.git_provider.publish_description(pr_title, pr_body)
-                self.git_provider.publish_labels(pr_types)
+                if self.git_provider.is_supported("get_labels"):
+                    current_labels = self.git_provider.get_labels()
+                    self.git_provider.publish_labels(pr_types + current_labels)
             self.git_provider.remove_initial_comment()
         return ""
 


### PR DESCRIPTION
PR Type:
**Enhancement**

___
PR Description:
**This PR introduces a new feature to preserve existing labels in pull requests when new labels are added. The changes include modifications in the git providers' classes to support the 'get_labels' capability and to fetch the current labels before publishing new ones.**

___
PR Main Files Walkthrough:
-`bitbucket_provider.py`: Updated the 'is_supported' method to include 'get_labels' in the list of unsupported capabilities.
-`git_provider.py`: Added an abstract method 'get_labels' to the base class for git providers.
-`github_provider.py`: Implemented the 'get_labels' method to fetch existing labels from a PR. Also, improved error logging in 'publish_labels' method.
-`gitlab_provider.py`: Updated the 'is_supported' method to include 'get_labels' in the list of unsupported capabilities.
-`pr_description.py`: Modified the 'describe' method to fetch current labels if the 'get_labels' capability is supported by the git provider, and then publish the new labels along with the existing ones.
