### PR TITLE
Use OAuth token for GitLab authentication

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -14,7 +14,6 @@ from .git_provider import EDIT_TYPE, FilePatchInfo, GitProvider
 
 class GitLabProvider(GitProvider):
 
-
     def __init__(self, merge_request_url: Optional[str] = None, incremental: Optional[bool] = False):
         gitlab_url = settings.get("GITLAB.URL", None)
         if not gitlab_url:
@@ -23,8 +22,8 @@ class GitLabProvider(GitProvider):
         if not gitlab_access_token:
             raise ValueError("GitLab personal access token is not set in the config file")
         self.gl = gitlab.Gitlab(
-            gitlab_url,
-            gitlab_access_token
+            url=gitlab_url,
+            oauth_token=gitlab_access_token
         )
         self.id_project = None
         self.id_mr = None


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR modifies the GitLabProvider class to use OAuth tokens for authentication instead of personal access tokens. The change is made to enhance the security of the application.

___
## PR Main Files Walkthrough:
-`git_providers/gitlab_provider.py`: The GitLabProvider class's constructor has been modified. Instead of using a personal access token for authentication, it now uses an OAuth token. The token is still fetched from the settings, but the parameter name in the Gitlab object initialization has been changed from 'gitlab_access_token' to 'oauth_token'.
