### PR TITLE
Support for Repo-Specific Configuration File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## 2023-08-01
+2023-08-01
 
 ### Enhanced
 - Introduced the ability to retrieve commit messages from pull requests across different git providers.
 - Implemented commit messages retrieval for GitHub and GitLab providers.
 - Updated the PR description template to include a section for commit messages if they exist.
+- Added support for repository-specific configuration files (.pr_agent.yaml) for the PR Agent.
+- Implemented this feature for both GitHub and GitLab providers.
+- Added a new configuration option 'use_repo_settings_file' to enable or disable the use of a repo-specific settings file.
+
 
 ## 2023-07-30
 

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shlex
 import tempfile
@@ -47,7 +48,10 @@ class PRAgent:
                     get_settings().load_file(repo_settings_file)
             finally:
                 if repo_settings_file:
-                    os.remove(repo_settings_file)
+                    try:
+                        os.remove(repo_settings_file)
+                    except Exception as e:
+                        logging.error(f"Failed to remove temporary settings file {repo_settings_file}", e)
 
         # Then, apply user specific settings if exists
         request = request.replace("'", "\\'")

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -1,7 +1,10 @@
+import os
 import shlex
+import tempfile
 
 from pr_agent.algo.utils import update_settings_from_args
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import get_git_provider
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_information_from_user import PRInformationFromUser
@@ -31,11 +34,28 @@ class PRAgent:
         pass
 
     async def handle_request(self, pr_url, request) -> bool:
+        # First, apply repo specific settings if exists
+        if get_settings().config.use_repo_settings_file:
+            repo_settings_file = None
+            try:
+                git_provider = get_git_provider()(pr_url)
+                repo_settings = git_provider.get_repo_settings()
+                if repo_settings:
+                    repo_settings_file = None
+                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
+                    os.write(fd, repo_settings)
+                    get_settings().load_file(repo_settings_file)
+            finally:
+                if repo_settings_file:
+                    os.remove(repo_settings_file)
+
+        # Then, apply user specific settings if exists
         request = request.replace("'", "\\'")
         lexer = shlex.shlex(request, posix=True)
         lexer.whitespace_split = True
         action, *args = list(lexer)
         args = update_settings_from_args(args)
+
         action = action.lstrip("/").lower()
         if action == "reflect_and_review" and not get_settings().pr_reviewer.ask_and_reflect:
             action = "review"

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -266,7 +266,7 @@ class GithubProvider(GitProvider):
 
     def get_repo_settings(self):
         try:
-            contents = self.repo_obj.get_contents(".pr_agent.yaml", ref=self.pr.head.sha).decoded_content
+            contents = self.repo_obj.get_contents(".pr_agent.toml", ref=self.pr.head.sha).decoded_content
             return contents
         except Exception:
             return ""

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import tempfile
 from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -9,11 +7,11 @@ from github import AppAuthentication, Auth, Github, GithubException
 from retry import retry
 from starlette_context import context
 
+from .git_provider import FilePatchInfo, GitProvider, IncrementalPR
 from ..algo.language_handler import is_valid_file
 from ..algo.utils import load_large_diff
 from ..config_loader import get_settings
 from ..servers.utils import RateLimitExceeded
-from .git_provider import FilePatchInfo, GitProvider, IncrementalPR
 
 
 class GithubProvider(GitProvider):
@@ -33,17 +31,6 @@ class GithubProvider(GitProvider):
         if pr_url:
             self.set_pr(pr_url)
             self.last_commit_id = list(self.pr.get_commits())[-1]
-        if get_settings().config.use_repo_settings_file:
-            repo_settings = self.get_repo_settings()
-            if repo_settings:
-                repo_settings_file = None
-                try:
-                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
-                    os.write(fd, repo_settings)
-                    get_settings().load_file(repo_settings_file)
-                finally:
-                    if repo_settings_file:
-                        os.remove(repo_settings_file)
 
     def is_supported(self, capability: str) -> bool:
         return True

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1,7 +1,5 @@
 import logging
-import os
 import re
-import tempfile
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
@@ -37,17 +35,6 @@ class GitLabProvider(GitProvider):
         self.RE_HUNK_HEADER = re.compile(
             r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
         self.incremental = incremental
-        if get_settings().config.use_repo_settings_file:
-            repo_settings = self.get_repo_settings()
-            if repo_settings:
-                repo_settings_file = None
-                try:
-                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
-                    os.write(fd, repo_settings.encode())
-                    get_settings().load_file(repo_settings_file)
-                finally:
-                    if repo_settings_file:
-                        os.remove(repo_settings_file)
 
     def is_supported(self, capability: str) -> bool:
         if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments']:
@@ -268,7 +255,7 @@ class GitLabProvider(GitProvider):
 
     def get_repo_settings(self):
         try:
-            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=self.mr.source_branch).decode()
+            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=self.mr.source_branch)
             return contents
         except Exception:
             return ""

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -42,7 +42,7 @@ class GitLabProvider(GitProvider):
             if repo_settings:
                 repo_settings_file = None
                 try:
-                    fd, repo_settings_file = tempfile.mkstemp(suffix='.yaml')
+                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
                     os.write(fd, repo_settings.encode())
                     get_settings().load_file(repo_settings_file)
                 finally:
@@ -268,7 +268,7 @@ class GitLabProvider(GitProvider):
 
     def get_repo_settings(self):
         try:
-            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.yaml', ref=self.mr.source_branch).decode()
+            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=self.mr.source_branch).decode()
             return contents
         except Exception:
             return ""

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -6,6 +6,7 @@ publish_output=true
 publish_output_progress=true
 verbosity_level=0 # 0,1,2
 use_extra_bad_extensions=false
+use_repo_settings_file=true
 
 [pr_reviewer] # /review #
 require_focused_review=true


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the ability to use a repository-specific configuration file (.pr_agent.yaml) for the PR Agent. This allows different repositories to have different settings according to their specific needs. The changes are implemented for both GitHub and GitLab providers.

___
## PR Main Files Walkthrough:
- `pr_agent/git_providers/github_provider.py`: Added logic to check if the use of a repo-specific settings file is enabled. If so, it attempts to fetch the .pr_agent.yaml file from the repository, creates a temporary file with its contents, and loads the settings from it.
- `pr_agent/git_providers/gitlab_provider.py`: Similar changes as in the GitHub provider, but adapted for GitLab's API.
- `pr_agent/settings/configuration.toml`: Added a new configuration option 'use_repo_settings_file' to enable or disable the use of a repo-specific settings file.
