### PR TITLE
Configurable AI Timeout

### DIFF
--- a/pr_agent/algo/ai_handler.py
+++ b/pr_agent/algo/ai_handler.py
@@ -1,13 +1,15 @@
 import logging
 
+import litellm
 import openai
+from litellm import acompletion
 from openai.error import APIError, RateLimitError, Timeout, TryAgain
 from retry import retry
-import litellm
-from litellm import acompletion
+
 from pr_agent.config_loader import get_settings
-import traceback
-OPENAI_RETRIES=5
+
+OPENAI_RETRIES = 5
+
 
 class AiHandler:
     """
@@ -69,15 +71,16 @@ class AiHandler:
         """
         try:
             response = await acompletion(
-                            model=model,
-                            deployment_id=self.deployment_id,
-                            messages=[
-                                {"role": "system", "content": system},
-                                {"role": "user", "content": user}
-                            ],
-                            temperature=temperature,
-                            azure=self.azure
-                        )
+                model=model,
+                deployment_id=self.deployment_id,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user}
+                ],
+                temperature=temperature,
+                azure=self.azure,
+                force_timeout=get_settings().config.ai_timeout
+            )
         except (APIError, Timeout, TryAgain) as e:
             logging.error("Error during OpenAI inference: ", e)
             raise

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -7,6 +7,7 @@ publish_output_progress=true
 verbosity_level=0 # 0,1,2
 use_extra_bad_extensions=false
 use_repo_settings_file=true
+ai_timeout=180
 
 [pr_reviewer] # /review #
 require_focused_review=true


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a configurable timeout for AI operations. The default timeout is now set to 180 seconds, but can be adjusted in the configuration file.

___
## PR Main Files Walkthrough:
- `pr_agent/algo/ai_handler.py`: The `chat_completion` method of the `AiHandler` class has been updated to include a `force_timeout` parameter, which is set to the `ai_timeout` value from the configuration settings.
- `pr_agent/settings/configuration.toml`: A new `ai_timeout` field has been added to the configuration file, allowing the timeout for AI operations to be configured.
