### PR TITLE
Add Eyes Reaction to Comments 

### DIFF
--- a/pr_agent/algo/ai_handler.py
+++ b/pr_agent/algo/ai_handler.py
@@ -1,13 +1,15 @@
 import logging
 
+import litellm
 import openai
+from litellm import acompletion
 from openai.error import APIError, RateLimitError, Timeout, TryAgain
 from retry import retry
-import litellm
-from litellm import acompletion
+
 from pr_agent.config_loader import get_settings
-import traceback
-OPENAI_RETRIES=5
+
+OPENAI_RETRIES = 5
+
 
 class AiHandler:
     """
@@ -69,15 +71,16 @@ class AiHandler:
         """
         try:
             response = await acompletion(
-                            model=model,
-                            deployment_id=self.deployment_id,
-                            messages=[
-                                {"role": "system", "content": system},
-                                {"role": "user", "content": user}
-                            ],
-                            temperature=temperature,
-                            azure=self.azure
-                        )
+                model=model,
+                deployment_id=self.deployment_id,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user}
+                ],
+                temperature=temperature,
+                azure=self.azure,
+                force_timeout=get_settings().config.ai_timeout
+            )
         except (APIError, Timeout, TryAgain) as e:
             logging.error("Error during OpenAI inference: ", e)
             raise

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -89,6 +89,12 @@ class BitbucketProvider:
     def get_issue_comments(self):
         raise NotImplementedError("Bitbucket provider does not support issue comments yet")
 
+    def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
+        return True
+
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        return True
+
     @staticmethod
     def _parse_pr_url(pr_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(pr_url)

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 # enum EDIT_TYPE (ADDED, DELETED, MODIFIED, RENAMED)
 from enum import Enum
+from typing import Optional
 
 
 class EDIT_TYPE(Enum):
@@ -88,6 +89,13 @@ class GitProvider(ABC):
     def get_issue_comments(self):
         pass
 
+    @abstractmethod
+    def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        pass
 
 def get_main_pr_language(languages, files) -> str:
     """

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -2,10 +2,10 @@ import logging
 import hashlib
 
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 from urllib.parse import urlparse
 
-from github import AppAuthentication, Auth, Github, GithubException
+from github import AppAuthentication, Auth, Github, GithubException, Reaction
 from retry import retry
 from starlette_context import context
 
@@ -262,6 +262,23 @@ class GithubProvider(GitProvider):
             return contents
         except Exception:
             return ""
+
+    def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
+        try:
+            reaction = self.pr.get_issue_comment(issue_comment_id).create_reaction("eyes")
+            return reaction.id
+        except Exception as e:
+            logging.exception(f"Failed to add eyes reaction, error: {e}")
+            return None
+
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        try:
+            self.pr.get_issue_comment(issue_comment_id).delete_reaction(reaction_id)
+            return True
+        except Exception as e:
+            logging.exception(f"Failed to remove eyes reaction, error: {e}")
+            return False
+
 
     @staticmethod
     def _parse_pr_url(pr_url: str) -> Tuple[str, int]:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -287,6 +287,12 @@ class GitLabProvider(GitProvider):
         except Exception:
             return ""
 
+    def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
+        return True
+
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        return True
+
     def _parse_merge_request_url(self, merge_request_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(merge_request_url)
 

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -64,10 +64,8 @@ async def run_action():
                     body = comment_body.strip().lower()
                     comment_id = event_payload.get("comment", {}).get("id")
                     provider = get_git_provider()(pr_url=pr_url)
-                    added_reaction = provider.add_eyes_reaction(comment_id)
+                    provider.add_eyes_reaction(comment_id)
                     await PRAgent().handle_request(pr_url, body)
-                    if added_reaction:
-                        provider.remove_reaction(comment_id, added_reaction)
 
 
 if __name__ == '__main__':

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -4,6 +4,7 @@ import os
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import get_git_provider
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
@@ -61,7 +62,12 @@ async def run_action():
                 pr_url = event_payload.get("issue", {}).get("pull_request", {}).get("url")
                 if pr_url:
                     body = comment_body.strip().lower()
+                    comment_id = event_payload.get("comment", {}).get("id")
+                    provider = get_git_provider()(pr_url=pr_url)
+                    added_reaction = provider.add_eyes_reaction(comment_id)
                     await PRAgent().handle_request(pr_url, body)
+                    if added_reaction:
+                        provider.remove_reaction(comment_id, added_reaction)
 
 
 if __name__ == '__main__':

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -11,6 +11,7 @@ from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.git_providers import get_git_provider
 from pr_agent.servers.utils import verify_signature
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -80,7 +81,13 @@ async def handle_request(body: Dict[str, Any]):
             return {}
         pull_request = body["issue"]["pull_request"]
         api_url = pull_request.get("url")
+        comment_id = body.get("comment", {}).get("id")
+        provider = get_git_provider()(pr_url=api_url)
+        added_reaction = provider.add_eyes_reaction(comment_id)
         await agent.handle_request(api_url, comment_body)
+        if added_reaction:
+            provider.remove_reaction(comment_id, added_reaction)
+
 
     elif action == "opened" or 'reopened' in action:
         pull_request = body.get("pull_request")

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -83,10 +83,8 @@ async def handle_request(body: Dict[str, Any]):
         api_url = pull_request.get("url")
         comment_id = body.get("comment", {}).get("id")
         provider = get_git_provider()(pr_url=api_url)
-        added_reaction = provider.add_eyes_reaction(comment_id)
+        provider.add_eyes_reaction(comment_id)
         await agent.handle_request(api_url, comment_body)
-        if added_reaction:
-            provider.remove_reaction(comment_id, added_reaction)
 
 
     elif action == "opened" or 'reopened' in action:

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -98,8 +98,12 @@ async def polling_loop():
                                             if user_tag not in comment_body:
                                                 continue
                                             rest_of_comment = comment_body.split(user_tag)[1].strip()
-
+                                            comment_id = comment['id']
+                                            git_provider.set_pr(pr_url)
+                                            added_reaction = git_provider.add_eyes_reaction(comment_id)
                                             success = await agent.handle_request(pr_url, rest_of_comment)
+                                            if added_reaction:
+                                                git_provider.remove_reaction(comment_id, added_reaction)
                                             if not success:
                                                 git_provider.set_pr(pr_url)
                                                 git_provider.publish_comment("### How to use PR-Agent\n" +

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -100,10 +100,8 @@ async def polling_loop():
                                             rest_of_comment = comment_body.split(user_tag)[1].strip()
                                             comment_id = comment['id']
                                             git_provider.set_pr(pr_url)
-                                            added_reaction = git_provider.add_eyes_reaction(comment_id)
+                                            git_provider.add_eyes_reaction(comment_id)
                                             success = await agent.handle_request(pr_url, rest_of_comment)
-                                            if added_reaction:
-                                                git_provider.remove_reaction(comment_id, added_reaction)
                                             if not success:
                                                 git_provider.set_pr(pr_url)
                                                 git_provider.publish_comment("### How to use PR-Agent\n" +

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -7,6 +7,7 @@ publish_output_progress=true
 verbosity_level=0 # 0,1,2
 use_extra_bad_extensions=false
 use_repo_settings_file=true
+ai_timeout=180
 
 [pr_reviewer] # /review #
 require_focused_review=true


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This pull request introduces two main enhancements. Firstly, it adds the ability to add and remove an 'eyes' reaction to comments in GitHub, Bitbucket, and GitLab. This is done through the addition of two new methods in the GitProvider class and its subclasses: 'add_eyes_reaction' and 'remove_reaction'. Secondly, it makes the AI timeout configurable, with a default value of 180 seconds. This is achieved by adding a new 'ai_timeout' configuration option in the 'configuration.toml' file and using this value when calling the 'chat_completion' method in the 'AiHandler' class.

___
## PR Main Files Walkthrough:
-`pr_agent/algo/ai_handler.py`: Updated the 'chat_completion' method to use the new 'ai_timeout' configuration option.
-`pr_agent/git_providers/git_provider.py`: Added the 'add_eyes_reaction' and 'remove_reaction' abstract methods.
-`pr_agent/git_providers/github_provider.py`: Implemented the 'add_eyes_reaction' and 'remove_reaction' methods for GitHub.
-`pr_agent/git_providers/bitbucket_provider.py` and `pr_agent/git_providers/gitlab_provider.py`: Implemented the 'add_eyes_reaction' and 'remove_reaction' methods for Bitbucket and GitLab, respectively.
-`pr_agent/servers/github_action_runner.py`, `pr_agent/servers/github_app.py`, and `pr_agent/servers/github_polling.py`: Updated to add an 'eyes' reaction to a comment when it is processed and remove it afterwards.
-`pr_agent/settings/configuration.toml`: Added the 'ai_timeout' configuration option.
