### PR TITLE
Fixed incorrect usage for Azure OpenAI API

### DIFF
--- a/pr_agent/algo/ai_handler.py
+++ b/pr_agent/algo/ai_handler.py
@@ -87,8 +87,6 @@ class AiHandler:
                     f"Generating completion with {model}"
                     f"{(' from deployment ' + deployment_id) if deployment_id else ''}"
                 )
-            if self.azure:
-                model = self.azure + "/" + model
             response = await acompletion(
                 model=model,
                 deployment_id=deployment_id,
@@ -97,6 +95,7 @@ class AiHandler:
                     {"role": "user", "content": user}
                 ],
                 temperature=temperature,
+                azure=self.azure,
                 force_timeout=get_settings().config.ai_timeout
             )
         except (APIError, Timeout, TryAgain) as e:


### PR DESCRIPTION
Using the [latest](https://github.com/Codium-ai/pr-agent/tree/33ef23289f0dfd0f7adc96c9dcd24962266df3d5) version of this repo and running `python3 pr_agent/cli.py --pr_url ... describe` and I'm getting this error:
```python
Traceback (most recent call last):
  File "/Users/zmeir/git/pr-agent/pr_agent/algo/ai_handler.py", line 91, in chat_completion
    model = self.azure + "/" + model
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```

This part of the code changed in #228 so I reverted this to how it was before and it works now.

