### PR TITLE
Bugfix: ignored github_app.commands on .pr-agent.toml

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -122,7 +122,7 @@ async def handle_request(body: Dict[str, Any], event: str):
                 if body.get("requested_reviewer", {}).get("login", "") != bot_user:
                     return {}
             get_logger().info(f"Performing review for {api_url=} because of {event=} and {action=}")
-            await _perform_commands(get_settings().github_app.pr_commands, agent, body, api_url, log_context)
+            await _perform_commands(agent, body, api_url, log_context)
 
     # handle pull_request event with synchronize action - "push trigger" for new commits
     elif event == 'pull_request' and action == 'synchronize' and get_settings().github_app.handle_push_trigger:
@@ -174,7 +174,7 @@ async def handle_request(body: Dict[str, Any], event: str):
                 get_logger().info(f"Skipping incremental review because there was no initial review for {api_url=} yet")
                 return {}
             get_logger().info(f"Performing incremental review for {api_url=} because of {event=} and {action=}")
-            await _perform_commands(get_settings().github_app.push_commands, agent, body, api_url, log_context)
+            await _perform_commands(agent, body, api_url, log_context)
 
         finally:
             # release the waiting task block
@@ -203,8 +203,9 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict, bot_us
     return pull_request, api_url
 
 
-async def _perform_commands(commands: List[str], agent: PRAgent, body: dict, api_url: str, log_context: dict):
+async def _perform_commands(agent: PRAgent, body: dict, api_url: str, log_context: dict):
     apply_repo_settings(api_url)
+    commands = get_settings().github_app.pr_commands
     for command in commands:
         split_command = command.split(" ")
         command = split_command[0]


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes:
- Refactoring of the `get_repo_settings` method in `bitbucket_provider.py` to fetch file via API request instead of using `get_contents`.
- Refactoring of the `_perform_commands` function in `github_app.py` to improve command handling.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/git_providers/bitbucket_provider.py`: The `get_repo_settings` method has been refactored to fetch the file via an API request instead of using the `get_contents` method. The API request URL is constructed and a GET request is made. The response text is then encoded to 'utf-8'.
`pr_agent/servers/github_app.py`: The `_perform_commands` function has been refactored. The `commands` parameter has been removed and instead, the `pr_commands` from the GitHub app settings are fetched directly within the function. This change improves the flexibility of command handling.
</details>
