### PR TITLE
Update Bitbucket Provider to Use 'position' Instead of 'start_line' for Inline Comments

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -183,7 +183,7 @@ class BitbucketProvider(GitProvider):
 
     def publish_inline_comments(self, comments: list[dict]):
         for comment in comments:
-            self.publish_inline_comment(comment['body'], comment['start_line'], comment['path'])
+            self.publish_inline_comment(comment['body'], comment['position'], comment['path'])
 
     def get_title(self):
         return self.pr.title


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR updates the `publish_inline_comments` method in the `bitbucket_provider.py` file. The change involves using the 'position' attribute instead of 'start_line' when publishing inline comments. This adjustment ensures that the correct line position is used when adding comments.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/git_providers/bitbucket_provider.py`: The 'publish_inline_comments' method has been updated. Now, it uses the 'position' attribute from the comment dictionary instead of 'start_line' when calling the 'publish_inline_comment' method.
</details>
