### PR TITLE
Improve error handling in settings retrieval

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -25,7 +25,7 @@ def get_setting_or_env(key: str, default: Union[str, bool] = None) -> Union[str,
     try:
         value = get_settings().get(key, default)
     except AttributeError:  # TBD still need to debug why this happens on GitHub Actions
-        value = os.getenv(key, None) or os.getenv(key.upper(), None) or os.getenv(key.lower(), None)
+        value = os.getenv(key, None) or os.getenv(key.upper(), None) or os.getenv(key.lower(), None) or default
     return value
 
 


### PR DESCRIPTION
Fix bug where default values were not being used in GitHub Action runners when environmental variables are not set. Now, if an environmental variable cannot be found and no default is given, the default value will be used if one exists. This will prevent errors during setup on different environments and ensure system stability.