### PR TITLE
Use `pip install` with `--no-cache-dir` in `Dockerfile.github_action`

### DIFF
--- a/Dockerfile.github_action
+++ b/Dockerfile.github_action
@@ -3,7 +3,7 @@ FROM python:3.12 as base
 WORKDIR /app
 ADD pyproject.toml .
 ADD requirements.txt .
-RUN pip install . && rm pyproject.toml requirements.txt
+RUN pip install --no-cache-dir . && rm pyproject.toml requirements.txt
 ENV PYTHONPATH=/app
 ADD docs docs
 ADD pr_agent pr_agent


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile.github_action` file. The change modifies the `pip install` command to use the `--no-cache-dir` option, which prevents the caching of packages during installation.

* [`Dockerfile.github_action`](diffhunk://#diff-e18b685370151a3e574de5890d93010fb040e118f57027f8ce2dc9f64756f365L6-R6): Modified the `pip install` command to use `--no-cache-dir` option for a cleaner installation.

This will help minimize the Docker image size, as below:

```
REPOSITORY            TAG             IMAGE ID       CREATED         SIZE
pr-agent              after           d7d7a03e546b   3 hours ago     1.48GB
pr-agent              before          ef44e279f5aa   3 hours ago     1.59GB
```

cc #1510



