### PR TITLE
Add OpenAI o3 & o4-mini reasoning models

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -36,6 +36,10 @@ MAX_TOKENS = {
     'o1': 204800,  # 200K, but may be limited by config.max_model_tokens
     'o3-mini': 204800,  # 200K, but may be limited by config.max_model_tokens
     'o3-mini-2025-01-31': 204800,  # 200K, but may be limited by config.max_model_tokens
+    'o3': 200000,  # 200K, but may be limited by config.max_model_tokens
+    'o3-2025-04-16': 200000,  # 200K, but may be limited by config.max_model_tokens
+    'o4-mini': 200000, # 200K, but may be limited by config.max_model_tokens
+    'o4-mini-2025-04-16': 200000, # 200K, but may be limited by config.max_model_tokens
     'claude-instant-1': 100000,
     'claude-2': 100000,
     'command-nightly': 4096,
@@ -125,12 +129,20 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "o1-2024-12-17",
     "o3-mini",
     "o3-mini-2025-01-31",
-    "o1-preview"
+    "o1-preview",
+    "o3",
+    "o3-2025-04-16",
+    "o4-mini",
+    "o4-mini-2025-04-16",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [
     "o3-mini",
-    "o3-mini-2025-01-31"
+    "o3-mini-2025-01-31",
+    "o3",
+    "o3-2025-04-16",
+    "o4-mini",
+    "o4-mini-2025-04-16",
 ]
 
 CLAUDE_EXTENDED_THINKING_MODELS = [


### PR DESCRIPTION
### **User description**
Reference:
- https://platform.openai.com/docs/models/o3
- https://platform.openai.com/docs/models/o4-mini
- https://openai.com/index/introducing-o3-and-o4-mini/


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for OpenAI `o3` and `o4-mini` reasoning models.

- Updated token limits for new models in `pr_agent/algo/__init__.py`.

- Extended model lists for reasoning and temperature support categories.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Added OpenAI o3 and o4-mini models with configurations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/__init__.py

<li>Added <code>o3</code> and <code>o4-mini</code> models with token limits.<br> <li> Included new models in <code>NO_SUPPORT_TEMPERATURE_MODELS</code> list.<br> <li> Included new models in <code>SUPPORT_REASONING_EFFORT_MODELS</code> list.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1702/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>