### PR TITLE
feat: add support for PR changes diagram in PR description 

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -104,6 +104,7 @@ enable_pr_type=true
 final_update_message = true
 enable_help_text=false
 enable_help_comment=true
+enable_pr_diagram=false # adds a section with a diagram of the PR changes
 # describe as comment
 publish_description_as_comment=false
 publish_description_as_comment_persistent=true

--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -81,7 +81,7 @@ pr_files:
 {%- endif %}
 {%- if enable_pr_diagram %}
   changes_diagram: |
-    ```mermaind
+    ```mermaid
     ...
     ```
 {%- endif %}
@@ -168,7 +168,7 @@ pr_files:
 {%- endif %}
 {%- if enable_pr_diagram %}
   changes_diagram: |
-    ```mermaind
+    ```mermaid
     ...
     ```
 {%- endif %}

--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -49,6 +49,9 @@ class PRDescription(BaseModel):
 {%- if enable_semantic_files_types %}
     pr_files: List[FileDescription] = Field(max_items=20, description="a list of all the files that were changed in the PR, and summary of their changes. Each file must be analyzed regardless of change size.")
 {%- endif %}
+{%- if enable_pr_diagram %}
+    changes_diagram: str = Field(description="a horizontal diagram that represents the main PR changes, in the format of a mermaid flowchart. The diagram should be concise and easy to read. Leave empty if no diagram is relevant.")
+{%- endif %}
 =====
 
 
@@ -75,6 +78,12 @@ pr_files:
   label: |
     label_key_1
 ...
+{%- endif %}
+{%- if enable_pr_diagram %}
+  changes_diagram: |
+    ```mermaind
+    ...
+    ```
 {%- endif %}
 ```
 
@@ -156,6 +165,12 @@ pr_files:
   label: |
     label_key_1
 ...
+{%- endif %}
+{%- if enable_pr_diagram %}
+  changes_diagram: |
+    ```mermaind
+    ...
+    ```
 {%- endif %}
 ```
 (replace '...' with the actual values)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -73,6 +73,7 @@ class PRDescription:
             "related_tickets": "",
             "include_file_summary_changes": len(self.git_provider.get_diff_files()) <= self.COLLAPSIBLE_FILE_LIST_THRESHOLD,
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
+            'enable_pr_diagram': get_settings().pr_description.get('enable_pr_diagram', False),
         }
 
         self.user_description = self.git_provider.get_user_description()
@@ -257,6 +258,7 @@ class PRDescription:
                         tasks.append(task)
                 # Wait for all tasks to complete
                 results = await asyncio.gather(*tasks)
+
             file_description_str_list = []
             for i, result in enumerate(results):
                 prediction_files = result.strip().removeprefix('```yaml').strip('`').strip()
@@ -456,6 +458,10 @@ class PRDescription:
             self.data['labels'] = self.data.pop('labels')
         if 'description' in self.data:
             self.data['description'] = self.data.pop('description')
+        if 'changes_diagram' in self.data:
+            changes_diagram = self.data.pop('changes_diagram')
+            if changes_diagram.strip():
+                self.data['changes_diagram'] = changes_diagram
         if 'pr_files' in self.data:
             self.data['pr_files'] = self.data.pop('pr_files')
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for PR changes diagram in PR description

- Update configuration to enable or disable diagram feature

- Extend prompt templates to include diagram section

- Adjust data preparation to handle diagram field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Add and process PR changes diagram field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Add <code>enable_pr_diagram</code> to prompt context<br> <li> Handle <code>changes_diagram</code> field in data preparation<br> <li> Minor formatting and whitespace adjustments


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1826/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_description_prompts.toml</strong><dd><code>Extend prompt template to support diagram section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_description_prompts.toml

<li>Add conditional <code>changes_diagram</code> field to prompt template<br> <li> Update example output to include diagram section<br> <li> Adjust YAML output instructions for diagram


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1826/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add configuration option for PR diagram feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<li>Add <code>enable_pr_diagram</code> configuration option with default false<br> <li> Update comments to describe new setting


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1826/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>