### PR TITLE
Fix gitea get file content error

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -471,11 +471,11 @@ class GiteaProvider(GitProvider):
 
             if status == 'added':
                 edit_type = EDIT_TYPE.ADDED
-            elif status == 'removed':
+            elif status == 'removed' or status == 'deleted':
                 edit_type = EDIT_TYPE.DELETED
             elif status == 'renamed':
                 edit_type = EDIT_TYPE.RENAMED
-            elif status == 'modified':
+            elif status == 'modified' or status == 'changed':
                 edit_type = EDIT_TYPE.MODIFIED
             else:
                 self.logger.error(f"Unknown edit type: {status}")


### PR DESCRIPTION
### **User description**
## What this PR does
This PR fixes issue for gitea provider. 
Example of error:
```
pr_agent.git_providers.gitea_provider:get_file_content:893 - Error getting file: pom.xml, content: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Server': 'nginx', 'Date': 'Wed, 04 Jun 2025 14:36:56 GMT', 'Content-Type': 'application/json;charset=utf-8', 'Content-Length': '99', 'Connection': 'keep-alive', 'Keep-Alive': 'timeout=60', 'Cache-Control': 'max-age=0, private, must-revalidate, no-transform', 'Warning': 'token and access_token API authentication is deprecated and will be removed in gitea 1.23. Please use AuthorizationHeaderToken instead. Existing queries will continue to work but without authorization.', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN'})
HTTP response body: b'{"message":"The target couldn\'t be found.","url":"https://forgejo.pyn.ru/api/swagger","errors":[]}\n'
``` 
The problem is because methods _get_file_content_from_base and _get_file_content_from_latest_commit pass branch name instead of repo name.

Also add forgejo statuses to fix "Unknown edit type" if we use forgejo


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect parameter usage in Gitea file content retrieval

- Add support for Forgejo-specific file status values

- Prevent "Unknown edit type" errors for Forgejo


___

### **Changes diagram**

```mermaid
flowchart LR
  get_file_content_from_base["get_file_content_from_base()"]
  get_file_content_from_latest_commit["get_file_content_from_latest_commit()"]
  get_diff_files["get_diff_files()"]
  repo_api["repo_api.get_file_content()"]
  edit_type["Edit type detection"]

  get_file_content_from_base -- "use correct repo param" --> repo_api
  get_file_content_from_latest_commit -- "use correct repo param" --> repo_api
  get_diff_files -- "handle Forgejo statuses" --> edit_type
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitea_provider.py</strong><dd><code>Fix file content retrieval and status handling for Gitea/Forgejo</code></dd></summary>
<hr>

pr_agent/git_providers/gitea_provider.py

<li>Corrected <code>repo</code> parameter in file content retrieval methods<br> <li> Added handling for Forgejo-specific file status values (<code>deleted</code>, <br><code>changed</code>)<br> <li> Improved edit type detection to avoid "Unknown edit type" errors


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1852/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>