### PR TITLE
[:bug:]Sometimes pr-agent comment on code that has already been deleted.

### DIFF
--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -47,6 +47,7 @@ Specific guidelines for generating code suggestions:
 - Provide up to {{ num_code_suggestions }} distinct and insightful code suggestions. Return less suggestions if no pertinent ones are applicable.
 {%- endif %}
 - Focus your suggestions ONLY on improving the new code introduced in the PR (lines starting with '+' in the diff). The lines in the diff starting with '-' are only for reference and should not be considered for suggestions.
+- Suggestions must NOT refer to, quote, or be based on any line prefixed with '-' (deleted code).
 {%- if not focus_only_on_problems %}
 - Prioritize suggestions that address potential issues, critical problems, and bugs in the PR code. Avoid repeating changes already implemented in the PR. If no pertinent suggestions are applicable, return an empty list.
 - Don't suggest to add docstring, type hints, or comments, to remove unused imports, or to use more specific exception types.
@@ -60,6 +61,9 @@ Specific guidelines for generating code suggestions:
 {%- endif %}
 - When mentioning code elements (variables, names, or files) in your response, surround them with markdown backticks (`). For example: "verify that `user_id` is..."
 - Note that you will only see partial code segments that were changed (diff hunks in a PR code), and not the entire codebase. Avoid suggestions that might duplicate existing functionality of the outer codebase. In addition, the absence of a definition, declaration, import, or initialization for any entity in the PR code is NEVER a basis for a suggestion.
+- `existing_code` MUST consist solely of code that remains after the PR is applied (i.e., lines beginning with '+', and any necessary unchanged context lines).
+- Each CodeSuggestion must reference at least one line that begins with '+'.
+- If the issue you found does not involve a '+' line, DO NOT output a suggestion.
 - Also note that if the code ends at an opening brace or statement that begins a new scope (like 'if', 'for', 'try'), don't treat it as incomplete. Instead, acknowledge the visible scope boundary and analyze only the code shown.
 
 {%- if extra_instructions %}


### PR DESCRIPTION
### **User description**
## Abstract
[bugfix] Sometimes pr-agent comment on code that has already been deleted.

## issue
https://github.com/qodo-ai/pr-agent/issues/1854

## detail
When we investigated the cause with debug, there was no problem with the diff being passed.
In fact, when we tested it with claude-3.7-sonnet, it worked without any issues.
However, since claude-3.7-sonnet was expensive, we needed to run it on claude-3.5-haiku.
Therefore, we modified the prompt, and since it worked here, we are submitting a PR.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Strengthens prompt to prevent suggestions on deleted code.

- Enforces that suggestions only reference added ('+') lines.

- Clarifies that `existing_code` must exclude deleted lines.

- Ensures suggestions are not based on removed code context.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Prompt for code suggestions"] -- "Clarify rules" --> B["Do not reference '-' (deleted) lines"]
  B -- "Enforce '+'-line focus" --> C["Each suggestion must reference added lines"]
  C -- "Clarify `existing_code` definition" --> D["Only code after PR applied"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions_prompts_not_decoupled.toml</strong><dd><code>Strengthen prompt to avoid suggestions on deleted code</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml

<li>Adds explicit rule to not reference deleted ('-') lines.<br> <li> Requires suggestions to only reference added ('+') lines.<br> <li> Clarifies <code>existing_code</code> must only include post-PR code.<br> <li> Ensures suggestions are not made if no '+' lines are involved.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1855/files#diff-6a060c7790e0b4427bb8e6d7c8f60303accd2e2445dbc12274788bfb6afebd45">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>