### PR TITLE
fix: set Azure DevOps comment thread status to 'active' 

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -350,7 +350,8 @@ class AzureDevopsProvider(GitProvider):
             get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
             return None
         comment = Comment(content=pr_comment)
-        thread = CommentThread(comments=[comment], thread_context=thread_context, status="closed")
+        # Set status to 'active' to prevent auto-resolve (see CommentThreadStatus docs)
+        thread = CommentThread(comments=[comment], thread_context=thread_context, status='active')
         thread_response = self.azure_devops_client.create_thread(
             comment_thread=thread,
             project=self.workspace_slug,


### PR DESCRIPTION



___

### **PR Type**
Bug fix


___

### **Description**
• Changed Azure DevOps comment thread status from 'closed' to 'active'
• Prevents automatic resolution of comment threads
• Added explanatory comment referencing CommentThreadStatus documentation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Comment Thread Creation"] --> B["Status: 'closed'"] 
  B --> C["Auto-resolve Issue"]
  A --> D["Status: 'active'"] 
  D --> E["Prevents Auto-resolve"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Fix comment thread status to prevent auto-resolve</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

• Modified <code>publish_comment</code> method to set thread status to 'active'<br> • <br>Added comment explaining the change prevents auto-resolve<br> • Changed <br>from 'closed' to 'active' status in CommentThread creation


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1865/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>