### PR TITLE
Update webhook handler to use X-Event-Key header for Bitbucket Cloud and removes JWT mechanism

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -31,8 +31,7 @@ class BitbucketProvider(GitProvider):
         s = requests.Session()
         s.headers["Content-Type"] = "application/json"
 
-        self.auth_type = get_settings().get("BITBUCKET.AUTH_TYPE", "bearer")
-
+        self.auth_type = get_settings().get("BITBUCKET.AUTH_TYPE", "basic")
         try:
             def get_token(token_name, auth_type_name):
                 token = get_settings().get(f"BITBUCKET.{token_name.upper()}", None)


### PR DESCRIPTION
I’m diving into Python for this change, so please treat this as a rough draft. I’ve reverse-engineered the existing handler to support Bitbucket Cloud webhooks correctly. Any feedback is appreciated!

Currently the `/webhook` handler function looks up the `Authorization` header in the incoming webhook request payload. However, Bitbucket webhooks now sign the request body with an auth token via HMAC and no longer include an `Authorization` header in the request headers. See https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/ for details.

Hence I have removed parts of the code which used for forming JWT token
Also the webhook event type is now being sent in the request headers rather than in the request body, Updated the lookup of event type from JSON request body to request header `x-event-key`
here's the snippet
```
'x-forwarded-scheme': 'https', 'x-scheme': 'https', 'content-length': '16451', 'x-event-key': 'pullrequest:comment_created'
```

Here's working config after these changes on K8s
App Config
```
CONFIG.GIT_PROVIDER=bitbucket
BITBUCKET__AUTH_TYPE=basic
BITBUCKET__BASIC_TOKEN=cGF2YW4
OPENAI_API_KEY=sk-proj-
```

`BITBUCKET__BASIC_TOKEN=$(echo -n <bitbucket_email_id>:<bitbucket_api_token> | base64)`

solves Issue: https://github.com/qodo-ai/pr-agent/issues/1915 


