### PR TITLE
fix: correct FAQ answer numbering for questions 6 and 7

### DIFF
--- a/docs/docs/faq/index.md
+++ b/docs/docs/faq/index.md
@@ -66,7 +66,7 @@ ___
 ___
 
 ??? note "Q: Can Qodo Merge review draft/offline PRs?"
-    #### Answer:<span style="display:none;">5</span>
+    #### Answer:<span style="display:none;">6</span>
 
     Yes. While Qodo Merge won't automatically review draft PRs, you can still get feedback by manually requesting it through [online commenting](https://qodo-merge-docs.qodo.ai/usage-guide/automations_and_usage/#online-usage).
 
@@ -74,7 +74,7 @@ ___
 ___
 
 ??? note "Q: Can the 'Review effort' feedback be calibrated or customized?"
-    #### Answer:<span style="display:none;">5</span>
+    #### Answer:<span style="display:none;">7</span>
 
     Yes, you can customize review effort estimates using the `extra_instructions` configuration option (see [documentation](https://qodo-merge-docs.qodo.ai/tools/review/#configuration-options)).
     


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed FAQ answer numbering for questions 6 and 7


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.md</strong><dd><code>Correct FAQ answer numbering sequence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/faq/index.md

<li>Updated hidden span numbering from 5 to 6 for draft PR question<br> <li> Updated hidden span numbering from 5 to 7 for review effort question


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1924/files#diff-3da72c80c0b0818b033e74a8b107fd4b017ccfa2d8b498a32652bcbdd41837ae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>