### PR TITLE
fix: Add ignore logic for Bitbucket Server webhook

### DIFF
--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -102,26 +102,25 @@ def should_process_pr_logic(data) -> bool:
         # Allow_only_specific_folders
         allowed_folders = get_settings().config.get("allow_only_specific_folders", [])
         if allowed_folders and pr_id and project_key and repo_slug:
-            try:
-                from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
-                bitbucket_server_url = get_settings().get("BITBUCKET_SERVER.URL", "")
-                pr_url = f"{bitbucket_server_url}/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}"
-                provider = BitbucketServerProvider(pr_url=pr_url)
-                changed_files = provider.get_files()
-                if changed_files:
-                    # Check if ALL files are outside allowed folders
-                    all_files_outside = True
-                    for file_path in changed_files:
-                        if any(file_path.startswith(folder) for folder in allowed_folders):
-                            all_files_outside = False
-                            break
-                    
-                    if all_files_outside:
-                        get_logger().info(f"Ignoring PR because all files {changed_files} are outside allowed folders {allowed_folders}")
-                        return False
+            from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
+            bitbucket_server_url = get_settings().get("BITBUCKET_SERVER.URL", "")
+            pr_url = f"{bitbucket_server_url}/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}"
+            provider = BitbucketServerProvider(pr_url=pr_url)
+            changed_files = provider.get_files()
+            if changed_files:
+                # Check if ALL files are outside allowed folders
+                all_files_outside = True
+                for file_path in changed_files:
+                    if any(file_path.startswith(folder) for folder in allowed_folders):
+                        all_files_outside = False
+                        break
+                
+                if all_files_outside:
+                    get_logger().info(f"Ignoring PR because all files {changed_files} are outside allowed folders {allowed_folders}")
+                    return False
     except Exception as e:
         get_logger().error(f"Failed 'should_process_pr_logic': {e}")
-        return True
+        return True # On exception - we continue. Otherwise, we could just end up with filtering all PRs
     return True
 
 @router.post("/")


### PR DESCRIPTION
### **User description**
part of: #1928


___

### **PR Type**
Bug fix


___

### **Description**
- Implement ignore logic for Bitbucket Server webhooks

- Add support for ignoring PRs by repository, author, title, and branches

- Integrate ignore checks into PR processing workflow


___

### **Changes diagram**

```mermaid
flowchart LR
  webhook["Webhook Request"] --> ignore_check["should_process_pr_logic()"]
  ignore_check --> config_check["Check Config Settings"]
  config_check --> repo_ignore["Repository Ignore"]
  config_check --> author_ignore["Author Ignore"]
  config_check --> title_ignore["Title Ignore"]
  config_check --> branch_ignore["Branch Ignore"]
  ignore_check --> process["Process PR"] 
  ignore_check --> skip["Skip PR"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_webhook.py</strong><dd><code>Implement PR ignore logic for Bitbucket Server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/bitbucket_server_webhook.py

<li>Add <code>should_process_pr_logic()</code> function to check ignore conditions<br> <li> Implement repository, author, title, and branch ignore logic<br> <li> Integrate ignore checks into PR opened event handling<br> <li> Add proper logging for ignored PRs


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1929/files#diff-ba0834fc2337468d35345ca206434bc48a0894426929d63be442d0793c5d84ba">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>