### PR TITLE
fix: rstrip error

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -609,13 +609,15 @@ class PRDescription:
                 changes_walkthrough += "</details>\n\n"
             elif key.lower().strip() == 'description':
                 if isinstance(value, list):
-                    value = ', '.join(v.rstrip() for v in value)
+                    # Handle both strings and dictionaries in the list
+                    value = ', '.join(str(v).rstrip() if hasattr(v, 'rstrip') else str(v) for v in value)
                 value = value.replace('\n-', '\n\n-').strip() # makes the bullet points more readable by adding double space
                 pr_body += f"{value}\n"
             else:
                 # if the value is a list, join its items by comma
                 if isinstance(value, list):
-                    value = ', '.join(v.rstrip() for v in value)
+                    # Handle both strings and dictionaries in the list
+                    value = ', '.join(str(v).rstrip() if hasattr(v, 'rstrip') else str(v) for v in value)
                 pr_body += f"{value}\n"
             if idx < len(self.data) - 1:
                 pr_body += "\n\n___\n\n"


### PR DESCRIPTION
### **User description**
Fix error in gitlab when doing describe command:

`2025-07-22 19:54:48.831 | INFO     | pr_agent.tools.pr_description:extend_uncovered_files:375 - Adding 1 unprocessed extra files to table prediction
2025-07-22 19:54:48.838 | WARNING  | pr_agent.tools.pr_description:_prepare_file_labels:645 - Empty changes summary in file label dict, skipping file
2025-07-22 19:54:48.839 | ERROR    | pr_agent.tools.pr_description:run:197 - Error generating PR description https://gitlab.com/...: 'dict' object has no attribute 'rstrip'
`


___

### **PR Type**
Bug fix


___

### **Description**
- Fix AttributeError when processing non-string values in PR description

- Add type checking for `rstrip()` method availability

- Handle mixed data types in list processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["List with mixed types"] --> B["Type checking"] --> C["Safe string conversion"] --> D["Apply rstrip() only to strings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Fix rstrip AttributeError for mixed data types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<ul><li>Add <code>hasattr(v, 'rstrip')</code> check before calling <code>rstrip()</code> method<br> <li> Convert non-string values to string using <code>str(v)</code> before processing<br> <li> Apply fix to both description and general value processing sections</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1950/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

