### PR TITLE
docs: improve document for enable using commands in PR comments the GitHub Actions

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -202,6 +202,20 @@ publish_labels = false
 
 to prevent Qodo Merge from publishing labels when running the `describe` tool.
 
+#### Enable using commands in PR
+
+You can configure your GitHub Actions workflow to trigger on `issue_comment` [events](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment) (`created` and `edited`).
+
+Example GitHub Actions workflow configuration:
+
+```yaml
+on:
+  issue_comment:
+    types: [created, edited]
+```
+
+When this is configured, Qodo merge can be invoked by commenting on the PR.
+
 #### Quick Reference: Model Configuration in GitHub Actions
 
 For detailed step-by-step examples of configuring different models (Gemini, Claude, Azure OpenAI, etc.) in GitHub Actions, see the [Configuration Examples](../installation/github.md#configuration-examples) section in the installation guide.


### PR DESCRIPTION
### **User description**
This PR corrects the commit author information from #1973.
No code changes are included.

I think that the commit hash for subsequent work has changed, so it may be difficult for this PR to be approved... 🥲
But if possible, please apply it 🙏

cc. @mrT23 
___

### **PR Type**
Documentation


___

### **Description**
- Add interactive Q&A feature documentation for PR comments

- Include GitHub Actions workflow configuration for issue_comment events

- Document command usage in PR reviews


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] --> B["issue_comment Events"]
  B --> C["PR Comment Commands"]
  C --> D["Qodo Merge Interactive Q&A"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automations_and_usage.md</strong><dd><code>Add interactive PR command documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/automations_and_usage.md

<ul><li>Add new section "Enable using commands in PR"<br> <li> Include GitHub Actions workflow example for <code>issue_comment</code> events<br> <li> Document how to invoke Qodo merge via PR comments</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1975/files#diff-878bb0ecba4567cf6a5fa750521c6822078e4da41864153ab50a2e236e8e9451">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

