### PR TITLE
fix: URL-encode branch names in git provider links

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -2,7 +2,7 @@ import difflib
 import json
 import re
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 import requests
 from atlassian.bitbucket import Cloud
@@ -115,7 +115,7 @@ class BitbucketProvider(GitProvider):
             parsed_pr_url = urlparse(self.pr_url)
             scheme_and_netloc = parsed_pr_url.scheme + "://" + parsed_pr_url.netloc
             workspace_name, project_name = (self.workspace_slug, self.repo_slug)
-        prefix = f"{scheme_and_netloc}/{workspace_name}/{project_name}/src/{desired_branch}"
+        prefix = f"{scheme_and_netloc}/{workspace_name}/{project_name}/src/{quote(desired_branch, safe='')}"
         suffix = "" #None
         return (prefix, suffix)
 

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -3,7 +3,7 @@ import re
 
 from packaging.version import parse as parse_version
 from typing import Optional, Tuple
-from urllib.parse import quote_plus, urlparse
+from urllib.parse import quote_plus, urlparse, quote
 
 from atlassian.bitbucket import Bitbucket
 from requests.exceptions import HTTPError
@@ -81,7 +81,7 @@ class BitbucketServerProvider(GitProvider):
             get_logger().error(f"workspace_name or project_name not found in context, either git url: {repo_git_url} or uninitialized workspace/project.")
             return ("", "")
         prefix = f"{self.bitbucket_server_url}/projects/{workspace_name}/repos/{project_name}/browse"
-        suffix = f"?at=refs%2Fheads%2F{desired_branch}"
+        suffix = f"?at=refs%2Fheads%2F{quote(desired_branch, safe='')}"
         return (prefix, suffix)
 
     def get_repo_settings(self):

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 from typing import Any, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 import giteapy
 from giteapy.rest import ApiException
@@ -506,11 +506,11 @@ class GiteaProvider(GitProvider):
 
     def get_line_link(self, relevant_file, relevant_line_start, relevant_line_end = None) -> str:
         if relevant_line_start == -1:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}"
+            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{quote(self.get_pr_branch(), safe='')}/{relevant_file}"
         elif relevant_line_end:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}#L{relevant_line_start}-L{relevant_line_end}"
+            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{quote(self.get_pr_branch(), safe='')}/{relevant_file}#L{relevant_line_start}-L{relevant_line_end}"
         else:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}#L{relevant_line_start}"
+            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{quote(self.get_pr_branch(), safe='')}/{relevant_file}#L{relevant_line_start}"
 
         self.logger.info(f"Generated link: {link}")
         return link

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -8,7 +8,7 @@ import traceback
 import json
 from datetime import datetime
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 from github.Issue import Issue
 from github import AppAuthentication, Auth, Github, GithubException
@@ -138,7 +138,7 @@ class GithubProvider(GitProvider):
             get_logger().error(f"Unable to get canonical url parts since missing context (PR or explicit git url)")
             return ("", "")
 
-        prefix = f"{scheme_and_netloc}/{owner}/{repo}/blob/{desired_branch}"
+        prefix = f"{scheme_and_netloc}/{owner}/{repo}/blob/{quote(desired_branch, safe='')}"
         suffix = ""  # github does not add a suffix
         return (prefix, suffix)
 

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -2,7 +2,7 @@ import difflib
 import hashlib
 import re
 from typing import Optional, Tuple, Any, Union
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, quote
 
 import gitlab
 import requests
@@ -95,7 +95,7 @@ class GitLabProvider(GitProvider):
                 return ("", "")
         else: #Use repo git url
             repo_path = repo_git_url.split('.git')[0].split('.com/')[-1]
-        prefix = f"{self.gitlab_url}/{repo_path}/-/blob/{desired_branch}"
+        prefix = f"{self.gitlab_url}/{repo_path}/-/blob/{quote(desired_branch, safe='')}"
         suffix = "?ref_type=heads"  # gitlab cloud adds this suffix. gitlab server does not, but it is harmless.
         return (prefix, suffix)
 
@@ -640,11 +640,11 @@ class GitLabProvider(GitProvider):
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         if relevant_line_start == -1:
-            link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads"
+            link = f"{self.gl.url}/{self.id_project}/-/blob/{quote(self.mr.source_branch, safe='')}/{relevant_file}?ref_type=heads"
         elif relevant_line_end:
-            link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{relevant_line_start}-{relevant_line_end}"
+            link = f"{self.gl.url}/{self.id_project}/-/blob/{quote(self.mr.source_branch, safe='')}/{relevant_file}?ref_type=heads#L{relevant_line_start}-{relevant_line_end}"
         else:
-            link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{relevant_line_start}"
+            link = f"{self.gl.url}/{self.id_project}/-/blob/{quote(self.mr.source_branch, safe='')}/{relevant_file}?ref_type=heads#L{relevant_line_start}"
         return link
 
 
@@ -660,7 +660,7 @@ class GitLabProvider(GitProvider):
 
             if absolute_position != -1:
                 # link to right file only
-                link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{absolute_position}"
+                link = f"{self.gl.url}/{self.id_project}/-/blob/{quote(self.mr.source_branch, safe='')}/{relevant_file}?ref_type=heads#L{absolute_position}"
 
                 # # link to diff
                 # sha_file = hashlib.sha1(relevant_file.encode('utf-8')).hexdigest()


### PR DESCRIPTION
### **User description**
Branch names with special characters like '#' caused broken URLs because they weren't encoded correctly. This often happens when branch names come from GitLab issues (e.g., 'project#456'), since the hash symbol is mistakenly seen as a URL fragment.

This change uses `urllib.parse.quote()` to encode the branch name component when generating links. This ensures special characters are correctly handled (e.g., '#test' becomes '%23test'), making the URLs robust.

The fix has been applied to the link generation logic for the following providers:
- GitLab
- GitHub
- Gitea
- Bitbucket
- Bitbucket Server


___

### **PR Type**
Bug fix


___

### **Description**
- URL-encode branch names in git provider links

- Fix broken URLs with special characters like '#'

- Apply fix across GitLab, GitHub, Gitea, Bitbucket providers

- Use `urllib.parse.quote()` for proper encoding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Branch names with special chars"] --> B["urllib.parse.quote()"]
  B --> C["Encoded URLs"]
  C --> D["GitLab links"]
  C --> E["GitHub links"] 
  C --> F["Gitea links"]
  C --> G["Bitbucket links"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_provider.py</strong><dd><code>Add URL encoding for Bitbucket branch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_provider.py

<ul><li>Import <code>quote</code> from urllib.parse<br> <li> Apply URL encoding to branch name in <code>get_canonical_url_parts()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2041/files#diff-3f47323db85f534fa282b2d48c6cf542f00a5e791b62379253ef3d3e8c6bb3b2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Add URL encoding for Bitbucket Server branch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_server_provider.py

<ul><li>Import <code>quote</code> from urllib.parse<br> <li> Apply URL encoding to branch name in query parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2041/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitea_provider.py</strong><dd><code>Add URL encoding for Gitea branch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitea_provider.py

<ul><li>Import <code>quote</code> from urllib.parse<br> <li> Apply URL encoding to branch names in <code>get_line_link()</code> method<br> <li> Fix encoding for all three link generation scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2041/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Add URL encoding for GitHub branch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/github_provider.py

<ul><li>Import <code>quote</code> from urllib.parse<br> <li> Apply URL encoding to branch name in <code>get_canonical_url_parts()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2041/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Add URL encoding for GitLab branch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<ul><li>Import <code>quote</code> from urllib.parse<br> <li> Apply URL encoding to branch names in <code>get_canonical_url_parts()</code><br> <li> Fix encoding in <code>get_line_link()</code> and <br><code>generate_link_to_relevant_line_number()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2041/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

