### PR TITLE
feat: provider-agnostic push outputs + optional Slack relay (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,33 @@ ___
 </div>
 <hr>
 
+## Provider-agnostic push outputs and Slack relay
+
+PR-Agent can optionally emit review results to external sinks without calling git provider APIs.
+This is disabled by default. To enable and forward to Slack via a lightweight relay:
+
+1) Start the relay (in a separate shell):
+   - Set an Incoming Webhook URL for Slack:
+     - CMD:  set SLACK_WEBHOOK_URL=https://hooks.slack.com/services/TXXXX/BXXXX/XXXXXXXX
+     - PS:   $env:SLACK_WEBHOOK_URL="https://hooks.slack.com/services/TXXXX/BXXXX/XXXXXXXX"
+   - Run:
+     uvicorn pr_agent.servers.push_outputs_relay:app --host 0.0.0.0 --port 8000
+
+2) In your repository, configure PR-Agent to emit to the relay by creating .pr_agent.toml:
+
+```
+[push_outputs]
+enable = true
+channels = ["webhook"]
+webhook_url = "http://localhost:8000/relay"
+presentation = "markdown"
+```
+
+Notes:
+- This mechanism is provider-agnostic and uses minimal API calls.
+- You can also use the "file" channel to append JSONL records locally.
+- The relay transforms the generic payload into Slack’s Incoming Webhook schema.
+
 ## Try It Now
 
 Try the GPT-5 powered PR-Agent instantly on _your public GitHub repository_. Just mention `@CodiumAI-Agent` and add the desired command in any PR comment. The agent will generate a response based on your command.

--- a/pr_agent/servers/push_outputs_relay.py
+++ b/pr_agent/servers/push_outputs_relay.py
@@ -1,0 +1,95 @@
+"""
+Provider-agnostic push outputs relay for Slack
+
+This FastAPI service receives generic PR-Agent push outputs (from [push_outputs]) and relays them
+as Slack Incoming Webhook messages.
+
+Usage
+-----
+1) Run the relay (choose one):
+   - uvicorn pr_agent.servers.push_outputs_relay:app --host 0.0.0.0 --port 8000
+   - python -m pr_agent.servers.push_outputs_relay
+
+2) Configure the destination Slack webhook:
+   - Set environment variable SLACK_WEBHOOK_URL to your Slack Incoming Webhook URL.
+
+3) Point PR-Agent to the relay:
+   In your configuration (e.g., .pr_agent.toml or central config), enable generic push outputs:
+
+   [push_outputs]
+   enable = true
+   channels = ["webhook"]
+   webhook_url = "http://localhost:8000/relay"  # adjust host/port if needed
+   presentation = "markdown"
+
+Security
+--------
+- Keep the relay private or place it behind an auth gateway if exposed externally.
+- You can also wrap this service with a reverse proxy that enforces authentication and rate limits.
+
+Notes
+-----
+- The relay is intentionally Slack-specific while living outside the provider-agnostic core.
+- If record['markdown'] is present, it will be used as Slack message text. Otherwise, a JSON fallback
+  is generated from record['payload'].
+- Slack supports basic Markdown (mrkdwn). Complex HTML/GitGFM sections may not render perfectly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import requests
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI(title="PR-Agent Push Outputs Relay (Slack)")
+
+
+def _to_slack_text(record: Dict[str, Any]) -> str:
+    """
+    Prefer full review markdown; otherwise fallback to a compact JSON of the payload.
+    """
+    markdown = record.get("markdown")
+    if isinstance(markdown, str) and markdown.strip():
+        return markdown
+
+    payload = record.get("payload") or {}
+    try:
+        return "```\n" + json.dumps(payload, ensure_ascii=False, indent=2) + "\n```"
+    except Exception:
+        return str(payload)
+
+
+@app.post("/relay")
+async def relay(record: Dict[str, Any]):
+    slack_url = os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+    if not slack_url:
+        raise HTTPException(status_code=500, detail="SLACK_WEBHOOK_URL environment variable is not set")
+
+    text = _to_slack_text(record)
+
+    body = {
+        "text": text,
+        "mrkdwn": True,
+    }
+
+    try:
+        resp = requests.post(slack_url, json=body, timeout=8)
+        if resp.status_code >= 300:
+            raise HTTPException(status_code=resp.status_code, detail=f"Slack webhook error: {resp.text}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to post to Slack: {e}")
+
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    # Allow running directly: python -m pr_agent.servers.push_outputs_relay
+    import uvicorn
+
+    port = int(os.environ.get("PORT", "8000"))
+    uvicorn.run("pr_agent.servers.push_outputs_relay:app", host="0.0.0.0", port=port, reload=False)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -390,3 +390,13 @@ pr_commands = [
     "/review",
     "/improve",
 ]
+
+# Generic push outputs configuration (disabled by default). This allows emitting PR outputs
+# to stdout, a local file, or a generic webhook without calling provider-specific APIs.
+# To enable, set enable=true and choose one or more channels.
+[push_outputs]
+enable = false
+channels = ["stdout"]
+file_path = "pr-agent-outputs/reviews.jsonl"
+webhook_url = ""
+presentation = "markdown"

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -15,7 +15,7 @@ from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRReviewHeader,
                                  convert_to_markdown_v2, github_action_output,
-                                 load_yaml, show_relevant_configurations)
+                                 load_yaml, show_relevant_configurations, push_outputs)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (get_git_provider,
                                     get_git_provider_with_context)
@@ -269,6 +269,13 @@ class PRReviewer:
         # Output the relevant configurations if enabled
         if get_settings().get('config', {}).get('output_relevant_configurations', False):
             markdown_text += show_relevant_configurations(relevant_section='pr_reviewer')
+
+        # Push outputs to optional external channels (stdout/file/webhook) without provider APIs
+        try:
+            push_outputs("review", payload=data.get('review', {}), markdown=markdown_text)
+        except Exception:
+            # non-fatal
+            pass
 
         # Add custom labels from the review prediction (effort, security)
         self.set_review_labels(data)


### PR DESCRIPTION
### **User description**
## Description
Resolves: Enable Slack Notifications for Newly Reviewed PRs or Any PR-Agent Response #2025

## Summary
This PR implements a provider-agnostic mechanism to emit PR-Agent outputs to external sinks (e.g., Slack) with zero coupling to any specific git provider API. It adds:
- A generic push_outputs facility with channels (stdout, file, webhook)
- Disabled-by-default [push_outputs] configuration
- A small optional Slack relay service (FastAPI) that converts the generic payload to Slack’s expected format (Incoming Webhooks or Workflow “triggers”)
- A concise README section describing how to enable and use the feature

This meets the requirements in #2025:
- Agnostic across all supported git providers: no provider-specific APIs are used. Works with GitHub, GitLab, Bitbucket, Azure DevOps, etc.
- Minimal API calls: zero external calls for stdout/file; a single HTTP POST for webhook; the optional relay makes exactly one POST to Slack.
- Generic, easy-to-adapt presentation: a structured JSON payload plus a markdown field suitable for human reading and simple remapping.
- Enable flag off by default: the feature is opt-in and doesn’t change existing behavior unless explicitly configured.

## What changed
- pr_agent/algo/utils.py
  - Added push_outputs(message_type, payload=None, markdown=None)
  - Behavior:
    - If [push_outputs].enable is false (default), does nothing
    - Channels:
      - stdout: prints one-line JSON
      - file: appends JSONL records (creates parent dir if needed)
      - webhook: POSTs JSON record to a configured URL
    - Non-fatal on errors (warn only)
- pr_agent/tools/pr_reviewer.py
  - After generating the review markdown and before labels, calls push_outputs("review", payload=data['review'], markdown=markdown_text)
  - This is independent of config.publish_output (so you can disable PR comments and still push to Slack)
- pr_agent/settings/configuration.toml
  - New [push_outputs] section (disabled by default):
    [push_outputs]
    enable = false
    channels = ["stdout"]
    file_path = "pr-agent-outputs/reviews.jsonl"
    webhook_url = ""
    presentation = "markdown"
- pr_agent/servers/push_outputs_relay.py (optional)
  - FastAPI relay that accepts the generic payload and forwards to Slack:
    - For Incoming Webhooks (hooks.slack.com/services/…), sends {text, mrkdwn}
    - For Workflow Webhooks (hooks.slack.com/triggers/…), sends top-level {markdown, payload} to match Workflow variables
  - SLACK_WEBHOOK_URL is provided via environment variable
  - One POST per message; errors returned to caller with appropriate status code
- pr_agent/README.md
  - Added a short “Provider-agnostic push outputs and Slack relay” section with quick start steps

## Why this design
- Provider-agnostic: Does not call or depend on any git provider API. Works uniformly across all providers and deployment modes (CLI, actions, webhooks).
- Minimal API: stdout/file use no network; webhook is exactly one POST; optional relay does one POST to Slack.
- Generic presentation: the record includes:
  - type: e.g., "review"
  - timestamp: ISO UTC
  - payload: structured review data for automation
  - markdown: human-readable text for notification systems
- Disabled by default: no behavior change unless explicitly configured.

## Configuration examples
- Emit to Slack via the relay:
  [push_outputs]
  enable = true
  channels = ["webhook"]
  webhook_url = "http://your-relay-host:8000/relay"
  presentation = "markdown"
- Emit to a local file only:
  [push_outputs]
  enable = true
  channels = ["file"]
  file_path = "pr-agent-outputs/reviews.jsonl"

## Optional Slack relay usage
- Incoming Webhook:
  - Set SLACK_WEBHOOK_URL=https://hooks.slack.com/services/… on the relay process
  - Relay transforms to {text, mrkdwn:true}
- Slack Workflow (triggers):
  - Create a Workflow with a Webhook trigger and variables named markdown (and optionally payload)
  - Set SLACK_WEBHOOK_URL to the triggers URL
  - Relay sends top-level {markdown, payload} so the Workflow “Send a message” step can insert the markdown variable

## Failure handling
- push_outputs is non-fatal; if webhook/file fails, the agent run is not interrupted
- File channel ensures parent directories are created
- Webhook timeouts/logging use warnings

## Backward compatibility
- Default config keeps the feature disabled; existing behavior is unchanged
- No changes to provider classes or PR publishing flows
- The new integration point merely adds an optional emit path

## Security and privacy
- No provider tokens are exposed
- Relay best practice: keep private or behind an auth gateway
- Slack webhook lives in the relay environment, not in PR-Agent config
- No data retention changes; optional file channel writes to local disk where configured

## Performance impact
- Negligible. One JSON dump and optionally a single POST when enabled

## Known limitations and future work
- Slack presentation uses markdown; richer block layouts could be added later if desired
- Additional channels (e.g., direct “slack” channel without relay) can be added in future if maintainers prefer

## Testing performed
- Local: Verified push_outputs stdout and file channels
- Webhook error path: Verified non-fatal behavior on connection failure
- Slack relay:
  - Incoming Webhook path confirmed posts message
  - Workflow “triggers” path confirmed variables markdown/payload accepted and posted as message
- README instructions followed to reproduce

## Notes
- All local testing artifacts used during development (repo-level overrides, ad-hoc test scripts) were removed before this PR
- Only production-ready code and docs are included

## Request
- Please review the overall approach and configuration defaults
- Feedback welcome on config naming and README placement


___

### **PR Type**
Enhancement


___

### **Description**
- Add provider-agnostic push outputs mechanism with stdout/file/webhook channels

- Integrate Slack relay server for external notifications

- Enable review data emission without git provider APIs

- Add configuration section with disabled-by-default settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Review"] --> B["push_outputs()"]
  B --> C["stdout channel"]
  B --> D["file channel"]
  B --> E["webhook channel"]
  E --> F["Slack Relay Server"]
  F --> G["Slack Webhook"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add generic push outputs mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<ul><li>Add <code>push_outputs()</code> function supporting stdout, file, and webhook <br>channels<br> <li> Include timestamp, payload, and markdown in output records<br> <li> Implement error handling with non-fatal warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2043/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push_outputs_relay.py</strong><dd><code>Add Slack relay server implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/push_outputs_relay.py

<ul><li>Create FastAPI relay server for Slack integration<br> <li> Support both Incoming Webhooks and Workflow triggers<br> <li> Transform generic payload to Slack-compatible format<br> <li> Include comprehensive documentation and usage examples</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2043/files#diff-1c4fa201c452a15395e7093780aed70199f4e62836b889383c12121754794b0b">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Integrate push outputs into reviewer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_reviewer.py

<ul><li>Import <code>push_outputs</code> function<br> <li> Call <code>push_outputs()</code> after review generation with payload and markdown<br> <li> Add non-fatal error handling for push operations</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2043/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document push outputs feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add documentation section for push outputs and Slack relay<br> <li> Include setup instructions for relay server<br> <li> Provide configuration examples for <code>.pr_agent.toml</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2043/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add push outputs configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<ul><li>Add <code>[push_outputs]</code> configuration section<br> <li> Set default values with feature disabled<br> <li> Include channels, file path, and webhook URL options</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2043/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

