### PR TITLE
Remove useless pass from git_provider

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -376,7 +376,6 @@ def get_main_pr_language(languages, files) -> str:
                         break
         except Exception as e:
             get_logger().exception(f"Failed to get main language: {e}")
-            pass
 
         ## old approach:
         # most_common_extension = max(set(extension_list), key=extension_list.count)
@@ -401,7 +400,6 @@ def get_main_pr_language(languages, files) -> str:
 
     except Exception as e:
         get_logger().exception(e)
-        pass
 
     return main_language_str
 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove redundant `pass` statements after exception logging


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_provider.py</strong><dd><code>Remove redundant pass statements from exception blocks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/git_provider.py

<ul><li>Removed two redundant <code>pass</code> statements after exception logging calls<br> <li> Cleaned up exception handling blocks in <code>get_main_pr_language</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2059/files#diff-52d45f12b836f77ed1aef86e972e65404634ea4e2a6083fb71a9b0f9bb9e062f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

