### PR TITLE
fix: safe attribute access in review prompt template

### DIFF
--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -217,7 +217,7 @@ Ticket Description:
 #####
 {%- endif %}
 
-{%- if ticket.requirements is defined %}
+{%- if ticket.requirements is defined and ticket.requirements %}
 Ticket Requirements:
 #####
 {{ ticket.requirements }}


### PR DESCRIPTION
### **User description**

fix https://github.com/qodo-ai/pr-agent/issues/2066

This change fixes a crash in `/review` when the PR description includes a GitHub Issue link. 

The reviewer prompt template previously accessed `ticket.requirements`, which does not exist for GitHub Issues, this resulted in an AttributeError. We now guard the section with `{% if ticket.requirements is defined %}` so it renders only when present.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed AttributeError when PR description contains GitHub Issue links

- Added safe attribute check for `ticket.requirements` in reviewer prompt template

- Changed condition from `{% if ticket.requirements %}` to `{% if ticket.requirements is defined %}`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR with GitHub Issue link"] --> B["Review prompt template"]
  B --> C["Safe attribute check"]
  C --> D["Render requirements section only if defined"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Add safe attribute check for ticket requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<ul><li>Updated conditional check from <code>{% if ticket.requirements %}</code> to <code>{% if </code><br><code>ticket.requirements is defined %}</code><br> <li> Prevents AttributeError when <code>ticket.requirements</code> attribute doesn't <br>exist</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2067/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

