### PR TITLE
fix: try_fix_yaml failed on snippets with prefix ``` or ```yml

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -812,14 +812,19 @@ def try_fix_yaml(response_text: str,
             pass
 
     # second fallback - try to extract only range from first ```yaml to the last ```
-    snippet_pattern = r'```yaml([\s\S]*?)```(?=\s*$|")'
+    snippet_pattern = r'```(yaml|yml)?([\s\S]*?)```(?=\s*$|")'
     snippet = re.search(snippet_pattern, '\n'.join(response_text_lines_copy))
     if not snippet:
         snippet = re.search(snippet_pattern, response_text_original) # before we removed the "```"
     if snippet:
         snippet_text = snippet.group()
+        prefix = (
+            '```yaml'
+            if snippet_text.startswith('```yaml')
+            else ('```yml' if snippet_text.startswith('```yml') else '```')
+        )
         try:
-            data = yaml.safe_load(snippet_text.removeprefix('```yaml').rstrip('`'))
+            data = yaml.safe_load(snippet_text.removeprefix(prefix).rstrip('`'))
             get_logger().info(f"Successfully parsed AI prediction after extracting yaml snippet")
             return data
         except:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -823,8 +823,8 @@ def try_fix_yaml(response_text: str,
             data = yaml.safe_load(snippet_text)
             get_logger().info(f"Successfully parsed AI prediction after extracting yaml snippet")
             return data
-        except:
-            pass
+        except Exception as e:
+            get_logger().debug(f"Failed to parse AI prediction after extracting yaml snippet: {e}")
 
 
     # third fallback - try to remove leading and trailing curly brackets

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -817,14 +817,10 @@ def try_fix_yaml(response_text: str,
     if not snippet:
         snippet = re.search(snippet_pattern, response_text_original) # before we removed the "```"
     if snippet:
-        snippet_text = snippet.group()
-        prefix = (
-            '```yaml'
-            if snippet_text.startswith('```yaml')
-            else ('```yml' if snippet_text.startswith('```yml') else '```')
-        )
+        # group(2) is the snippet body, without the ``` fences or the optional yaml/yml language identifier
+        snippet_text = snippet.group(2)
         try:
-            data = yaml.safe_load(snippet_text.removeprefix(prefix).rstrip('`'))
+            data = yaml.safe_load(snippet_text)
             get_logger().info(f"Successfully parsed AI prediction after extracting yaml snippet")
             return data
         except:

--- a/tests/unittest/test_try_fix_yaml.py
+++ b/tests/unittest/test_try_fix_yaml.py
@@ -21,7 +21,7 @@ class TestTryFixYaml:
 
     # The function extracts YAML snippet
     def test_extract_snippet(self):
-        review_text = '''\
+        review_text1 = '''\
 Here is the answer in YAML format:
 
 ```yaml
@@ -29,8 +29,26 @@ name: John Smith
 age: 35
 ```
 '''
+        review_text2 = '''\
+Here is the answer in YAML format:
+
+```yml
+name: John Smith
+age: 35
+```
+'''
+        review_text3 = '''\
+Here is the answer in YAML format:
+
+```
+name: John Smith
+age: 35
+```
+'''
         expected_output = {'name': 'John Smith', 'age': 35}
-        assert try_fix_yaml(review_text) == expected_output
+        assert try_fix_yaml(review_text1) == expected_output
+        assert try_fix_yaml(review_text2) == expected_output
+        assert try_fix_yaml(review_text3) == expected_output
 
 
     # The YAML string is empty.


### PR DESCRIPTION
### **User description**
LLMs might return code wrapped with \`\`\` or  ```yml.


___

### **PR Type**
Bug fix


___

### **Description**
- Enhanced `try_fix_yaml` to handle code snippets with `\`\`\``, `\`\`\`yaml`, or `\`\`\`yml` prefixes

- Updated regex pattern to match optional language identifiers (yaml/yml)

- Added dynamic prefix detection to correctly remove code fence markers

- Extended test coverage with three snippet format variations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Code snippet with prefix"] --> B["Updated regex pattern"]
  B --> C["Detect prefix type"]
  C --> D["Remove correct prefix"]
  D --> E["Parse YAML successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Enhance regex and prefix handling for code fences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<ul><li>Updated <code>snippet_pattern</code> regex from <code>r'</code><code></code>yaml([\s\S]*?)<code></code><code>(?=\s*$|")'</code> to <br><code>r'</code><code></code>(yaml|yml)?([\s\S]*?)<code></code><code>(?=\s*$|")'</code> to match optional language <br>identifiers<br> <li> Added dynamic prefix detection logic that determines whether snippet <br>starts with <code>\</code>\<code>\</code>yaml<code>, </code>\<code>\</code>\<code>yml</code>, or plain <code>\</code>\<code>\</code><code><br> <li> Modified </code>removeprefix()<code> call to use detected prefix instead of <br>hardcoded </code>'<code></code><code>yaml'</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2097/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_try_fix_yaml.py</strong><dd><code>Add test cases for multiple code fence formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_try_fix_yaml.py

<ul><li>Renamed original test variable from <code>review_text</code> to <code>review_text1</code> for <br>clarity<br> <li> Added <code>review_text2</code> test case with <code>\</code>\<code>\</code>yml<code> prefix format<br> <li> Added </code>review_text3<code> test case with plain </code>\<code>\</code>\<code></code> prefix format<br> <li> Updated assertions to test all three snippet format variations</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2097/files#diff-bc25bf4b27d571ec45ec71c74e64066ce32cc6d12437f9c4b233a02e0b169503">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

