### PR TITLE
Add Claude Opus 4.5 to PR Banchmark

### DIFF
--- a/docs/docs/pr_benchmark/index.md
+++ b/docs/docs/pr_benchmark/index.md
@@ -167,6 +167,12 @@ A list of the models used for generating the baseline suggestions, and example r
       <td style="text-align:center;"><b>32.4</b></td>
     </tr>
     <tr>
+      <td style="text-align:left;">Claude-opus-4.5</td>
+      <td style="text-align:left;">2025-11-01</td>
+      <td style="text-align:left;">high</td>
+      <td style="text-align:center;"><b>30.3</b></td>
+    </tr>
+    <tr>
       <td style="text-align:left;">GPT-4.1</td>
       <td style="text-align:left;">2025-04-14</td>
       <td style="text-align:left;"></td>
@@ -423,16 +429,33 @@ Final score: **32.8**
 
 Strengths:
 
-- **Focused and concise fixes:** When the model does detect a problem it usually proposes a minimal, well-scoped patch that compiles and directly addresses the defect without unnecessary noise.  
-- **Good critical-bug instinct:** It often prioritises show-stoppers (compile failures, crashes, security issues) over cosmetic matters and occasionally spots subtle issues that all other reviewers miss.  
-- **Clear explanations & snippets:** Explanations are short, readable and paired with ready-to-paste code, making the advice easy to apply.  
+- **Focused and concise fixes:** When the model does detect a problem it usually proposes a minimal, well-scoped patch that compiles and directly addresses the defect without unnecessary noise.
+- **Good critical-bug instinct:** It often prioritises show-stoppers (compile failures, crashes, security issues) over cosmetic matters and occasionally spots subtle issues that all other reviewers miss.
+- **Clear explanations & snippets:** Explanations are short, readable and paired with ready-to-paste code, making the advice easy to apply.
 
 Weaknesses:
 
-- **High miss rate:** In a large fraction of examples the model returned an empty list or covered only one minor issue while overlooking more serious newly-introduced bugs.  
-- **Inconsistent accuracy:** A noticeable subset of answers contain wrong or even harmful fixes (e.g., removing valid flags, creating compile errors, re-introducing bugs).  
-- **Limited breadth:** Even when it finds a real defect it rarely reports additional related problems that peers catch, leading to partial reviews.  
+- **High miss rate:** In a large fraction of examples the model returned an empty list or covered only one minor issue while overlooking more serious newly-introduced bugs.
+- **Inconsistent accuracy:** A noticeable subset of answers contain wrong or even harmful fixes (e.g., removing valid flags, creating compile errors, re-introducing bugs).
+- **Limited breadth:** Even when it finds a real defect it rarely reports additional related problems that peers catch, leading to partial reviews.
 - **Occasional guideline slips:** A few replies modify unchanged lines, suggest new imports, or duplicate suggestions, showing imperfect compliance with instructions.
+
+### Claude-Opus-4.5 (high thinking budget)
+
+Final score: **30.3**
+
+Strengths:
+
+- **High rule compliance & formatting:** Consistently produces valid YAML, respects the ≤3-suggestion limit, and usually confines edits to added lines, avoiding many guideline violations seen in peers.
+- **Low false-positive rate:** Tends to stay silent unless convinced of a real problem; when the diff is a pure version bump / docs tweak it often (correctly) returns an empty list, beating noisier baselines.
+- **Clear, focused patches when it fires:** In the minority of cases where it does spot a bug, it explains the issue crisply and supplies concise, copy-paste-able code snippets.
+
+Weaknesses:
+
+- **Very low recall:** In the vast majority of examples it misses obvious critical issues or suggests only a subset, frequently returning an empty list; this places it below most baselines on overall usefulness.
+- **Shallow coverage:** Even when it catches a defect it typically lists a single point and overlooks other high-impact problems present in the same diff.
+- **Occasional incorrect or incomplete fixes:** A non-trivial number of suggestions are wrong, compile-breaking, duplicate unchanged code, or touch out-of-scope lines, reducing trust.
+- **Inconsistent severity tagging & duplication:** Sometimes mis-labels critical vs general, repeats the same suggestion, or leaves `improved_code` blocks empty.
 
 ## Appendix - Example Results
 


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Add Claude Opus 4.5 model to PR benchmark comparison table

- Include model performance metrics and release date information

- Add comprehensive strengths and weaknesses analysis section

- Fix formatting inconsistencies in existing benchmark documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Benchmark Docs"] -->|Add Model Entry| B["Claude Opus 4.5 Table Row"]
  A -->|Add Analysis Section| C["Strengths & Weaknesses"]
  C -->|Document| D["Performance: 30.3 Score"]
  C -->|Document| E["Key Characteristics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.md</strong><dd><code>Add Claude Opus 4.5 benchmark data and analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/pr_benchmark/index.md

<ul><li>Added Claude Opus 4.5 model row to benchmark comparison table with <br>score 30.3 and release date 2025-11-01<br> <li> Added comprehensive analysis section documenting model strengths (high <br>rule compliance, low false-positive rate, clear patches)<br> <li> Added weaknesses section highlighting low recall, shallow coverage, <br>and occasional incorrect fixes<br> <li> Fixed trailing whitespace formatting in existing strengths and <br>weaknesses bullet points</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2118/files#diff-671626a12a79b57a36ab5f9f10a17fb0340e601e096e066ddfbf4d0e23c07b24">+29/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

