### PR TITLE
change deprecated dict() to model_dump() pydantic method

### DIFF
--- a/pr_agent/tools/pr_similar_issue.py
+++ b/pr_agent/tools/pr_similar_issue.py
@@ -438,7 +438,7 @@ class PRSimilarIssue:
                                                   level=IssueLevel.COMMENT)
                             )
                             corpus.append(comment_record)
-        df = pd.DataFrame(corpus.dict()["documents"])
+        df = pd.DataFrame(corpus.model_dump()["documents"])
         get_logger().info('Done')
 
         get_logger().info('Embedding...')
@@ -534,7 +534,7 @@ class PRSimilarIssue:
                                                     level=IssueLevel.COMMENT)
                             )
                             corpus.append(comment_record)
-        df = pd.DataFrame(corpus.dict()["documents"])
+        df = pd.DataFrame(corpus.model_dump()["documents"])
         get_logger().info('Done')
 
         get_logger().info('Embedding...')
@@ -633,7 +633,7 @@ class PRSimilarIssue:
                             )
                             corpus.append(comment_record)
 
-        df = pd.DataFrame(corpus.dict()["documents"])
+        df = pd.DataFrame(corpus.model_dump()["documents"])
         get_logger().info('Done')
 
         get_logger().info('Embedding...')


### PR DESCRIPTION
### **User description**
https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel
dict() in pydanticV2 was deprecated. In this PR I was changed dict() to model_dump() method.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated Pydantic `dict()` method with `model_dump()`

- Update three occurrences in similar issue indexing methods

- Ensure Pydantic V2 compatibility across codebase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pydantic V2 Deprecation"] -->|"Replace dict() calls"| B["model_dump() method"]
  B -->|"Applied to"| C["pr_similar_issue.py"]
  C -->|"3 locations updated"| D["Compatibility achieved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_similar_issue.py</strong><dd><code>Update deprecated Pydantic dict() calls to model_dump()</code>&nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_similar_issue.py

<ul><li>Replaced <code>corpus.dict()</code> with <code>corpus.model_dump()</code> in <br><code>_update_index_with_issues()</code> method<br> <li> Replaced <code>corpus.dict()</code> with <code>corpus.model_dump()</code> in <br><code>_update_table_with_issues()</code> method<br> <li> Replaced <code>corpus.dict()</code> with <code>corpus.model_dump()</code> in <br><code>_update_qdrant_with_issues()</code> method<br> <li> All three changes maintain identical functionality while using <br>Pydantic V2 API</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2123/files#diff-593201e09c7e1e2cc484fdb85fa7f047eef067a6e51d168778efe637e9e0d74e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

