### PR TITLE
Fix GitLab clone URL parsing for self-hosted domains

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -963,7 +963,6 @@ class GitLabProvider(GitProvider):
         # Build a clone URL that works with any host (e.g., gitlab.example.com).
         if repo_url_to_clone.startswith(("http://", "https://")):
             try:
-                from urllib.parse import urlparse
                 parsed = urlparse(repo_url_to_clone)
                 if not parsed.scheme or not parsed.netloc:
                     raise ValueError("missing scheme or host")
@@ -982,7 +981,6 @@ class GitLabProvider(GitProvider):
                 # Handle SCP-like URLs: git@gitlab.com:group/repo.git
                 repo_url_to_clone = "ssh://" + repo_url_to_clone.replace(":", "/", 1)
 
-            from urllib.parse import urlparse
             parsed = urlparse(repo_url_to_clone)
             if not parsed.netloc:
                 raise ValueError("missing host")

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -956,8 +956,7 @@ class GitLabProvider(GitProvider):
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
         access_token = getattr(self.gl, 'oauth_token', None) or getattr(self.gl, 'private_token', None)
         if not access_token:
-            get_logger().error("No access token found for GitLab clone.")
-            return None
+            return self._log_missing_clone_token()
 
         # Note: GitLab instances are not always hosted under a gitlab.* domain.
         # Build a clone URL that works with any host (e.g., gitlab.example.com).
@@ -994,3 +993,8 @@ class GitLabProvider(GitProvider):
                 artifact={"error": str(e)},
             )
             return None
+
+    @staticmethod
+    def _log_missing_clone_token() -> None:
+        get_logger().error("No access token found for GitLab clone.")
+        return None

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -954,22 +954,36 @@ class GitLabProvider(GitProvider):
         return ""
     #Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
+        access_token = getattr(self.gl, 'oauth_token', None) or getattr(self.gl, 'private_token', None)
+        if not access_token:
+            get_logger().error("No access token found for GitLab clone.")
+            return None
+
+        # Note: GitLab instances are not always hosted under a gitlab.* domain.
+        # Build a clone URL that works with any host (e.g., gitlab.example.com).
+        if repo_url_to_clone.startswith(("http://", "https://")):
+            try:
+                from urllib.parse import urlparse
+                parsed = urlparse(repo_url_to_clone)
+                if not parsed.scheme or not parsed.netloc:
+                    raise ValueError("missing scheme or host")
+                netloc = parsed.netloc.split("@")[-1]
+                return f"{parsed.scheme}://oauth2:{access_token}@{netloc}{parsed.path}"
+            except Exception as exc:
+                get_logger().error(
+                    f"Repo URL: {repo_url_to_clone} could not be parsed for clone.",
+                    artifact={"error": str(exc)},
+                )
+                return None
+
+        # Fallback to legacy gitlab.* parsing when a raw URL is provided.
         if "gitlab." not in repo_url_to_clone:
             get_logger().error(f"Repo URL: {repo_url_to_clone} is not a valid gitlab URL.")
             return None
-        (scheme, base_url) = repo_url_to_clone.split("gitlab.")
-        access_token = getattr(self.gl, 'oauth_token', None) or getattr(self.gl, 'private_token', None)
-        if not all([scheme, access_token, base_url]):
-            get_logger().error(f"Either no access token found, or repo URL: {repo_url_to_clone} "
-                               f"is missing prefix: {scheme} and/or base URL: {base_url}.")
+        scheme, base_url = repo_url_to_clone.split("gitlab.")
+        if not all([scheme, base_url]):
+            get_logger().error(
+                f"Repo URL: {repo_url_to_clone} is missing prefix: {scheme} and/or base URL: {base_url}."
+            )
             return None
-
-        #Note that the ""official"" method found here:
-        # https://docs.gitlab.com/user/profile/personal_access_tokens/#clone-repository-using-personal-access-token
-        # requires a username, which may not be applicable.
-        # The following solution is taken from: https://stackoverflow.com/questions/25409700/using-gitlab-token-to-clone-without-authentication/35003812#35003812
-        # For example: For repo url: https://gitlab.codium-inc.com/qodo/autoscraper.git
-        # Then to clone one will issue: 'git clone https://oauth2:<access token>@gitlab.codium-inc.com/qodo/autoscraper.git'
-
-        clone_url = f"{scheme}oauth2:{access_token}@gitlab.{base_url}"
-        return clone_url
+        return f"{scheme}oauth2:{access_token}@gitlab.{base_url}"

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -217,3 +217,19 @@ class TestGitLabProvider:
         result = gitlab_provider._prepare_clone_url_with_token(repo_url)
 
         assert result is None
+
+    def test_prepare_clone_url_with_token_scp_style(self, gitlab_provider):
+        gitlab_provider.gl.oauth_token = "token123"
+        repo_url = "git@gitlab.example.com:group/repo.git"
+
+        result = gitlab_provider._prepare_clone_url_with_token(repo_url)
+
+        assert result == "ssh://oauth2:token123@gitlab.example.com/group/repo.git"
+
+    def test_prepare_clone_url_with_token_ssh_url(self, gitlab_provider):
+        gitlab_provider.gl.oauth_token = "token123"
+        repo_url = "ssh://git@gitlab.example.com/group/repo.git"
+
+        result = gitlab_provider._prepare_clone_url_with_token(repo_url)
+
+        assert result == "ssh://oauth2:token123@gitlab.example.com/group/repo.git"

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -35,6 +35,7 @@ class TestGitLabProvider:
             provider = GitLabProvider("https://gitlab.com/test/repo/-/merge_requests/1")
             provider.gl = mock_gitlab_client
             provider.id_project = "test/repo"
+            provider.gl.oauth_token = "fake_token"
             return provider
 
     def test_get_pr_file_content_success(self, gitlab_provider, mock_project):
@@ -192,3 +193,27 @@ class TestGitLabProvider:
         assert first == second == [{"diff": "d"}]
         m_pbp.assert_called_once_with("grp/repo")
         proj.repository_compare.assert_called_once_with("old", "new")
+
+    def test_prepare_clone_url_with_token_gitlab_com(self, gitlab_provider):
+        gitlab_provider.gl.oauth_token = "token123"
+        repo_url = "https://gitlab.com/group/repo.git"
+
+        result = gitlab_provider._prepare_clone_url_with_token(repo_url)
+
+        assert result == "https://oauth2:token123@gitlab.com/group/repo.git"
+
+    def test_prepare_clone_url_with_token_custom_domain(self, gitlab_provider):
+        gitlab_provider.gl.oauth_token = "token123"
+        repo_url = "https://gitlab.example.com/group/repo.git"
+
+        result = gitlab_provider._prepare_clone_url_with_token(repo_url)
+
+        assert result == "https://oauth2:token123@gitlab.example.com/group/repo.git"
+
+    def test_prepare_clone_url_with_token_invalid_url(self, gitlab_provider):
+        gitlab_provider.gl.oauth_token = "token123"
+        repo_url = "gitlab.example.com/group/repo.git"
+
+        result = gitlab_provider._prepare_clone_url_with_token(repo_url)
+
+        assert result is None


### PR DESCRIPTION
### **User description**
## Summary
- Support GitLab clone URLs on custom domains (not only gitlab.*)
- Preserve legacy parsing for gitlab.* hostnames
- Add unit tests for gitlab.com, custom domains, and invalid URLs

## Testing
- python3 -m pytest tests/unittest/test_gitlab_provider.py


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor GitLab clone URL parsing to support custom domains
  - Use `urllib.parse.urlparse()` for robust URL handling
  - Support any GitLab host, not just gitlab.* domains

- Preserve legacy parsing as fallback for raw URLs

- Add comprehensive unit tests for gitlab.com, custom domains, and invalid URLs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Clone URL Input"] --> B{"Has http/https scheme?"}
  B -->|Yes| C["Parse with urlparse"]
  C --> D["Extract scheme, host, path"]
  D --> E["Build authenticated URL"]
  E --> F["Return clone URL"]
  B -->|No| G{"Contains gitlab.?"}
  G -->|Yes| H["Legacy gitlab. parsing"]
  H --> F
  G -->|No| I["Return error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Refactor clone URL parsing for custom domains</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<ul><li>Replaced string-based <code>gitlab.</code> domain splitting with <br><code>urllib.parse.urlparse()</code> for robust URL parsing<br> <li> Added support for custom GitLab domains (e.g., <code>gitlab.example.com</code>) in <br>addition to <code>gitlab.*</code> domains<br> <li> Simplified token validation logic to check only for access token <br>existence<br> <li> Preserved legacy parsing as fallback for non-HTTP URLs<br> <li> Improved error handling with detailed logging and exception artifacts</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2155/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+29/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gitlab_provider.py</strong><dd><code>Add clone URL parsing tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_gitlab_provider.py

<ul><li>Added <code>provider.gl.oauth_token = "fake_token"</code> to fixture for token <br>availability<br> <li> Added test for <code>gitlab.com</code> clone URL with token injection<br> <li> Added test for custom domain clone URL (e.g., <code>gitlab.example.com</code>)<br> <li> Added test for invalid URL without scheme handling</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2155/files#diff-c238be75ae92bb320f78fd1ba04127d984c65bc7adb6e68cafc34b03a798857b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

