### PR TITLE
Fix GitLab /ask_line for single-line diff notes

### DIFF
--- a/tests/unittest/test_gitlab_webhook.py
+++ b/tests/unittest/test_gitlab_webhook.py
@@ -1,0 +1,71 @@
+import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_gitlab_url():
+    os.environ.setdefault("GITLAB__URL", "https://gitlab.example.com")
+    yield
+
+
+def _load_module():
+    import pr_agent.servers.gitlab_webhook as gitlab_webhook
+
+    return importlib.reload(gitlab_webhook)
+
+
+def _base_payload(position):
+    return {
+        "object_attributes": {
+            "position": position,
+            "discussion_id": "discussion-1",
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "line_range_type,expected_side,start_key,end_key,path_key",
+    [
+        ("new", "RIGHT", "new_line", "new_line", "new_path"),
+        ("old", "LEFT", "old_line", "old_line", "old_path"),
+    ],
+)
+def test_handle_ask_line_line_range(line_range_type, expected_side, start_key, end_key, path_key):
+    module = _load_module()
+    position = {
+        "line_range": {
+            "start": {start_key: 10, "type": line_range_type},
+            "end": {end_key: 12, "type": line_range_type},
+        },
+        "new_path": "src/new.py",
+        "old_path": "src/old.py",
+    }
+    payload = _base_payload(position)
+
+    result = module.handle_ask_line("/ask what is this?", payload)
+
+    assert f"--line_start=10" in result
+    assert f"--line_end=12" in result
+    assert f"--side={expected_side}" in result
+    assert f"--file_name={position[path_key]}" in result
+
+
+@pytest.mark.parametrize(
+    "position,expected_side,expected_path",
+    [
+        ({"new_line": 5, "new_path": "src/new.py"}, "RIGHT", "src/new.py"),
+        ({"old_line": 7, "old_path": "src/old.py"}, "LEFT", "src/old.py"),
+    ],
+)
+def test_handle_ask_line_single_line(position, expected_side, expected_path):
+    module = _load_module()
+    payload = _base_payload(position)
+
+    result = module.handle_ask_line("/ask explain", payload)
+
+    assert "--line_start" in result
+    assert "--line_end" in result
+    assert f"--side={expected_side}" in result
+    assert f"--file_name={expected_path}" in result


### PR DESCRIPTION
### **User description**
## Summary
- Handle GitLab diff notes that do not include line_range (single-line notes)
- Correctly map LEFT/RIGHT side and file path for both old/new ranges
- Add unit tests for multi-line and single-line note payloads

## Testing
- python3 -m pytest tests/unittest/test_gitlab_webhook.py


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Handle GitLab single-line diff notes without `line_range` field

- Support both old and new file sides with correct path mapping

- Add comprehensive unit tests for multi-line and single-line scenarios

- Improve error handling with validation for missing line numbers/paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitLab webhook payload"] -->|"with line_range"| B["Extract multi-line range"]
  A -->|"without line_range"| C["Extract single-line position"]
  B --> D["Determine side: LEFT/RIGHT"]
  C --> D
  D --> E["Map file path: old/new"]
  E --> F["Build /ask_line command"]
  G["Unit tests"] -->|"multi-line cases"| H["Validate range extraction"]
  G -->|"single-line cases"| I["Validate position extraction"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Enhanced /ask_line handler for single-line diff notes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<ul><li>Refactored <code>handle_ask_line()</code> to handle both multi-line ranges and <br>single-line notes<br> <li> Added support for extracting line numbers from <code>position.new_line</code> or <br><code>position.old_line</code> when <code>line_range</code> is absent<br> <li> Implemented proper LEFT/RIGHT side determination based on line type <br>(old vs new)<br> <li> Added validation to ensure line numbers and file paths are present <br>before processing<br> <li> Improved defensive coding with <code>.get()</code> methods and null checks</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2156/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+26/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gitlab_webhook.py</strong><dd><code>Add unit tests for GitLab webhook ask_line handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_gitlab_webhook.py

<ul><li>Created new test file with parametrized tests for multi-line diff <br>notes<br> <li> Added test cases for both "new" and "old" line types with correct <br>side/path mapping<br> <li> Added parametrized tests for single-line diff notes without <code>line_range</code><br> <li> Included pytest fixture to set required <code>GITLAB__URL</code> environment <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2156/files#diff-2cc2c8f2987c9b8d1d9e314373a6c80c47d62a63a508c20c6a03dbe9b3292043">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

