### PR TITLE
Handle /similar_issue on non-GitHub providers

### DIFF
--- a/tests/unittest/test_similar_issue_non_github.py
+++ b/tests/unittest/test_similar_issue_non_github.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pr_agent.tools.pr_similar_issue import PRSimilarIssue
+
+
+@pytest.mark.asyncio
+async def test_similar_issue_non_github_publishes_message(monkeypatch):
+    class FakeProvider:
+        def __init__(self):
+            self.comments = []
+
+        def publish_comment(self, body):
+            self.comments.append(body)
+
+    fake_provider = FakeProvider()
+
+    class FakeSettings:
+        class config:
+            git_provider = "gitlab"
+            publish_output = True
+
+    monkeypatch.setattr("pr_agent.tools.pr_similar_issue.get_settings", lambda: FakeSettings)
+    monkeypatch.setattr(
+        "pr_agent.git_providers.get_git_provider_with_context",
+        lambda _: fake_provider,
+    )
+
+    tool = PRSimilarIssue("https://gitlab.example.com/group/repo/-/merge_requests/1", None)
+    result = await tool.run()
+
+    assert result == ""
+    assert fake_provider.comments == [
+        "The /similar_issue tool is currently supported only for GitHub."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_similar_issue_non_github_no_publish(monkeypatch):
+    class FakeSettings:
+        class config:
+            git_provider = "gitlab"
+            publish_output = False
+
+    monkeypatch.setattr("pr_agent.tools.pr_similar_issue.get_settings", lambda: FakeSettings)
+
+    tool = PRSimilarIssue("https://gitlab.example.com/group/repo/-/merge_requests/1", None)
+    result = await tool.run()
+
+    assert result == ""


### PR DESCRIPTION
### **User description**
## Summary
- Avoid raising for non-GitHub providers
- Publish a friendly message when /similar_issue is invoked outside GitHub
- Add unit tests for non-GitHub behavior

## Testing
- python3 -m pytest tests/unittest/test_similar_issue_non_github.py


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace exception with graceful handling for non-GitHub providers

- Publish friendly message when /similar_issue invoked outside GitHub

- Add comprehensive unit tests for non-GitHub behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Non-GitHub Provider Detected"] --> B["Set supported flag to false"]
  B --> C["Return early from run method"]
  C --> D{publish_output enabled?}
  D -->|Yes| E["Publish friendly message"]
  D -->|No| F["Return empty string"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_similar_issue.py</strong><dd><code>Graceful non-GitHub provider handling with messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_similar_issue.py

<ul><li>Changed exception raising to graceful handling for non-GitHub <br>providers<br> <li> Added <code>supported</code> flag to track GitHub availability<br> <li> Early return in <code>__init__</code> for unsupported providers<br> <li> Added message publishing logic in <code>run()</code> method when provider <br>unsupported<br> <li> Attempts to publish user-friendly message if <code>publish_output</code> is enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2158/files#diff-593201e09c7e1e2cc484fdb85fa7f047eef067a6e51d168778efe637e9e0d74e">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_similar_issue_non_github.py</strong><dd><code>Unit tests for non-GitHub provider behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_similar_issue_non_github.py

<ul><li>New test file with two async test cases<br> <li> Test verifies message publication when <code>publish_output</code> is enabled<br> <li> Test verifies silent return when <code>publish_output</code> is disabled<br> <li> Uses monkeypatch to mock settings and git provider behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2158/files#diff-619997f3de5132b2f1d400e63583ec72543a22ccd620284aebf22cba60967750">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

