### PR TITLE
Preserve full question text for /help_docs

### DIFF
--- a/pr_agent/tools/pr_help_docs.py
+++ b/pr_agent/tools/pr_help_docs.py
@@ -286,7 +286,7 @@ class PRHelpDocs(object):
     def __init__(self, ctx_url, ai_handler:partial[BaseAiHandler,] = LiteLLMAIHandler, args: tuple[str]=None, return_as_string: bool=False):
         try:
             self.ctx_url = ctx_url
-            self.question = args[0] if args else None
+            self.question = self._parse_args(args)
             self.return_as_string = return_as_string
             self.repo_url_given_explicitly = True
             self.repo_url = get_settings().get('PR_HELP_DOCS.REPO_URL', '')
@@ -325,6 +325,12 @@ class PRHelpDocs(object):
         except Exception as e:
             get_logger().exception(f"Caught exception during init. Setting self.question to None to prevent run() to do anything.")
             self.question = None
+
+    @staticmethod
+    def _parse_args(args) -> str | None:
+        if not args:
+            return None
+        return " ".join(args).strip()
 
     async def run(self):
         if not self.question:

--- a/tests/unittest/test_help_docs_args.py
+++ b/tests/unittest/test_help_docs_args.py
@@ -1,0 +1,14 @@
+from pr_agent.tools.pr_help_docs import PRHelpDocs
+
+
+def test_parse_args_empty():
+    assert PRHelpDocs._parse_args(None) is None
+    assert PRHelpDocs._parse_args([]) is None
+
+
+def test_parse_args_single():
+    assert PRHelpDocs._parse_args(["/help"]) == "/help"
+
+
+def test_parse_args_multiword():
+    assert PRHelpDocs._parse_args(["how", "to", "run", "tests?"]) == "how to run tests?"


### PR DESCRIPTION
### **User description**
## Summary
- Parse /help_docs arguments into a full question string
- Add unit tests for argument parsing

## Testing
- python3 -m pytest tests/unittest/test_help_docs_args.py


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Parse multiple arguments into full question string for /help_docs

- Replace single argument extraction with proper argument joining

- Add unit tests for argument parsing functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  args["args tuple"] -- "_parse_args" --> question["full question string"]
  question -- "used in" --> run["run method"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_help_docs.py</strong><dd><code>Add argument parsing for full question text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_help_docs.py

<ul><li>Changed question initialization from extracting first argument only to <br>parsing all arguments<br> <li> Added <code>_parse_args</code> static method that joins multiple arguments with <br>spaces<br> <li> Method returns None for empty or None arguments, preserving full <br>question text</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2159/files#diff-8c72a3c2b57653aa2209fe950eea699d3ce0fcfda61292134771338359465e6e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_help_docs_args.py</strong><dd><code>Unit tests for argument parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_help_docs_args.py

<ul><li>Added test for empty/None arguments returning None<br> <li> Added test for single argument preservation<br> <li> Added test for multiple arguments joined with spaces</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2159/files#diff-7987df78bf75ea350d6eef363814b28a268f8ced0da15d3dba69b78a79bc5c71">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

