### PR TITLE
Add support for OpenAI's gpt-5.2-codex

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -40,6 +40,7 @@ MAX_TOKENS = {
     'gpt-5.2': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.2-2025-12-11': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.2-chat-latest': 128000,  # 128K, but may be limited by config.max_model_tokens
+    'gpt-5.2-codex': 400000,  # 400K, but may be limited by config.max_model_tokens
     'o1-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-mini-2024-09-12': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-preview': 128000,  # 128K, but may be limited by config.max_model_tokens
@@ -223,6 +224,7 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "o4-mini-2025-04-16",
     "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
+    "gpt-5.2-codex",
     "gpt-5-mini"
 ]
 


### PR DESCRIPTION
### **User description**
Reference:
- https://openai.com/index/introducing-gpt-5-2-codex/
- https://platform.openai.com/docs/models/gpt-5.2-codex


___

### **PR Type**
Enhancement


___

### **Description**
- Add gpt-5.2-codex model with 400K token context window

- Mark gpt-5.2-codex as unsupported for temperature parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gpt-5.2-codex Model"] -- "400K context tokens" --> B["Model Configuration"]
  A -- "no temperature support" --> C["NO_SUPPORT_TEMPERATURE_MODELS"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Register gpt-5.2-codex model configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/__init__.py

<ul><li>Added <code>gpt-5.2-codex</code> entry to model context window mapping with 400K <br>tokens<br> <li> Added <code>gpt-5.2-codex</code> to <code>NO_SUPPORT_TEMPERATURE_MODELS</code> list to disable <br>temperature parameter support</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2166/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

