### PR TITLE
chore: refine PR reviewer prompt guidance

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -159,8 +159,8 @@ extra_instructions = "..."
 
     The `review` can tool automatically add labels to your Pull Requests:
 
-    - **`possible security issue`**: This label is applied if the tool detects a potential [security vulnerability](https://github.com/qodo-ai/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L121) in the PR's code. This feedback is controlled by the 'enable_review_labels_security' flag (default is true).
-    - **`review effort [x/5]`**: This label estimates the [effort](https://github.com/qodo-ai/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L105) required to review the PR on a relative scale of 1 to 5, where 'x' represents the assessed effort. This feedback is controlled by the 'enable_review_labels_effort' flag (default is true).
+    - **`possible security issue`**: This label is applied if the tool detects a potential [security vulnerability](https://github.com/qodo-ai/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L134) in the PR's code. This feedback is controlled by the 'enable_review_labels_security' flag (default is true).
+    - **`review effort [x/5]`**: This label estimates the [effort](https://github.com/qodo-ai/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L118) required to review the PR on a relative scale of 1 to 5, where 'x' represents the assessed effort. This feedback is controlled by the 'enable_review_labels_effort' flag (default is true).
     - **`ticket compliance`**: Adds a label indicating code compliance level ("Fully compliant" | "PR Code Verified" | "Partially compliant" | "Not compliant") to any GitHub/Jira/Linea ticket linked in the PR. Controlled by the 'require_ticket_labels' flag (default: false). If 'require_no_ticket_labels' is also enabled, PRs without ticket links will receive a "No ticket found" label.
 
 

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -1,7 +1,7 @@
 [pr_review_prompt]
 system="""You are PR-Reviewer, a language model designed to review a Git Pull Request (PR).
 Your task is to provide constructive and concise feedback for the PR.
-The review should focus on new code added in the PR code diff (lines starting with '+')
+The review should focus on new code added in the PR code diff (lines starting with '+'), and only on issues introduced by this PR.
 
 
 The format we will use to present the PR code diff:
@@ -38,14 +38,27 @@ __new hunk__
 
 - In the format above, the diff is organized into separate '__new hunk__' and '__old hunk__' sections for each code chunk. '__new hunk__' contains the updated code, while '__old hunk__' shows the removed code. If no code was removed in a specific chunk, the __old hunk__ section will be omitted.
 - We also added line numbers for the '__new hunk__' code, to help you refer to the code lines in your suggestions. These line numbers are not part of the actual code, and should only be used for reference.
-- Code lines are prefixed with symbols ('+', '-', ' '). The '+' symbol indicates new code added in the PR, the '-' symbol indicates code removed in the PR, and the ' ' symbol indicates unchanged code. \
- The review should address new code added in the PR code diff (lines starting with '+').
+- Code lines are prefixed with symbols ('+', '-', ' '). The '+' symbol indicates new code added in the PR, the '-' symbol indicates code removed in the PR, and the ' ' symbol indicates unchanged code.
 {%- if is_ai_metadata %}
 - If available, an AI-generated summary will appear and provide a high-level overview of the file changes. Note that this summary may not be fully accurate or complete.
 {%- endif %}
 - When quoting variables, names or file paths from the code, use backticks (`) instead of single quote (').
 - Note that you only see changed code segments (diff hunks in a PR), not the entire codebase. Avoid suggestions that might duplicate existing functionality or questioning code elements (like variables declarations or import statements) that may be defined elsewhere in the codebase.
 - Also note that if the code ends at an opening brace or statement that begins a new scope (like 'if', 'for', 'try'), don't treat it as incomplete. Instead, acknowledge the visible scope boundary and analyze only the code shown.
+
+Determining what to flag:
+- For clear bugs and security issues, be thorough. Do not skip a genuine problem just because the trigger scenario is narrow.
+- For lower-severity concerns, be certain before flagging. If you cannot confidently explain why something is a problem with a concrete scenario, do not flag it.
+- Each issue must be discrete and actionable, not a vague concern about the codebase in general.
+- Do not speculate that a change might break other code unless you can identify the specific affected code path from the diff context.
+- Do not flag intentional design choices or stylistic preferences unless they introduce a clear defect.
+- When confidence is limited but the potential impact is high (e.g., data loss, security), report it with an explicit note on what remains uncertain. Otherwise, prefer not reporting over guessing.
+
+Constructing comments:
+- Be direct about why something is a problem and the realistic scenario where it manifests.
+- Communicate severity accurately. Do not overstate impact. If an issue only arises under specific inputs or environments, say so upfront.
+- Keep each issue description concise. Write so the reader grasps the point immediately without close reading.
+- Use a matter-of-fact, helpful tone. Avoid accusatory language, excessive praise, or filler phrases like 'Great job', 'Thanks for'.
 
 {%- if extra_instructions %}
 
@@ -68,7 +81,7 @@ class SubPR(BaseModel):
 class KeyIssuesComponentLink(BaseModel):
     relevant_file: str = Field(description="The full file path of the relevant file")
     issue_header: str = Field(description="One or two word title for the issue. For example: 'Possible Bug', etc.")
-    issue_content: str = Field(description="A short and concise summary of what should be further inspected and validated during the PR review process for this issue. Do not mention line numbers in this field.")
+    issue_content: str = Field(description="A short and concise description of the issue, why it matters, and the specific scenario or input that triggers it. Do not mention line numbers in this field.")
     start_line: int = Field(description="The start line that corresponds to this issue in the relevant file")
     end_line: int = Field(description="The end line that corresponds to this issue in the relevant file")
 
@@ -116,7 +129,7 @@ class Review(BaseModel):
 {%- if question_str %}
     insights_from_user_answers: str = Field(description="shortly summarize the insights you gained from the user's answers to the questions")
 {%- endif %}
-    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A short and diverse list (0-{{ num_max_findings }} issues) of high-priority bugs, problems or performance concerns introduced in the PR code, which the PR reviewer should further focus on and validate during the review process.")
+    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A concise list (0-{{ num_max_findings }} issues) of bugs, security vulnerabilities, or significant performance concerns introduced in this PR. Only include issues you are confident about. If confidence is limited but the potential impact is high (e.g., data loss, security), you may include it only if you explicitly note what remains uncertain. Each issue must identify a concrete problem with a realistic trigger scenario. An empty list is acceptable if no clear issues are found.")
 {%- if require_security_review %}
     security_concerns: str = Field(description="Does this PR code introduce vulnerabilities such as exposure of sensitive information (e.g., API keys, secrets, passwords), or security concerns like SQL injection, XSS, CSRF, and others ? Answer 'No' (without explaining why) if there are no possible issues. If there are security concerns or issues, start your answer with a short header, such as: 'Sensitive information exposure: ...', 'SQL injection: ...', etc. Explain your answer. Be specific and give examples if possible")
 {%- endif %}


### PR DESCRIPTION
### **User description**
Tighten scope to issues introduced by the PR and clarify what to flag.

Improve issue descriptions to be more concrete and actionable while allowing high-impact, lower-confidence risks when uncertainty is stated.

GitHub Copilot PR summary:

> This pull request updates the PR reviewer prompt and related field descriptions to clarify the reviewer's focus, improve the quality and precision of review comments, and set clearer expectations for issue reporting. The changes emphasize actionable, concrete, and confident feedback, especially for critical issues, and provide more detailed guidance on how to structure review comments.
> 
> **Prompt and Review Guidance Improvements:**
> 
> * The PR reviewer prompt now explicitly instructs reviewers to focus only on issues introduced by the current PR, not on pre-existing code or general concerns.
> * Expanded instructions clarify how to determine what to flag, emphasizing confidence, specificity, and actionable feedback—especially for bugs, security, and high-impact issues. Reviewers are advised to avoid speculation and to clearly communicate the severity and context of each issue.
> * Added guidelines on constructing review comments: be direct, concise, matter-of-fact, and avoid filler or overly positive/negative language.
> 
> **Field Description Refinements:**
> 
> * The `issue_content` field in `KeyIssuesComponentLink` now requires a concise description of the issue, why it matters, and a specific scenario or input that triggers it, instead of a generic summary.
> * The `key_issues_to_review` field in the `Review` model is updated to require only confident findings of bugs, security vulnerabilities, or significant performance concerns, with explicit instructions for handling limited-confidence/high-impact issues and requiring concrete, realistic trigger scenarios.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Clarify reviewer scope to focus only on issues introduced by the PR

- Expand guidance on determining what issues to flag with confidence levels

- Improve issue description requirements to include concrete trigger scenarios

- Refine comment construction guidelines for clarity and accuracy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Reviewer Scope"] -->|"Focus on new code only"| B["Issues Introduced by PR"]
  C["Issue Determination"] -->|"Clear bugs & security"| D["Flag Thoroughly"]
  C -->|"Lower-severity concerns"| E["Flag Only if Confident"]
  C -->|"High-impact, low-confidence"| F["Flag with Uncertainty Note"]
  B --> G["Issue Description"]
  D --> G
  E --> G
  F --> G
  G -->|"Include concrete scenario"| H["Actionable Feedback"]
  I["Comment Construction"] -->|"Direct, concise, matter-of-fact"| H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Enhance reviewer guidance with confidence and specificity standards</code></dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<ul><li>Clarified that review should focus only on issues introduced by the <br>PR, not pre-existing code<br> <li> Added new "Determining what to flag" section with guidance on <br>confidence levels for different issue types<br> <li> Added new "Constructing comments" section with guidelines for direct, <br>accurate, and helpful feedback<br> <li> Updated <code>issue_content</code> field description to require concrete trigger <br>scenarios and explanation of why issues matter<br> <li> Updated <code>key_issues_to_review</code> field description to emphasize <br>confidence, allow high-impact uncertain issues with explicit notes, <br>and require realistic trigger scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2209/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

