### PR TITLE
feat: add Claude Code CLI as an AI provider

### DIFF
--- a/Dockerfile.github_action_claude_code
+++ b/Dockerfile.github_action_claude_code
@@ -1,0 +1,18 @@
+FROM python:3.12.10-slim AS base
+
+RUN apt-get update && apt-get install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN curl -fsSL https://cli.claude.ai/install.sh | sh
+ENV PATH="/root/.claude/bin:${PATH}"
+
+WORKDIR /app
+ADD pyproject.toml .
+ADD requirements.txt .
+RUN pip install --no-cache-dir . && rm pyproject.toml requirements.txt
+ENV PYTHONPATH=/app
+ADD docs docs
+ADD pr_agent pr_agent
+ADD github_action/entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.github_action_claude_code
+++ b/Dockerfile.github_action_claude_code
@@ -3,7 +3,7 @@ FROM python:3.12.10-slim AS base
 RUN apt-get update && apt-get install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI
-RUN curl -fsSL https://cli.claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.claude/bin:${PATH}"
 
 WORKDIR /app

--- a/github_action_claude_code/action.yml
+++ b/github_action_claude_code/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Install Claude Code CLI
       shell: bash
       run: |
-        curl -fsSL https://cli.claude.ai/install.sh | sh
+        curl -fsSL https://claude.ai/install.sh | bash
         echo "$HOME/.claude/bin" >> $GITHUB_PATH
 
     - name: Configure Claude Code token

--- a/github_action_claude_code/action.yml
+++ b/github_action_claude_code/action.yml
@@ -19,7 +19,9 @@ runs:
 
     - name: Install PR Agent
       shell: bash
-      run: pip install "${{ github.action_path }}/.."
+      run: |
+        pip install -r "${{ github.action_path }}/../requirements.txt"
+        pip install "${{ github.action_path }}/.."
 
     - name: Run PR Agent
       shell: bash

--- a/github_action_claude_code/action.yml
+++ b/github_action_claude_code/action.yml
@@ -1,0 +1,34 @@
+name: 'PR Agent (Claude Code)'
+description: 'Summarize, review and suggest improvements for pull requests using Claude Code CLI'
+branding:
+  icon: 'award'
+  color: 'green'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install Claude Code CLI
+      shell: bash
+      run: |
+        curl -fsSL https://cli.claude.ai/install.sh | sh
+        echo "$HOME/.claude/bin" >> $GITHUB_PATH
+
+    - name: Configure Claude Code token
+      if: env.CLAUDE_CODE_TOKEN != ''
+      shell: bash
+      run: |
+        echo "$CLAUDE_CODE_TOKEN" | claude setup-token
+
+    - name: Install PR Agent
+      shell: bash
+      run: pip install "${{ github.action_path }}/.."
+
+    - name: Run PR Agent
+      shell: bash
+      env:
+        PYTHONPATH: ${{ github.action_path }}/..
+      run: python "${{ github.action_path }}/../pr_agent/servers/github_action_runner.py"

--- a/github_action_claude_code/action.yml
+++ b/github_action_claude_code/action.yml
@@ -17,12 +17,6 @@ runs:
         curl -fsSL https://claude.ai/install.sh | bash
         echo "$HOME/.claude/bin" >> $GITHUB_PATH
 
-    - name: Configure Claude Code token
-      if: env.CLAUDE_CODE_TOKEN != ''
-      shell: bash
-      run: |
-        echo "$CLAUDE_CODE_TOKEN" | claude setup-token
-
     - name: Install PR Agent
       shell: bash
       run: pip install "${{ github.action_path }}/.."

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -213,6 +213,10 @@ MAX_TOKENS = {
     "mistral/codestral-mamba-latest": 256000,
     "codestral/codestral-latest": 8191,
     "codestral/codestral-2405": 8191,
+    'claude-code/claude-opus-4-6': 200000,
+    'claude-code/claude-sonnet-4-5': 200000,
+    'claude-code/claude-sonnet-4': 200000,
+    'claude-code/claude-haiku-4-5': 200000,
 }
 
 USER_MESSAGE_ONLY_MODELS = [
@@ -238,7 +242,11 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
     "gpt-5.2-codex",
-    "gpt-5-mini"
+    "gpt-5-mini",
+    "claude-code/claude-opus-4-6",
+    "claude-code/claude-sonnet-4-5",
+    "claude-code/claude-sonnet-4",
+    "claude-code/claude-haiku-4-5",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [

--- a/pr_agent/algo/ai_handlers/claude_code_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/claude_code_ai_handler.py
@@ -1,7 +1,5 @@
 import asyncio
 import json
-import os
-import subprocess
 
 import httpx
 import openai
@@ -22,43 +20,16 @@ class ClaudeCodeAIHandler(BaseAiHandler):
     separate API keys.
 
     Authentication:
-        Set the CLAUDE_CODE_TOKEN environment variable for headless/CI usage.
-        The token is obtained by running `claude setup-token` locally
-        (requires a Claude subscription).
+        Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN as an environment
+        variable. The CLI picks these up automatically.
+        For subscription-based auth, run `claude setup-token` locally to
+        obtain an OAuth token, then set it as CLAUDE_CODE_OAUTH_TOKEN.
     """
-
-    _token_setup_done = False
 
     def __init__(self):
         self.cli_path = get_settings().get("claude_code.cli_path", "claude")
         self.timeout = get_settings().get("claude_code.timeout", 120)
         self.model_override = get_settings().get("claude_code.model", "")
-        self._ensure_token_setup()
-
-    @classmethod
-    def _ensure_token_setup(cls):
-        """Run `claude setup-token` if CLAUDE_CODE_TOKEN env var is set."""
-        if cls._token_setup_done:
-            return
-        token = os.environ.get("CLAUDE_CODE_TOKEN")
-        if not token:
-            return
-        try:
-            cli_path = get_settings().get("claude_code.cli_path", "claude")
-            result = subprocess.run(
-                [cli_path, "setup-token"],
-                input=token,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode == 0:
-                get_logger().info("Claude Code token configured successfully")
-            else:
-                get_logger().warning(f"claude setup-token failed: {result.stderr.strip()}")
-        except Exception as e:
-            get_logger().warning(f"Failed to configure Claude Code token: {e}")
-        cls._token_setup_done = True
 
     @property
     def deployment_id(self):

--- a/pr_agent/algo/ai_handlers/claude_code_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/claude_code_ai_handler.py
@@ -1,0 +1,150 @@
+import asyncio
+import json
+
+import httpx
+import openai
+from tenacity import retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt
+
+from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+MODEL_RETRIES = 2
+_DUMMY_REQUEST = httpx.Request("POST", "https://claude-code-cli/v1/chat")
+
+
+class ClaudeCodeAIHandler(BaseAiHandler):
+    """
+    AI handler that invokes the Claude Code CLI (claude) as a subprocess.
+    Users with Claude Code installed can use this handler without needing
+    separate API keys.
+    """
+
+    def __init__(self):
+        self.cli_path = get_settings().get("claude_code.cli_path", "claude")
+        self.timeout = get_settings().get("claude_code.timeout", 120)
+        self.model_override = get_settings().get("claude_code.model", "")
+
+    @property
+    def deployment_id(self):
+        return None
+
+    @staticmethod
+    def _strip_model_prefix(model: str) -> str:
+        """Strip the 'claude-code/' prefix from model names."""
+        if model.startswith("claude-code/"):
+            return model[len("claude-code/"):]
+        return model
+
+    @retry(
+        retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
+        stop=stop_after_attempt(MODEL_RETRIES),
+    )
+    async def chat_completion(self, model: str, system: str, user: str,
+                              temperature: float = 0.2, img_path: str = None):
+        try:
+            # Determine which model to use
+            effective_model = self.model_override or self._strip_model_prefix(model)
+
+            cmd = [
+                self.cli_path,
+                "-p",
+                "--output-format", "json",
+            ]
+
+            if effective_model:
+                cmd.extend(["--model", effective_model])
+
+            if system:
+                cmd.extend(["--system-prompt", system])
+
+            get_logger().debug(f"Running Claude Code CLI: {' '.join(cmd[:6])}...")
+            if get_settings().config.verbosity_level >= 2:
+                get_logger().info(f"\nSystem prompt:\n{system}")
+                get_logger().info(f"\nUser prompt:\n{user}")
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(input=user.encode("utf-8")),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                raise openai.APIError(
+                    f"Claude Code CLI timed out after {self.timeout}s",
+                    request=_DUMMY_REQUEST, body=None,
+                )
+
+            if proc.returncode != 0:
+                error_text = stderr.decode("utf-8", errors="replace").strip()
+                raise openai.APIError(
+                    f"Claude Code CLI exited with code {proc.returncode}: {error_text}",
+                    request=_DUMMY_REQUEST, body=None,
+                )
+
+            raw_output = stdout.decode("utf-8", errors="replace").strip()
+
+            # Parse JSON output
+            try:
+                response_data = json.loads(raw_output)
+            except json.JSONDecodeError:
+                # If not valid JSON, use raw output as the response text
+                resp = raw_output
+                get_logger().debug("Claude Code CLI returned non-JSON output, using raw text")
+                return resp, "stop"
+
+            # Extract response text from JSON output
+            resp = self._extract_response(response_data)
+
+            get_logger().debug(f"\nAI response:\n{resp}")
+            if get_settings().config.verbosity_level >= 2:
+                get_logger().info(f"\nAI response:\n{resp}")
+
+            return resp, "stop"
+
+        except openai.APIError:
+            raise
+        except Exception as e:
+            get_logger().warning(f"Error during Claude Code CLI inference: {e}")
+            raise openai.APIError(
+                f"Claude Code CLI error: {e}",
+                request=_DUMMY_REQUEST, body=None,
+            ) from e
+
+    @staticmethod
+    def _extract_response(response_data) -> str:
+        """Extract text content from Claude Code JSON output."""
+        # Handle the case where the response is a list of message blocks
+        if isinstance(response_data, list):
+            text_parts = []
+            for block in response_data:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text_parts.append(block.get("text", ""))
+            if text_parts:
+                return "\n".join(text_parts)
+            # Fallback: return the entire JSON as a string
+            return json.dumps(response_data)
+
+        # Handle dict response with a "result" or "text" field
+        if isinstance(response_data, dict):
+            if "result" in response_data:
+                result = response_data["result"]
+                if isinstance(result, str):
+                    return result
+                # result might be a list of blocks
+                return ClaudeCodeAIHandler._extract_response(result)
+            if "text" in response_data:
+                return response_data["text"]
+            if "content" in response_data:
+                return ClaudeCodeAIHandler._extract_response(response_data["content"])
+
+        # Fallback
+        return str(response_data)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -265,6 +265,13 @@ class LiteLLMAIHandler(BaseAiHandler):
         stop=stop_after_attempt(MODEL_RETRIES),
     )
     async def chat_completion(self, model: str, system: str, user: str, temperature: float = 0.2, img_path: str = None):
+        # Route claude-code/ models to the Claude Code CLI handler
+        if model.startswith("claude-code/"):
+            from pr_agent.algo.ai_handlers.claude_code_ai_handler import ClaudeCodeAIHandler
+            if not hasattr(self, '_claude_code_handler'):
+                self._claude_code_handler = ClaudeCodeAIHandler()
+            return await self._claude_code_handler.chat_completion(model, system, user, temperature, img_path)
+
         try:
             resp, finish_reason = None, None
             deployment_id = self.deployment_id

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -345,6 +345,11 @@ failure_callback = []
 service_callback = []
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
+[claude_code]
+# cli_path = "claude"  # path to the Claude Code CLI binary
+# model = ""           # override model (leave empty to use config.model with prefix stripped)
+# timeout = 120        # timeout in seconds for CLI invocations
+
 [pr_similar_issue]
 skip_comments = false
 force_update_dataset = false

--- a/tests/unittest/test_claude_code_ai_handler.py
+++ b/tests/unittest/test_claude_code_ai_handler.py
@@ -1,0 +1,173 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from tenacity import RetryError
+
+from pr_agent.algo.ai_handlers.claude_code_ai_handler import ClaudeCodeAIHandler
+
+
+def create_mock_settings():
+    """Create a fake settings object for ClaudeCodeAIHandler."""
+    return type('', (), {
+        'config': type('', (), {
+            'verbosity_level': 0,
+            'get': lambda self, key, default=None: default
+        })(),
+        'get': lambda self, key, default=None: {
+            'claude_code.cli_path': 'claude',
+            'claude_code.timeout': 120,
+            'claude_code.model': '',
+        }.get(key, default)
+    })()
+
+
+class TestStripModelPrefix:
+    def test_strips_claude_code_prefix(self):
+        assert ClaudeCodeAIHandler._strip_model_prefix("claude-code/claude-sonnet-4-5") == "claude-sonnet-4-5"
+
+    def test_leaves_other_prefixes_unchanged(self):
+        assert ClaudeCodeAIHandler._strip_model_prefix("anthropic/claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
+
+    def test_leaves_bare_model_unchanged(self):
+        assert ClaudeCodeAIHandler._strip_model_prefix("claude-sonnet-4-5") == "claude-sonnet-4-5"
+
+
+class TestExtractResponse:
+    def test_extract_from_text_block_list(self):
+        data = [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": "World"},
+        ]
+        assert ClaudeCodeAIHandler._extract_response(data) == "Hello\nWorld"
+
+    def test_extract_from_dict_with_result(self):
+        data = {"result": "some response text"}
+        assert ClaudeCodeAIHandler._extract_response(data) == "some response text"
+
+    def test_extract_from_dict_with_text(self):
+        data = {"text": "some text"}
+        assert ClaudeCodeAIHandler._extract_response(data) == "some text"
+
+    def test_extract_from_dict_with_content_list(self):
+        data = {"content": [{"type": "text", "text": "nested"}]}
+        assert ClaudeCodeAIHandler._extract_response(data) == "nested"
+
+    def test_fallback_to_str(self):
+        data = {"unknown_field": 123}
+        assert ClaudeCodeAIHandler._extract_response(data) == str(data)
+
+    def test_list_without_text_blocks(self):
+        data = [{"type": "image", "url": "http://example.com"}]
+        result = ClaudeCodeAIHandler._extract_response(data)
+        assert result == json.dumps(data)
+
+
+@pytest.mark.asyncio
+class TestChatCompletion:
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.get_settings')
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.asyncio')
+    async def test_successful_response(self, mock_asyncio, mock_get_settings):
+        mock_get_settings.return_value = create_mock_settings()
+
+        response_data = [{"type": "text", "text": "AI response here"}]
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(
+            return_value=(json.dumps(response_data).encode(), b"")
+        )
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_proc)
+        mock_asyncio.subprocess = MagicMock()
+        mock_asyncio.subprocess.PIPE = -1
+        mock_asyncio.wait_for = AsyncMock(
+            return_value=(json.dumps(response_data).encode(), b"")
+        )
+
+        handler = ClaudeCodeAIHandler()
+        resp, finish = await handler.chat_completion(
+            model="claude-code/claude-sonnet-4-5",
+            system="You are helpful",
+            user="Hello",
+        )
+        assert resp == "AI response here"
+        assert finish == "stop"
+
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.get_settings')
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.asyncio')
+    async def test_cli_error_raises(self, mock_asyncio, mock_get_settings):
+        mock_get_settings.return_value = create_mock_settings()
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"CLI error"))
+        mock_proc.kill = AsyncMock()
+        mock_proc.wait = AsyncMock()
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_proc)
+        mock_asyncio.subprocess = MagicMock()
+        mock_asyncio.subprocess.PIPE = -1
+        mock_asyncio.wait_for = AsyncMock(return_value=(b"", b"CLI error"))
+
+        handler = ClaudeCodeAIHandler()
+        with pytest.raises(RetryError):
+            await handler.chat_completion(
+                model="claude-code/claude-sonnet-4-5",
+                system="sys",
+                user="usr",
+            )
+
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.get_settings')
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.asyncio')
+    async def test_timeout_raises(self, mock_asyncio, mock_get_settings):
+        import asyncio as real_asyncio
+        mock_get_settings.return_value = create_mock_settings()
+
+        mock_proc = AsyncMock()
+        mock_proc.kill = AsyncMock()
+        mock_proc.wait = AsyncMock()
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_proc)
+        mock_asyncio.subprocess = MagicMock()
+        mock_asyncio.subprocess.PIPE = -1
+        mock_asyncio.wait_for = AsyncMock(side_effect=real_asyncio.TimeoutError)
+        mock_asyncio.TimeoutError = real_asyncio.TimeoutError
+
+        handler = ClaudeCodeAIHandler()
+        with pytest.raises(RetryError):
+            await handler.chat_completion(
+                model="claude-code/claude-sonnet-4-5",
+                system="sys",
+                user="usr",
+            )
+
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.get_settings')
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.asyncio')
+    async def test_non_json_output_returned_as_raw(self, mock_asyncio, mock_get_settings):
+        mock_get_settings.return_value = create_mock_settings()
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(
+            return_value=(b"plain text response", b"")
+        )
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_proc)
+        mock_asyncio.subprocess = MagicMock()
+        mock_asyncio.subprocess.PIPE = -1
+        mock_asyncio.wait_for = AsyncMock(
+            return_value=(b"plain text response", b"")
+        )
+
+        handler = ClaudeCodeAIHandler()
+        resp, finish = await handler.chat_completion(
+            model="claude-code/claude-sonnet-4-5",
+            system="sys",
+            user="usr",
+        )
+        assert resp == "plain text response"
+        assert finish == "stop"
+
+
+class TestDeploymentId:
+    @patch('pr_agent.algo.ai_handlers.claude_code_ai_handler.get_settings')
+    def test_deployment_id_is_none(self, mock_get_settings):
+        mock_get_settings.return_value = create_mock_settings()
+        handler = ClaudeCodeAIHandler()
+        assert handler.deployment_id is None


### PR DESCRIPTION
### **User description**
## Summary
- Adds `ClaudeCodeAIHandler` that invokes the `claude` CLI as a subprocess, allowing users with Claude Code installed to use it as an AI backend without separate API keys
- Routes `claude-code/` model prefix through `LiteLLMAIHandler` like other providers (e.g. `anthropic/`, `bedrock/`, `vertex_ai/`)
- Adds `claude-code/*` models to `MAX_TOKENS` and `NO_SUPPORT_TEMPERATURE_MODELS`

## Usage
```bash
pr-agent --pr_url https://github.com/owner/repo/pull/123 review --config.model="claude-code/claude-sonnet-4-5"
```

## Test plan
- [x] 14 unit tests passing (`pytest tests/unittest/test_claude_code_ai_handler.py`)
- [x] Live tested `review`, `improve`, and `describe` commands against a real PR
- [x] Fallback to default model works when Claude Code CLI is unavailable
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Claude Code CLI as an AI provider via `claude-code/` model prefix

- Routes claude-code models through LiteLLMAIHandler with dedicated handler

- Registers claude-code models in MAX_TOKENS and NO_SUPPORT_TEMPERATURE_MODELS

- Includes GitHub Action and Docker support for Claude Code CLI integration

- Adds comprehensive unit tests for Claude Code AI handler functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Request<br/>claude-code/model"] --> B["LiteLLMAIHandler"]
  B --> C["ClaudeCodeAIHandler"]
  C --> D["Claude CLI<br/>Subprocess"]
  D --> E["JSON Response"]
  E --> F["Extract & Return"]
  G["GitHub Action"] --> H["Docker Image<br/>with Claude CLI"]
  H --> I["PR Agent"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Register claude-code models in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/__init__.py

<ul><li>Added four claude-code models to MAX_TOKENS dictionary with 200000 <br>token limit<br> <li> Added four claude-code models to NO_SUPPORT_TEMPERATURE_MODELS list<br> <li> Models: claude-opus-4-6, claude-sonnet-4-5, claude-sonnet-4, <br>claude-haiku-4-5</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.github_action_claude_code</strong><dd><code>Create Docker image with Claude Code CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.github_action_claude_code

<ul><li>New Docker image for GitHub Action with Claude Code CLI pre-installed<br> <li> Based on Python 3.12.10-slim with git and curl dependencies<br> <li> Installs Claude CLI via official install script and sets PATH<br> <li> Copies PR Agent code and sets up entrypoint</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-9f64196eb4a6c5ec0de1b7f20d032771b0d21d3bb04cade3c1aff2221208f05b">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Add GitHub Action composite workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

github_action_claude_code/action.yml

<ul><li>New composite GitHub Action for PR Agent with Claude Code support<br> <li> Sets up Python 3.12 environment<br> <li> Installs Claude Code CLI and PR Agent dependencies<br> <li> Configures PYTHONPATH and runs github_action_runner.py</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-a1aac33050f3571b1f2b4d1d4c7ba20328e6c2ba89e7be60def4ef73a3870a9c">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add Claude Code configuration section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<ul><li>Added new <code>[claude_code]</code> configuration section<br> <li> Configurable cli_path, model override, and timeout settings<br> <li> Defaults: cli_path="claude", timeout=120s, model="" (use config.model)</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude_code_ai_handler.py</strong><dd><code>Implement Claude Code CLI subprocess handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/claude_code_ai_handler.py

<ul><li>New handler class that invokes Claude Code CLI as subprocess<br> <li> Implements chat_completion with JSON output parsing and error handling<br> <li> Supports model prefix stripping and response extraction from various <br>JSON formats<br> <li> Includes retry logic for API errors and timeout handling with <br>configurable timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-9e596a271a31f9e884253bfe943dccf2b1623c833d8a83b648c8fc6b58b4b463">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Route claude-code models to dedicated handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<ul><li>Added routing logic to detect <code>claude-code/</code> model prefix<br> <li> Delegates claude-code requests to ClaudeCodeAIHandler instance<br> <li> Lazy initialization of handler to avoid unnecessary imports</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_claude_code_ai_handler.py</strong><dd><code>Add comprehensive unit tests for Claude Code handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_claude_code_ai_handler.py

<ul><li>14 unit tests covering model prefix stripping functionality<br> <li> Tests for JSON response extraction from various formats<br> <li> Tests for successful chat completion, CLI errors, and timeout <br>scenarios<br> <li> Tests for non-JSON output handling and deployment_id property</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2215/files#diff-944904f5d3d50214c00d1895dd77170200a106b553a02a102dd47c5dec35c49c">+173/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

