### PR TITLE
fix: defer Azure DevOps annotations to avoid import-time crash

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import Optional, Tuple
 from urllib.parse import urlparse


### PR DESCRIPTION
### **User description**
Fixes #2216

### Problem
`pr_agent/git_providers/__init__.py` imports `AzureDevopsProvider` unconditionally. When Azure DevOps deps are missing or fail to import, `azuredevops_provider.py` still defines methods annotated with Azure types (e.g. `-> Comment`), and those annotations are evaluated at import-time, causing:
`NameError: name 'Comment' is not defined`
This can break GitHub-only deployments at startup.
### Change
- Add `from __future__ import annotations` to `pr_agent/git_providers/azuredevops_provider.py` so type annotations are not evaluated at import time.
### Notes
- No behavior change when Azure dependencies are installed.
- Azure provider still raises `ImportError` on instantiation when deps are unavailable; this just prevents non-Azure deployments from crashing during import.


___

### **PR Type**
Bug fix


___

### **Description**
- Defer type annotation evaluation in Azure provider module

- Prevents import-time NameError when Azure dependencies unavailable

- Enables GitHub-only deployments to start without crashing

- No behavior change when Azure dependencies are installed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Azure Provider Module"] -->|"Add __future__ annotations"| B["Deferred Type Evaluation"]
  B -->|"Prevents"| C["Import-time NameError"]
  C -->|"Fixes"| D["GitHub-only Deployments"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Add deferred annotations import to Azure provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<ul><li>Added <code>from __future__ import annotations</code> at module start<br> <li> Defers evaluation of type annotations to runtime<br> <li> Prevents NameError when Azure DevOps types are undefined at import <br>time<br> <li> Allows module to be imported even when Azure dependencies are missing</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2219/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

