### PR TITLE
feat: Add OpenAI's gpt-5.3-codex model support

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -41,6 +41,7 @@ MAX_TOKENS = {
     'gpt-5.2-2025-12-11': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.2-chat-latest': 128000,  # 128K, but may be limited by config.max_model_tokens
     'gpt-5.2-codex': 400000,  # 400K, but may be limited by config.max_model_tokens
+    'gpt-5.3-codex': 400000,  # 400K, but may be limited by config.max_model_tokens
     'o1-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-mini-2024-09-12': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-preview': 128000,  # 128K, but may be limited by config.max_model_tokens
@@ -249,6 +250,7 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
     "gpt-5.2-codex",
+    "gpt-5.3-codex",
     "gpt-5-mini"
 ]
 

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -38,6 +38,25 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == expected
 
+    @pytest.mark.parametrize("model", [
+        "gpt-5.1-codex",
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+    ])
+    def test_gpt_codex_models_max_tokens(self, monkeypatch, model):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        expected = MAX_TOKENS[model]
+
+        assert get_max_tokens(model) == expected
+
     def test_model_not_max_tokens_and_not_has_custom(self, monkeypatch):
         fake_settings = type('', (), {
             'config': type('', (), {

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -307,7 +307,7 @@ class TestLiteLLMReasoningEffort:
         fake_settings = create_mock_settings("medium")
         monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
 
-        gpt5_models = ["gpt-5-2025-08-07", "gpt-5.1", "gpt-5-turbo", "gpt-5.1-codex"]
+        gpt5_models = ["gpt-5-2025-08-07", "gpt-5.1", "gpt-5-turbo", "gpt-5.1-codex", "gpt-5.3-codex"]
 
         for model in gpt5_models:
             with patch('pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion', new_callable=AsyncMock) as mock_completion:


### PR DESCRIPTION
### **User description**
Reference:
- https://openai.com/index/introducing-gpt-5-3-codex/
- https://developers.openai.com/api/docs/models/gpt-5.3-codex


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for OpenAI's gpt-5.3-codex model

- Register model with 400K token context window

- Include model in reasoning effort support list

- Add test coverage for gpt-5.3-codex model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gpt-5.3-codex model"] -- "register with 400K tokens" --> B["MAX_TOKENS mapping"]
  A -- "add to reasoning models" --> C["SUPPORT_REASONING_EFFORT_MODELS"]
  A -- "test coverage" --> D["Unit tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Register gpt-5.3-codex model configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/__init__.py

<ul><li>Add <code>gpt-5.3-codex</code> entry to <code>MAX_TOKENS</code> dictionary with 400K token limit<br> <li> Include <code>gpt-5.3-codex</code> in <code>SUPPORT_REASONING_EFFORT_MODELS</code> list</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2233/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_get_max_tokens.py</strong><dd><code>Add test coverage for GPT codex models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_get_max_tokens.py

<ul><li>Add parametrized test for GPT codex models including gpt-5.3-codex<br> <li> Test verifies max token retrieval for gpt-5.1-codex, gpt-5.2-codex, <br>and gpt-5.3-codex</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2233/files#diff-542a4562a15acee3cee1c8a0b4c7b69b0ff7149939d9f85ff12d272dc2fd0817">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_litellm_reasoning_effort.py</strong><dd><code>Include gpt-5.3-codex in reasoning effort tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_litellm_reasoning_effort.py

<ul><li>Add <code>gpt-5.3-codex</code> to the list of GPT-5 models tested for reasoning <br>effort logic</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2233/files#diff-f945d5d9967e34f791fc2eed306f7e693525ecb557805c378b4a60b277c25ed4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

