### PR TITLE
Use `git_provider.remove_comment` to delete Azure DevOps comment removal

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -186,7 +186,7 @@ class PRCodeSuggestions:
                                artifact={"traceback": traceback.format_exc()})
             if get_settings().config.publish_output:
                 if self.progress_response:
-                    self.progress_response.delete()
+                    self.git_provider.remove_comment(self.progress_response)
                 else:
                     try:
                         self.git_provider.remove_initial_comment()


### PR DESCRIPTION
### **User description**
Fixes #2236


___

### **PR Type**
Bug fix


___

### **Description**
- Replace direct `.delete()` call with `git_provider.remove_comment()` method

- Ensures consistent comment removal across different Git providers

- Fixes Azure DevOps comment deletion issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["progress_response.delete()"] -- "replaced with" --> B["git_provider.remove_comment()"]
  B -- "ensures" --> C["Provider-agnostic comment removal"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Replace direct delete with provider method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<ul><li>Changed error handling to use <code>git_provider.remove_comment()</code> instead of <br>direct <code>.delete()</code> call<br> <li> Improves compatibility with Azure DevOps and other Git providers<br> <li> Maintains consistent API usage across provider implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2237/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

