### PR TITLE
docs: fix banner accessibility and hover color contrast

### DIFF
--- a/docs/docs/css/custom.css
+++ b/docs/docs/css/custom.css
@@ -105,3 +105,18 @@
     border-color: rgba(226, 232, 240, 0.2);
     outline-color: rgba(226, 232, 240, 0.3);
 }
+
+.md-banner {
+    background-color: #1d4ed8;
+}
+
+[data-md-color-scheme="slate"] .md-banner {
+    background-color: #2563eb;
+}
+
+.md-banner .md-typeset a,
+.md-banner .md-typeset a:hover,
+.md-banner .md-typeset a:focus {
+    color: currentColor;
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Apply WCAG AA compliant background colors for the announcement banner in both light and dark modes
- Fix dark mode banner color from `#1e3a5f` (1.49:1 distinction vs header) to `#2563eb` (3.31:1 distinction)
- Fix link hover/focus color staying white instead of changing to accent color (which was invisible against the blue banner)

## Accessibility
| Mode | Banner BG | White Text Contrast | WCAG AA | Header Distinction |
|------|-----------|--------------------|---------|--------------------|
| Light | `#1d4ed8` | 6.70:1 | PASS | 2.66:1 |
| Dark | `#2563eb` | 5.17:1 | PASS | 3.31:1 |

## Test plan
- [x] Verify banner text is readable in light mode
- [x] Verify banner text is readable in dark mode
- [x] Verify banner link hover state stays white in both modes
- [x] Verify banner is visually distinct from header in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)