### PR TITLE
fix: avoid UnboundLocalError in _calc_claude_tokens error handler

### DIFF
--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -147,8 +147,11 @@ class TokenHandler:
             return default_estimate
 
         if ModelTypeValidator.is_anthropic_model(model_name) and get_settings(use_context=False).get('anthropic.key'):
-            return self._calc_claude_tokens(patch)
-        
+            claude_count = self._calc_claude_tokens(patch)
+            if claude_count > 0:
+                return claude_count
+            return self._apply_estimation_factor(model_name, default_estimate)
+
         return self._apply_estimation_factor(model_name, default_estimate)
     
     def count_tokens(self, patch: str, force_accurate: bool = False) -> int:

--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -122,7 +122,7 @@ class TokenHandler:
 
         except Exception as e:
             get_logger().error(f"Error in Anthropic token counting: {e}")
-            return max_tokens
+            return 0
 
     def _apply_estimation_factor(self, model_name: str, default_estimate: int) -> int:
         factor = 1 + get_settings().get('config.model_token_count_estimate_factor', 0)


### PR DESCRIPTION
## Bug description

In `token_handler.py`, `_calc_claude_tokens()` references `max_tokens` in its except block, but this variable is only assigned inside the try block after the `anthropic` import and API key validation. If either fails, `max_tokens` is never defined.

```python
def _calc_claude_tokens(self, patch: str) -> int:
    try:
        import anthropic                    # can raise ImportError
        client = anthropic.Anthropic(...)   # can raise if no API key
        max_tokens = MAX_TOKENS[...]        # only assigned here
        ...
    except Exception as e:
        get_logger().error(...)
        return max_tokens                   # ← UnboundLocalError
```

This means the error handler itself crashes, masking the original error with `UnboundLocalError`.

## Fix

Return `0` instead of the undefined `max_tokens`. This lets the caller fall back to its default token estimation logic.

## Affected files

- `pr_agent/algo/token_handler.py` (L125) — 1 line change