### PR TITLE
fix: use pr_url variable instead of literal "pr_url" for provider cache lookup

### DIFF
--- a/pr_agent/git_providers/__init__.py
+++ b/pr_agent/git_providers/__init__.py
@@ -48,9 +48,9 @@ def get_git_provider_with_context(pr_url) -> GitProvider:
     except Exception:
         pass  # we are not in a context environment (CLI)
 
-    # check if context["git_provider"]["pr_url"] exists
-    if is_context_env and context.get("git_provider", {}).get("pr_url", {}):
-        git_provider = context["git_provider"]["pr_url"]
+    # check if context["git_provider"][pr_url] exists
+    if is_context_env and context.get("git_provider", {}).get(pr_url):
+        git_provider = context["git_provider"][pr_url]
         # possibly check if the git_provider is still valid, or if some reset is needed
         # ...
         return git_provider


### PR DESCRIPTION
## Bug description

`get_git_provider_with_context()` stores the provider with the actual URL as key but retrieves it using the literal string `"pr_url"`:

```python
# Store (L64) — uses variable value as key
context["git_provider"] = {pr_url: git_provider}

# Retrieve (L52-53) — uses literal string "pr_url" as key
if ... context.get("git_provider", {}).get("pr_url", {}):
    git_provider = context["git_provider"]["pr_url"]
```

The cache never hits because `"pr_url"` (the string) never matches the actual PR URL stored as the key.

## Impact

In server mode (GitHub App, etc.), a new `GitProvider` is created for every tool invocation on the same PR. This increases API calls to GitHub/GitLab and makes it easier to hit rate limits.

## Fix

Use the `pr_url` variable instead of the `"pr_url"` literal on lines 52-53.

## Affected files

- `pr_agent/git_providers/__init__.py` (L51-53) — 2 line change