### PR TITLE
Add OpenAI's latest GPT-5.4-mini and GPT-5.4-nano model

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -46,6 +46,8 @@ MAX_TOKENS = {
     'gpt-5.4-2026-03-05': 272000,  # 272K safe default without opt-in 1M context parameters
     'gpt-5.4-mini': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.4-mini-2026-03-17': 400000,  # 400K, but may be limited by config.max_model_tokens
+    'gpt-5.4-nano': 400000,  # 400K, but may be limited by config.max_model_tokens
+    'gpt-5.4-nano-2026-03-17': 400000,  # 400K, but may be limited by config.max_model_tokens
     'o1-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-mini-2024-09-12': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-preview': 128000,  # 128K, but may be limited by config.max_model_tokens

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -48,6 +48,19 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == 400000
 
+    @pytest.mark.parametrize("model", ["gpt-5.4-nano", "gpt-5.4-nano-2026-03-17"])
+    def test_gpt54_nano_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 400000
+
     # Test situations where the model is not registered and exists as a custom model
     def test_model_has_custom(self, monkeypatch):
         fake_settings = type('', (), {

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -311,6 +311,8 @@ class TestLiteLLMReasoningEffort:
             "gpt-5-2025-08-07",
             "gpt-5.1",
             "gpt-5.4",
+            "gpt-5.4-nano",
+            "gpt-5.4-nano-2026-03-17",
             "gpt-5.4-mini",
             "gpt-5.4-mini-2026-03-17",
             "gpt-5.4-2026-03-05",


### PR DESCRIPTION
Reference:

- https://developers.openai.com/api/docs/models/gpt-5.4-mini
- https://developers.openai.com/api/docs/models/gpt-5.4-nano
- https://openai.com/index/introducing-gpt-5-4-mini-and-nano/