### PR TITLE
fix: initialize max_tokens before try block in _calc_claude_tokens

### DIFF
--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -97,10 +97,11 @@ class TokenHandler:
             return 0
 
     def _calc_claude_tokens(self, patch: str) -> int:
+        max_tokens = 0
         try:
             import anthropic
             from pr_agent.algo import MAX_TOKENS
-            
+
             client = anthropic.Anthropic(api_key=get_settings(use_context=False).get('anthropic.key'))
             max_tokens = MAX_TOKENS[get_settings().config.model]
 


### PR DESCRIPTION
## Summary
- In _calc_claude_tokens, the except block references max_tokens which is only assigned inside the try block at line 105
- If an exception occurs before that assignment (e.g., anthropic import fails, API key is invalid, or model name is not in MAX_TOKENS), the except handler raises NameError: name 'max_tokens' is not defined
- This masks the original error and crashes instead of gracefully handling the failure
## Changes
pr_agent/algo/token_handler.py: Initialize max_tokens = 0 before the try block as a safe fallback
## Test plan
- Verify that _calc_claude_tokens handles missing anthropic dependency gracefully
- Verify that normal Anthropic token counting still works correctly
