### PR TITLE
fix: use instance prompt variable for user prompt in code suggestions

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -389,7 +389,7 @@ class PRCodeSuggestions:
         variables["diff_no_line_numbers"] = patches_diff_no_line_number  # update diff
         environment = Environment(undefined=StrictUndefined)
         system_prompt = environment.from_string(self.pr_code_suggestions_prompt_system).render(variables)
-        user_prompt = environment.from_string(get_settings().pr_code_suggestions_prompt.user).render(variables)
+        user_prompt = environment.from_string(self.pr_code_suggestions_prompt_user).render(variables)
         response, finish_reason = await self.ai_handler.chat_completion(
             model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
         if not get_settings().config.publish_output:


### PR DESCRIPTION
## Summary
- In _get_prediction, the system prompt correctly uses self.pr_code_suggestions_prompt_system which respects the decouple_hunks configuration
- However, the user prompt is hardcoded to get_settings().pr_code_suggestions_prompt.user, always using the decoupled variant regardless of configuration
- When decouple_hunks is False, the system prompt uses the not_decoupled version while the user prompt uses the decoupled version, creating contradictory instructions for the AI model
## Changes
pr_agent/tools/pr_code_suggestions.py: Changed to use self.pr_code_suggestions_prompt_user instead of get_settings().pr_code_suggestions_prompt.user
## Test plan
- Verify that when decouple_hunks is False, both system and user prompts use the not_decoupled variants
- Verify default behavior (decouple_hunks=True) is unchanged