### PR TITLE
fix: prevent KeyError when removing type from PR description data

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -561,7 +561,7 @@ class PRDescription:
         if 'labels' in self.data and self.git_provider.is_supported("get_labels"):
             self.data.pop('labels')
         if not get_settings().pr_description.enable_pr_type:
-            self.data.pop('type')
+            self.data.pop('type', None)
 
         # Remove the 'PR Title' key from the dictionary
         ai_title = self.data.pop('title', self.vars["title"])


### PR DESCRIPTION
## Summary
- When enable_pr_type is False, self.data.pop('type') raises KeyError if the AI response YAML does not contain a type field
- This is inconsistent with the adjacent labels removal which guards with if 'labels' in self.data before popping
- Use pop('type', None) for safe removal
## Changes
pr_agent/tools/pr_description.py: Changed self.data.pop('type') to self.data.pop('type', None)
## Test plan
- Verify that /describe works correctly when enable_pr_type is False and AI response omits the type field
- Verify normal behavior when type field is present