### PR TITLE
fix: close file descriptor after writing temp settings file

### DIFF
--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -36,6 +36,7 @@ def apply_repo_settings(pr_url):
                 try:
                     fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
                     os.write(fd, repo_settings)
+                    os.close(fd)
 
                     try:
                         dynconf_kwargs = {'core_loaders': [],  # DISABLE default loaders, otherwise will load toml files more than once.


### PR DESCRIPTION
## Summary
- tempfile.mkstemp() returns an open file descriptor that was never closed after os.write()
- The finally block removes the temp file with os.remove() but does not close the fd
- In a long-running server process, each call to apply_repo_settings() leaks one file descriptor, eventually exhausting the system fd limit
## Changes
pr_agent/git_providers/utils.py: Added os.close(fd) after os.write(fd, repo_settings)
## Test plan
- Verify that repo settings are still applied correctly after the change
- Verify no file descriptor leak by monitoring fd count across multiple settings applications