### PR TITLE
fix: use False as default for draft field in pull request event check

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -384,7 +384,7 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict) -> Tup
     if not api_url:
         return invalid_result
     log_context["api_url"] = api_url
-    if pull_request.get("draft", True) or pull_request.get("state") != "open":
+    if pull_request.get("draft", False) or pull_request.get("state") != "open":
         return invalid_result
     if action in ("review_requested", "synchronize") and pull_request.get("created_at") == pull_request.get("updated_at"):
         # avoid double reviews when opening a PR for the first time


### PR DESCRIPTION
## Summary
- pull_request.get("draft", True) defaults to True when the draft field is absent from the webhook payload
- This means PRs without an explicit draft field are treated as drafts and silently skipped
- The safe default should be False (assume not a draft), otherwise legitimate PRs may be ignored without any log indication
## Changes
pr_agent/servers/github_app.py: Changed default value from True to False
## Test plan
- Verify that PRs without a draft field in the webhook payload are processed normally
- Verify that actual draft PRs (with "draft": true) are still correctly skipped