### PR TITLE
fix: return empty list on ValueError in _get_commands_list_from_settings

### DIFF
--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -243,11 +243,12 @@ def _to_list(command_string: str) -> list:
         raise ValueError(f"Invalid command string: {e}")
 
 
-def _get_commands_list_from_settings(setting_key:str ) -> list:
+def _get_commands_list_from_settings(setting_key: str) -> list:
     try:
         return get_settings().get(setting_key, [])
     except ValueError as e:
         get_logger().error(f"Failed to get commands list from settings {setting_key}: {e}")
+        return []
 
 
 @router.get("/")


### PR DESCRIPTION
## Summary
- _get_commands_list_from_settings() catches ValueError and logs the error, but has no return statement in the except block, causing the function to implicitly return None
- Callers use .extend() on the return value, which raises TypeError: 'NoneType' object is not iterable when the result is None
- This causes the entire webhook processing flow to fail when settings are misconfigured
## Changes
pr_agent/servers/bitbucket_server_webhook.py: Added return [] to the except ValueError block
## Test plan
- Verify that Bitbucket Server webhook processing continues gracefully when settings retrieval fails
- Verify normal settings retrieval still returns the expected command list