### PR TITLE
fix: raise HTTPException instead of returning it in Gerrit server

### DIFF
--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -39,7 +39,7 @@ async def handle_gerrit_request(action: Action, item: Item):
 
     if action == Action.ask:
         if not item.msg:
-            return HTTPException(
+            raise HTTPException(
                 status_code=400,
                 detail="msg is required for ask command"
             )


### PR DESCRIPTION
## Summary
In handle_gerrit_request, HTTPException was returned instead of raised when item.msg is empty for an ask action. FastAPI requires exceptions to be raised to produce proper HTTP error responses. Returning the exception object results in an HTTP 200 status with the exception serialized as the response body, and execution continues past the guard into handle_request() with an empty message.
## Changes
pr_agent/servers/gerrit_server.py: Changed return HTTPException(...) to raise HTTPException(...)
## Test plan
- Verify that sending a POST to /api/v1/gerrit/ask without a msg field now returns HTTP 400 instead of 200
- Verify that normal ask requests with a valid msg continue to work