### PR TITLE
feat(ollama): Add API key support for Ollama Cloud

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -82,6 +82,8 @@ class LiteLLMAIHandler(BaseAiHandler):
         if get_settings().get("OLLAMA.API_BASE", None):
             litellm.api_base = get_settings().ollama.api_base
             self.api_base = get_settings().ollama.api_base
+        if get_settings().get("OLLAMA.API_KEY", None):
+            litellm.api_key = get_settings().ollama.api_key
         if get_settings().get("HUGGINGFACE.REPETITION_PENALTY", None):
             self.repetition_penalty = float(get_settings().huggingface.repetition_penalty)
         if get_settings().get("VERTEXAI.VERTEX_PROJECT", None):
@@ -403,6 +405,8 @@ class LiteLLMAIHandler(BaseAiHandler):
             if get_settings().config.verbosity_level >= 2:
                 get_logger().info(f"\nSystem prompt:\n{system}")
                 get_logger().info(f"\nUser prompt:\n{user}")
+
+            kwargs["api_key"] = litellm.api_key
 
             # Get completion with automatic streaming detection
             resp, finish_reason, response_obj = await self._get_completion(**kwargs)

--- a/pr_agent/settings/.secrets_template.toml
+++ b/pr_agent/settings/.secrets_template.toml
@@ -50,7 +50,8 @@ key = "" # Optional, uncomment if you want to use Huggingface Inference API. Acq
 api_base = "" # the base url for your huggingface inference endpoint
 
 [ollama]
-api_base = "" # the base url for your local Llama 2, Code Llama, and other models inference endpoint. Acquire through https://ollama.ai/
+api_base = "" # the base url for your Ollama endpoint, e.g. https://ollama.com for Ollama Cloud or http://localhost:11434 for local
+api_key = "" # required for Ollama Cloud (ollama.com); leave empty for local Ollama
 
 [vertexai]
 vertex_project = "" # the google cloud platform project name for your vertexai deployment


### PR DESCRIPTION
Add API key support for Ollama Cloud authentication

This change enables PR-Agent to authenticate with Ollama Cloud (ollama.com)
by adding support for the `OLLAMA.API_KEY` configuration option. Previously,
only local Ollama instances without authentication were supported.

The API key is now passed through to litellm completion calls when configured,
allowing users to leverage hosted Ollama models that require authentication.

Also updates the secrets template documentation to clarify the distinction
between Ollama Cloud and local Ollama deployments.

Fixes #2267