### PR TITLE
 fix: Gemini API key invalid due to Ollama Cloud key overwrite

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -406,8 +406,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 get_logger().info(f"\nSystem prompt:\n{system}")
                 get_logger().info(f"\nUser prompt:\n{user}")
             
-            # Specific only for ollma cloud api key
-            if get_settings().get("OLLAMA.API_KEY", None):
+            # Support for Ollama Cloud
+            if model.startswith('ollama') and get_settings().get("OLLAMA.API_KEY", None):
                 kwargs["api_key"] = litellm.api_key
             
             # Get completion with automatic streaming detection


### PR DESCRIPTION
Log
```
WARNING  | pr_agent.algo.ai_handlers.litellm_ai_handler:chat_completion:420 - Error during LLM inference: litellm.AuthenticationError: GeminiException - {
  "error": {
    "code": 400,
    "message": "API key not valid. Please pass a valid API key.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "API_KEY_INVALID",
        "domain": "googleapis.com",
        "metadata": {
          "service": "generativelanguage.googleapis.com"
        }
      },
      {
        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
        "locale": "en-US",
        "message": "API key not valid. Please pass a valid API key."
      }
    ]
  }
}

```
Solution: Fixes Gemini key overwrite when an Ollama Cloud API key is not present.
Reference: https://github.com/qodo-ai/pr-agent/issues/2287, https://github.com/qodo-ai/pr-agent/issues/2292