### PR TITLE
Expand and fix auto-generated file filtering in is_valid_file()

### DIFF
--- a/pr_agent/algo/language_handler.py
+++ b/pr_agent/algo/language_handler.py
@@ -20,10 +20,16 @@ def is_valid_file(filename:str, bad_extensions=None) -> bool:
         if get_settings().config.use_extra_bad_extensions:
             bad_extensions += get_settings().bad_extensions.extra
 
-    auto_generated_files = ['package-lock.json', 'yarn.lock', 'composer.lock', 'Gemfile.lock', 'poetry.lock']
-    for forbidden_file in auto_generated_files:
-        if filename.endswith(forbidden_file):
-            return False
+    auto_generated_files_exact = {
+        'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'composer.lock', 'Gemfile.lock',
+        'poetry.lock', 'go.sum', '.terraform.lock.hcl', 'uv.lock',
+        'Cargo.lock', 'Pipfile.lock', 'mix.lock', 'pubspec.lock', 'bun.lockb',
+    }
+    auto_generated_suffixes = ('.min.js', '.min.css', '.js.map', '.ts.map', '.css.map')
+    if filename.replace('\\', '/').split('/')[-1] in auto_generated_files_exact:
+        return False
+    if filename.endswith(auto_generated_suffixes):
+        return False
 
     return filename.split('.')[-1] not in bad_extensions
 


### PR DESCRIPTION
Split exact generated filenames from suffix matches so lockfiles are matched by basename, while generated assets such as minified files and source maps use suffix matching. Normalize path separators before basename matching so nested paths are handled consistently.

GitHub Copilot PR summary:

> This pull request updates the logic in the `is_valid_file` function to more accurately filter out auto-generated files and certain file types. The main improvement is a more comprehensive and robust check for files that should be ignored, such as lock files and minified or source map files.
> 
> File filtering improvements:
> 
> * Expanded the list of auto-generated files to ignore by using a set (`auto_generated_files_exact`) that now includes additional lock files like `pnpm-lock.yaml`, `go.sum`, `.terraform.lock.hcl`, `uv.lock`, `Cargo.lock`, `Pipfile.lock`, `mix.lock`, `pubspec.lock`, and `bun.lockb`. The check now matches the exact filename rather than just suffixes.
> * Added a tuple (`auto_generated_suffixes`) to filter out files ending with `.min.js`, `.min.css`, `.js.map`, `.ts.map`, and `.css.map`, ensuring minified and source map files are ignored.