### PR TITLE
fix(gitea): fetch PR-specific commits instead of all repo commits

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
@@ -86,11 +87,16 @@ class GiteaProvider(GitProvider):
             self.sha = self.pr.head.sha if self.pr.head.sha else ""
             self.__add_file_content()
             self.__add_file_diff()
-            self.pr_commits = self.repo_api.list_all_commits(
+            pr_commits_data = self.repo_api.get_pr_commits(
                 owner=self.owner,
-                repo=self.repo
+                repo=self.repo,
+                pr_number=self.pr_number
             )
-            self.last_commit = self.pr_commits[-1]
+            self.pr_commits = pr_commits_data if pr_commits_data else []
+            if self.pr_commits:
+                self.last_commit = SimpleNamespace(**self.pr_commits[-1])
+            else:
+                self.last_commit = None
             self.last_commit_id = self.last_commit
             self.base_sha = self.pr.base.sha if self.pr.base.sha else ""
             self.base_ref = self.pr.base.ref if self.pr.base.ref else ""

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1,3 +1,4 @@
+import json
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -103,3 +104,70 @@ class TestGiteaProvider:
         args, kwargs = mock_api_client.call_api.call_args
         assert args[0] == '/repos/owner/repo/pulls/123/commits'
         assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    @patch('pr_agent.git_providers.gitea_provider.giteapy.ApiClient')
+    @patch('pr_agent.git_providers.gitea_provider.filter_ignored')
+    def test_init_uses_pr_commits_not_repo_commits(self, mock_filter, mock_api_client_cls, mock_get_settings):
+        """Verify __init__ fetches PR-specific commits, not all repo commits.
+
+        Regression test for https://github.com/qodo-ai/pr-agent/issues/2206
+        """
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {
+            'GITEA.URL': 'https://gitea.example.com',
+            'GITEA.PERSONAL_ACCESS_TOKEN': 'test-token',
+            'GITEA.REPO_SETTING': None,
+            'GITEA.SKIP_SSL_VERIFICATION': False,
+            'GITEA.SSL_CA_CERT': None,
+        }.get(k, d)
+        mock_get_settings.return_value = settings
+
+        mock_api_client = mock_api_client_cls.return_value
+        mock_api_client.configuration.api_key = {}
+
+        # Track which endpoints are called
+        called_paths = []
+
+        pr_commits_json = json.dumps([
+            {"sha": "older_commit_sha", "html_url": "https://gitea.example.com/owner/repo/commit/older_commit_sha"},
+            {"sha": "latest_commit_sha", "html_url": "https://gitea.example.com/owner/repo/commit/latest_commit_sha"},
+        ])
+
+        mock_pr = MagicMock()
+        mock_pr.head.sha = "latest_commit_sha"
+        mock_pr.base.sha = "base_sha"
+        mock_pr.base.ref = "main"
+
+        def call_api_side_effect(path, method, **kwargs):
+            called_paths.append(path)
+            mock_resp = MagicMock()
+            if 'pulls' in path and 'files' in path:
+                mock_resp.data = BytesIO(b'[]')
+            elif 'pulls' in path and 'commits' in path:
+                mock_resp.data = BytesIO(pr_commits_json.encode())
+            elif path.endswith('.diff'):
+                mock_resp.data = BytesIO(b'')
+            else:
+                mock_resp.data = BytesIO(b'{}')
+            return mock_resp
+
+        mock_api_client.call_api.side_effect = call_api_side_effect
+        mock_filter.side_effect = lambda files, **kw: files
+
+        # Mock repo_get_pull_request to return our PR object
+        with patch('pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi.repo_get_pull_request', return_value=mock_pr):
+            from pr_agent.git_providers.gitea_provider import GiteaProvider
+            provider = GiteaProvider("https://gitea.example.com/owner/repo/pulls/42")
+
+        # Verify PR-specific commits endpoint was called (not repo-level commits)
+        pr_commits_calls = [p for p in called_paths if 'commits' in p]
+        assert any('/pulls/' in p and '/commits' in p for p in pr_commits_calls), \
+            f"Expected PR-specific commits endpoint, got: {pr_commits_calls}"
+        assert not any(p.endswith('/commits') and '/pulls/' not in p for p in pr_commits_calls), \
+            f"Should not call repo-level commits endpoint, got: {pr_commits_calls}"
+
+        # Verify last_commit has the latest PR commit's SHA
+        assert provider.last_commit is not None
+        assert provider.last_commit.sha == "latest_commit_sha"
+        assert provider.last_commit.html_url == "https://gitea.example.com/owner/repo/commit/latest_commit_sha"


### PR DESCRIPTION
### **PR Type**
Bug fix

### **Description**

`GiteaProvider.__init__` calls `list_all_commits(owner, repo)` which hits `GET /repos/{owner}/{repo}/commits` — the **repo-level** commits endpoint. This returns commits from the default branch, not from the PR branch. As a result, `self.last_commit` points at the wrong commit.

The same file already has `get_pr_commits(owner, repo, pr_number)` which correctly calls `GET /repos/{owner}/{repo}/pulls/{pr_number}/commits`, and it's already used by `get_commit_messages()` (line 402). This fix switches `__init__` to use that method too.

**Before:** `last_commit` is the oldest commit on the default branch → inline comments posted against wrong commit, persistent reviews never detect new changes, `_get_file_content_from_latest_commit()` fetches wrong content.

**After:** `last_commit` is the latest commit on the PR branch, consistent with the GitHub provider.

Since `get_pr_commits` returns raw JSON dicts (unlike the giteapy model objects from `list_all_commits`), the fix wraps the commit dict in a `SimpleNamespace` so existing `.sha` / `.html_url` attribute access continues to work.

Added a regression test that verifies the PR-specific endpoint is called and `last_commit.sha` matches the expected value.

Fixes #2206