### PR TITLE
fix(gerrit): prevent path traversal in publish_code_suggestions

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -342,10 +342,16 @@ class GerritProvider(GitProvider):
 
     def publish_code_suggestions(self, code_suggestions: list):
         msg = []
+        repo_root = pathlib.Path(self.repo_path).resolve()
         for suggestion in code_suggestions:
+            # Sanitize file path to prevent directory traversal
+            target_path = (repo_root / suggestion["relevant_file"]).resolve()
+            if not str(target_path).startswith(str(repo_root)):
+                get_logger().warning(f"Skipping suggestion with path traversal: {suggestion['relevant_file']}")
+                continue
             description, code = self.split_suggestion(suggestion['body'])
             add_suggestion(
-                pathlib.Path(self.repo_path) / suggestion["relevant_file"],
+                target_path,
                 code,
                 suggestion["relevant_lines_start"],
                 suggestion["relevant_lines_end"],

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -344,9 +344,15 @@ class GerritProvider(GitProvider):
         msg = []
         repo_root = pathlib.Path(self.repo_path).resolve()
         for suggestion in code_suggestions:
+            # Validate suggestion structure before accessing keys
+            if not isinstance(suggestion, dict) or not isinstance(suggestion.get("relevant_file"), str):
+                get_logger().warning(f"Skipping malformed suggestion: missing or invalid 'relevant_file'")
+                continue
             # Sanitize file path to prevent directory traversal
-            target_path = (repo_root / suggestion["relevant_file"]).resolve()
-            if not str(target_path).startswith(str(repo_root)):
+            try:
+                target_path = (repo_root / suggestion["relevant_file"]).resolve()
+                target_path.relative_to(repo_root)
+            except ValueError:
                 get_logger().warning(f"Skipping suggestion with path traversal: {suggestion['relevant_file']}")
                 continue
             description, code = self.split_suggestion(suggestion['body'])

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -346,7 +346,7 @@ class GerritProvider(GitProvider):
         for suggestion in code_suggestions:
             # Validate suggestion structure before accessing keys
             if not isinstance(suggestion, dict) or not isinstance(suggestion.get("relevant_file"), str):
-                get_logger().warning(f"Skipping malformed suggestion: missing or invalid 'relevant_file'")
+                get_logger().warning("Skipping malformed suggestion: missing or invalid 'relevant_file'")
                 continue
             # Sanitize file path to prevent directory traversal
             try:


### PR DESCRIPTION
## Summary
- Sanitize `relevant_file` path in `publish_code_suggestions()` to prevent directory traversal
- Resolve the target path and verify it stays within `repo_path` before writing
- Skip suggestions with suspicious paths and log a warning

## Problem
`suggestion['relevant_file']` comes from AI output and is used directly in `Path(repo_path) / relevant_file` without validation. A path like `../../etc/passwd` could write outside the repo directory.

## Test plan
- [ ] Verify normal file paths still work
- [ ] Verify `../` paths are rejected with a warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)