### PR TITLE
fix(gerrit): raise HTTPException instead of returning it

### DIFF
--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -39,7 +39,7 @@ async def handle_gerrit_request(action: Action, item: Item):
 
     if action == Action.ask:
         if not item.msg:
-            return HTTPException(
+            raise HTTPException(
                 status_code=400,
                 detail="msg is required for ask command"
             )


### PR DESCRIPTION
## Summary
- Change `return HTTPException(...)` to `raise HTTPException(...)` in gerrit_server.py
- Without this fix, FastAPI returns 200 OK with the exception serialized as JSON instead of a proper 400 error

## Test plan
- [ ] Verify gerrit server returns 400 on invalid requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)