### PR TITLE
fix(gitlab): add null check for target_file in publish_code_suggestions

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -673,6 +673,9 @@ class GitLabProvider(GitProvider):
                         if file.filename == relevant_file:
                             target_file = file
                             break
+                if target_file is None:
+                    get_logger().warning(f"Skipping suggestion: file '{relevant_file}' not found in diff")
+                    continue
                 range = relevant_lines_end - relevant_lines_start # no need to add 1
                 body = body.replace('```suggestion', f'```suggestion:-0+{range}')
                 lines = target_file.head_file.splitlines()


### PR DESCRIPTION
## Summary
- In `GitLabProvider.publish_code_suggestions()`, `target_file` is initialized to `None` and set only if a matching file is found in the diff. If no match is found, the code proceeds to access `target_file.head_file`, causing an `AttributeError`.
- Added a `None` check after the file-search loop: if `target_file` is `None`, log a warning and `continue` to skip that suggestion gracefully.
- This follows defensive input validation (null check before dereference) and preserves the existing behavior of publishing remaining suggestions even when one fails.

## Test plan
- [ ] Verify that when a suggestion references a file not present in the diff, the suggestion is skipped with a warning log instead of crashing
- [ ] Verify that valid suggestions for files present in the diff are still published normally
- [ ] Verify no regression in the existing `publish_code_suggestions` flow for GitLab MRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)