### PR TITLE
fix(gerrit): explicitly set git provider in server startup

### DIFF
--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -64,6 +64,7 @@ async def root():
 
 
 def start():
+    get_settings().set("CONFIG.GIT_PROVIDER", "gerrit")
     # to prevent adding help messages with the output
     get_settings().set("CONFIG.CLI_MODE", True)
     middleware = [Middleware(RawContextMiddleware)]


### PR DESCRIPTION
## Summary

- The Gerrit server's `start()` function was missing `get_settings().set("CONFIG.GIT_PROVIDER", "gerrit")`, causing it to rely on implicit URL format detection instead of explicit configuration
- Other servers (e.g., `bitbucket_app.py`, `gitlab_webhook.py`) already set their provider explicitly at startup -- this aligns the Gerrit server with the same pattern
- Adds a single line to `gerrit_server.py:start()` to set the provider before the app starts

## Test plan

- [ ] Verify the Gerrit server starts correctly with the explicit provider setting
- [ ] Confirm `get_settings().config.git_provider` returns `"gerrit"` after `start()` is called
- [ ] Validate that existing Gerrit request handling (review, describe, ask, improve) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)