### PR TITLE
fix(github-action): handle string "false" for ENABLE_OUTPUT setting

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1256,7 +1256,10 @@ def validate_and_await_rate_limit(github_token):
 
 def github_action_output(output_data: dict, key_name: str):
     try:
-        if not get_settings().get('github_action_config.enable_output', False):
+        enable_output = get_settings().get('github_action_config.enable_output', False)
+        if isinstance(enable_output, str):
+            enable_output = enable_output.lower().strip() not in ("false", "0", "no", "")
+        if not enable_output:
             return
 
         key_data = output_data.get(key_name, {})

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -61,6 +61,8 @@ async def run_action():
     get_settings().set("GITHUB.USER_TOKEN", GITHUB_TOKEN)
     get_settings().set("GITHUB.DEPLOYMENT_TYPE", "user")
     enable_output = get_setting_or_env("GITHUB_ACTION_CONFIG.ENABLE_OUTPUT", True)
+    if isinstance(enable_output, str):
+        enable_output = enable_output.lower().strip() not in ("false", "0", "no", "")
     get_settings().set("GITHUB_ACTION_CONFIG.ENABLE_OUTPUT", enable_output)
 
     # Load the event payload

--- a/tests/unittest/test_github_action_output.py
+++ b/tests/unittest/test_github_action_output.py
@@ -42,6 +42,35 @@ class TestGitHubOutput:
 
         assert not os.path.exists(str(tmp_path / 'output'))
 
+    def test_github_action_output_disabled_string_false(self, monkeypatch, tmp_path):
+        """String 'false' from env vars should be treated as falsy, not truthy."""
+        get_settings().set('GITHUB_ACTION_CONFIG.ENABLE_OUTPUT', "false")
+        monkeypatch.setenv('GITHUB_OUTPUT', str(tmp_path / 'output'))
+        output_data = {'key1': {'value1': 1, 'value2': 2}}
+        key_name = 'key1'
+
+        github_action_output(output_data, key_name)
+
+        assert not os.path.exists(str(tmp_path / 'output'))
+
+    def test_github_action_output_enabled_string_true(self, monkeypatch, tmp_path):
+        """String 'true' from env vars should be treated as truthy."""
+        get_settings().set('GITHUB_ACTION_CONFIG.ENABLE_OUTPUT', "true")
+        monkeypatch.setenv('GITHUB_OUTPUT', str(tmp_path / 'output'))
+        output_data = {'key1': {'value1': 1, 'value2': 2}}
+        key_name = 'key1'
+
+        github_action_output(output_data, key_name)
+
+        with open(str(tmp_path / 'output'), 'r') as f:
+            env_value = f.read()
+
+        actual_key = env_value.split('=')[0]
+        actual_data = json.loads(env_value.split('=')[1])
+
+        assert actual_key == key_name
+        assert actual_data == output_data[key_name]
+
     def test_github_action_output_error_case(self, monkeypatch, tmp_path):
         monkeypatch.setenv('GITHUB_OUTPUT', str(tmp_path / 'output'))
         output_data = None # invalid data


### PR DESCRIPTION
## Summary
- **Bug**: `GITHUB_ACTION_CONFIG.ENABLE_OUTPUT` can arrive as a string `"false"` from environment variables or YAML config. Since non-empty strings are truthy in Python, `if enable_output:` evaluates to `True` even when the user explicitly set it to `"false"`, causing unwanted GitHub Action output writes.
- **Fix**: Added explicit string-to-boolean coercion at both the ingestion point (`github_action_runner.py`) and the consumption point (`utils.py`), treating `"false"`, `"0"`, `"no"`, and `""` as falsy.
- **Tests**: Added two new test cases verifying that string `"false"` disables output and string `"true"` enables it.

## Test plan
- [x] Existing 4 tests continue to pass (bool `True`, bool `False`, not set, error case)
- [x] New `test_github_action_output_disabled_string_false` — string `"false"` does not write to `GITHUB_OUTPUT`
- [x] New `test_github_action_output_enabled_string_true` — string `"true"` correctly writes to `GITHUB_OUTPUT`
- [ ] Manual: set `enable_output: "false"` in a GitHub Action workflow and verify no output is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)