### PR TITLE
fix(labels): escape single quotes in custom label descriptions

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -956,7 +956,8 @@ def set_custom_labels(variables, git_provider=None):
     counter = 0
     labels_minimal_to_labels_dict = {}
     for k, v in labels.items():
-        description = "'" + v['description'].strip('\n').replace('\n', '\\n').replace("'", "\\'") + "'"
+        description = v.get('description', '') if isinstance(v, dict) else str(v)
+        description = "'" + description.strip('\n').replace('\n', '\\n').replace("'", "\\'") + "'"
         # variables["custom_labels_class"] += f"\n    {k.lower().replace(' ', '_')} = '{k}' # {description}"
         variables["custom_labels_class"] += f"\n    {k.lower().replace(' ', '_')} = {description}"
         labels_minimal_to_labels_dict[k.lower().replace(' ', '_')] = k

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -956,7 +956,7 @@ def set_custom_labels(variables, git_provider=None):
     counter = 0
     labels_minimal_to_labels_dict = {}
     for k, v in labels.items():
-        description = "'" + v['description'].strip('\n').replace('\n', '\\n') + "'"
+        description = "'" + v['description'].strip('\n').replace('\n', '\\n').replace("'", "\\'") + "'"
         # variables["custom_labels_class"] += f"\n    {k.lower().replace(' ', '_')} = '{k}' # {description}"
         variables["custom_labels_class"] += f"\n    {k.lower().replace(' ', '_')} = {description}"
         labels_minimal_to_labels_dict[k.lower().replace(' ', '_')] = k


### PR DESCRIPTION
## Summary
- **Bug:** `set_custom_labels()` in `pr_agent/algo/utils.py` wraps label descriptions in single quotes without escaping. A description like `Don't merge` produces the malformed string `'Don't merge'`, breaking the generated `custom_labels_class` Enum schema sent to the LLM.
- **Fix:** Added `.replace("'", "\\'")` to escape single quotes in descriptions before they are wrapped in single-quote delimiters. This is chained after the existing `.replace('\n', '\\n')` call on line 959.
- Affects both `pr_description.py` and `pr_generate_labels.py` since both call the shared `set_custom_labels()` utility.

## Test plan
- [ ] Configure a custom label with a single-quote in its description (e.g., `description = "Don't merge this"`)
- [ ] Run `/describe` or `/generate_labels` and verify the generated `custom_labels_class` contains properly escaped strings
- [ ] Verify labels without single quotes still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)