### PR TITLE
fix(azure): use last_merge_source_commit for PR head SHA

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -198,7 +198,7 @@ class AzureDevopsProvider(GitProvider):
                 return self.diff_files
 
             base_sha = self.pr.last_merge_target_commit
-            head_sha = self.pr.last_merge_commit
+            head_sha = getattr(self.pr, 'last_merge_source_commit', None) or self.pr.last_merge_commit
 
             # Get PR iterations
             iterations = self.azure_devops_client.get_pull_request_iterations(


### PR DESCRIPTION
## Summary
- Fix incorrect diff computation in Azure DevOps provider caused by using `last_merge_commit` (a merge commit) instead of `last_merge_source_commit` (the actual source branch head) for the PR head SHA.
- Uses `getattr` with a fallback to `last_merge_commit` to handle cases where `last_merge_source_commit` is not available.

## Test plan
- [ ] Verify Azure DevOps PRs produce correct diffs by comparing `head_sha` before/after the fix
- [ ] Confirm fallback works when `last_merge_source_commit` is `None` or absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)