### PR TITLE
fix(patch): guard against None match in hunk header extraction

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -354,8 +354,9 @@ __old hunk__
 
         if line.startswith('@@'):
             header_line = line
+            prev_match = match  # save previous match before overwriting
             match = RE_HUNK_HEADER.match(line)
-            if match and (new_content_lines or old_content_lines):  # found a new hunk, split the previous lines
+            if prev_match and (new_content_lines or old_content_lines):  # flush the previous hunk
                 if prev_header_line:
                     patch_with_lines_str += f'\n{prev_header_line}\n'
                 is_plus_lines = is_minus_lines = False
@@ -392,9 +393,11 @@ __old hunk__
             new_content_lines.append(line)
             old_content_lines.append(line)
 
-    # finishing last hunk
-    if match and new_content_lines:
-        patch_with_lines_str += f'\n{header_line}\n'
+    # finishing last hunk — use prev_header_line (not match/header_line) because
+    # match may have been set to None by a trailing malformed @@ line, and
+    # header_line may point to that malformed line instead of the last valid hunk
+    if prev_header_line and new_content_lines:
+        patch_with_lines_str += f'\n{prev_header_line}\n'
         is_plus_lines = is_minus_lines = False
         if new_content_lines:
             is_plus_lines = any([line.startswith('+') for line in new_content_lines])

--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -375,8 +375,9 @@ __old hunk__
                 old_content_lines = []
             if match:
                 prev_header_line = header_line
-
-            section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
+                section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
+            else:
+                continue  # skip lines that start with @@ but don't match the hunk header pattern
 
         elif line.startswith('+'):
             new_content_lines.append(line)
@@ -430,6 +431,9 @@ def extract_hunk_lines_from_patch(patch: str, file_name, line_start, line_end, s
                 header_line = line
 
                 match = RE_HUNK_HEADER.match(line)
+                if not match:
+                    skip_hunk = True
+                    continue
 
                 section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
 

--- a/tests/unittest/test_malformed_hunk_header.py
+++ b/tests/unittest/test_malformed_hunk_header.py
@@ -1,0 +1,119 @@
+"""
+Tests for malformed @@ hunk headers in decouple_and_convert_to_hunks_with_lines_numbers().
+
+Verifies that:
+1. A malformed @@ line does not crash the function.
+2. Content from valid hunks before and after a malformed @@ is preserved.
+3. When a malformed @@ is the last @@-starting line, the preceding hunk is
+   still finalized correctly.
+"""
+
+from pr_agent.algo.git_patch_processing import decouple_and_convert_to_hunks_with_lines_numbers
+from pr_agent.config_loader import get_settings
+
+get_settings(use_context=False).set("CONFIG.CLI_MODE", True)
+
+
+class _FakeFile:
+    """Minimal file object expected by the function under test."""
+
+    def __init__(self, filename="test_file.py"):
+        self.filename = filename
+
+
+class TestMalformedHunkHeader:
+    def test_malformed_hunk_does_not_crash(self):
+        """A patch whose only @@ line is malformed should not raise."""
+        patch = "@@ THIS IS NOT A VALID HUNK HEADER @@\n+added line\n-removed line"
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        assert isinstance(result, str)
+
+    def test_valid_hunk_before_malformed_is_preserved(self):
+        """Content from a valid hunk that precedes a malformed @@ must appear in output."""
+        patch = (
+            "@@ -1,3 +1,4 @@ section\n"
+            " context\n"
+            "+added_line\n"
+            " more_context\n"
+            "@@ MALFORMED @@ not a real header\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        # The valid hunk's added line must be present
+        assert "+added_line" in result
+        assert "__new hunk__" in result
+
+    def test_malformed_hunk_between_two_valid_hunks(self):
+        """A malformed @@ between two valid hunks must not drop either hunk's content."""
+        patch = (
+            "@@ -1,3 +1,4 @@ first_section\n"
+            " ctx1\n"
+            "+add1\n"
+            " ctx2\n"
+            "@@ GARBAGE @@ not valid\n"
+            "@@ -10,2 +11,3 @@ second_section\n"
+            " ctx3\n"
+            "+add2\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        assert "+add1" in result, "First hunk content was dropped"
+        assert "+add2" in result, "Second hunk content was dropped"
+
+    def test_trailing_malformed_hunk_does_not_drop_last_valid(self):
+        """When a malformed @@ is the LAST @@-line, the previous hunk must still be finalized."""
+        patch = (
+            "@@ -5,3 +5,4 @@ my_func\n"
+            " existing_line\n"
+            "+new_line\n"
+            " another_existing\n"
+            "@@ INVALID HEADER\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        # The valid hunk before the malformed trailing @@ must be present
+        assert "+new_line" in result
+        assert "__new hunk__" in result
+        # The malformed header text should NOT appear as a hunk header in the output
+        assert "INVALID HEADER" not in result
+
+    def test_line_numbers_correct_with_malformed_between(self):
+        """Line numbers from valid hunks are correct even when a malformed @@ sits between them."""
+        patch = (
+            "@@ -1,2 +1,3 @@ header1\n"
+            " line_a\n"
+            "+line_b\n"
+            "@@ NOT_VALID\n"
+            "@@ -10,2 +11,3 @@ header2\n"
+            " line_c\n"
+            "+line_d\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        # First hunk starts at new-line 1: "1  line_a", "2 +line_b"
+        assert "1  line_a" in result
+        assert "2 +line_b" in result
+        # Second hunk starts at new-line 11: "11  line_c", "12 +line_d"
+        assert "11  line_c" in result
+        assert "12 +line_d" in result
+
+    def test_only_malformed_hunks_returns_file_header_only(self):
+        """A patch with ONLY malformed @@ lines should return just the file header."""
+        patch = (
+            "@@ BROKEN1 @@\n"
+            "+orphan_add\n"
+            "@@ BROKEN2 @@\n"
+            "-orphan_del\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        # No valid hunk was ever parsed, so no __new hunk__ / __old hunk__ sections
+        assert "__new hunk__" not in result
+        assert "__old hunk__" not in result
+
+    def test_deletion_only_hunk_before_malformed(self):
+        """A hunk with only deletions before a malformed @@ is still finalized."""
+        patch = (
+            "@@ -1,3 +1,2 @@ section\n"
+            " context\n"
+            "-removed_line\n"
+            "@@ NOT VALID @@\n"
+        )
+        result = decouple_and_convert_to_hunks_with_lines_numbers(patch, _FakeFile())
+        assert "-removed_line" in result
+        assert "__old hunk__" in result


### PR DESCRIPTION
## Summary
- Guard `extract_hunk_headers(match)` calls against `None` match results in two functions within `pr_agent/algo/git_patch_processing.py`
- In `decouple_and_convert_to_hunks_with_lines_numbers` (line ~379): moved `extract_hunk_headers` inside the existing `if match:` block and added `continue` for non-matching `@@` lines
- In `extract_hunk_lines_from_patch` (line ~434): added an explicit `if not match:` guard that sets `skip_hunk = True` and continues, preventing the crash

## Bug
If a line starts with `@@` but doesn't fully match the `RE_HUNK_HEADER` regex pattern, `re.match()` returns `None`. The code then calls `extract_hunk_headers(None)`, which invokes `None.groups()` and raises `AttributeError: 'NoneType' object has no attribute 'groups'`.

This can occur with malformed or unusual diff output (e.g. conflict markers, truncated patches, or non-standard `@@` lines).

## Test plan
- [ ] Verify existing tests pass (`pytest tests/ -v`)
- [ ] Manually test with a patch containing a malformed `@@` line (e.g. `@@ invalid header @@`) to confirm it no longer crashes
- [ ] Verify normal patch processing still works correctly with valid hunk headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)