### PR TITLE
fix(gerrit): use action parameter for dispatch and clean up temp repos

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -393,7 +393,7 @@ class GerritProvider(GitProvider):
             try:
                 shutil.rmtree(self.repo_path, ignore_errors=True)
                 get_logger().info("Cleaned up temp repo at %s", self.repo_path)
-            except Exception as e:
+            except (OSError, PermissionError) as e:
                 get_logger().warning(
                     "Failed to clean up temp repo at %s: %s",
                     self.repo_path, e

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -387,10 +387,27 @@ class GerritProvider(GitProvider):
         # but required by the interface
         pass
 
+    def cleanup(self):
+        """Remove the temporary cloned repository from disk."""
+        if self.repo_path and pathlib.Path(self.repo_path).exists():
+            try:
+                shutil.rmtree(self.repo_path, ignore_errors=True)
+                get_logger().info("Cleaned up temp repo at %s", self.repo_path)
+            except Exception as e:
+                get_logger().warning(
+                    "Failed to clean up temp repo at %s: %s",
+                    self.repo_path, e
+                )
+
+    def __del__(self):
+        """Safety net: clean up temp repo if cleanup() was not called."""
+        try:
+            self.cleanup()
+        except Exception:
+            pass
+
     def remove_initial_comment(self):
-        # remove repo, cloned in previous steps
-        # shutil.rmtree(self.repo_path)
-        pass
+        self.cleanup()
 
     def remove_comment(self, comment):
         pass

--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -59,15 +59,24 @@ async def handle_gerrit_request(action: Action, item: Item):
         # Clean up the cloned temp repo created by GerritProvider.
         # The provider is cached in the starlette context during
         # get_git_provider_with_context().
+        #
+        # We guard against two failure modes:
+        #   1. The starlette context is inaccessible (e.g. middleware not
+        #      active) — caught by the outer try/except.
+        #   2. The provider was never stored in the context (e.g. an error
+        #      occurred before get_git_provider_with_context ran) — the
+        #      dict will simply be empty, and the GerritProvider.__del__
+        #      safety net handles cleanup on garbage collection.
         try:
             git_providers = context.get("git_provider", {})
-            for provider in git_providers.values():
-                if isinstance(provider, GerritProvider):
-                    provider.cleanup()
-        except Exception:
+            if isinstance(git_providers, dict):
+                for provider in git_providers.values():
+                    if isinstance(provider, GerritProvider):
+                        provider.cleanup()
+        except (LookupError, RuntimeError):
             get_logger().debug(
                 "Could not retrieve GerritProvider for cleanup; "
-                "temp directory may persist"
+                "temp directory will be cleaned up by __del__"
             )
 
 

--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -11,6 +11,7 @@ from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.git_providers.gerrit_provider import GerritProvider
 from pr_agent.log import get_logger, setup_logger
 
 setup_logger()
@@ -29,7 +30,7 @@ class Action(str, Enum):
 class Item(BaseModel):
     refspec: str
     project: str
-    msg: str
+    msg: str = ""
 
 
 @router.post("/api/v1/gerrit/{action}")
@@ -37,16 +38,37 @@ async def handle_gerrit_request(action: Action, item: Item):
     get_logger().debug("Received a Gerrit request")
     context["settings"] = copy.deepcopy(global_settings)
 
+    # For the "ask" action, the question must come from item.msg.
+    # For all other actions, use the action path parameter as the command.
     if action == Action.ask:
         if not item.msg:
-            return HTTPException(
+            raise HTTPException(
                 status_code=400,
                 detail="msg is required for ask command"
             )
-    await PRAgent().handle_request(
-        f"{item.project}:{item.refspec}",
-        f"/{item.msg.strip()}"
-    )
+        command = f"/{action.value} {item.msg.strip()}"
+    else:
+        command = f"/{action.value}"
+
+    try:
+        await PRAgent().handle_request(
+            f"{item.project}:{item.refspec}",
+            command
+        )
+    finally:
+        # Clean up the cloned temp repo created by GerritProvider.
+        # The provider is cached in the starlette context during
+        # get_git_provider_with_context().
+        try:
+            git_providers = context.get("git_provider", {})
+            for provider in git_providers.values():
+                if isinstance(provider, GerritProvider):
+                    provider.cleanup()
+        except Exception:
+            get_logger().debug(
+                "Could not retrieve GerritProvider for cleanup; "
+                "temp directory may persist"
+            )
 
 
 async def get_body(request):


### PR DESCRIPTION
## Summary
- **Action parameter ignored**: The `{action}` path parameter in `POST /api/v1/gerrit/{action}` was captured but never used for command dispatch. Instead, `item.msg` was always passed as the command. Now the action enum value determines the command (`/review`, `/describe`, etc.), with `item.msg` only appended for the `ask` action. Also made `msg` optional with a default empty string since non-ask actions don't require it.
- **HTTPException returned instead of raised**: `return HTTPException(...)` silently returns a 200 with the exception object serialized as JSON. Changed to `raise HTTPException(...)` so the 400 status code is actually sent.
- **Temp repo never cleaned up**: `prepare_repo()` creates a temp directory via `mkdtemp()` but `remove_initial_comment()` had `shutil.rmtree` commented out. Added a `cleanup()` method to `GerritProvider` that safely removes the temp directory, called from the server's `finally` block after each request. A `__del__` method serves as a safety net. `remove_initial_comment()` now delegates to `cleanup()`.

## Test plan
- [ ] Verify `POST /api/v1/gerrit/review` with empty `msg` dispatches `/review` command (not `/ `)
- [ ] Verify `POST /api/v1/gerrit/ask` with `msg: "what does this do?"` dispatches `/ask what does this do?`
- [ ] Verify `POST /api/v1/gerrit/ask` with empty `msg` returns 400
- [ ] Verify temp directories under `/tmp/` are cleaned up after request completes
- [ ] Verify temp directories are cleaned up even when `handle_request` raises an exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)