### PR TITLE
fix: prevent Ollama key from polluting global litellm state

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -33,6 +33,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         self.azure = False
         self.api_base = None
         self.repetition_penalty = None
+        self.ollama_api_key = None
 
         if get_settings().get("LITELLM.DISABLE_AIOHTTP", False):
             litellm.disable_aiohttp_transport = True
@@ -84,7 +85,7 @@ class LiteLLMAIHandler(BaseAiHandler):
             litellm.api_base = get_settings().ollama.api_base
             self.api_base = get_settings().ollama.api_base
         if get_settings().get("OLLAMA.API_KEY", None):
-            litellm.api_key = get_settings().ollama.api_key
+            self.ollama_api_key = get_settings().ollama.api_key
         if get_settings().get("HUGGINGFACE.REPETITION_PENALTY", None):
             self.repetition_penalty = float(get_settings().huggingface.repetition_penalty)
         if get_settings().get("VERTEXAI.VERTEX_PROJECT", None):
@@ -411,6 +412,11 @@ class LiteLLMAIHandler(BaseAiHandler):
             # like Groq, XAI, Azure AD, and OpenRouter. Skip if None or placeholder.
             if litellm.api_key and litellm.api_key != DUMMY_LITELLM_API_KEY:
                 kwargs["api_key"] = litellm.api_key
+
+            # Inject Ollama API key per-request instead of globally, to avoid
+            # polluting litellm.api_key which is shared across all providers.
+            if self.ollama_api_key and model.startswith(("ollama/", "ollama_chat/")):
+                kwargs["api_key"] = self.ollama_api_key
 
             # Get completion with automatic streaming detection
             resp, finish_reason, response_obj = await self._get_completion(**kwargs)

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -277,14 +277,13 @@ class TestApiKeyGuard:
     async def test_ollama_and_groq_coexist(self, monkeypatch):
         """Verify both Ollama and Groq keys can coexist and be forwarded correctly.
 
-        When multiple providers are configured, litellm.api_key gets overwritten
-        sequentially during __init__. The sentinel guard should still forward
-        whatever real key is currently in litellm.api_key.
+        Ollama key is stored on the handler instance (not globally) and only
+        injected for ollama/ models. Groq key stays in litellm.api_key and is
+        forwarded for non-Ollama models.
         """
         groq_key = "gsk-groq-key"
         ollama_key = "ollama-key"
 
-        # Simulate: Groq key set first, then Ollama overwrites litellm.api_key
         mixed_settings = type("Settings", (), {
             "config": type("Config", (), {
                 "reasoning_effort": None,
@@ -320,14 +319,15 @@ class TestApiKeyGuard:
             mock_call.return_value = _mock_response()
             handler = LiteLLMAIHandler()
 
-            # After init, litellm.api_key should be Ollama (last assignment)
-            assert litellm.api_key == ollama_key
+            # After init, litellm.api_key should be Groq (Ollama no longer pollutes global)
+            assert litellm.api_key == groq_key
+            # Ollama key stored on the instance
+            assert handler.ollama_api_key == ollama_key
 
-            # Call with Ollama model — should get Ollama key
+            # Call with Ollama model — should get Ollama key (per-request)
             await handler.chat_completion(model="ollama/mistral", system="sys", user="usr")
             assert mock_call.call_args[1]["api_key"] == ollama_key
 
-            # Call with non-Ollama model — should still forward the key
-            # (which is Ollama in this case, but the guard correctly allows real keys through)
+            # Call with non-Ollama model — should get Groq key (from litellm.api_key)
             await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
-            assert mock_call.call_args[1]["api_key"] == ollama_key
+            assert mock_call.call_args[1]["api_key"] == groq_key


### PR DESCRIPTION
## Summary

- **Root cause**: `LiteLLMAIHandler.__init__()` sets `litellm.api_key` globally when `OLLAMA.API_KEY` is configured. Since `litellm` is a module-level singleton, this overwrites the API key for ALL providers (Groq, xAI, OpenAI, Anthropic, etc.). Any non-Ollama call then sends the Ollama key and fails authentication.
- **Fix**: Store the Ollama key on the handler instance (`self.ollama_api_key`) instead of globally, and inject it per-request via litellm's `api_key` kwarg only when the model uses the `ollama/` or `ollama_chat/` prefix.
- **Tests updated**: The `test_ollama_and_groq_coexist` test now verifies correct per-provider key isolation -- Ollama models get the Ollama key, non-Ollama models get the Groq key.

This builds on prior fixes #2288 and #2293 which addressed related symptoms (Gemini broken by Ollama key, dummy key forwarding) but left the root cause (global `litellm.api_key` mutation) in place.

### Note on GitLab submodule content fetching

There is a separate issue in `gitlab_provider.py` where `_expand_submodule_changes()` creates synthetic diff entries with paths like `submodule_path/file.py`, but `get_diff_files()` still calls `get_pr_file_content()` against the parent project ID. These paths don't exist in the parent repo -- the content lives in the submodule project. This is a real bug but requires more invasive changes (threading submodule project resolution through content fetching) and is left for a separate PR.

## Test plan

- [x] All 7 existing tests in `test_litellm_api_key_guard.py` pass
- [x] `test_ollama_and_groq_coexist` now correctly verifies Ollama key goes only to Ollama models and Groq key goes to non-Ollama models
- [ ] Manual verification with Ollama + another provider configured simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)