### PR TITLE
fix(bitbucket): remove invalid links from Connect manifest

### DIFF
--- a/pr_agent/servers/atlassian-connect.json
+++ b/pr_agent/servers/atlassian-connect.json
@@ -30,9 +30,5 @@
         "url": "/webhook"
       }
     ]
-  },
-  "links": {
-    "privacy": "https://qodo.ai/privacy-policy",
-    "terms": "https://qodo.ai/terms"
   }
 }


### PR DESCRIPTION
## Problem

Installing PR-Agent as a Bitbucket Cloud Connect app fails with:

```
The add-on server returned invalid data.
Invalid JSON: Additional properties are not allowed ('terms', 'privacy' were unexpected) at links
```

The `links` object in `atlassian-connect.json` contains `privacy` and `terms` properties, but the [Bitbucket Cloud Connect app descriptor schema](https://developer.atlassian.com/cloud/bitbucket/app-descriptor/) does not allow these properties under `links`.

## Fix

Remove the `links` block from `atlassian-connect.json`. This is a 4-line deletion with no behavioral change -- the app works identically, it just passes Bitbucket's manifest validation.

## How to reproduce

1. Deploy PR-Agent with `bitbucket_app` target, setting `BITBUCKET.APP_KEY` and `BITBUCKET.BASE_URL`
2. Go to Bitbucket workspace settings > Manage apps > Install app from URL
3. Paste the app descriptor URL
4. Observe the error above

## Testing

After this fix, the same installation flow succeeds and PR-Agent registers as a workspace-level Connect app.