### PR TITLE
Fix/litellm custom provider override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .venv/
 venv/
 pr_agent/settings/.secrets.toml
+pr_agent/settings_prod/.secrets.toml
 __pycache__
 dist/
 *.egg-info/

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -449,9 +449,15 @@ class LiteLLMAIHandler(BaseAiHandler):
         custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
         api_base_value = kwargs.get("api_base")
         api_base = kwargs.get("api_base").strip().lower() if isinstance(api_base_value, str) else ""
+        force_streaming_provider = str(get_settings().get("LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER", "") or "").strip().lower()
+        force_streaming_api_base_substrings = [
+            str(value).strip().lower()
+            for value in (get_settings().get("LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS", []) or [])
+            if str(value).strip()
+        ]
         force_streaming = (
-            custom_llm_provider == "openai"
-            and "snowflakecomputing.com" in api_base
+            custom_llm_provider == force_streaming_provider
+            and any(substring in api_base for substring in force_streaming_api_base_substrings)
         )
 
         # Some OpenAI-compatible endpoints can return an empty-string

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -446,8 +446,9 @@ class LiteLLMAIHandler(BaseAiHandler):
         Wrapper that automatically handles streaming for required models.
         """
         model = kwargs["model"]
-        custom_llm_provider = kwargs.get("custom_llm_provider")
-        api_base = (kwargs.get("api_base") or "").lower()
+        custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
+        api_base_value = kwargs.get("api_base")
+        api_base = kwargs.get("api_base").strip().lower() if isinstance(api_base_value, str) else ""
         force_streaming = (
             custom_llm_provider == "openai"
             and "snowflakecomputing.com" in api_base

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -395,7 +395,9 @@ class LiteLLMAIHandler(BaseAiHandler):
             # Support for custom OpenAI body fields (e.g., Flex Processing)
             kwargs = _process_litellm_extra_body(kwargs)
 
-            custom_llm_provider = get_settings().get("LITELLM.CUSTOM_LLM_PROVIDER", None)
+            custom_llm_provider = str(
+                get_settings().get("LITELLM.CUSTOM_LLM_PROVIDER", "") or ""
+            ).strip().lower()
             if custom_llm_provider:
                 kwargs["custom_llm_provider"] = custom_llm_provider
 
@@ -476,7 +478,10 @@ class LiteLLMAIHandler(BaseAiHandler):
         if model in self.streaming_required_models or force_streaming:
             kwargs["stream"] = True
             if force_streaming and model not in self.streaming_required_models:
-                get_logger().info(f"Using streaming mode for model {model} due to OpenAI-compatible endpoint compatibility")
+                get_logger().info(
+                    f"Using streaming mode for model {model} "
+                    "due to OpenAI-compatible endpoint compatibility"
+                )
             else:
                 get_logger().info(f"Using streaming mode for model {model}")
             response = await acompletion(**kwargs)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -395,6 +395,10 @@ class LiteLLMAIHandler(BaseAiHandler):
             # Support for custom OpenAI body fields (e.g., Flex Processing)
             kwargs = _process_litellm_extra_body(kwargs)
 
+            custom_llm_provider = get_settings().get("LITELLM.CUSTOM_LLM_PROVIDER", None)
+            if custom_llm_provider:
+                kwargs["custom_llm_provider"] = custom_llm_provider
+
             # Support for Bedrock custom inference profile via model_id
             model_id = get_settings().get("litellm.model_id")
             if model_id and 'bedrock/' in model:

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -396,7 +396,7 @@ class LiteLLMAIHandler(BaseAiHandler):
             kwargs = _process_litellm_extra_body(kwargs)
 
             custom_llm_provider = str(
-                get_settings().get("LITELLM.CUSTOM_LLM_PROVIDER", "") or ""
+                get_settings().get("litellm.custom_llm_provider", "") or ""
             ).strip().lower()
             if custom_llm_provider:
                 kwargs["custom_llm_provider"] = custom_llm_provider
@@ -452,10 +452,10 @@ class LiteLLMAIHandler(BaseAiHandler):
         api_base_value = kwargs.get("api_base")
         api_base = kwargs.get("api_base").strip().lower() if isinstance(api_base_value, str) else ""
         force_streaming_provider = str(
-            get_settings().get("LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER", "") or ""
+            get_settings().get("litellm.force_streaming_custom_llm_provider", "") or ""
         ).strip().lower()
         raw_force_streaming_api_base_substrings = get_settings().get(
-            "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS", []
+            "litellm.force_streaming_api_base_substrings", []
         )
         if isinstance(raw_force_streaming_api_base_substrings, (list, tuple, set)):
             force_streaming_api_base_substrings = [
@@ -466,7 +466,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         else:
             if raw_force_streaming_api_base_substrings:
                 get_logger().warning(
-                    "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS must be a list, tuple, or set."
+                    "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS must be a list, tuple, or set. "
                     "Ignoring invalid value."
                 )
             force_streaming_api_base_substrings = []

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -464,6 +464,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                 if str(value).strip()
             ]
         else:
+            if raw_force_streaming_api_base_substrings:
+                get_logger().warning(
+                    "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS must be a list, tuple, or set."
+                    "Ignoring invalid value."
+                )
             force_streaming_api_base_substrings = []
         force_streaming = (
             bool(force_streaming_provider)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -446,9 +446,22 @@ class LiteLLMAIHandler(BaseAiHandler):
         Wrapper that automatically handles streaming for required models.
         """
         model = kwargs["model"]
-        if model in self.streaming_required_models:
+        custom_llm_provider = kwargs.get("custom_llm_provider")
+        api_base = (kwargs.get("api_base") or "").lower()
+        force_streaming = (
+            custom_llm_provider == "openai"
+            and "snowflakecomputing.com" in api_base
+        )
+
+        # Some OpenAI-compatible endpoints can return an empty-string
+        # finish_reason on non-streaming responses, which LiteLLM rejects during
+        # response normalization. Streaming avoids that conversion path.
+        if model in self.streaming_required_models or force_streaming:
             kwargs["stream"] = True
-            get_logger().info(f"Using streaming mode for model {model}")
+            if force_streaming and model not in self.streaming_required_models:
+                get_logger().info(f"Using streaming mode for model {model} due to OpenAI-compatible endpoint compatibility")
+            else:
+                get_logger().info(f"Using streaming mode for model {model}")
             response = await acompletion(**kwargs)
             resp, finish_reason = await _handle_streaming_response(response)
             # Create MockResponse for streaming since we don't have the full response object

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -449,14 +449,24 @@ class LiteLLMAIHandler(BaseAiHandler):
         custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
         api_base_value = kwargs.get("api_base")
         api_base = kwargs.get("api_base").strip().lower() if isinstance(api_base_value, str) else ""
-        force_streaming_provider = str(get_settings().get("LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER", "") or "").strip().lower()
-        force_streaming_api_base_substrings = [
-            str(value).strip().lower()
-            for value in (get_settings().get("LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS", []) or [])
-            if str(value).strip()
-        ]
+        force_streaming_provider = str(
+            get_settings().get("LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER", "") or ""
+        ).strip().lower()
+        raw_force_streaming_api_base_substrings = get_settings().get(
+            "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS", []
+        )
+        if isinstance(raw_force_streaming_api_base_substrings, (list, tuple, set)):
+            force_streaming_api_base_substrings = [
+                str(value).strip().lower()
+                for value in raw_force_streaming_api_base_substrings
+                if str(value).strip()
+            ]
+        else:
+            force_streaming_api_base_substrings = []
         force_streaming = (
-            custom_llm_provider == force_streaming_provider
+            bool(force_streaming_provider)
+            and custom_llm_provider == force_streaming_provider
+            and bool(force_streaming_api_base_substrings)
             and any(substring in api_base for substring in force_streaming_api_base_substrings)
         )
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -323,9 +323,6 @@ enable_callbacks = false
 success_callback = []
 failure_callback = []
 service_callback = []
-# custom_llm_provider = "" # Optional: Override LiteLLM provider inference for hosted OpenAI-compatible endpoints
-# force_streaming_custom_llm_provider = "openai" # Optional: provider value that enables forced streaming workaround
-# force_streaming_api_base_substrings = ["snowflakecomputing.com"] # Optional: api_base substrings that trigger forced streaming workaround
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [pr_similar_issue]

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -324,6 +324,8 @@ success_callback = []
 failure_callback = []
 service_callback = []
 # custom_llm_provider = "" # Optional: Override LiteLLM provider inference for hosted OpenAI-compatible endpoints
+force_streaming_custom_llm_provider = "openai"
+force_streaming_api_base_substrings = ["snowflakecomputing.com"]
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [pr_similar_issue]

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -323,6 +323,9 @@ enable_callbacks = false
 success_callback = []
 failure_callback = []
 service_callback = []
+custom_llm_provider = ""
+force_streaming_custom_llm_provider = ""
+force_streaming_api_base_substrings = []
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [pr_similar_issue]

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -323,6 +323,7 @@ enable_callbacks = false
 success_callback = []
 failure_callback = []
 service_callback = []
+# custom_llm_provider = "" # Optional: Override LiteLLM provider inference for hosted OpenAI-compatible endpoints
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [pr_similar_issue]

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -324,8 +324,8 @@ success_callback = []
 failure_callback = []
 service_callback = []
 # custom_llm_provider = "" # Optional: Override LiteLLM provider inference for hosted OpenAI-compatible endpoints
-force_streaming_custom_llm_provider = "openai"
-force_streaming_api_base_substrings = ["snowflakecomputing.com"]
+# force_streaming_custom_llm_provider = "openai" # Optional: provider value that enables forced streaming workaround
+# force_streaming_api_base_substrings = ["snowflakecomputing.com"] # Optional: api_base substrings that trigger forced streaming workaround
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [pr_similar_issue]

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -269,3 +269,35 @@ async def test_force_streaming_ignores_non_collection_substring_setting(monkeypa
 
         call_kwargs = mock_completion.call_args[1]
         assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_force_streaming_warns_on_invalid_substring_setting(monkeypatch):
+    fake_settings = create_mock_settings(
+        "openai",
+        force_streaming_custom_llm_provider="openai",
+        force_streaming_api_base_substrings="snowflakecomputing.com",
+    )
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with (
+        patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_completion,
+        patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_logger") as mock_logger,
+    ):
+        mock_completion.return_value = create_mock_acompletion_response()
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
+            custom_llm_provider="openai",
+        )
+
+        mock_logger.return_value.warning.assert_called_once_with(
+            "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS must be a list, tuple, or set. "
+            "Ignoring invalid value."
+        )

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -6,14 +6,25 @@ import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 
 
-def create_mock_settings(custom_llm_provider=None):
+def create_mock_settings(
+    custom_llm_provider=None,
+    force_streaming_custom_llm_provider="openai",
+    force_streaming_api_base_substrings=None,
+):
+    if force_streaming_api_base_substrings is None:
+        force_streaming_api_base_substrings = ["snowflakecomputing.com"]
+
     litellm_settings = type("", (), {"get": lambda self, key, default=None: default})()
     if custom_llm_provider is not None:
         litellm_settings.custom_llm_provider = custom_llm_provider
+    litellm_settings.force_streaming_custom_llm_provider = force_streaming_custom_llm_provider
+    litellm_settings.force_streaming_api_base_substrings = force_streaming_api_base_substrings
 
     def get_value(key, default=None):
         values = {
             "LITELLM.CUSTOM_LLM_PROVIDER": custom_llm_provider,
+            "LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER": force_streaming_custom_llm_provider,
+            "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS": force_streaming_api_base_substrings,
         }
         return values.get(key, default)
 
@@ -168,6 +179,34 @@ async def test_openai_compatible_endpoint_ignores_non_string_api_base(monkeypatc
             messages=[],
             timeout=120,
             api_base=123,
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_force_streaming_is_settings_driven(monkeypatch):
+    fake_settings = create_mock_settings(
+        "openai",
+        force_streaming_custom_llm_provider="openai",
+        force_streaming_api_base_substrings=["example-gateway.local"],
+    )
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
             custom_llm_provider="openai",
         )
 

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -23,8 +23,11 @@ def create_mock_settings(
     def get_value(key, default=None):
         values = {
             "LITELLM.CUSTOM_LLM_PROVIDER": custom_llm_provider,
+            "litellm.custom_llm_provider": custom_llm_provider,
             "LITELLM.FORCE_STREAMING_CUSTOM_LLM_PROVIDER": force_streaming_custom_llm_provider,
+            "litellm.force_streaming_custom_llm_provider": force_streaming_custom_llm_provider,
             "LITELLM.FORCE_STREAMING_API_BASE_SUBSTRINGS": force_streaming_api_base_substrings,
+            "litellm.force_streaming_api_base_substrings": force_streaming_api_base_substrings,
         }
         return values.get(key, default)
 

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+
+
+def create_mock_settings(custom_llm_provider=None):
+    litellm_settings = type("", (), {"get": lambda self, key, default=None: default})()
+    if custom_llm_provider is not None:
+        litellm_settings.custom_llm_provider = custom_llm_provider
+
+    def get_value(key, default=None):
+        values = {
+            "LITELLM.CUSTOM_LLM_PROVIDER": custom_llm_provider,
+        }
+        return values.get(key, default)
+
+    return type("", (), {
+        "config": type("", (), {
+            "ai_timeout": 120,
+            "custom_reasoning_model": False,
+            "verbosity_level": 0,
+            "get": lambda self, key, default=None: default,
+        })(),
+        "litellm": litellm_settings,
+        "get": staticmethod(get_value),
+    })()
+
+
+def create_mock_acompletion_response():
+    mock_response = MagicMock()
+    mock_response.__getitem__ = lambda self, key: {
+        "choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]
+    }[key]
+    mock_response.dict.return_value = {"choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]}
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_custom_llm_provider_is_forwarded_without_rewriting_model(monkeypatch):
+    fake_settings = create_mock_settings("openai")
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler.chat_completion(
+            model="claude-sonnet-4-5",
+            system="test system",
+            user="test user",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-5"
+        assert call_kwargs["custom_llm_provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_custom_llm_provider_is_omitted_when_unset(monkeypatch):
+    fake_settings = create_mock_settings()
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler.chat_completion(
+            model="claude-sonnet-4-5",
+            system="test system",
+            user="test user",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "custom_llm_provider" not in call_kwargs

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -212,3 +212,59 @@ async def test_force_streaming_is_settings_driven(monkeypatch):
 
         call_kwargs = mock_completion.call_args[1]
         assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_force_streaming_requires_non_empty_provider_setting(monkeypatch):
+    fake_settings = create_mock_settings(
+        "openai",
+        force_streaming_custom_llm_provider="",
+        force_streaming_api_base_substrings=["snowflakecomputing.com"],
+    )
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
+            custom_llm_provider="",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "stream" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_force_streaming_ignores_non_collection_substring_setting(monkeypatch):
+    fake_settings = create_mock_settings(
+        "openai",
+        force_streaming_custom_llm_provider="openai",
+        force_streaming_api_base_substrings="snowflakecomputing.com",
+    )
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "stream" not in call_kwargs

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -17,16 +17,24 @@ def create_mock_settings(custom_llm_provider=None):
         }
         return values.get(key, default)
 
-    return type("", (), {
-        "config": type("", (), {
-            "ai_timeout": 120,
-            "custom_reasoning_model": False,
-            "verbosity_level": 0,
-            "get": lambda self, key, default=None: default,
-        })(),
-        "litellm": litellm_settings,
-        "get": staticmethod(get_value),
-    })()
+    return type(
+        "",
+        (),
+        {
+            "config": type(
+                "",
+                (),
+                {
+                    "ai_timeout": 120,
+                    "custom_reasoning_model": False,
+                    "verbosity_level": 0,
+                    "get": lambda self, key, default=None: default,
+                },
+            )(),
+            "litellm": litellm_settings,
+            "get": staticmethod(get_value),
+        },
+    )()
 
 
 def create_mock_acompletion_response():
@@ -34,7 +42,9 @@ def create_mock_acompletion_response():
     mock_response.__getitem__ = lambda self, key: {
         "choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]
     }[key]
-    mock_response.dict.return_value = {"choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]}
+    mock_response.dict.return_value = {
+        "choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]
+    }
     return mock_response
 
 
@@ -43,7 +53,10 @@ async def test_custom_llm_provider_is_forwarded_without_rewriting_model(monkeypa
     fake_settings = create_mock_settings("openai")
     monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
 
-    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_completion:
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
         mock_completion.return_value = create_mock_acompletion_response()
 
         handler = LiteLLMAIHandler()
@@ -63,7 +76,10 @@ async def test_custom_llm_provider_is_omitted_when_unset(monkeypatch):
     fake_settings = create_mock_settings()
     monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
 
-    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_completion:
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
         mock_completion.return_value = create_mock_acompletion_response()
 
         handler = LiteLLMAIHandler()
@@ -75,3 +91,32 @@ async def test_custom_llm_provider_is_omitted_when_unset(monkeypatch):
 
         call_kwargs = mock_completion.call_args[1]
         assert "custom_llm_provider" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_endpoint_calls_force_streaming(monkeypatch):
+    fake_settings = create_mock_settings("openai")
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with (
+        patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_completion,
+        patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler._handle_streaming_response",
+            new_callable=AsyncMock,
+        ) as mock_stream_handler,
+    ):
+        mock_stream_handler.return_value = ("test", "stop")
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["stream"] is True

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -49,19 +49,20 @@ def create_mock_settings(
 
 
 def create_mock_acompletion_response():
-    mock_response = MagicMock()
-    mock_response.__getitem__ = lambda self, key: {
-        "choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]
-    }[key]
-    mock_response.dict.return_value = {
+    response_payload = {
         "choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]
     }
-    return mock_response
+
+    class MockCompletionResponse(dict):
+        def dict(self):
+            return dict(self)
+
+    return MockCompletionResponse(response_payload)
 
 
 @pytest.mark.asyncio
 async def test_custom_llm_provider_is_forwarded_without_rewriting_model(monkeypatch):
-    fake_settings = create_mock_settings("openai")
+    fake_settings = create_mock_settings(" OpenAI ")
     monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
 
     with patch(

--- a/tests/unittest/test_litellm_custom_provider.py
+++ b/tests/unittest/test_litellm_custom_provider.py
@@ -120,3 +120,56 @@ async def test_openai_compatible_endpoint_calls_force_streaming(monkeypatch):
 
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_endpoint_normalizes_custom_provider_for_streaming(monkeypatch):
+    fake_settings = create_mock_settings(" OpenAI ")
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with (
+        patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_completion,
+        patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler._handle_streaming_response",
+            new_callable=AsyncMock,
+        ) as mock_stream_handler,
+    ):
+        mock_stream_handler.return_value = ("test", "stop")
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base="https://example-account.snowflakecomputing.com/api/v2/cortex/v1",
+            custom_llm_provider=" OpenAI ",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_endpoint_ignores_non_string_api_base(monkeypatch):
+    fake_settings = create_mock_settings("openai")
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as mock_completion:
+        mock_completion.return_value = create_mock_acompletion_response()
+
+        handler = LiteLLMAIHandler()
+        await handler._get_completion(
+            model="claude-sonnet-4-5",
+            messages=[],
+            timeout=120,
+            api_base=123,
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert "stream" not in call_kwargs


### PR DESCRIPTION
This came out of trying to run PR-Agent against Snowflake Cortex through its OpenAI-compatible API.

The main change is adding support for `LITELLM__CUSTOM_LLM_PROVIDER`, so PR-Agent can keep raw hosted model IDs like `claude-sonnet-4-5` while still telling LiteLLM which provider path to use.

I also added a small Snowflake-specific streaming workaround. In my testing, non-streaming responses on the Cortex OpenAI-compatible endpoint could trip LiteLLM response normalization, so forcing streaming for that path avoids the failure.