### PR TITLE
fix: per-request settings clone in bitbucket-server & azuredevops webhooks (#2345)

### DIFF
--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -2,6 +2,7 @@
 # The server listens for incoming webhooks from Azure DevOps Server and forwards them to the PR Agent.
 # ADO webhook documentation: https://learn.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops
 
+import copy
 import json
 import os
 import re
@@ -17,11 +18,12 @@ from starlette.background import BackgroundTasks
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.agent.pr_agent import PRAgent, command2class
 from pr_agent.algo.utils import update_settings_from_args
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.git_providers.utils import apply_repo_settings
@@ -58,7 +60,7 @@ def handle_line_comment(body: str, thread_id: int, provider: AzureDevopsProvider
     thread_context = provider.get_thread_context(thread_id)
     if not thread_context:
         return body
-    
+
     path = thread_context.file_path
     if thread_context.left_file_end or thread_context.left_file_start:
         start_line = thread_context.left_file_start.line
@@ -71,7 +73,7 @@ def handle_line_comment(body: str, thread_id: int, provider: AzureDevopsProvider
     else:
         get_logger().info("No line range found in thread context", artifact={"thread_context": thread_context})
         return body
-    
+
     question = body[5:].lstrip() # remove 4 chars: '/ask '
     return f"/ask_line --line_start={start_line} --line_end={end_line} --side={side} --file_name={path} --comment_id={thread_id} {question}"
 
@@ -80,7 +82,7 @@ def handle_line_comment(body: str, thread_id: int, provider: AzureDevopsProvider
 def authorize(credentials: HTTPBasicCredentials = Depends(security)):
     if WEBHOOK_USERNAME is None or WEBHOOK_PASSWORD is None:
         return
-    
+
     is_user_ok = secrets.compare_digest(credentials.username, WEBHOOK_USERNAME)
     is_pass_ok = secrets.compare_digest(credentials.password, WEBHOOK_PASSWORD)
     if not (is_user_ok and is_pass_ok):
@@ -172,6 +174,7 @@ async def handle_request_azure(data, log_context):
 async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
     log_context = {"server_type": "azure_devops_server"}
     data = await request.json()
+    context["settings"] = copy.deepcopy(global_settings)
     # get_logger().info(json.dumps(data))
 
     background_tasks.add_task(handle_request_azure, data, log_context)

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import json
 import os
 import re
@@ -13,11 +14,12 @@ from starlette.background import BackgroundTasks
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.utils import update_settings_from_args
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.servers.utils import verify_signature
@@ -45,22 +47,22 @@ def should_process_pr_logic(data) -> bool:
     try:
         pr_data = data.get("pullRequest", {})
         title = pr_data.get("title", "")
-        
+
         from_ref = pr_data.get("fromRef", {})
         source_branch = from_ref.get("displayId", "") if from_ref else ""
-        
+
         to_ref = pr_data.get("toRef", {})
         target_branch = to_ref.get("displayId", "") if to_ref else ""
-        
+
         author = pr_data.get("author", {})
         user = author.get("user", {}) if author else {}
         sender = user.get("name", "") if user else ""
-        
+
         repository = to_ref.get("repository", {}) if to_ref else {}
         project = repository.get("project", {}) if repository else {}
         project_key = project.get("key", "") if project else ""
         repo_slug = repository.get("slug", "") if repository else ""
-        
+
         repo_full_name = f"{project_key}/{repo_slug}" if project_key and repo_slug else ""
         pr_id = pr_data.get("id", None)
 
@@ -102,7 +104,8 @@ def should_process_pr_logic(data) -> bool:
         # Allow_only_specific_folders
         allowed_folders = get_settings().config.get("allow_only_specific_folders", [])
         if allowed_folders and pr_id and project_key and repo_slug:
-            from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
+            from pr_agent.git_providers.bitbucket_server_provider import \
+                BitbucketServerProvider
             bitbucket_server_url = get_settings().get("BITBUCKET_SERVER.URL", "")
             pr_url = f"{bitbucket_server_url}/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}"
             provider = BitbucketServerProvider(pr_url=pr_url)
@@ -114,7 +117,7 @@ def should_process_pr_logic(data) -> bool:
                     if any(file_path.startswith(folder) for folder in allowed_folders):
                         all_files_outside = False
                         break
-                
+
                 if all_files_outside:
                     get_logger().info(f"Ignoring PR because all files {changed_files} are outside allowed folders {allowed_folders}")
                     return False
@@ -131,6 +134,7 @@ async def redirect_to_webhook():
 async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
     log_context = {"server_type": "bitbucket_server"}
     data = await request.json()
+    context["settings"] = copy.deepcopy(global_settings)
     get_logger().info(json.dumps(data))
 
     webhook_secret = get_settings().get("BITBUCKET_SERVER.WEBHOOK_SECRET", None)

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -134,7 +134,6 @@ async def redirect_to_webhook():
 async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
     log_context = {"server_type": "bitbucket_server"}
     data = await request.json()
-    context["settings"] = copy.deepcopy(global_settings)
     get_logger().info(json.dumps(data))
 
     webhook_secret = get_settings().get("BITBUCKET_SERVER.WEBHOOK_SECRET", None)
@@ -146,6 +145,11 @@ async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
             )
         signature_header = request.headers.get("x-hub-signature", None)
         verify_signature(body_bytes, webhook_secret, signature_header)
+
+    # Install a per-request settings clone only after auth/connection-test checks, so
+    # rejected traffic doesn't pay the deepcopy cost. Must precede apply_repo_settings(),
+    # which mutates get_settings() (context["settings"] when present).
+    context["settings"] = copy.deepcopy(global_settings)
 
     pr_id = data["pullRequest"]["id"]
     repository_name = data["pullRequest"]["toRef"]["repository"]["slug"]

--- a/tests/unittest/test_apply_repo_settings.py
+++ b/tests/unittest/test_apply_repo_settings.py
@@ -1,0 +1,121 @@
+import copy
+
+import pytest
+from starlette_context import context, request_cycle_context
+
+from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.git_providers import utils as git_utils
+
+REPO_A_TOML = b"""
+[pr_reviewer]
+extra_instructions = "MARKER-FROM-REPO-A"
+
+[pr_code_suggestions]
+extra_instructions = "MARKER-FROM-REPO-A"
+"""
+
+
+class FakeGitProvider:
+    def __init__(self, repo_settings: bytes):
+        self._repo_settings = repo_settings
+
+    def get_repo_settings(self):
+        return self._repo_settings
+
+    def is_supported(self, feature):
+        return False
+
+    def publish_comment(self, body):
+        pass
+
+    def publish_persistent_comment(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def fresh_global_settings():
+    """Restore module-level global_settings after each test in case anything mutated it."""
+    snapshot = copy.deepcopy(global_settings.as_dict())
+    yield
+    for section in set(global_settings.as_dict().keys()) - set(snapshot.keys()):
+        global_settings.unset(section)
+    for section, contents in snapshot.items():
+        global_settings.unset(section)
+        global_settings.set(section, copy.deepcopy(contents), merge=False)
+
+
+def _extra_instructions(section: str) -> str:
+    return get_settings().get(f"{section}.extra_instructions", "") or ""
+
+
+class TestApplyRepoSettings:
+    """Verify that the per-request settings clone (set by webhook handlers via
+    `context['settings'] = copy.deepcopy(global_settings)`) successfully
+    isolates `apply_repo_settings()` mutations to the request that produced
+    them — preventing cross-repo `.pr_agent.toml` state leaks reported in #2345.
+    """
+
+    def test_repo_settings_from_toml_are_applied(self, fresh_global_settings, monkeypatch):
+        monkeypatch.setattr(
+            "pr_agent.git_providers.utils.get_git_provider_with_context",
+            lambda url: FakeGitProvider(REPO_A_TOML),
+        )
+        with request_cycle_context({}):
+            context["settings"] = copy.deepcopy(global_settings)
+            git_utils.apply_repo_settings("https://git.example/projects/A/repos/a/pull-requests/1")
+            assert "MARKER-FROM-REPO-A" in _extra_instructions("pr_reviewer")
+            assert "MARKER-FROM-REPO-A" in _extra_instructions("pr_code_suggestions")
+
+    def test_repo_without_toml_does_not_inherit_previous_repo_settings(
+        self, fresh_global_settings, monkeypatch
+    ):
+        # Request 1: Repo A with .pr_agent.toml — mutates only this request's settings clone.
+        monkeypatch.setattr(
+            "pr_agent.git_providers.utils.get_git_provider_with_context",
+            lambda url: FakeGitProvider(REPO_A_TOML),
+        )
+        with request_cycle_context({}):
+            context["settings"] = copy.deepcopy(global_settings)
+            git_utils.apply_repo_settings("https://git.example/projects/A/repos/a/pull-requests/1")
+            assert "MARKER-FROM-REPO-A" in _extra_instructions("pr_reviewer"), "precondition"
+
+        # Request 2: Repo B with no .pr_agent.toml — fresh clone of the unmutated global_settings.
+        monkeypatch.setattr(
+            "pr_agent.git_providers.utils.get_git_provider_with_context",
+            lambda url: FakeGitProvider(b""),
+        )
+        with request_cycle_context({}):
+            context["settings"] = copy.deepcopy(global_settings)
+            git_utils.apply_repo_settings("https://git.example/projects/B/repos/b/pull-requests/1")
+            assert "MARKER-FROM-REPO-A" not in _extra_instructions("pr_reviewer"), \
+                "repo A's [pr_reviewer].extra_instructions leaked into repo B"
+            assert "MARKER-FROM-REPO-A" not in _extra_instructions("pr_code_suggestions"), \
+                "repo A's [pr_code_suggestions].extra_instructions leaked into repo B"
+
+    def test_unknown_section_does_not_leak_to_next_repo(self, fresh_global_settings, monkeypatch):
+        """Catches the case where a repo's `.pr_agent.toml` introduces a section
+        name not present in the startup defaults. With the per-request clone,
+        the new section lives in `context['settings']` and dies with the request.
+        """
+        custom_section_toml = b"""
+[my_custom_repo_section]
+foo = "X-FROM-REPO-A"
+"""
+        monkeypatch.setattr(
+            "pr_agent.git_providers.utils.get_git_provider_with_context",
+            lambda url: FakeGitProvider(custom_section_toml),
+        )
+        with request_cycle_context({}):
+            context["settings"] = copy.deepcopy(global_settings)
+            git_utils.apply_repo_settings("https://git.example/projects/A/repos/a/pull-requests/1")
+            assert get_settings().get("my_custom_repo_section.foo") == "X-FROM-REPO-A", "precondition"
+
+        monkeypatch.setattr(
+            "pr_agent.git_providers.utils.get_git_provider_with_context",
+            lambda url: FakeGitProvider(b""),
+        )
+        with request_cycle_context({}):
+            context["settings"] = copy.deepcopy(global_settings)
+            git_utils.apply_repo_settings("https://git.example/projects/B/repos/b/pull-requests/1")
+            assert get_settings().get("my_custom_repo_section.foo") is None, \
+                "repo A's [my_custom_repo_section] leaked into repo B"


### PR DESCRIPTION
### **User description**
## Summary

Fixes #2345 — `apply_repo_settings()` leaking `.pr_agent.toml` state across PRs from different repositories.

## Root cause

`global_settings` is a module-level Dynaconf singleton. `apply_repo_settings()` mutates it without resetting between requests, so settings loaded for one repo persist into subsequent reviews of unrelated repos in the same long-lived webhook process.

## Fix

5 of 7 webhook servers already isolate per-request settings with `context["settings"] = copy.deepcopy(global_settings)` (github_app, gitlab_webhook, gitea_app, bitbucket_app, gerrit_server). This PR aligns the last 2 (`bitbucket_server_webhook`, `azuredevops_server_webhook`) with that existing pattern. `get_settings()` already prefers `context["settings"]` over `global_settings`, so the per-request clone is sufficient.

## Tests

`tests/unittest/test_apply_repo_settings.py` covers:
- Repo settings get applied within a request
- Repo A's `[pr_reviewer]` extra_instructions don't leak into a subsequent Repo B request that has no `.pr_agent.toml`
- Repo A's *unknown* section (e.g. `[my_custom_repo_section]`) doesn't leak either

## Test plan

- [x] `PYTHONPATH=. .venv/bin/pytest tests/unittest/test_apply_repo_settings.py -v` (3 passed)
- [x] `PYTHONPATH=. .venv/bin/pytest tests/unittest -q` (297 passed, no regressions)
- [x] `pre-commit run --files <changed>` (clean)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `.pr_agent.toml` state leaking across PRs from different repositories

- Add `context["settings"] = copy.deepcopy(global_settings)` per-request isolation to `bitbucket_server_webhook` and `azuredevops_server_webhook` handlers

- Add regression tests covering settings isolation, unknown section leaks, and TOML application

- Minor whitespace/formatting cleanup in both webhook server files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming Webhook Request"]
  B["bitbucket_server_webhook\nhandle_webhook()"]
  C["azuredevops_server_webhook\nhandle_webhook()"]
  D["context['settings'] =\ncopy.deepcopy(global_settings)"]
  E["apply_repo_settings()\nmutates context['settings']"]
  F["global_settings\n(module-level singleton)\nremains clean"]
  G["Next request gets\nfresh settings clone"]

  A -- "POST /webhook" --> B
  A -- "POST /" --> C
  B -- "per-request clone" --> D
  C -- "per-request clone" --> D
  D -- "isolated mutation" --> E
  F -- "deep copy source" --> D
  E -- "request ends" --> F
  F -- "next request" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_server_webhook.py</strong><dd><code>Add per-request settings clone to Azure DevOps webhook handler</code></dd></summary>
<hr>

pr_agent/servers/azuredevops_server_webhook.py

<ul><li>Added <code>import copy</code> and imported <code>context</code> from <code>starlette_context</code> and <br><code>global_settings</code> from <code>config_loader</code><br> <li> Added <code>context["settings"] = copy.deepcopy(global_settings)</code> at the <br>start of <code>handle_webhook()</code> to isolate per-request settings<br> <li> Minor whitespace cleanup (trailing spaces removed in several <br>functions)</ul>


</details>


  </td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2351/files#diff-4525cb1c9c5ffe691dee1db5501c614ab50388fdf711220ee18db18cf64a7358">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_webhook.py</strong><dd><code>Add per-request settings clone to Bitbucket Server webhook handler</code></dd></summary>
<hr>

pr_agent/servers/bitbucket_server_webhook.py

<ul><li>Added <code>import copy</code> and imported <code>context</code> from <code>starlette_context</code> and <br><code>global_settings</code> from <code>config_loader</code><br> <li> Added <code>context["settings"] = copy.deepcopy(global_settings)</code> at the <br>start of <code>handle_webhook()</code> to isolate per-request settings<br> <li> Minor whitespace cleanup (trailing spaces removed in several <br>functions)<br> <li> Reformatted a long import line for <code>BitbucketServerProvider</code></ul>


</details>


  </td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2351/files#diff-ba0834fc2337468d35345ca206434bc48a0894426929d63be442d0793c5d84ba">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_apply_repo_settings.py</strong><dd><code>Add regression tests for cross-repo settings isolation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_apply_repo_settings.py

<ul><li>New test file with <code>FakeGitProvider</code> stub and <code>fresh_global_settings</code> <br>fixture<br> <li> <code>test_repo_settings_from_toml_are_applied</code>: verifies TOML settings are <br>applied within a request context<br> <li> <code>test_repo_without_toml_does_not_inherit_previous_repo_settings</code>: <br>verifies repo A's settings don't leak into repo B with no <br><code>.pr_agent.toml</code><br> <li> <code>test_unknown_section_does_not_leak_to_next_repo</code>: verifies <br>custom/unknown TOML sections don't persist across requests</ul>


</details>


  </td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2351/files#diff-bec29a8c02282f90551ff85d2d2711e41afa956b6d06260bd0f68f0bfc2ec929">+121/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

