### PR TITLE
Add OpenAI's GPT-5.5 model support

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -49,6 +49,8 @@ MAX_TOKENS = {
     'gpt-5.4-mini-2026-03-17': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.4-nano': 400000,  # 400K, but may be limited by config.max_model_tokens
     'gpt-5.4-nano-2026-03-17': 400000,  # 400K, but may be limited by config.max_model_tokens
+    'gpt-5.5': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
+    'gpt-5.5-2026-04-23': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
     'o1-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-mini-2024-09-12': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-preview': 128000,  # 128K, but may be limited by config.max_model_tokens

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -61,6 +61,19 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == 400000
 
+    @pytest.mark.parametrize("model", ["gpt-5.5", "gpt-5.5-2026-04-23"])
+    def test_gpt55_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1050000
+
     # Test situations where the model is not registered and exists as a custom model
     def test_model_has_custom(self, monkeypatch):
         fake_settings = type('', (), {

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -316,6 +316,8 @@ class TestLiteLLMReasoningEffort:
             "gpt-5.4-mini",
             "gpt-5.4-mini-2026-03-17",
             "gpt-5.4-2026-03-05",
+            "gpt-5.5",
+            "gpt-5.5-2026-04-23",
             "gpt-5-turbo",
             "gpt-5.1-codex",
             "gpt-5.3-codex",


### PR DESCRIPTION
Reference:
- https://platform.openai.com/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/models/gpt-5.5