### PR TITLE
ci(release): add release-drafter and automated publish workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,89 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - feature
+      - enhancement
+  - title: '🐛 Bug Fixes'
+    labels:
+      - bug
+      - 'Bug fix'
+      - 'Bug fix with tests'
+  - title: '⚡ Performance'
+    labels:
+      - performance
+  - title: '📚 Documentation'
+    labels:
+      - documentation
+      - 'Includes Documentation'
+  - title: '🧹 Maintenance'
+    labels:
+      - chore
+      - Refactoring
+      - Configuration
+      - 'Configuration changes'
+  - title: '⬆️ Dependencies'
+    labels:
+      - dependencies
+
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+change-title-escapes: '\<*_&'
+
+autolabeler:
+  - label: feature
+    title:
+      - '/^feat(\(.+\))?!?:/i'
+  - label: bug
+    title:
+      - '/^fix(\(.+\))?!?:/i'
+  - label: documentation
+    title:
+      - '/^docs(\(.+\))?!?:/i'
+  - label: performance
+    title:
+      - '/^perf(\(.+\))?!?:/i'
+  - label: Refactoring
+    title:
+      - '/^refactor(\(.+\))?!?:/i'
+  - label: chore
+    title:
+      - '/^chore(\(.+\))?!?:/i'
+  - label: dependencies
+    title:
+      - '/^build\(deps/i'
+      - '/^deps(\(.+\))?!?:/i'
+  - label: breaking
+    title:
+      - '/^[a-z]+(\(.+\))?!:/i'
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feature
+      - enhancement
+  patch:
+    labels:
+      - bug
+      - 'Bug fix'
+      - 'Bug fix with tests'
+      - documentation
+      - 'Includes Documentation'
+      - chore
+      - Refactoring
+      - Configuration
+      - 'Configuration changes'
+      - performance
+      - dependencies
+  default: patch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,10 @@ on:
 permissions:
   contents: read
 
+# Normalize the concurrency key so a release event (tag `v0.3.2`) and a
+# workflow_dispatch (input `0.3.2`) for the same version can never overlap.
 concurrency:
-  group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+  group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || format('v{0}', inputs.version) }}
   cancel-in-progress: false
 
 jobs:
@@ -36,8 +38,10 @@ jobs:
             VERSION="${{ inputs.version }}"
             TAG="v${VERSION}"
           fi
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.+-]+)?$'; then
-            echo "::error::Version '$VERSION' is not a valid semver string."
+          # Strict SemVer 2.0.0 regex (https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
+          SEMVER='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          if ! printf '%s' "$VERSION" | grep -Pq "$SEMVER"; then
+            echo "::error::Version '$VERSION' is not a valid SemVer 2.0.0 string."
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -49,11 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ needs.prepare.outputs.sha }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 
@@ -62,14 +66,23 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           python - <<'PY'
-          import os, re, pathlib
+          import os
+          import pathlib
+          import re
+
           version = os.environ["VERSION"]
-          p = pathlib.Path("pyproject.toml")
-          text = p.read_text()
-          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
-          if n != 1:
-              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
-          p.write_text(new_text)
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'^version = "[^"]+"',
+              f'version = "{version}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
+          path.write_text(new_text)
           print(f"Set pyproject.toml version to {version}")
           PY
 
@@ -78,7 +91,7 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -135,11 +148,11 @@ jobs:
             suffix: gitlab_lambda
             rolling: gitlab_lambda
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ needs.prepare.outputs.sha }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 
@@ -148,19 +161,28 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           python - <<'PY'
-          import os, re, pathlib
+          import os
+          import pathlib
+          import re
+
           version = os.environ["VERSION"]
-          p = pathlib.Path("pyproject.toml")
-          text = p.read_text()
-          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
-          if n != 1:
-              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
-          p.write_text(new_text)
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'^version = "[^"]+"',
+              f'version = "{version}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
+          path.write_text(new_text)
           PY
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -181,7 +203,7 @@ jobs:
           fi
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -198,11 +220,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
 
       - name: Configure git identity
         run: |
@@ -214,14 +240,23 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           python - <<'PY'
-          import os, re, pathlib
+          import os
+          import pathlib
+          import re
+
           version = os.environ["VERSION"]
-          p = pathlib.Path("pyproject.toml")
-          text = p.read_text()
-          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
-          if n != 1:
-              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
-          p.write_text(new_text)
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'^version = "[^"]+"',
+              f'version = "{version}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
+          path.write_text(new_text)
           PY
 
       - name: Commit & push bump
@@ -258,11 +293,17 @@ jobs:
             gh release create "$TAG" --target "$SHA" --title "$TAG" --generate-notes
           fi
 
+      # Tag move runs after PyPI/Docker have already published. We don't want a
+      # tag-protection failure or transient push error to fail the workflow at
+      # this point — surface a warning so a maintainer can sync the tag manually.
       - name: Move release tag to bump commit (release event only)
         if: github.event_name == 'release' && steps.commit.outputs.bumped == 'true'
         env:
           TAG: ${{ needs.prepare.outputs.tag }}
           SHA: ${{ steps.commit.outputs.sha }}
         run: |
-          git tag -f "$TAG" "$SHA"
-          git push --force origin "refs/tags/$TAG"
+          if git tag -f "$TAG" "$SHA" && git push --force origin "refs/tags/$TAG"; then
+            echo "Moved tag $TAG to $SHA so it matches the published version."
+          else
+            echo "::warning::Failed to force-update tag $TAG to bump commit $SHA. PyPI and Docker artifacts are already published. The tag may be protected; align it manually with: git tag -f $TAG $SHA && git push --force origin refs/tags/$TAG"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,268 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.3.2). Will overwrite pyproject.toml on main.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve version
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            TAG="${GITHUB_REF_NAME}"
+          else
+            VERSION="${{ inputs.version }}"
+            TAG="v${VERSION}"
+          fi
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.+-]+)?$'; then
+            echo "::error::Version '$VERSION' is not a valid semver string."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  publish-pypi:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set version in pyproject.toml
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os, re, pathlib
+          version = os.environ["VERSION"]
+          p = pathlib.Path("pyproject.toml")
+          text = p.read_text()
+          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
+          if n != 1:
+              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
+          p.write_text(new_text)
+          print(f"Set pyproject.toml version to {version}")
+          PY
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-docker:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: docker/Dockerfile
+            target: cli
+            suffix: ''
+            rolling: latest
+          - dockerfile: docker/Dockerfile
+            target: github_app
+            suffix: github_app
+            rolling: ''
+          - dockerfile: docker/Dockerfile
+            target: bitbucket_app
+            suffix: bitbucket_app
+            rolling: ''
+          - dockerfile: docker/Dockerfile
+            target: bitbucket_server_webhook
+            suffix: bitbucket_server_webhook
+            rolling: bitbucket_server_webhook
+          - dockerfile: docker/Dockerfile
+            target: github_polling
+            suffix: github_polling
+            rolling: ''
+          - dockerfile: docker/Dockerfile
+            target: gitlab_webhook
+            suffix: gitlab_webhook
+            rolling: gitlab_webhook
+          - dockerfile: docker/Dockerfile
+            target: azure_devops_webhook
+            suffix: azure_devops_webhook
+            rolling: ''
+          - dockerfile: docker/Dockerfile
+            target: gitea_app
+            suffix: gitea_app
+            rolling: gitea_app
+          - dockerfile: Dockerfile.github_action
+            target: ''
+            suffix: github_action
+            rolling: github_action
+          - dockerfile: docker/Dockerfile.lambda
+            target: github_lambda
+            suffix: github_lambda
+            rolling: github_lambda
+          - dockerfile: docker/Dockerfile.lambda
+            target: gitlab_lambda
+            suffix: gitlab_lambda
+            rolling: gitlab_lambda
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set version in pyproject.toml
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os, re, pathlib
+          version = os.environ["VERSION"]
+          p = pathlib.Path("pyproject.toml")
+          text = p.read_text()
+          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
+          if n != 1:
+              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
+          p.write_text(new_text)
+          PY
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          V="${{ needs.prepare.outputs.version }}"
+          SUFFIX="${{ matrix.suffix }}"
+          ROLLING="${{ matrix.rolling }}"
+          if [ -z "$SUFFIX" ]; then
+            TAGS="codiumai/pr-agent:${V}"
+          else
+            TAGS="codiumai/pr-agent:${V}-${SUFFIX}"
+          fi
+          if [ -n "$ROLLING" ]; then
+            TAGS="${TAGS},codiumai/pr-agent:${ROLLING}"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.suffix || 'cli' }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.suffix || 'cli' }}
+
+  finalize:
+    needs: [prepare, publish-pypi, publish-docker]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump pyproject.toml on main
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os, re, pathlib
+          version = os.environ["VERSION"]
+          p = pathlib.Path("pyproject.toml")
+          text = p.read_text()
+          new_text, n = re.subn(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
+          if n != 1:
+              raise SystemExit("Could not locate `version = \"...\"` in pyproject.toml")
+          p.write_text(new_text)
+          PY
+
+      - name: Commit & push bump
+        id: commit
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          if git diff --quiet pyproject.toml; then
+            echo "pyproject.toml already at $VERSION on main; nothing to commit."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git add pyproject.toml
+          git commit -m "chore(release): bump version to $VERSION [skip ci]"
+          # Retry once on push race with main
+          if ! git push origin main; then
+            git pull --rebase origin main
+            git push origin main
+          fi
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and GitHub Release (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; not recreating."
+          else
+            gh release create "$TAG" --target "$SHA" --title "$TAG" --generate-notes
+          fi
+
+      - name: Move release tag to bump commit (release event only)
+        if: github.event_name == 'release' && steps.commit.outputs.bumped == 'true'
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          git tag -f "$TAG" "$SHA"
+          git push --force origin "refs/tags/$TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,16 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       sha: ${{ steps.resolve.outputs.sha }}
     steps:
+      # workflow_dispatch can be triggered from any branch in the UI, but the
+      # finalize job pushes the version bump to main and creates the tag. If
+      # we let it run from a non-main ref we'd publish artifacts from a commit
+      # that isn't on main and tag main with mismatched code.
+      - name: Reject workflow_dispatch from non-main ref
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::workflow_dispatch must be triggered from the main branch (got ${{ github.ref }})."
+          exit 1
+
       - name: Resolve version
         id: resolve
         run: |
@@ -62,29 +72,7 @@ jobs:
           python-version: '3.12'
 
       - name: Set version in pyproject.toml
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          python - <<'PY'
-          import os
-          import pathlib
-          import re
-
-          version = os.environ["VERSION"]
-          path = pathlib.Path("pyproject.toml")
-          text = path.read_text()
-          new_text, count = re.subn(
-              r'^version = "[^"]+"',
-              f'version = "{version}"',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if count != 1:
-              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
-          path.write_text(new_text)
-          print(f"Set pyproject.toml version to {version}")
-          PY
+        run: python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
 
       - name: Build distributions
         run: |
@@ -94,6 +82,10 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # Re-running the workflow for the same version (e.g. after a
+          # transient registry failure) should not fail because the wheel
+          # already exists on PyPI.
+          skip-existing: true
 
   publish-docker:
     needs: prepare
@@ -157,28 +149,7 @@ jobs:
           python-version: '3.12'
 
       - name: Set version in pyproject.toml
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          python - <<'PY'
-          import os
-          import pathlib
-          import re
-
-          version = os.environ["VERSION"]
-          path = pathlib.Path("pyproject.toml")
-          text = path.read_text()
-          new_text, count = re.subn(
-              r'^version = "[^"]+"',
-              f'version = "{version}"',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if count != 1:
-              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
-          path.write_text(new_text)
-          PY
+        run: python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
@@ -220,9 +191,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Check out the exact commit publish-pypi/publish-docker built from, so
+      # the bump commit's parent equals what was actually published. We push
+      # to main fast-forward only — if main has moved during the run, we skip
+      # the push (and the tag move below) rather than rebasing onto a newer
+      # commit that wasn't built. This preserves the invariant that
+      # `git checkout vX.Y.Z` resolves to a commit whose tree was published.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: main
+          ref: ${{ needs.prepare.outputs.sha }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -235,50 +212,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump pyproject.toml on main
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          python - <<'PY'
-          import os
-          import pathlib
-          import re
+      - name: Bump pyproject.toml
+        run: python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
 
-          version = os.environ["VERSION"]
-          path = pathlib.Path("pyproject.toml")
-          text = path.read_text()
-          new_text, count = re.subn(
-              r'^version = "[^"]+"',
-              f'version = "{version}"',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if count != 1:
-              raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
-          path.write_text(new_text)
-          PY
-
-      - name: Commit & push bump
+      - name: Commit & push bump (fast-forward only)
         id: commit
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          PUBLISHED_SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           if git diff --quiet pyproject.toml; then
-            echo "pyproject.toml already at $VERSION on main; nothing to commit."
+            echo "pyproject.toml already at $VERSION on $PUBLISHED_SHA; nothing to commit."
             echo "bumped=false" >> "$GITHUB_OUTPUT"
-            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            echo "sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git add pyproject.toml
           git commit -m "chore(release): bump version to $VERSION [skip ci]"
-          # Retry once on push race with main
-          if ! git push origin main; then
-            git pull --rebase origin main
-            git push origin main
+          if git push origin "HEAD:refs/heads/main"; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::main has moved past the published commit ($PUBLISHED_SHA); skipping bump push and tag-move so the tag continues to point at built artifacts. Bump pyproject.toml on main manually:  git checkout main && python scripts/set_pyproject_version.py $VERSION && git commit -am 'chore(release): bump version to $VERSION' && git push"
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            echo "sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
           fi
-          echo "bumped=true" >> "$GITHUB_OUTPUT"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create tag and GitHub Release (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 0.3.2). Will overwrite pyproject.toml on main.'
+        description: 'Version to publish (e.g., 0.35.0). Will overwrite pyproject.toml on main.'
         required: true
         type: string
 
 permissions:
   contents: read
 
-# Normalize the concurrency key so a release event (tag `v0.3.2`) and a
-# workflow_dispatch (input `0.3.2`) for the same version can never overlap.
+# Normalize the concurrency key so a release event (tag `v0.35.0`) and a
+# workflow_dispatch (input `0.35.0`) for the same version can never overlap.
 concurrency:
   group: publish-${{ github.event_name == 'release' && github.event.release.tag_name || format('v{0}', inputs.version) }}
   cancel-in-progress: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@67e173cadb2fbd3de94f4a861e0c48c913b462ae  # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/set_pyproject_version.py
+++ b/scripts/set_pyproject_version.py
@@ -1,0 +1,39 @@
+"""Set the project version in pyproject.toml.
+
+Used by the release workflow so each job can sync pyproject.toml to the
+target release version without duplicating the rewrite logic in YAML.
+
+Usage:
+    python scripts/set_pyproject_version.py 0.35.0
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: set_pyproject_version.py <version>")
+
+    version = sys.argv[1]
+    path = pathlib.Path("pyproject.toml")
+    text = path.read_text()
+    new_text, count = re.subn(
+        r'^version = "[^"]+"',
+        f'version = "{version}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise SystemExit('Could not locate `version = "..."` in pyproject.toml')
+
+    path.write_text(new_text)
+    print(f"Set pyproject.toml version to {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Sets up a two-workflow release pipeline for `pr-agent`. Today every release is manual; this PR makes them fully automated and reproducible.

### What ships

- **`.github/release-drafter.yml`** — categories, autolabeler, version-resolver. Categories map to existing repo labels (`feature`, `bug`, `documentation`, `performance`, `chore`, `Refactoring`, `Configuration`, `dependencies`, plus the project's `Bug fix` / `Bug fix with tests` / `Includes Documentation` / `Configuration changes` variants). Autolabeler uses regex on PR title prefixes per the project's Conventional Commits policy (`CONTRIBUTING.md:16`). Tag template is standard semver `v$RESOLVED_VERSION`.
- **`.github/workflows/release-drafter.yml`** — runs on `push: main` and `pull_request_target` (so labels apply to fork PRs). Updates the draft release on every merge.
- **`.github/workflows/publish.yml`** — triggered by `release: published` or `workflow_dispatch`. Validates the version, rewrites `pyproject.toml` in the runner, publishes to PyPI, builds and pushes 11 `codiumai/pr-agent:*` Docker tags, then commits the bump back to `main` and aligns the tag with the bump commit so `git checkout v0.3.2` matches what was published.

### Docker tags produced per release

Sourced from `RELEASE_NOTES.md`, `action.yaml`, and `docs/docs/installation/*.md`. Versioned tags (immutable per release) for: `cli`, `github_app`, `bitbucket_app`, `bitbucket_server_webhook`, `github_polling`, `gitlab_webhook`, `azure_devops_webhook`, `gitea_app`, `github_action`, `github_lambda`, `gitlab_lambda`. Rolling tags (overwritten each release) for the variants users `docker pull` unversioned in the docs — `latest`, `github_action` (critical, `action.yaml` resolves to this), `gitlab_webhook`, `bitbucket_server_webhook`, `gitea_app`, `github_lambda`, `gitlab_lambda`.

The `test` target in `docker/Dockerfile` is intentionally not published.

### Versioning

Going forward, releases use **standard semver** (`v0.3.2` tag, `pr-agent==0.3.2` on PyPI, `codiumai/pr-agent:0.3.2-<target>` on Docker Hub) — aligning the tag format with `pyproject.toml` and PyPI. Historical `v0.X` concatenated tags are left untouched.

### Maintainer flow

**Path A (primary) — publish a drafted release:**
1. PRs land on `main`; release-drafter keeps a draft updated.
2. Open the draft, confirm tag (e.g., `v0.3.2`), click **Publish release**.
3. Workflow runs: PyPI + 11 Docker tags + bump commit on `main` + tag aligned to the bump commit.

**Path B — manual dispatch:**
1. Run `Publish` workflow with `version=0.3.2`.
2. Same publish steps run, then `finalize` commits the bump, creates the tag, and creates the GitHub Release with auto-generated notes.

Re-runs are safe — both `pypa/gh-action-pypi-publish` and `docker/build-push-action` are idempotent for identical content, and the bump step no-ops if `pyproject.toml` is already at the target version.

### Required setup before the first publish

1. **GitHub Environment named `release`** (used by `publish-pypi`, `publish-docker`, and `finalize`). Add required-reviewer protection here if you want a manual approval gate.
2. **Secrets:**
   - `PYPI_API_TOKEN` — PyPI token scoped to the `pr-agent` project.
   - `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` — write access to `codiumai/pr-agent`.
   - `RELEASE_TOKEN` (optional) — fine-grained PAT with `contents: write` if `main` is branch-protected; the workflow falls back to `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}`.

## Test plan

- [ ] YAML lints clean for all three files (verified locally with `yaml.safe_load`).
- [ ] Every Dockerfile target referenced by the publish matrix exists (verified against `docker/Dockerfile`, `docker/Dockerfile.lambda`, and `Dockerfile.github_action`).
- [ ] After merge, open a PR and confirm release-drafter labels it from the title prefix and the draft release lists it under the right category.
- [ ] Configure the `release` Environment + secrets, then dispatch `Publish` with the current `pyproject.toml` version (`0.3.1`) as a smoke test — or temporarily flip `push: false` in the docker job to dry-run the matrix builds without publishing.
- [ ] After the first real release: `docker pull codiumai/pr-agent:github_action` and `pip install pr-agent==<version>` to confirm both endpoints are healthy.