### PR TITLE
ci(release): rename codiumai/pr-agent to pragent/pr-agent

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,7 +28,7 @@ jobs:
           file: ./docker/Dockerfile
           push: false
           load: true
-          tags: codiumai/pr-agent:test
+          tags: pragent/pr-agent:test
           cache-from: type=gha,scope=dev
           cache-to: type=gha,mode=max,scope=dev
           target: test
@@ -36,4 +36,4 @@ jobs:
       - id: test
         name: Test dev docker
         run: |
-          docker run --rm codiumai/pr-agent:test pytest -v tests/unittest
+          docker run --rm pragent/pr-agent:test pytest -v tests/unittest

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -29,7 +29,7 @@ jobs:
           file: ./docker/Dockerfile
           push: false
           load: true
-          tags: codiumai/pr-agent:test
+          tags: pragent/pr-agent:test
           cache-from: type=gha,scope=dev
           cache-to: type=gha,mode=max,scope=dev
           target: test
@@ -37,7 +37,7 @@ jobs:
       - id: code_cov
         name: Test dev docker
         run: |
-          docker run --name test_container codiumai/pr-agent:test  pytest  tests/unittest --cov=pr_agent --cov-report term --cov-report xml:coverage.xml
+          docker run --name test_container pragent/pr-agent:test  pytest  tests/unittest --cov=pr_agent --cov-report term --cov-report xml:coverage.xml
           docker cp test_container:/app/coverage.xml coverage.xml
           docker rm test_container
 

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -24,7 +24,7 @@ jobs:
           file: ./docker/Dockerfile
           push: false
           load: true
-          tags: codiumai/pr-agent:test
+          tags: pragent/pr-agent:test
           cache-from: type=gha,scope=dev
           cache-to: type=gha,mode=max,scope=dev
           target: test
@@ -32,14 +32,14 @@ jobs:
       - id: test1
         name: E2E test github app
         run: |
-          docker run -e GITHUB.USER_TOKEN=${{ secrets.TOKEN_GITHUB }} --rm codiumai/pr-agent:test pytest -v tests/e2e_tests/test_github_app.py
+          docker run -e GITHUB.USER_TOKEN=${{ secrets.TOKEN_GITHUB }} --rm pragent/pr-agent:test pytest -v tests/e2e_tests/test_github_app.py
 
       - id: test2
         name: E2E gitlab webhook
         run: |
-          docker run -e gitlab.PERSONAL_ACCESS_TOKEN=${{ secrets.TOKEN_GITLAB }} --rm codiumai/pr-agent:test pytest -v tests/e2e_tests/test_gitlab_webhook.py
+          docker run -e gitlab.PERSONAL_ACCESS_TOKEN=${{ secrets.TOKEN_GITLAB }} --rm pragent/pr-agent:test pytest -v tests/e2e_tests/test_gitlab_webhook.py
 
       - id: test3
         name: E2E bitbucket app
         run: |
-          docker run -e BITBUCKET.USERNAME=${{ secrets.BITBUCKET_USERNAME }}  -e BITBUCKET.PASSWORD=${{ secrets.BITBUCKET_PASSWORD }} --rm codiumai/pr-agent:test pytest -v tests/e2e_tests/test_bitbucket_app.py
+          docker run -e BITBUCKET.USERNAME=${{ secrets.BITBUCKET_USERNAME }}  -e BITBUCKET.PASSWORD=${{ secrets.BITBUCKET_PASSWORD }} --rm pragent/pr-agent:test pytest -v tests/e2e_tests/test_bitbucket_app.py

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ What else changed:
 
 ## Getting Started
 
+> [!NOTE]
+> **Docker Hub namespace migration.** Releases `0.34.2` and later are published under [`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). Older releases (up to and including `v0.31`) remain available at the legacy [`codiumai/pr-agent`](https://hub.docker.com/r/codiumai/pr-agent) namespace as a frozen archive — no new images are pushed there. Update any pinned `image:` / `docker pull` / `uses: docker://` references when upgrading to `0.34.2+`.
+
 ### 🚀 Quick Start for PR-Agent
 
 #### 1. GitHub Action (Recommended)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ For example, to github action:
 steps:
   - name: PR Agent action step
     id: pragent
-    uses: docker://codiumai/pr-agent:0.26-github_action
+    uses: docker://pragent/pr-agent:0.34.2-github_action
 ```
 
 #### Enhanced Security with Docker Digest
@@ -52,7 +52,7 @@ For maximum security, you can specify the Docker image using its digest:
 steps:
   - name: PR Agent action step
     id: pragent
-    uses: docker://codiumai/pr-agent@sha256:14165e525678ace7d9b51cda8652c2d74abb4e1d76b57c4a6ccaeba84663cc64
+    uses: docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c
 ```
 
 ## Reporting a Vulnerability

--- a/docs/docs/installation/azure.md
+++ b/docs/docs/installation/azure.md
@@ -28,7 +28,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     container:
-      image: codiumai/pr-agent:latest
+      image: pragent/pr-agent:latest
       options: --entrypoint ""
     variables:
       - group: pr_agent

--- a/docs/docs/installation/bitbucket.md
+++ b/docs/docs/installation/bitbucket.md
@@ -10,7 +10,7 @@ pipelines:
       '**':
         - step:
             name: PR Agent Review
-            image: codiumai/pr-agent:latest
+            image: pragent/pr-agent:latest
             script:
               - pr-agent --pr_url=https://bitbucket.org/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID review
 ```
@@ -67,8 +67,8 @@ python cli.py --pr_url https://git.on-prem-instance-of-bitbucket.com/projects/PR
 To run PR-Agent as webhook, build the docker image:
 
 ```bash
-docker build . -t codiumai/pr-agent:bitbucket_server_webhook --target bitbucket_server_webhook -f docker/Dockerfile
-docker push codiumai/pr-agent:bitbucket_server_webhook  # Push to your Docker repository
+docker build . -t pragent/pr-agent:bitbucket_server_webhook --target bitbucket_server_webhook -f docker/Dockerfile
+docker push pragent/pr-agent:bitbucket_server_webhook  # Push to your Docker repository
 ```
 
 Navigate to `Projects` or `Repositories`, `Settings`, `Webhooks`, `Create Webhook`.

--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -27,7 +27,7 @@ git clone https://github.com/the-pr-agent/pr-agent.git
 
 ```bash
 docker build -f /docker/Dockerfile -t pr-agent:gitea_app --target gitea_app .
-docker push codiumai/pr-agent:gitea_webhook  # Push to your Docker repository
+docker push pragent/pr-agent:gitea_webhook  # Push to your Docker repository
 ```
 
 7. Set the environmental variables, the method depends on your docker runtime. Skip this step if you included your secrets/configuration directly in the Docker image.

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -487,23 +487,23 @@ For more detailed configuration options, see:
 ### Using a specific release
 
 !!! tip ""
-    if you want to pin your action to a specific release (v0.23 for example) for stability reasons, use:
+    if you want to pin your action to a specific release (v0.34.2 for example) for stability reasons, use:
     ```yaml
     ...
         steps:
           - name: PR Agent action step
             id: pragent
-            uses: docker://codiumai/pr-agent:0.23-github_action
+            uses: docker://pragent/pr-agent:0.34.2-github_action
     ...
     ```
 
-    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/repository/docker/codiumai/pr-agent/tags):
+    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/repository/docker/pragent/pr-agent/tags):
     ```yaml
     ...
         steps:
           - name: PR Agent action step
             id: pragent
-            uses: docker://codiumai/pr-agent@sha256:14165e525678ace7d9b51cda8652c2d74abb4e1d76b57c4a6ccaeba84663cc64
+            uses: docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c
     ...
     ```
 
@@ -591,8 +591,8 @@ cp pr_agent/settings/.secrets_template.toml pr_agent/settings/.secrets.toml
 6) Build a Docker image for the app and optionally push it to a Docker repository. We'll use Dockerhub as an example:
 
     ```bash
-    docker build . -t codiumai/pr-agent:github_app --target github_app -f docker/Dockerfile
-    docker push codiumai/pr-agent:github_app  # Push to your Docker repository
+    docker build . -t pragent/pr-agent:github_app --target github_app -f docker/Dockerfile
+    docker push pragent/pr-agent:github_app  # Push to your Docker repository
     ```
 
 7. Host the app using a server, serverless function, or container environment. Alternatively, for development and
@@ -622,7 +622,7 @@ For example: `GITHUB.WEBHOOK_SECRET` --> `GITHUB__WEBHOOK_SECRET`
 2. Build a docker image that can be used as a lambda function
 
     ```shell
-    docker buildx build --platform=linux/amd64 . -t codiumai/pr-agent:github_lambda --target github_lambda -f docker/Dockerfile.lambda
+    docker buildx build --platform=linux/amd64 . -t pragent/pr-agent:github_lambda --target github_lambda -f docker/Dockerfile.lambda
    ```
    (Note: --target github_lambda is optional as it's the default target)
 
@@ -630,8 +630,8 @@ For example: `GITHUB.WEBHOOK_SECRET` --> `GITHUB__WEBHOOK_SECRET`
 3. Push image to ECR
 
     ```shell
-    docker tag codiumai/pr-agent:github_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/codiumai/pr-agent:github_lambda
-    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/codiumai/pr-agent:github_lambda
+    docker tag pragent/pr-agent:github_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:github_lambda
+    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:github_lambda
     ```
 
 4. Create a lambda function that uses the uploaded image. Set the lambda timeout to be at least 3m.

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -11,7 +11,7 @@ stages:
 pr_agent_job:
   stage: pr_agent
   image:
-    name: codiumai/pr-agent:latest
+    name: pragent/pr-agent:latest
     entrypoint: [""]
   script:
     - cd /app
@@ -76,7 +76,7 @@ git clone https://github.com/the-pr-agent/pr-agent.git
 
 ```bash
 docker build . -t gitlab_pr_agent --target gitlab_webhook -f docker/Dockerfile
-docker push codiumai/pr-agent:gitlab_webhook  # Push to your Docker repository
+docker push pragent/pr-agent:gitlab_webhook  # Push to your Docker repository
 ```
 
 7. Set the environmental variables, the method depends on your docker runtime. Skip this step if you included your secrets/configuration directly in the Docker image.
@@ -104,14 +104,14 @@ For example: `GITLAB.PERSONAL_ACCESS_TOKEN` --> `GITLAB__PERSONAL_ACCESS_TOKEN`
 2. Build a docker image that can be used as a lambda function
 
     ```shell
-    docker buildx build --platform=linux/amd64 . -t codiumai/pr-agent:gitlab_lambda --target gitlab_lambda -f docker/Dockerfile.lambda
+    docker buildx build --platform=linux/amd64 . -t pragent/pr-agent:gitlab_lambda --target gitlab_lambda -f docker/Dockerfile.lambda
    ```
 
 3. Push image to ECR
 
     ```shell
-    docker tag codiumai/pr-agent:gitlab_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/codiumai/pr-agent:gitlab_lambda
-    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/codiumai/pr-agent:gitlab_lambda
+    docker tag pragent/pr-agent:gitlab_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:gitlab_lambda
+    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:gitlab_lambda
     ```
 
 4. Create a lambda function that uses the uploaded image. Set the lambda timeout to be at least 3m.

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -8,3 +8,6 @@ There are several ways to use PR-Agent:
 - [BitBucket integration](./bitbucket.md)
 - [Azure DevOps integration](./azure.md)
 - [Gitea integration](./gitea.md)
+
+!!! note "Docker Hub namespace migration"
+    Releases **`0.34.2` and later** are published under [`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). Older releases (up to and including `v0.31`) remain at the legacy [`codiumai/pr-agent`](https://hub.docker.com/r/codiumai/pr-agent) namespace as a frozen archive — no new images are pushed there. The examples on this site reference the new namespace; if you are pinning to a release before `0.34.2`, swap `pragent/pr-agent` for `codiumai/pr-agent` in your `image:` / `docker pull` / `uses: docker://` references.

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -12,7 +12,7 @@ To invoke a tool (for example `review`), you can run PR-Agent directly from the 
 - For GitHub:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your_openai_key> -e GITHUB.USER_TOKEN=<your_github_token> codiumai/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI.KEY=<your_openai_key> -e GITHUB.USER_TOKEN=<your_github_token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you are using GitHub enterprise server, you need to specify the custom url as variable.
@@ -25,7 +25,7 @@ To invoke a tool (for example `review`), you can run PR-Agent directly from the 
 - For GitLab:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitlab -e GITLAB.PERSONAL_ACCESS_TOKEN=<your token> codiumai/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitlab -e GITLAB.PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you have a dedicated GitLab instance, you need to specify the custom url as variable:
@@ -37,13 +37,13 @@ To invoke a tool (for example `review`), you can run PR-Agent directly from the 
 - For BitBucket:
 
     ```bash
-    docker run --rm -it -e CONFIG.GIT_PROVIDER=bitbucket -e OPENAI.KEY=$OPENAI_API_KEY -e BITBUCKET.BEARER_TOKEN=$BITBUCKET_BEARER_TOKEN codiumai/pr-agent:latest --pr_url=<pr_url> review
+    docker run --rm -it -e CONFIG.GIT_PROVIDER=bitbucket -e OPENAI.KEY=$OPENAI_API_KEY -e BITBUCKET.BEARER_TOKEN=$BITBUCKET_BEARER_TOKEN pragent/pr-agent:latest --pr_url=<pr_url> review
     ```
 
 - For Gitea:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitea -e GITEA.PERSONAL_ACCESS_TOKEN=<your token> codiumai/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitea -e GITEA.PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you have a dedicated Gitea instance, you need to specify the custom url as variable:
@@ -74,7 +74,7 @@ OPENAI__KEY="<your key>"
 Then, you can run `pr_agent` using Docker with the following command:
 
 ```shell
-docker run --rm -it --env-file .env codiumai/pr-agent:latest <tool> <tool parameter>
+docker run --rm -it --env-file .env pragent/pr-agent:latest <tool> <tool parameter>
 ```
 
 ---

--- a/docs/docs/tools/help_docs.md
+++ b/docs/docs/tools/help_docs.md
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Run PR Agent on Issues
         if: ${{ env.ISSUE_URL != '' }}
-        uses: docker://codiumai/pr-agent:latest
+        uses: docker://pragent/pr-agent:latest
         with:
           entrypoint: /bin/bash #Replace invoking cli.py directly with a shell
           args: |

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -98,7 +98,7 @@ class BitbucketProvider(GitProvider):
             return ""
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
-    # Example: git clone git clone https://bitbucket.org/codiumai/pr-agent.git and branch: main -> prefix: "https://bitbucket.org/codiumai/pr-agent/src/main", suffix: ""
+    # Example: git clone git clone https://bitbucket.org/pragent/pr-agent.git and branch: main -> prefix: "https://bitbucket.org/pragent/pr-agent/src/main", suffix: ""
     # In case git url is not provided, provider will use PR context (which includes branch) to determine the prefix and suffix.
     def get_canonical_url_parts(self, repo_git_url:str=None, desired_branch:str=None) -> Tuple[str, str]:
         scheme_and_netloc = None

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -313,7 +313,7 @@ class GitLabProvider(GitProvider):
         return f"{issues_or_pr_url.split(repo_path)[0]}{repo_path}.git"
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
-    # Example: https://gitlab.com/codiumai/pr-agent.git and branch: t1 -> prefix: "https://gitlab.com/codiumai/pr-agent/-/blob/t1", suffix: "?ref_type=heads"
+    # Example: https://gitlab.com/pragent/pr-agent.git and branch: t1 -> prefix: "https://gitlab.com/pragent/pr-agent/-/blob/t1", suffix: "?ref_type=heads"
     # In case git url is not provided, provider will use PR context (which includes branch) to determine the prefix and suffix.
     def get_canonical_url_parts(self, repo_git_url:str=None, desired_branch:str=None) -> Tuple[str, str]:
         repo_path = ""

--- a/tests/e2e_tests/test_gitlab_webhook.py
+++ b/tests/e2e_tests/test_gitlab_webhook.py
@@ -26,7 +26,7 @@ def test_e2e_run_github_app():
     GITLAB_URL = "https://gitlab.com"
     GITLAB_TOKEN = get_settings().gitlab.PERSONAL_ACCESS_TOKEN
     gl = gitlab.Gitlab(GITLAB_URL, private_token=GITLAB_TOKEN)
-    repo_url = 'codiumai/pr-agent-tests'
+    repo_url = 'pragent/pr-agent-tests'
     project = gl.projects.get(repo_url)
 
     base_branch = "main"  # or any base branch you want


### PR DESCRIPTION
## Summary

Renames the Docker image namespace from `codiumai/pr-agent` to `pragent/pr-agent` across docs, CI workflows, and the GitHub Action's base image.

**This PR is stacked on top of #2359** (release workflow) — the base is set to `ci/release-workflow` so the diff shows only the rename. Once #2359 merges to `main`, retarget this PR's base to `main` (GitHub will offer this automatically) and merge.

### Why split from #2359

#2359 should land first publishing under the existing `codiumai/pr-agent` namespace so we can validate the release flow against the registry users currently depend on. Once verified, this PR migrates the namespace.

### Changed in this PR

- `.github/workflows/publish.yml` — registry tags switch to `pragent/pr-agent`
- `Dockerfile.github_action_dockerhub` — base image flips to `pragent/pr-agent:github_action` (so the GitHub Action stays in sync after the migration)
- `.github/workflows/build-and-test.yaml`, `code_coverage.yaml`, `e2e_tests.yaml` — local `:test` tag uses the new namespace for consistency
- `SECURITY.md`, `docs/docs/installation/{azure,bitbucket,gitea,github,gitlab,locally}.md`, `docs/docs/tools/help_docs.md` — user-facing `docker pull` / `image:` references

### Intentionally NOT changed

- `RELEASE_NOTES.md` — historical record of past publishes under the old namespace
- `pr_agent/git_providers/{bitbucket_provider,gitlab_provider}.py` — the `codiumai/pr-agent` strings in those files are git-URL examples in code comments (`bitbucket.org/codiumai/pr-agent.git`, `gitlab.com/codiumai/pr-agent.git`), not Docker images
- `tests/e2e_tests/test_gitlab_webhook.py` — `'codiumai/pr-agent-tests'` is a separate fixtures repo

## Test plan

- [ ] Wait for #2359 to merge and the first release run to validate the publish flow.
- [ ] Rebase this PR onto `main` (or let GitHub auto-retarget once base merges).
- [ ] Cut a release after merging this PR and confirm Docker Hub now serves `pragent/pr-agent:*` and that `action.yaml` (via `Dockerfile.github_action_dockerhub`) pulls cleanly.
- [ ] Update Docker Hub access (PAT/team perms) so the `DOCKERHUB_TOKEN` secret has write access to the `pragent` namespace before merging.