### PR TITLE
fix(release): publish under pragent/pr-agent (the actual Docker Hub repo)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,12 +165,12 @@ jobs:
           SUFFIX="${{ matrix.suffix }}"
           ROLLING="${{ matrix.rolling }}"
           if [ -z "$SUFFIX" ]; then
-            TAGS="codiumai/pr-agent:${V}"
+            TAGS="pragent/pr-agent:${V}"
           else
-            TAGS="codiumai/pr-agent:${V}-${SUFFIX}"
+            TAGS="pragent/pr-agent:${V}-${SUFFIX}"
           fi
           if [ -n "$ROLLING" ]; then
-            TAGS="${TAGS},codiumai/pr-agent:${ROLLING}"
+            TAGS="${TAGS},pragent/pr-agent:${ROLLING}"
           fi
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 

--- a/Dockerfile.github_action_dockerhub
+++ b/Dockerfile.github_action_dockerhub
@@ -1,1 +1,1 @@
-FROM codiumai/pr-agent:github_action
+FROM pragent/pr-agent:github_action


### PR DESCRIPTION
## Summary

The first run of the release workflow (v0.34.1, run [25260195008](https://github.com/The-PR-Agent/pr-agent/actions/runs/25260195008)) failed because the publish matrix tagged images under \`codiumai/pr-agent\`, but the \`DOCKERHUB_TOKEN\` configured for this repo only has push access to \`pragent/pr-agent\`. Every Docker job failed with:

> \`failed to push codiumai/pr-agent:0.34.1: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed\`

This PR flips the namespace where it actually matters for publishing:

- \`.github/workflows/publish.yml\` — versioned and rolling tags now use \`pragent/pr-agent\`.
- \`Dockerfile.github_action_dockerhub\` — \`FROM\` flips to \`pragent/pr-agent:github_action\` so \`action.yaml\` keeps pulling a tag the publish workflow actually updates.

## Intentionally NOT changed

User-facing docs (\`docs/docs/installation/*.md\`, \`SECURITY.md\`, \`docs/docs/tools/help_docs.md\`) and \`RELEASE_NOTES.md\` (historical record) are left alone. They will be migrated in a follow-up after the first successful release run, so users don't see references to a namespace that doesn't yet have artifacts.

## Recovery for v0.34.1 after merge

- Re-run the [failed workflow run](https://github.com/The-PR-Agent/pr-agent/actions/runs/25260195008), or
- \`workflow_dispatch\` the Publish workflow from main with \`version=0.34.1\`. PyPI's \`skip-existing: true\` makes that idempotent; Docker pushes will succeed under the new namespace.

## Test plan

- [ ] After merge, re-run the workflow on v0.34.1 and confirm all 11 Docker jobs succeed and tags appear at https://hub.docker.com/r/pragent/pr-agent
- [ ] \`docker pull pragent/pr-agent:0.34.1-github_action\` and \`docker pull pragent/pr-agent:github_action\` both resolve.
- [ ] After v0.34.1 is healthy, open a follow-up PR migrating the docs / SECURITY.md / RELEASE_NOTES.md references.