### PR TITLE
docs(readme): point examples at the-pr-agent/pr-agent slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 <br>
 The Original Open-Source PR Reviewer
 <br><br>
-<a href="https://github.com/Codium-ai/pr-agent/commits/main">
-<img alt="GitHub" src="https://img.shields.io/github/last-commit/Codium-ai/pr-agent/main?style=for-the-badge" height="20">
+<a href="https://github.com/the-pr-agent/pr-agent/commits/main">
+<img alt="GitHub" src="https://img.shields.io/github/last-commit/the-pr-agent/pr-agent/main?style=for-the-badge" height="20">
 </a>
 </div>
 
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: PR Agent action step
-      uses: Codium-ai/pr-agent@main
+      uses: the-pr-agent/pr-agent@main
       env:
         OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,7 +169,7 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |                                                         |                                                                                                                     |        |        |           |              |       |
 | [USAGE](https://docs.pr-agent.ai/usage-guide/)   | [CLI](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#local-repo-cli)                            |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
 |                                                         | [App / webhook](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app)                      |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
-|                                                         | [Tagging bot](https://github.com/Codium-ai/pr-agent#try-it-now)                                                     |   ✅   |        |           |              |       |
+|                                                         | [Tagging bot](https://github.com/the-pr-agent/pr-agent#try-it-now)                                                     |   ✅   |        |           |              |       |
 |                                                         | [Actions](https://docs.pr-agent.ai/installation/github/#run-as-a-github-action)                              |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         |                                                                                                                     |        |        |           |              |       |
 | [CORE](https://docs.pr-agent.ai/core-abilities/) | [Adaptive and token-aware file patch fitting](https://docs.pr-agent.ai/core-abilities/compression_strategy/) |   ✅   |   ✅   |    ✅     |      ✅      |       |
@@ -187,7 +187,7 @@ ___
 ## See It in Action
 
 </div>
-<h4><a href="https://github.com/Codium-ai/pr-agent/pull/530">/describe</a></h4>
+<h4><a href="https://github.com/the-pr-agent/pr-agent/pull/530">/describe</a></h4>
 <div align="center">
 <p float="center">
 <img src="https://www.codium.ai/images/pr_agent/describe_new_short_main.png" width="512">
@@ -195,7 +195,7 @@ ___
 </div>
 <hr>
 
-<h4><a href="https://github.com/Codium-ai/pr-agent/pull/732#issuecomment-1975099151">/review</a></h4>
+<h4><a href="https://github.com/the-pr-agent/pr-agent/pull/732#issuecomment-1975099151">/review</a></h4>
 <div align="center">
 <p float="center">
 <kbd>
@@ -205,7 +205,7 @@ ___
 </div>
 <hr>
 
-<h4><a href="https://github.com/Codium-ai/pr-agent/pull/732#issuecomment-1975099159">/improve</a></h4>
+<h4><a href="https://github.com/the-pr-agent/pr-agent/pull/732#issuecomment-1975099159">/improve</a></h4>
 <div align="center">
 <p float="center">
 <kbd>


### PR DESCRIPTION
## Summary

The README still references the old \`Codium-ai/pr-agent\` slug in six places. Now that the repo has been transferred to the community-owned [\`the-pr-agent\`](https://github.com/the-pr-agent) org, those links should point at the canonical new home.

GitHub serves the old slug via a 301 redirect today, so nothing is currently broken — but pinning to the redirect is brittle (it can be reclaimed or removed by the original owner at any time), and copy-pasting the GitHub Action example tells new users to depend on a slug that's no longer the source of truth.

## Changes

| Location | Old | New |
|---|---|---|
| Last-commit badge link | \`Codium-ai/pr-agent/commits/main\` | \`the-pr-agent/pr-agent/commits/main\` |
| Last-commit badge image | \`shields.io/.../Codium-ai/pr-agent/...\` | \`shields.io/.../the-pr-agent/pr-agent/...\` |
| Quick Start example | \`uses: Codium-ai/pr-agent@main\` | \`uses: the-pr-agent/pr-agent@main\` |
| Features table — \"Tagging bot\" link | \`Codium-ai/pr-agent#try-it-now\` | \`the-pr-agent/pr-agent#try-it-now\` |
| See It in Action — \`/describe\` demo | \`Codium-ai/pr-agent/pull/530\` | \`the-pr-agent/pr-agent/pull/530\` |
| See It in Action — \`/review\` and \`/improve\` demos | \`Codium-ai/pr-agent/pull/732#...\` | \`the-pr-agent/pr-agent/pull/732#...\` |

Verified PR #530 and PR #732 resolve directly at \`the-pr-agent/pr-agent\` (HTTP 200), and the \`Codium-ai\` URLs 301-redirect to the same content. The original repo was transferred (not forked), so PR numbers and history are preserved.

## Intentionally NOT changed

Image URLs hosted at \`codium.ai\` (logos, screenshots) are left alone — they're CDN assets that would need re-uploading to a community-owned host first. Out of scope for this slug-only fix.

## Test plan

- [ ] After merge, render the README on github.com/the-pr-agent/pr-agent and confirm the badge shows the latest commit on main and all the linked PRs (530, 732) load.
- [ ] Confirm the \`uses: the-pr-agent/pr-agent@main\` example works end-to-end (i.e., the redirect from the old slug still works during the transition for users copying the README before this lands).