### PR TITLE
chore(metadata): update pyproject.toml for the-pr-agent ownership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,17 @@ build-backend = "setuptools.build_meta"
 name = "pr-agent"
 version = "0.34.2"
 
-authors = [{ name = "QodoAI", email = "ofir.f@qodo.ai" }]
+authors = [
+  { name = "Naor Peled", email = "me@naor.dev" },
+  { name = "QodoAI", email = "ofir.f@qodo.ai" },
+]
 
 maintainers = [
+  { name = "Naor Peled", email = "me@naor.dev" },
   { name = "Ofir Friedman", email = "ofir.f@qodo.ai" },
 ]
 
-description = "QodoAI PR-Agent aims to help efficiently review and handle pull requests, by providing AI feedbacks and suggestions."
+description = "PR-Agent aims to help efficiently review and handle pull requests, by providing AI feedback and suggestions."
 readme = "README.md"
 requires-python = ">=3.12"
 keywords = ["AI", "Agents", "Pull Request", "Automation", "Code Review"]
@@ -29,8 +33,10 @@ dynamic = ["dependencies"]
 dependencies = { file = ["requirements.txt"] }
 
 [project.urls]
-"Homepage" = "https://github.com/qodo-ai/pr-agent"
-"Documentation" = "https://qodo-merge-docs.qodo.ai/"
+"Homepage" = "https://github.com/the-pr-agent/pr-agent"
+"Documentation" = "https://docs.pr-agent.ai/"
+"Repository" = "https://github.com/the-pr-agent/pr-agent"
+"Issues" = "https://github.com/the-pr-agent/pr-agent/issues"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary

Brings the PyPI metadata in line with the project's new home under the [\`the-pr-agent\`](https://github.com/the-pr-agent) org.

### Authors / maintainers

Adds Naor Peled as the active author/maintainer for the community-owned project. The original \`QodoAI\` author entry and \`Ofir Friedman\` maintainer entry are kept for attribution — PR-Agent's existence is owed to that earlier work.

### Description

Drops the \`QodoAI\` prefix from the description string. The project is no longer a Qodo product and the PyPI listing should reflect that.

\`\`\`diff
- description = \"QodoAI PR-Agent aims to help efficiently review and handle pull requests, by providing AI feedbacks and suggestions.\"
+ description = \"PR-Agent aims to help efficiently review and handle pull requests, by providing AI feedback and suggestions.\"
\`\`\`

(Also flips \"feedbacks\" → \"feedback\" since it's a mass noun in this usage.)

### Project URLs

\`\`\`diff
 [project.urls]
-\"Homepage\" = \"https://github.com/qodo-ai/pr-agent\"
-\"Documentation\" = \"https://qodo-merge-docs.qodo.ai/\"
+\"Homepage\" = \"https://github.com/the-pr-agent/pr-agent\"
+\"Documentation\" = \"https://docs.pr-agent.ai/\"
+\"Repository\" = \"https://github.com/the-pr-agent/pr-agent\"
+\"Issues\" = \"https://github.com/the-pr-agent/pr-agent/issues\"
\`\`\`

- \`Homepage\` and \`Repository\` point at the new GitHub org.
- \`Documentation\` now points at \`docs.pr-agent.ai\` — verified via \`docs/docs/CNAME\` and a \`HTTP 200\` check. The previous \`qodo-merge-docs.qodo.ai\` URL was the Qodo Merge product docs, not PR-Agent's.
- Added explicit \`Repository\` and \`Issues\` URLs so PyPI's sidebar surfaces both alongside Homepage and Documentation.

## Test plan

- [ ] After this lands, the next release publishes to PyPI with the new metadata. Confirm at <https://pypi.org/project/pr-agent/> that:
  - the project description no longer leads with \"QodoAI\",
  - the sidebar links resolve to \`the-pr-agent/pr-agent\` and \`docs.pr-agent.ai\`,
  - both Naor Peled and the legacy QodoAI entries appear under \"Authors\".