### PR TITLE
ci: add CodeQL workflow for Python static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly on Monday at 06:00 UTC — catches advisories that landed
+    # without a corresponding code change in this repo.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: github/codeql-action/init@53e96ec3b35fce51c141c0d6f0e31028a448722d  # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended,security-and-quality
+
+      - uses: github/codeql-action/analyze@53e96ec3b35fce51c141c0d6f0e31028a448722d  # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds a CodeQL workflow so security findings surface under the repo's **Security → Code scanning** tab instead of relying solely on Dependabot alerts.

\`\`\`yaml
on:
  push:           [main]
  pull_request:   [main]
  schedule:       weekly (Mon 06:00 UTC)
\`\`\`

- **Language:** \`python\` (pr-agent is pure Python; no C extensions).
- **Build mode:** \`none\` — CodeQL's source-only analysis is enough here, and it's faster than the autobuild path.
- **Queries:** the standard \`security-extended,security-and-quality\` suites (a step above the default).
- **Schedule:** the weekly cron catches advisories that land without a corresponding code change in this repo, which the push/PR triggers wouldn't otherwise re-evaluate.
- **Action pinning:** \`actions/checkout\` and \`github/codeql-action\` pinned to commit SHAs — matches the policy already in \`publish.yml\`.

## Out of scope

- JavaScript/TypeScript analysis for the \`docs/\` tree (Docusaurus). Easy to add later via a second matrix entry if useful, but those files are documentation tooling, not shipped code.
- Custom query packs / suppressions. Start with the defaults and tune from real findings.

## Test plan

- [ ] After merge, watch the first run on \`main\` complete and confirm results show up at \`/security/code-scanning\` for the repo.
- [ ] Open a synthetic PR that introduces a known vulnerability pattern (e.g., an obvious SQLi sink) on a throwaway branch to verify PR annotations work — then close it.