### PR TITLE
chore(metadata): drop Naor Peled from authors, keep as maintainer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "pr-agent"
 version = "0.34.3"
 
 authors = [
-  { name = "Naor Peled", email = "me@naor.dev" },
   { name = "QodoAI", email = "ofir.f@qodo.ai" },
 ]
 


### PR DESCRIPTION
## Summary

Authorship credit on PyPI should stay with the original creators (QodoAI). Naor Peled is the active community maintainer and should be listed as such, not as a co-author.

\`\`\`diff
 authors = [
-  { name = \"Naor Peled\", email = \"me@naor.dev\" },
   { name = \"QodoAI\", email = \"ofir.f@qodo.ai\" },
 ]

 maintainers = [
   { name = \"Naor Peled\", email = \"me@naor.dev\" },
   { name = \"Ofir Friedman\", email = \"ofir.f@qodo.ai\" },
 ]
\`\`\`

The maintainer entry stays untouched. Effective on the next release.