### PR TITLE
Update default model to OpenAI's GPT-5.5

### DIFF
--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -1,6 +1,6 @@
 To run PR-Agent locally, you first need to acquire two keys:
 
-1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.4 and gpt-5.4-mini (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
+1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.5 and gpt-5.4-mini (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
 2. A personal access token from your Git platform (GitHub, GitLab, BitBucket, Gitea) with repo scope. GitHub token, for example, can be issued from [here](https://github.com/settings/tokens){:target="_blank"}
 
 ## Using Docker image

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -4,7 +4,7 @@
 
 [config]
 # models
-model="gpt-5.4-2026-03-05"
+model="gpt-5.5-2026-04-23"
 fallback_models=["gpt-5.4-mini"]
 #model_reasoning="gpt-5.4-mini" # dedicated reasoning model for self-reflection
 #model_weak="gpt-5.4-nano" # optional, a weaker model to use for some easier tasks


### PR DESCRIPTION
## GitHub Copilot Pull Request summary

> This pull request updates the default language model version used by PR-Agent to the latest available, ensuring improved capabilities and alignment with the latest model offerings. It also updates the documentation to reflect this change.
> 
> **Model version updates:**
> 
> * Updated the default model in `configuration.toml` from `gpt-5.4-2026-03-05` to `gpt-5.5-2026-04-23` to use the latest language model by default.
> 
> **Documentation updates:**
> 
> * Changed the installation instructions in `locally.md` to require access to GPT-5.5 (instead of GPT-5.4) and gpt-5.4-mini, ensuring users acquire the correct API key for the updated model.