### PR TITLE
Upgrade LiteLLM from v1.81.12 to v1.83.14 with dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.12.15
+aiohttp==3.13.4
 anthropic>=0.69.0
 #anthropic[vertex]==0.47.1
 atlassian-python-api==3.41.4
@@ -13,7 +13,7 @@ google-cloud-aiplatform==1.38.0
 google-generativeai==0.8.3
 google-cloud-storage==2.10.0
 Jinja2==3.1.6
-litellm==1.81.12
+litellm==1.83.14
 loguru==0.7.2
 msrest==0.7.1
 openai>=1.55.3
@@ -25,13 +25,13 @@ PyYAML==6.0.1
 python-gitlab==3.15.0
 retry==0.9.2
 starlette-context==0.3.6
-tiktoken==0.8.0
+tiktoken==0.12.0
 ujson==5.8.0
 uvicorn==0.22.0
 tenacity==8.2.3
 gunicorn==23.0.0
 pytest-cov==7.0.0
-pydantic==2.8.2
+pydantic==2.12.5
 html2text==2024.2.26
 giteapy==1.0.8
 # Uncomment the following lines to enable the 'similar issue' tool


### PR DESCRIPTION
Align directly pinned dependencies with the versions required by the new LiteLLM release so fresh installs resolve consistently.

LiteLLM v1.82.7 and v1.82.8 are intentionally omitted from the reviewed stable release list because they were removed from PyPI after their March 2026 supply-chain compromise. (https://github.com/BerriAI/litellm/issues/24518)

Stable releases reviewed:
- https://pypi.org/project/litellm/1.81.13/
- https://pypi.org/project/litellm/1.81.14/
- https://pypi.org/project/litellm/1.81.15/
- https://pypi.org/project/litellm/1.81.16/
- https://pypi.org/project/litellm/1.82.0/
- https://pypi.org/project/litellm/1.82.1/
- https://pypi.org/project/litellm/1.82.2/
- https://pypi.org/project/litellm/1.82.3/
- https://pypi.org/project/litellm/1.82.4/
- https://pypi.org/project/litellm/1.82.5/
- https://pypi.org/project/litellm/1.82.6/
- https://pypi.org/project/litellm/1.83.0/
- https://pypi.org/project/litellm/1.83.1/
- https://pypi.org/project/litellm/1.83.2/
- https://pypi.org/project/litellm/1.83.3/
- https://pypi.org/project/litellm/1.83.4/
- https://pypi.org/project/litellm/1.83.5/
- https://pypi.org/project/litellm/1.83.6/
- https://pypi.org/project/litellm/1.83.7/
- https://pypi.org/project/litellm/1.83.8/
- https://pypi.org/project/litellm/1.83.9/
- https://pypi.org/project/litellm/1.83.10/
- https://pypi.org/project/litellm/1.83.11/
- https://pypi.org/project/litellm/1.83.12/
- https://pypi.org/project/litellm/1.83.13/
- https://pypi.org/project/litellm/1.83.14/