### PR TITLE
Update documented reasoning_effort configuration values

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -380,10 +380,10 @@ To bypass chat templates and temperature controls, set `config.custom_reasoning_
 
 ```toml
 [config]
-reasoning_effort = "medium" # "low", "medium", "high"
+reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
 ```
 
-With the OpenAI models that support reasoning effort (eg: gpt-5.4-mini), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to `high` or `low` based on your usage.
+With the OpenAI models that support reasoning effort (eg: gpt-5.4-mini), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to any supported value based on your usage. Available values depend on the model and provider.
 
 ### Anthropic models
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -56,7 +56,7 @@ ignore_language_framework = [] # a list of code-generation languages or framewor
 #
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata
-reasoning_effort = "medium" # "low", "medium", "high"
+reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048


### PR DESCRIPTION
Document the full set of values already accepted by ReasoningEffort. This keeps the settings comment and usage guide aligned with runtime validation.

## GitHub Copilot Pull Request Summary

> This pull request updates the configuration options for reasoning effort in both the documentation and the configuration file. The main change is the expansion of the allowed values for the `reasoning_effort` setting, providing users with finer control over model reasoning levels.
> 
> Configuration and documentation updates:
> 
> * Expanded the list of possible values for `reasoning_effort` from `"low", "medium", "high"` to include `"none", "minimal", "low", "medium", "high", "xhigh"` in both `pr_agent/settings/configuration.toml` and `docs/docs/usage-guide/changing_a_model.md` [[1]](diffhunk://#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78L59-R59) [[2]](diffhunk://#diff-7904af6a8722d533e7de626761ae6c1d9554069ed02634c3b719d2e7f8b39f4dL383-R386).
> * Updated documentation to clarify that available `reasoning_effort` values depend on the model and provider, and removed the implication that only "low", "medium", or "high" are supported.