### PR TITLE
Update Docker base images from Python v3.12.10 to v3.12.13

### DIFF
--- a/Dockerfile.github_action
+++ b/Dockerfile.github_action
@@ -1,4 +1,4 @@
-FROM python:3.12.10-slim AS base
+FROM python:3.12.13-slim AS base
 
 RUN apt-get update && apt-get install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.10-slim AS base
+FROM python:3.12.13-slim AS base
 
 RUN apt update && apt install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Use the current Python 3.12 security release for the container images while keeping them aligned with the runtime declared in `pyproject.toml`.

References:
- https://www.python.org/downloads/release/python-31213/
- https://hub.docker.com/_/python/tags?name=3.12.13-slim

## GitHub Copilot PR Summary

> This pull request updates the base Python version used in both the main and GitHub Action Dockerfiles to ensure consistency and to include the latest patches.
> 
> Dependency updates:
> 
> * Updated the base image in both `Dockerfile.github_action` and `docker/Dockerfile` from `python:3.12.10-slim` to `python:3.12.13-slim` to use the latest Python 3.12 patch release. [[1]](diffhunk://#diff-e18b685370151a3e574de5890d93010fb040e118f57027f8ce2dc9f64756f365L1-R1) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL1-R1)