### PR TITLE
feat: include per-repo context files (AGENTS.md, CLAUDE.md, etc.) as AI prompt context

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -144,7 +144,7 @@ LANGSMITH_BASE_URL=<url>
 
 ## Bringing per-repo context files to PR-Agent
 
-`Platforms supported: GitHub, GitLab, Gitea`
+`Platforms supported: GitHub, GitLab, Gitea, Bitbucket, Azure DevOps`
 
 To give PR-Agent's tools additional project context, you can have it include repository instruction files — such as [AGENTS.md](https://agents.md/) or [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices) — in the prompts for the `/review`, `/describe` and `/improve` tools.
 
@@ -162,8 +162,8 @@ You can list any repository-relative paths. The files are read from the PR's tar
 repo_context_files = ["AGENTS.md", "CLAUDE.md", "docs/conventions.md"]
 ```
 
-!!! note "Context is read from the PR's base commit"
-    On GitHub and Gitea, files are fetched at the PR's base commit (the commit the PR was opened against), not the live tip of the target branch. As a result, an instruction file that is added to (or changed on) the target branch *after* the PR was created will not be reflected until the PR is updated/rebased. On GitLab, files are read from the repository's default branch.
+!!! note "Context is read from the PR's target branch"
+    Instruction files are fetched from the branch the PR is merging into (its target/base branch), never from the PR's own head — so a PR cannot alter the guidance used to review it. On most providers the read is pinned to the target branch's commit at the time the PR was opened, so an instruction file added to (or changed on) the target branch *after* that point may not be reflected until the PR is updated/rebased.
 
 To bound how much of this context is sent to the model, `repo_context_max_lines` (default `500`) caps the total number of rendered lines, including the wrapper tags. Content beyond the budget is truncated safely:
 

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -142,25 +142,31 @@ LANGSMITH_PROJECT=<project>
 LANGSMITH_BASE_URL=<url>
 ```
 
-## Bringing additional repository metadata to PR-Agent
+## Bringing per-repo context files to PR-Agent
 
-To provide PR-Agent tools with additional context about your project, you can enable automatic repository metadata detection. 
+`Platforms supported: GitHub, GitLab, Gitea`
 
-If you set:
+To give PR-Agent's tools additional project context, you can have it include repository instruction files — such as [AGENTS.md](https://agents.md/), [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices), or [QODO.md](https://docs.codium.ai/qodo-documentation/qodo-command/getting-started/setup-and-quickstart) — in the prompts for the `/review`, `/describe` and `/improve` tools.
+
+By default, PR-Agent looks for an `AGENTS.md` file at the repository root:
 
 ```toml
 [config]
-add_repo_metadata = true
+repo_context_files = ["AGENTS.md"]
 ```
 
-PR-Agent automatically searches for repository metadata files in your PR's head branch root directory. By default, it looks for:
-[AGENTS.MD](https://agents.md/), [QODO.MD](https://docs.codium.ai/qodo-documentation/qodo-command/getting-started/setup-and-quickstart), [CLAUDE.MD](https://www.anthropic.com/engineering/claude-code-best-practices).
-
-You can also specify custom filenames to search for:
+You can list any repository-relative paths. The files are read from the PR's target branch (falling back to the repository's default branch), so only content already present on the branch you are merging into is used. Set the option to an empty list to disable the feature entirely:
 
 ```toml
 [config]
-add_repo_metadata_file_list= ["file1.md", "file2.md", ...]
+repo_context_files = ["AGENTS.md", "CLAUDE.md", "docs/conventions.md"]
+```
+
+To bound how much of this context is sent to the model, `repo_context_max_lines` (default `500`) caps the total number of rendered lines, including the wrapper tags. Content beyond the budget is truncated safely:
+
+```toml
+[config]
+repo_context_max_lines = 500
 ```
 
 ## Ignoring automatic commands in PRs

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -155,12 +155,15 @@ By default, PR-Agent looks for an `AGENTS.md` file at the repository root:
 repo_context_files = ["AGENTS.md"]
 ```
 
-You can list any repository-relative paths. The files are read from the PR's target branch (falling back to the repository's default branch), so only content already present on the branch you are merging into is used. Set the option to an empty list to disable the feature entirely:
+You can list any repository-relative paths. The files are read from the PR's target (base) branch, so only content already merged into the branch you are merging into is used — a PR cannot inject its own instruction files into its review. A file that is missing on the target branch is silently skipped. Set the option to an empty list to disable the feature entirely:
 
 ```toml
 [config]
 repo_context_files = ["AGENTS.md", "CLAUDE.md", "docs/conventions.md"]
 ```
+
+!!! note "Context is read from the PR's base commit"
+    On GitHub and Gitea, files are fetched at the PR's base commit (the commit the PR was opened against), not the live tip of the target branch. As a result, an instruction file that is added to (or changed on) the target branch *after* the PR was created will not be reflected until the PR is updated/rebased. On GitLab, files are read from the repository's default branch.
 
 To bound how much of this context is sent to the model, `repo_context_max_lines` (default `500`) caps the total number of rendered lines, including the wrapper tags. Content beyond the budget is truncated safely:
 

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -155,15 +155,22 @@ By default, PR-Agent looks for an `AGENTS.md` file at the repository root:
 repo_context_files = ["AGENTS.md"]
 ```
 
-You can list any repository-relative paths. The files are read from the PR's target (base) branch, so only content already merged into the branch you are merging into is used — a PR cannot inject its own instruction files into its review. A file that is missing on the target branch is silently skipped. Set the option to an empty list to disable the feature entirely:
+You can list any repository-relative paths. By default the files are read from the repository's **default branch**, so only trusted, already-merged content is used and a PR cannot influence the guidance used to review it. A file that is missing is silently skipped. Set the option to an empty list to disable the feature entirely:
 
 ```toml
 [config]
 repo_context_files = ["AGENTS.md", "CLAUDE.md", "docs/conventions.md"]
 ```
 
-!!! note "Context is read from the PR's target branch"
-    Instruction files are fetched from the branch the PR is merging into (its target/base branch), never from the PR's own head — so a PR cannot alter the guidance used to review it. On most providers the read is pinned to the target branch's commit at the time the PR was opened, so an instruction file added to (or changed on) the target branch *after* that point may not be reflected until the PR is updated/rebased.
+!!! note "Which branch the files are read from"
+    By default (`repo_context_from_default_branch = true`), instruction files are read from the repository's **default branch** — a single trusted source — so neither the PR nor its target branch can alter the guidance used to review it. This matches how Qodo Merge reads these files.
+
+    Set `repo_context_from_default_branch = false` to instead read from the PR's **target (base) branch**. This respects branch-specific instructions (for example a release branch, or a stacked PR that carries its own `AGENTS.md`), at the cost of trusting whoever can write to that target branch. Even then, files are never read from the PR's own head.
+
+    ```toml
+    [config]
+    repo_context_from_default_branch = false
+    ```
 
 To bound how much of this context is sent to the model, `repo_context_max_lines` (default `500`) caps the total number of rendered lines, including the wrapper tags. Content beyond the budget is truncated safely:
 

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -146,7 +146,7 @@ LANGSMITH_BASE_URL=<url>
 
 `Platforms supported: GitHub, GitLab, Gitea`
 
-To give PR-Agent's tools additional project context, you can have it include repository instruction files — such as [AGENTS.md](https://agents.md/), [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices), or [QODO.md](https://docs.codium.ai/qodo-documentation/qodo-command/getting-started/setup-and-quickstart) — in the prompts for the `/review`, `/describe` and `/improve` tools.
+To give PR-Agent's tools additional project context, you can have it include repository instruction files — such as [AGENTS.md](https://agents.md/) or [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices) — in the prompts for the `/review`, `/describe` and `/improve` tools.
 
 By default, PR-Agent looks for an `AGENTS.md` file at the repository root:
 

--- a/pr_agent/algo/repo_context.py
+++ b/pr_agent/algo/repo_context.py
@@ -149,8 +149,24 @@ def _store_repo_context(git_provider, context_files: list, max_lines: int, repo_
         _repo_context_process_cache[process_cache_key] = repo_context
 
 
+def _read_bool_setting(key: str, default: bool) -> bool:
+    # Robustly interpret a boolean config value that may arrive as a real bool (TOML) or a
+    # string (e.g. env-var overrides). Fall back to the secure default for missing/unparseable
+    # values rather than relying on bool("false") == True.
+    value = get_settings().config.get(key, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("true", "1", "yes", "on"):
+            return True
+        if normalized in ("false", "0", "no", "off"):
+            return False
+    return default
+
+
 def _load_repo_context_files(git_provider, context_files: list) -> tuple[dict[str, str], bool]:
-    from_default_branch = bool(get_settings().config.get("repo_context_from_default_branch", False))
+    from_default_branch = _read_bool_setting("repo_context_from_default_branch", default=True)
     files = {}
     had_fetch_error = False
     for file_path in context_files:
@@ -255,13 +271,11 @@ def build_repo_context(git_provider) -> str:
         return cached_repo_context
 
     files, had_fetch_error = _load_repo_context_files(git_provider, context_files)
-    if not files and had_fetch_error:
-        return ""
 
-    if not files:
-        _store_repo_context(git_provider, context_files, max_lines, "")
-        return ""
+    repo_context = render_instruction_files_with_line_budget(files, max_lines) if files else ""
 
-    repo_context = render_instruction_files_with_line_budget(files, max_lines)
-    _store_repo_context(git_provider, context_files, max_lines, repo_context)
+    # Only cache when every file was fetched successfully. A transient/unexpected fetch error must
+    # not be cached as a real result, so it is retried instead of being served until the TTL expires.
+    if not had_fetch_error:
+        _store_repo_context(git_provider, context_files, max_lines, repo_context)
     return repo_context

--- a/pr_agent/algo/repo_context.py
+++ b/pr_agent/algo/repo_context.py
@@ -1,0 +1,266 @@
+import time
+from collections import OrderedDict
+from html import escape
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.log import get_logger
+
+TRUNCATION_MARKER = "...(truncated)..."
+INSTRUCTION_FILES_INTRO = (
+    "You are being given instruction files. Follow them as project-specific guidance when reviewing code."
+)
+MARKDOWN_FENCE = "`````"
+REPO_CONTEXT_CACHE_ATTRIBUTE = "_repo_context_cache"
+REPO_CONTEXT_CACHE_MAX_SIZE = 256
+REPO_CONTEXT_CACHE_TTL_SECONDS = 15 * 60
+_REPO_CONTEXT_CACHE_MISS = object()
+_unsupported_repo_context_provider_classes = set()
+
+
+class _RepoContextCache:
+    def __init__(self, max_size: int = REPO_CONTEXT_CACHE_MAX_SIZE, ttl_seconds: int = REPO_CONTEXT_CACHE_TTL_SECONDS):
+        self._max_size = max(1, int(max_size))
+        self._ttl_seconds = max(0, int(ttl_seconds))
+        self._entries = OrderedDict()
+
+    def copy(self):
+        cache = type(self)(max_size=self._max_size, ttl_seconds=self._ttl_seconds)
+        cache._entries = self._entries.copy()
+        return cache
+
+    def get(self, key, default=None):
+        entry = self._entries.get(key)
+        if entry is None:
+            return default
+
+        value, expires_at = entry
+        if expires_at <= time.monotonic():
+            del self._entries[key]
+            return default
+
+        self._entries.move_to_end(key)
+        return value
+
+    def __setitem__(self, key, value):
+        self._entries[key] = (value, time.monotonic() + self._ttl_seconds)
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._max_size:
+            self._entries.popitem(last=False)
+
+
+_repo_context_process_cache = _RepoContextCache()
+
+
+def _get_markdown_fence(content: str) -> str:
+    fence = MARKDOWN_FENCE
+    while fence in content:
+        fence += "`"
+    return fence
+
+
+def _get_repo_context_cache_key(context_files: list, max_lines: int) -> tuple[tuple[tuple[str, str], ...], int]:
+    return tuple((type(file_path).__name__, str(file_path)) for file_path in context_files), max_lines
+
+
+def _get_repo_context_process_cache_key(git_provider, context_files: list, max_lines: int) -> tuple | None:
+    try:
+        pr_url = git_provider.get_pr_url()
+    except Exception:
+        pr_url = getattr(git_provider, "pr_url", None)
+
+    if not pr_url:
+        return None
+
+    return type(git_provider).__name__, pr_url, _get_repo_context_cache_key(context_files, max_lines)
+
+
+def _get_repo_context_config() -> tuple[list, int] | None:
+    context_files = get_settings().config.get("repo_context_files", [])
+    if not context_files:
+        return None
+
+    if isinstance(context_files, str):
+        get_logger().warning(
+            "repo_context_files should be a list of file paths; treating string value as one file path",
+            artifact={"repo_context_files": context_files},
+        )
+        context_files = [context_files]
+    elif not isinstance(context_files, list):
+        get_logger().warning(
+            "repo_context_files should be a list of file paths; skipping repo context",
+            artifact={"repo_context_files": context_files},
+        )
+        return None
+
+    max_lines = get_settings().config.get("repo_context_max_lines", 500)
+    try:
+        max_lines = max(0, int(max_lines))
+    except (TypeError, ValueError):
+        max_lines = 500
+
+    return context_files, max_lines
+
+
+def _provider_supports_repo_context(git_provider) -> bool:
+    provider_class = type(git_provider)
+    provider_method = getattr(provider_class, "get_repo_file_content", None)
+    if provider_method is not None and provider_method is not GitProvider.get_repo_file_content:
+        return True
+
+    if provider_class not in _unsupported_repo_context_provider_classes:
+        _unsupported_repo_context_provider_classes.add(provider_class)
+        get_logger().warning(
+            f"repo_context_files is configured, but {provider_class.__name__} does not support repository "
+            "file fetching; skipping repo context"
+        )
+    return False
+
+
+def _get_provider_repo_context_cache(git_provider) -> _RepoContextCache:
+    repo_context_cache = getattr(git_provider, REPO_CONTEXT_CACHE_ATTRIBUTE, None)
+    if repo_context_cache is None or not isinstance(repo_context_cache, _RepoContextCache):
+        repo_context_cache = _RepoContextCache()
+        setattr(git_provider, REPO_CONTEXT_CACHE_ATTRIBUTE, repo_context_cache)
+    return repo_context_cache
+
+
+def _get_cached_repo_context(git_provider, context_files: list, max_lines: int):
+    process_cache_key = _get_repo_context_process_cache_key(git_provider, context_files, max_lines)
+    if process_cache_key is not None:
+        cached_repo_context = _repo_context_process_cache.get(process_cache_key, _REPO_CONTEXT_CACHE_MISS)
+        if cached_repo_context is not _REPO_CONTEXT_CACHE_MISS:
+            return cached_repo_context
+
+    cache_key = _get_repo_context_cache_key(context_files, max_lines)
+    cached_repo_context = _get_provider_repo_context_cache(git_provider).get(cache_key, _REPO_CONTEXT_CACHE_MISS)
+    if cached_repo_context is not _REPO_CONTEXT_CACHE_MISS:
+        return cached_repo_context
+
+    return _REPO_CONTEXT_CACHE_MISS
+
+
+def _store_repo_context(git_provider, context_files: list, max_lines: int, repo_context: str) -> None:
+    cache_key = _get_repo_context_cache_key(context_files, max_lines)
+    _get_provider_repo_context_cache(git_provider)[cache_key] = repo_context
+
+    process_cache_key = _get_repo_context_process_cache_key(git_provider, context_files, max_lines)
+    if process_cache_key:
+        _repo_context_process_cache[process_cache_key] = repo_context
+
+
+def _load_repo_context_files(git_provider, context_files: list) -> tuple[dict[str, str], bool]:
+    files = {}
+    had_fetch_error = False
+    for file_path in context_files:
+        if not isinstance(file_path, str) or not file_path.strip():
+            get_logger().warning("Skipping invalid repo context file path", artifact={"file_path": file_path})
+            continue
+
+        file_path = file_path.strip()
+        try:
+            content = git_provider.get_repo_file_content(file_path)
+        except Exception as e:
+            had_fetch_error = True
+            get_logger().warning(f"Failed to load repo context file: {file_path}", artifact={"error": str(e)})
+            continue
+
+        if not content:
+            get_logger().debug(f"Repo context file is empty or missing: {file_path}")
+            continue
+
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+
+        files[file_path] = str(content).rstrip()
+
+    return files, had_fetch_error
+
+
+def render_instruction_files(files: dict[str, str]) -> str:
+    parts = [
+        INSTRUCTION_FILES_INTRO,
+        "<instruction_files>",
+    ]
+
+    for path, content in files.items():
+        scope = path.rsplit("/", 1)[0] if "/" in path else "repo-root"
+        fence = _get_markdown_fence(content)
+        parts.append(f'<file path="{escape(path, quote=True)}" scope="{escape(scope, quote=True)}">')
+        parts.append(f"{fence}markdown")
+        parts.append(content.rstrip())
+        parts.append(fence)
+        parts.append("</file>")
+        parts.append("")
+
+    parts.append("</instruction_files>")
+    return "\n".join(parts)
+
+
+def render_instruction_files_with_line_budget(files: dict[str, str], max_lines: int) -> str:
+    parts = [
+        INSTRUCTION_FILES_INTRO,
+        "<instruction_files>",
+    ]
+    closing_tag = "</instruction_files>"
+    if max_lines < len(parts) + 1:
+        return ""
+
+    for path, content in files.items():
+        scope = path.rsplit("/", 1)[0] if "/" in path else "repo-root"
+        fence = _get_markdown_fence(content)
+        file_header = [
+            f'<file path="{escape(path, quote=True)}" scope="{escape(scope, quote=True)}">',
+            f"{fence}markdown",
+        ]
+        file_footer = [
+            fence,
+            "</file>",
+            "",
+        ]
+        content_lines = content.rstrip().splitlines()
+        reserved_file_and_closing_lines = len(file_header) + len(file_footer) + 1
+        available_content_lines = max_lines - len(parts) - reserved_file_and_closing_lines
+        if available_content_lines < 0 or (content_lines and available_content_lines < 1):
+            break
+
+        parts.extend(file_header)
+        if available_content_lines >= len(content_lines):
+            parts.extend(content_lines)
+        else:
+            if available_content_lines > 1:
+                parts.extend(content_lines[: available_content_lines - 1])
+            parts.append(TRUNCATION_MARKER)
+            parts.extend(file_footer)
+            break
+
+        parts.extend(file_footer)
+
+    parts.append(closing_tag)
+    return "\n".join(parts).strip()
+
+
+def build_repo_context(git_provider) -> str:
+    repo_context_config = _get_repo_context_config()
+    if repo_context_config is None:
+        return ""
+
+    context_files, max_lines = repo_context_config
+    if not _provider_supports_repo_context(git_provider):
+        return ""
+
+    cached_repo_context = _get_cached_repo_context(git_provider, context_files, max_lines)
+    if cached_repo_context is not _REPO_CONTEXT_CACHE_MISS:
+        return cached_repo_context
+
+    files, had_fetch_error = _load_repo_context_files(git_provider, context_files)
+    if not files and had_fetch_error:
+        return ""
+
+    if not files:
+        _store_repo_context(git_provider, context_files, max_lines, "")
+        return ""
+
+    repo_context = render_instruction_files_with_line_budget(files, max_lines)
+    _store_repo_context(git_provider, context_files, max_lines, repo_context)
+    return repo_context

--- a/pr_agent/algo/repo_context.py
+++ b/pr_agent/algo/repo_context.py
@@ -150,6 +150,7 @@ def _store_repo_context(git_provider, context_files: list, max_lines: int, repo_
 
 
 def _load_repo_context_files(git_provider, context_files: list) -> tuple[dict[str, str], bool]:
+    from_default_branch = bool(get_settings().config.get("repo_context_from_default_branch", False))
     files = {}
     had_fetch_error = False
     for file_path in context_files:
@@ -159,7 +160,7 @@ def _load_repo_context_files(git_provider, context_files: list) -> tuple[dict[st
 
         file_path = file_path.strip()
         try:
-            content = git_provider.get_repo_file_content(file_path)
+            content = git_provider.get_repo_file_content(file_path, from_default_branch=from_default_branch)
         except Exception as e:
             had_fetch_error = True
             get_logger().warning(f"Failed to load repo context file: {file_path}", artifact={"error": str(e)})

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -174,6 +174,26 @@ class AzureDevopsProvider(GitProvider):
                 get_logger().error(f"Failed to get repo settings, error: {e}")
             return ""
 
+    def get_repo_file_content(self, file_path: str):
+        try:
+            # Read from the PR target (base) commit, matching the other providers.
+            version = GitVersionDescriptor(
+                version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
+            )
+            item = self.azure_devops_client.get_item(
+                repository_id=self.repo_slug,
+                path=file_path,
+                project=self.workspace_slug,
+                version_descriptor=version,
+                download=False,
+                include_content=True,
+            )
+            return item.content or ""
+        except Exception as e:
+            if get_settings().config.verbosity_level >= 2:
+                get_logger().warning(f"Failed to load repo file: {file_path}, error: {e}")
+            return ""
+
     def get_files(self):
         files = []
         for i in self.azure_devops_client.get_pull_request_commits(

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -174,12 +174,16 @@ class AzureDevopsProvider(GitProvider):
                 get_logger().error(f"Failed to get repo settings, error: {e}")
             return ""
 
-    def get_repo_file_content(self, file_path: str):
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
-            # Read from the PR target (base) commit, matching the other providers.
-            version = GitVersionDescriptor(
-                version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
-            )
+            # Read from the PR target (base) commit, matching the other providers. When
+            # from_default_branch is requested, omit the version so the default branch is used.
+            if from_default_branch:
+                version = None
+            else:
+                version = GitVersionDescriptor(
+                    version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
+                )
             item = self.azure_devops_client.get_item(
                 repository_id=self.repo_slug,
                 path=file_path,

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -89,9 +89,11 @@ class BitbucketProvider(GitProvider):
         except Exception:
             return ""
 
-    def get_repo_file_content(self, file_path: str):
-        # Read from the PR destination (target) branch, matching the other providers.
-        return self.get_pr_file_content(file_path, self.pr.destination_branch)
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
+        # Read from the PR destination (target) branch, matching the other providers,
+        # or from the repository default branch when from_default_branch is requested.
+        branch = self.get_repo_default_branch() if from_default_branch else self.pr.destination_branch
+        return self.get_pr_file_content(file_path, branch)
 
     def get_git_repo_url(self, pr_url: str=None) -> str: #bitbucket does not support issue url, so ignore param
         try:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -89,6 +89,10 @@ class BitbucketProvider(GitProvider):
         except Exception:
             return ""
 
+    def get_repo_file_content(self, file_path: str):
+        # Read from the PR destination (target) branch, matching the other providers.
+        return self.get_pr_file_content(file_path, self.pr.destination_branch)
+
     def get_git_repo_url(self, pr_url: str=None) -> str: #bitbucket does not support issue url, so ignore param
         try:
             parsed_url = urlparse(self.pr_url)

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -119,9 +119,15 @@ class BitbucketServerProvider(GitProvider):
             get_logger().info(f"Failed to load .pr_agent.toml file, error: {e}")
             return ""
 
-    def get_repo_file_content(self, file_path: str):
-        # Read from the PR target ref (the branch being merged into), matching the other providers.
-        return self.get_file(file_path, self.pr.toRef['latestCommit'])
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
+        # Read from the PR target ref (the branch being merged into), matching the other providers,
+        # or from the repository default branch when from_default_branch is requested.
+        if from_default_branch:
+            default_branch_dict = self.bitbucket_client.get_default_branch(self.workspace_slug, self.repo_slug)
+            ref = default_branch_dict.get('displayId') or self.pr.toRef['latestCommit']
+        else:
+            ref = self.pr.toRef['latestCommit']
+        return self.get_file(file_path, ref)
 
     def get_pr_id(self):
         return self.pr_num

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -119,6 +119,10 @@ class BitbucketServerProvider(GitProvider):
             get_logger().info(f"Failed to load .pr_agent.toml file, error: {e}")
             return ""
 
+    def get_repo_file_content(self, file_path: str):
+        # Read from the PR target ref (the branch being merged into), matching the other providers.
+        return self.get_file(file_path, self.pr.toRef['latestCommit'])
+
     def get_pr_id(self):
         return self.pr_num
 

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -277,7 +277,7 @@ class GitProvider(ABC):
     def get_repo_settings(self):
         pass
 
-    def get_repo_file_content(self, file_path: str):
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         return ""
 
     def get_workspace_name(self):

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -277,6 +277,9 @@ class GitProvider(ABC):
     def get_repo_settings(self):
         pass
 
+    def get_repo_file_content(self, file_path: str):
+        return ""
+
     def get_workspace_name(self):
         return ""
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -748,20 +748,21 @@ class GiteaProvider(GitProvider):
         return clone_url
 
     def get_repo_file_content(self, file_path: str) -> str:
-        """Get content of a file from the repository target branch.
+        """Get content of a file from the PR target (base) branch.
 
         This method implements the interface required by PR #2387 repo_context feature.
-        It retrieves file content from the PR target when available, falling back to
-        the PR head commit for non-PR contexts.
+        It reads only from the PR target ref (base sha/ref) and never from the PR head,
+        so a PR cannot supply its own instruction files to influence its own review.
         """
         try:
             if not self.owner or not self.repo:
                 self.logger.warning("Cannot get repo file content: owner or repo not set")
                 return ""
 
-            ref = self.base_sha or self.base_ref or self.sha
+            # Only trust the PR target (base) ref — never fall back to the PR head (self.sha).
+            ref = self.base_sha or self.base_ref
             if not ref:
-                self.logger.warning("Cannot get repo file content: ref not set")
+                self.logger.warning("Cannot get repo file content: no target/base ref available")
                 return ""
 
             content = self.repo_api.get_file_content(

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -776,9 +776,13 @@ class GiteaProvider(GitProvider):
                 filepath=file_path
             )
             return content
-        except Exception as e:
-            self.logger.debug(f"Failed to load repo file: {file_path}, error: {e}")
-            return ""
+        except ApiException as e:
+            # A missing file is an expected "no context" outcome. Let transient/unexpected
+            # errors propagate so build_repo_context() treats them as a fetch error and does
+            # not cache an empty result until the TTL expires.
+            if getattr(e, "status", None) == 404:
+                return ""
+            raise
 
 class RepoApi(giteapy.RepositoryApi):
     def __init__(self, client: giteapy.ApiClient):

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -747,20 +747,24 @@ class GiteaProvider(GitProvider):
         clone_url += f"{gitea_token}@{base_url}{repo_full_name}"
         return clone_url
 
-    def get_repo_file_content(self, file_path: str) -> str:
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False) -> str:
         """Get content of a file from the PR target (base) branch.
 
         This method implements the interface required by PR #2387 repo_context feature.
         It reads only from the PR target ref (base sha/ref) and never from the PR head,
         so a PR cannot supply its own instruction files to influence its own review.
+        When from_default_branch is set, it reads from the repository default branch instead.
         """
         try:
             if not self.owner or not self.repo:
                 self.logger.warning("Cannot get repo file content: owner or repo not set")
                 return ""
 
-            # Only trust the PR target (base) ref — never fall back to the PR head (self.sha).
-            ref = self.base_sha or self.base_ref
+            if from_default_branch:
+                ref = self.repo_api.repo_get(self.owner, self.repo).default_branch
+            else:
+                # Only trust the PR target (base) ref — never fall back to the PR head (self.sha).
+                ref = self.base_sha or self.base_ref
             if not ref:
                 self.logger.warning("Cannot get repo file content: no target/base ref available")
                 return ""

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -62,6 +62,8 @@ class GiteaProvider(GitProvider):
         self.file_contents = {}
         self.file_diffs = {}
         self.sha = None
+        self.base_sha = ""
+        self.base_ref = ""
         self.diff_files = []
         self.incremental = IncrementalPR(False)
         self.comments_list = []
@@ -240,7 +242,7 @@ class GiteaProvider(GitProvider):
     def publish_comment(self, comment: str,is_temporary: bool = False) -> None:
         """Publish a comment to the pull request"""
         if is_temporary and not get_settings().config.publish_output_progress:
-            get_logger().debug(f"Skipping publish_comment for temporary comment")
+            get_logger().debug("Skipping publish_comment for temporary comment")
             return None
 
         if self.enabled_issue:
@@ -744,6 +746,34 @@ class GiteaProvider(GitProvider):
         clone_url = scheme
         clone_url += f"{gitea_token}@{base_url}{repo_full_name}"
         return clone_url
+
+    def get_repo_file_content(self, file_path: str) -> str:
+        """Get content of a file from the repository target branch.
+
+        This method implements the interface required by PR #2387 repo_context feature.
+        It retrieves file content from the PR target when available, falling back to
+        the PR head commit for non-PR contexts.
+        """
+        try:
+            if not self.owner or not self.repo:
+                self.logger.warning("Cannot get repo file content: owner or repo not set")
+                return ""
+
+            ref = self.base_sha or self.base_ref or self.sha
+            if not ref:
+                self.logger.warning("Cannot get repo file content: ref not set")
+                return ""
+
+            content = self.repo_api.get_file_content(
+                owner=self.owner,
+                repo=self.repo,
+                commit_sha=ref,
+                filepath=file_path
+            )
+            return content
+        except Exception as e:
+            self.logger.debug(f"Failed to load repo file: {file_path}, error: {e}")
+            return ""
 
 class RepoApi(giteapy.RepositoryApi):
     def __init__(self, client: giteapy.ApiClient):

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -851,12 +851,16 @@ class GithubProvider(GitProvider):
         except Exception:
             return ""
 
-    def get_repo_file_content(self, file_path: str):
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
             # Prefer the PR target (base) ref so repo-context instruction files match the branch
-            # the PR is merging into. Fall back to the repo default branch when no PR base is available.
-            base = getattr(getattr(self, "pr", None), "base", None)
-            ref = getattr(base, "sha", None) or getattr(base, "ref", None)
+            # the PR is merging into. Fall back to the repo default branch when no PR base is
+            # available, or always when from_default_branch is requested.
+            if from_default_branch:
+                ref = None
+            else:
+                base = getattr(getattr(self, "pr", None), "base", None)
+                ref = getattr(base, "sha", None) or getattr(base, "ref", None)
             if ref:
                 contents = self.repo_obj.get_contents(file_path, ref=ref).decoded_content
             else:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -851,6 +851,23 @@ class GithubProvider(GitProvider):
         except Exception:
             return ""
 
+    def get_repo_file_content(self, file_path: str):
+        try:
+            # Prefer the PR target (base) ref so repo-context instruction files match the branch
+            # the PR is merging into. Fall back to the repo default branch when no PR base is available.
+            base = getattr(getattr(self, "pr", None), "base", None)
+            ref = getattr(base, "sha", None) or getattr(base, "ref", None)
+            if ref:
+                contents = self.repo_obj.get_contents(file_path, ref=ref).decoded_content
+            else:
+                contents = self.repo_obj.get_contents(file_path).decoded_content
+            if isinstance(contents, bytes):
+                return contents.decode("utf-8", errors="replace")
+            return contents
+        except Exception as e:
+            get_logger().warning(f"Failed to load repo file: {file_path}, error: {e}")
+            return ""
+
     def get_workspace_name(self):
         return self.repo.split('/')[0]
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -868,9 +868,13 @@ class GithubProvider(GitProvider):
             if isinstance(contents, bytes):
                 return contents.decode("utf-8", errors="replace")
             return contents
-        except Exception as e:
-            get_logger().warning(f"Failed to load repo file: {file_path}, error: {e}")
-            return ""
+        except GithubException as e:
+            # A missing file is an expected "no context" outcome. Let transient/unexpected
+            # errors propagate so build_repo_context() treats them as a fetch error and does
+            # not cache an empty result until the TTL expires.
+            if e.status == 404:
+                return ""
+            raise
 
     def get_workspace_name(self):
         return self.repo.split('/')[0]

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -800,12 +800,16 @@ class GitLabProvider(GitProvider):
         except Exception:
             return ""
 
-    def get_repo_file_content(self, file_path: str):
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
             project = self.gl.projects.get(self.id_project)
             # Read from the MR target branch (the branch being merged into), matching the other
-            # providers; fall back to the project default branch outside of an MR context.
-            ref = getattr(self.mr, "target_branch", None) or project.default_branch
+            # providers; fall back to the project default branch outside of an MR context, or
+            # always when from_default_branch is requested.
+            if from_default_branch:
+                ref = project.default_branch
+            else:
+                ref = getattr(self.mr, "target_branch", None) or project.default_branch
             contents = project.files.get(file_path=file_path, ref=ref).decode()
             return decode_if_bytes(contents)
         except GitlabGetError:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -671,9 +671,8 @@ class GitLabProvider(GitProvider):
                 target_file = None
                 for file in diff_files:
                     if file.filename == relevant_file:
-                        if file.filename == relevant_file:
-                            target_file = file
-                            break
+                        target_file = file
+                        break
                 if target_file is None:
                     get_logger().warning(f"Skipping suggestion: file '{relevant_file}' not found in diff")
                     continue

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -801,6 +801,14 @@ class GitLabProvider(GitProvider):
         except Exception:
             return ""
 
+    def get_repo_file_content(self, file_path: str):
+        try:
+            project = self.gl.projects.get(self.id_project)
+            contents = project.files.get(file_path=file_path, ref=project.default_branch).decode()
+            return decode_if_bytes(contents)
+        except GitlabGetError:
+            return ""
+
     def get_workspace_name(self):
         return self.id_project.split('/')[0]
 

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -803,7 +803,10 @@ class GitLabProvider(GitProvider):
     def get_repo_file_content(self, file_path: str):
         try:
             project = self.gl.projects.get(self.id_project)
-            contents = project.files.get(file_path=file_path, ref=project.default_branch).decode()
+            # Read from the MR target branch (the branch being merged into), matching the other
+            # providers; fall back to the project default branch outside of an MR context.
+            ref = getattr(self.mr, "target_branch", None) or project.default_branch
+            contents = project.files.get(file_path=file_path, ref=ref).decode()
             return decode_if_bytes(contents)
         except GitlabGetError:
             return ""

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -91,6 +91,15 @@ Extra user-provided instructions (should be addressed with high priority):
 ======
 {%- endif %}
 
+{%- if repo_context %}
+
+
+Repository context:
+======
+{{ repo_context }}
+======
+{%- endif %}
+
 
 The output must be a YAML object equivalent to type $PRCodeSuggestions, according to the following Pydantic definitions:
 =====

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -80,6 +80,15 @@ Extra user-provided instructions (should be addressed with high priority):
 ======
 {%- endif %}
 
+{%- if repo_context %}
+
+
+Repository context:
+======
+{{ repo_context }}
+======
+{%- endif %}
+
 
 The output must be a YAML object equivalent to type $PRCodeSuggestions, according to the following Pydantic definitions:
 =====

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -29,6 +29,7 @@ skip_keys = []
 custom_reasoning_model = false # when true, disables system messages and temperature controls for models that don't support chat-style inputs
 response_language="en-US" # Language locales code for PR responses in ISO 3166 and ISO 639 format (e.g., "en-US", "it-IT", "zh-CN", ...)
 repo_context_files = ["AGENTS.md"] # Repository-relative files (e.g. AGENTS.md, CLAUDE.md) to include as AI prompt context; set to [] to disable
+repo_context_from_default_branch = true # Read repo context files from the repository default branch (trusts only default-branch content). Set to false to read from the PR target branch instead.
 repo_context_max_lines = 500 # Maximum total rendered lines for repo context, including wrapper tags
 # token limits
 max_description_tokens = 500

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -28,6 +28,8 @@ ai_timeout=120 # 2 minutes
 skip_keys = []
 custom_reasoning_model = false # when true, disables system messages and temperature controls for models that don't support chat-style inputs
 response_language="en-US" # Language locales code for PR responses in ISO 3166 and ISO 639 format (e.g., "en-US", "it-IT", "zh-CN", ...)
+repo_context_files = ["AGENTS.md"] # Repository-relative files (e.g. AGENTS.md, CLAUDE.md) to include as AI prompt context; set to [] to disable
+repo_context_max_lines = 500 # Maximum total rendered lines for repo context, including wrapper tags
 # token limits
 max_description_tokens = 500
 max_commits_tokens = 500

--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -24,6 +24,13 @@ Extra instructions from the user:
 =====
 {% endif %}
 
+{%- if repo_context %}
+
+Repository context:
+=====
+{{ repo_context }}
+=====
+{% endif %}
 
 The output must be a YAML object equivalent to type $PRDescription, according to the following Pydantic definitions:
 =====

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -78,6 +78,15 @@ Extra instructions from the user:
 ======
 {% endif %}
 
+{%- if repo_context %}
+
+
+Repository context:
+======
+{{ repo_context }}
+======
+{% endif %}
+
 
 The output must be a YAML object equivalent to type $PRReview, according to the following Pydantic definitions:
 =====

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -18,6 +18,7 @@ from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
                                          get_pr_diff, get_pr_multi_diffs,
                                          retry_with_fallback_models)
 from pr_agent.algo.skills_loader import get_skills_context
+from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, load_yaml, replace_code_tags,
                                  show_relevant_configurations, get_max_tokens, clip_tokens, get_model)
@@ -69,6 +70,7 @@ class PRCodeSuggestions:
             "num_code_suggestions": num_code_suggestions,
             "extra_instructions": get_settings().pr_code_suggestions.extra_instructions,
             "skills_context": get_skills_context(),
+            "repo_context": build_repo_context(self.git_provider),
             "commit_messages_str": self.git_provider.get_commit_messages(),
             "relevant_best_practices": "",
             "is_ai_metadata": get_settings().get("config.enable_ai_metadata", False),

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -15,6 +15,7 @@ from pr_agent.algo.pr_processing import (OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD,
                                          get_pr_diff_multiple_patchs,
                                          retry_with_fallback_models)
 from pr_agent.algo.skills_loader import get_skills_context
+from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRDescriptionHeader, clip_tokens,
                                  get_max_tokens, get_user_labels, load_yaml,
@@ -69,6 +70,7 @@ class PRDescription:
             "diff": "",  # empty diff for initial calculation
             "extra_instructions": get_settings().pr_description.extra_instructions,
             "skills_context": get_skills_context(),
+            "repo_context": build_repo_context(self.git_provider),
             "commit_messages_str": self.git_provider.get_commit_messages(),
             "enable_custom_labels": get_settings().config.enable_custom_labels,
             "custom_labels_class": "",  # will be filled if necessary in 'set_custom_labels' function

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -13,6 +13,7 @@ from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
                                          get_pr_diff,
                                          retry_with_fallback_models)
 from pr_agent.algo.skills_loader import get_skills_context
+from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRReviewHeader,
                                  convert_to_markdown_v2, github_action_output,
@@ -94,6 +95,7 @@ class PRReviewer:
             'answer_str': answer_str,
             "extra_instructions": get_settings().pr_reviewer.extra_instructions,
             "skills_context": get_skills_context(),
+            "repo_context": build_repo_context(self.git_provider),
             "commit_messages_str": self.git_provider.get_commit_messages(),
             "custom_labels": "",
             "enable_custom_labels": get_settings().config.enable_custom_labels,

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -25,6 +25,20 @@ class TestAzureDevopsProviderRepoContext:
         assert kwargs["version_descriptor"].version == "base-sha"
         assert kwargs["version_descriptor"].version_type == "commit"
 
+    def test_get_repo_file_content_from_default_branch_omits_version(self):
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr = MagicMock()
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_item.return_value = MagicMock(content="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
+
+        assert content == "repo context"
+        _, kwargs = provider.azure_devops_client.get_item.call_args
+        assert kwargs["version_descriptor"] is None  # no version -> default branch
+
     def test_get_repo_file_content_treats_failure_as_empty(self):
         provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
         provider.repo_slug = "my-repo"

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+
+
+class TestAzureDevopsProviderRepoContext:
+    def test_get_repo_file_content_reads_from_target_commit(self):
+        # Repo-context files must be read from the PR target (base) commit, matching
+        # the other providers.
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr = MagicMock()
+        provider.pr.last_merge_target_commit.commit_id = "base-sha"
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_item.return_value = MagicMock(content="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        _, kwargs = provider.azure_devops_client.get_item.call_args
+        assert kwargs["path"] == "AGENTS.md"
+        assert kwargs["repository_id"] == "my-repo"
+        assert kwargs["project"] == "my-project"
+        assert kwargs["version_descriptor"].version == "base-sha"
+        assert kwargs["version_descriptor"].version_type == "commit"
+
+    def test_get_repo_file_content_treats_failure_as_empty(self):
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr = MagicMock()
+        provider.pr.last_merge_target_commit.commit_id = "base-sha"
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_item.side_effect = Exception("not found")
+
+        assert provider.get_repo_file_content("MISSING.md") == ""

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -28,6 +28,17 @@ class TestBitbucketProvider:
         assert content == "repo context"
         provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "release-1.0")
 
+    def test_get_repo_file_content_from_default_branch(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock(destination_branch="release-1.0")
+        provider.get_repo_default_branch = MagicMock(return_value="main")
+        provider.get_pr_file_content = MagicMock(return_value="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
+
+        assert content == "repo context"
+        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "main")
+
 
 class TestBitbucketServerProvider:
     def test_parse_pr_url(self):
@@ -55,6 +66,20 @@ class TestBitbucketServerProvider:
 
         assert content == "repo context"
         provider.get_file.assert_called_once_with("AGENTS.md", "base-sha")
+
+    def test_get_repo_file_content_from_default_branch(self):
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.workspace_slug = "AAA"
+        provider.repo_slug = "my-repo"
+        provider.pr = MagicMock(toRef={"latestCommit": "base-sha"})
+        provider.bitbucket_client = MagicMock()
+        provider.bitbucket_client.get_default_branch.return_value = {"displayId": "main"}
+        provider.get_file = MagicMock(return_value="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
+
+        assert content == "repo context"
+        provider.get_file.assert_called_once_with("AGENTS.md", "main")
 
     def _make_provider_for_repo_settings(self, get_content_side_effect):
         # Bypass __init__ (which performs live API calls) and only wire up the

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -16,6 +16,18 @@ class TestBitbucketProvider:
         assert repo_slug == "MY_TEST_REPO"
         assert pr_number == 321
 
+    def test_get_repo_file_content_reads_from_target_branch(self):
+        # Repo-context files must be read from the PR destination (target) branch,
+        # matching the other providers.
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock(destination_branch="release-1.0")
+        provider.get_pr_file_content = MagicMock(return_value="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "release-1.0")
+
 
 class TestBitbucketServerProvider:
     def test_parse_pr_url(self):
@@ -31,6 +43,18 @@ class TestBitbucketServerProvider:
         assert workspace_slug == "~username"
         assert repo_slug == "my-repo"
         assert pr_number == 1
+
+    def test_get_repo_file_content_reads_from_target_ref(self):
+        # Repo-context files must be read from the PR target ref (toRef), matching
+        # the other providers.
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.pr = MagicMock(toRef={"latestCommit": "base-sha"})
+        provider.get_file = MagicMock(return_value="repo context")
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        provider.get_file.assert_called_once_with("AGENTS.md", "base-sha")
 
     def _make_provider_for_repo_settings(self, get_content_side_effect):
         # Bypass __init__ (which performs live API calls) and only wire up the

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -290,6 +290,28 @@ class TestGiteaProvider:
             filepath="AGENTS.md"
         )
 
+    def test_get_repo_file_content_from_default_branch(self):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.base_sha = "base-sha"
+        provider.base_ref = "release-1.0"
+        provider.sha = "head-sha"
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.repo_get.return_value = MagicMock(default_branch="main")
+        provider.repo_api.get_file_content.return_value = "repo context"
+
+        content = provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
+
+        assert content == "repo context"
+        provider.repo_api.get_file_content.assert_called_once_with(
+            owner="owner",
+            repo="repo",
+            commit_sha="main",
+            filepath="AGENTS.md"
+        )
+
     def test_get_repo_file_content_never_reads_from_pr_head_when_base_missing(self):
         # Security: when no target/base ref is available, the provider must NOT fall back
         # to the PR head (self.sha) — otherwise a PR could supply its own instruction files.

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1,6 +1,8 @@
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+from pr_agent.git_providers.gitea_provider import GiteaProvider
+
 
 class TestGiteaProvider:
     @patch('pr_agent.git_providers.gitea_provider.get_settings')
@@ -245,6 +247,69 @@ class TestGiteaProvider:
         empty.repo_api = MagicMock()
         empty.repo_api.get_file_content.return_value = ''
         assert empty.get_repo_settings() == b""
+
+    def test_get_repo_file_content_loads_from_base_sha(self):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.sha = "head-sha"
+        provider.base_sha = "base-sha"
+        provider.base_ref = "main"
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.return_value = "repo context"
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        provider.repo_api.get_file_content.assert_called_once_with(
+            owner="owner",
+            repo="repo",
+            commit_sha="base-sha",
+            filepath="AGENTS.md"
+        )
+
+    def test_get_repo_file_content_loads_from_base_ref_when_base_sha_missing(self):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.sha = "head-sha"
+        provider.base_sha = ""
+        provider.base_ref = "main"
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.return_value = "repo context"
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        provider.repo_api.get_file_content.assert_called_once_with(
+            owner="owner",
+            repo="repo",
+            commit_sha="main",
+            filepath="AGENTS.md"
+        )
+
+    def test_get_repo_file_content_falls_back_to_head_sha_when_base_missing(self):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.sha = "head-sha"
+        provider.base_sha = ""
+        provider.base_ref = ""
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.return_value = "repo context"
+
+        content = provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        provider.repo_api.get_file_content.assert_called_once_with(
+            owner="owner",
+            repo="repo",
+            commit_sha="head-sha",
+            filepath="AGENTS.md"
+        )
 
 
 class TestGiteaProviderAddFileDiff:

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+import pytest
+from giteapy.rest import ApiException
+
 from pr_agent.git_providers.gitea_provider import GiteaProvider
 
 
@@ -311,6 +314,33 @@ class TestGiteaProvider:
             commit_sha="main",
             filepath="AGENTS.md"
         )
+
+    def test_get_repo_file_content_treats_404_as_missing(self):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.base_sha = "base-sha"
+        provider.base_ref = "main"
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.side_effect = ApiException(status=404)
+
+        assert provider.get_repo_file_content("MISSING.md") == ""
+
+    def test_get_repo_file_content_propagates_transient_error(self):
+        # Transient/unexpected errors must propagate so the repo-context loader flags a fetch
+        # error and does not cache an empty result.
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.base_sha = "base-sha"
+        provider.base_ref = "main"
+        provider.logger = MagicMock()
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.side_effect = ApiException(status=500)
+
+        with pytest.raises(ApiException):
+            provider.get_repo_file_content("AGENTS.md")
 
     def test_get_repo_file_content_never_reads_from_pr_head_when_base_missing(self):
         # Security: when no target/base ref is available, the provider must NOT fall back

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -290,7 +290,9 @@ class TestGiteaProvider:
             filepath="AGENTS.md"
         )
 
-    def test_get_repo_file_content_falls_back_to_head_sha_when_base_missing(self):
+    def test_get_repo_file_content_never_reads_from_pr_head_when_base_missing(self):
+        # Security: when no target/base ref is available, the provider must NOT fall back
+        # to the PR head (self.sha) — otherwise a PR could supply its own instruction files.
         provider = GiteaProvider.__new__(GiteaProvider)
         provider.owner = "owner"
         provider.repo = "repo"
@@ -303,13 +305,8 @@ class TestGiteaProvider:
 
         content = provider.get_repo_file_content("AGENTS.md")
 
-        assert content == "repo context"
-        provider.repo_api.get_file_content.assert_called_once_with(
-            owner="owner",
-            repo="repo",
-            commit_sha="head-sha",
-            filepath="AGENTS.md"
-        )
+        assert content == ""
+        provider.repo_api.get_file_content.assert_not_called()
 
 
 class TestGiteaProviderAddFileDiff:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -73,8 +73,9 @@ class TestGitLabProvider:
 
         assert content == ""
 
-    def test_get_repo_file_content_loads_from_default_branch(self, gitlab_provider, mock_gitlab_client, mock_project):
+    def test_get_repo_file_content_loads_from_mr_target_branch(self, gitlab_provider, mock_gitlab_client, mock_project):
         mock_project.default_branch = "main"
+        gitlab_provider.mr = MagicMock(target_branch="release-1.0")
         mock_file = MagicMock(ProjectFile)
         mock_file.decode.return_value = b"repo context"
         mock_project.files.get.return_value = mock_file
@@ -83,11 +84,24 @@ class TestGitLabProvider:
 
         assert content == "repo context"
         mock_gitlab_client.projects.get.assert_called_with("test/repo")
-        mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="main")
+        mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="release-1.0")
         mock_file.decode.assert_called_once()
+
+    def test_get_repo_file_content_falls_back_to_default_branch_without_mr(self, gitlab_provider, mock_project):
+        mock_project.default_branch = "main"
+        gitlab_provider.mr = None
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = b"repo context"
+        mock_project.files.get.return_value = mock_file
+
+        content = gitlab_provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="main")
 
     def test_get_repo_file_content_treats_missing_file_as_empty(self, gitlab_provider, mock_project):
         mock_project.default_branch = "main"
+        gitlab_provider.mr = MagicMock(target_branch="main")
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
 
         content = gitlab_provider.get_repo_file_content("AGENTS.md")

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -87,6 +87,18 @@ class TestGitLabProvider:
         mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="release-1.0")
         mock_file.decode.assert_called_once()
 
+    def test_get_repo_file_content_from_default_branch_ignores_target(self, gitlab_provider, mock_project):
+        mock_project.default_branch = "main"
+        gitlab_provider.mr = MagicMock(target_branch="release-1.0")
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = b"repo context"
+        mock_project.files.get.return_value = mock_file
+
+        content = gitlab_provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
+
+        assert content == "repo context"
+        mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="main")
+
     def test_get_repo_file_content_falls_back_to_default_branch_without_mr(self, gitlab_provider, mock_project):
         mock_project.default_branch = "main"
         gitlab_provider.mr = None

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -73,6 +73,27 @@ class TestGitLabProvider:
 
         assert content == ""
 
+    def test_get_repo_file_content_loads_from_default_branch(self, gitlab_provider, mock_gitlab_client, mock_project):
+        mock_project.default_branch = "main"
+        mock_file = MagicMock(ProjectFile)
+        mock_file.decode.return_value = b"repo context"
+        mock_project.files.get.return_value = mock_file
+
+        content = gitlab_provider.get_repo_file_content("AGENTS.md")
+
+        assert content == "repo context"
+        mock_gitlab_client.projects.get.assert_called_with("test/repo")
+        mock_project.files.get.assert_called_once_with(file_path="AGENTS.md", ref="main")
+        mock_file.decode.assert_called_once()
+
+    def test_get_repo_file_content_treats_missing_file_as_empty(self, gitlab_provider, mock_project):
+        mock_project.default_branch = "main"
+        mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
+
+        content = gitlab_provider.get_repo_file_content("AGENTS.md")
+
+        assert content == ""
+
     def test_create_or_update_pr_file_create_new(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
         mock_file = MagicMock()

--- a/tests/unittest/test_repo_context.py
+++ b/tests/unittest/test_repo_context.py
@@ -1,0 +1,541 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from jinja2 import Environment, StrictUndefined, select_autoescape
+
+from pr_agent.algo import repo_context
+from pr_agent.algo.repo_context import (
+    TRUNCATION_MARKER,
+    build_repo_context,
+    render_instruction_files,
+    render_instruction_files_with_line_budget,
+)
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+
+
+class FakeProvider:
+    def __init__(self, files, pr_url=None):
+        self.files = files
+        self.pr_url = pr_url
+        self.requested_paths = []
+
+    def get_repo_file_content(self, file_path: str):
+        self.requested_paths.append(file_path)
+        return self.files.get(file_path)
+
+
+class UnsupportedProvider:
+    get_repo_file_content = GitProvider.get_repo_file_content
+
+
+@pytest.fixture
+def repo_context_settings():
+    settings = get_settings()
+    original_files = settings.config.get("repo_context_files", [])
+    original_max_lines = settings.config.get("repo_context_max_lines", 500)
+    original_warned_provider_classes = repo_context._unsupported_repo_context_provider_classes.copy()
+    original_process_cache = repo_context._repo_context_process_cache.copy()
+
+    yield settings
+
+    settings.set("CONFIG.REPO_CONTEXT_FILES", original_files)
+    settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", original_max_lines)
+    repo_context._unsupported_repo_context_provider_classes = original_warned_provider_classes
+    repo_context._repo_context_process_cache = original_process_cache
+
+
+def test_default_config_ships_agents_md_as_repo_context():
+    import tomllib
+    from pathlib import Path
+
+    import pr_agent
+
+    config_path = Path(pr_agent.__file__).parent / "settings" / "configuration.toml"
+    with open(config_path, "rb") as config_file:
+        config = tomllib.load(config_file)
+
+    assert config["config"]["repo_context_files"] == ["AGENTS.md"]
+
+
+def test_build_repo_context_fetches_and_formats_configured_files(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md", "CONTRIBUTING.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    provider = FakeProvider({
+        "AGENTS.md": "# Agent Guide\nUse focused tests.",
+        "CONTRIBUTING.md": "Keep PRs small.",
+    })
+
+    context = build_repo_context(provider)
+
+    assert context == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="AGENTS.md" scope="repo-root">\n'
+        "`````markdown\n"
+        "# Agent Guide\n"
+        "Use focused tests.\n"
+        "`````\n"
+        "</file>\n\n"
+        '<file path="CONTRIBUTING.md" scope="repo-root">\n'
+        "`````markdown\n"
+        "Keep PRs small.\n"
+        "`````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+    assert provider.requested_paths == ["AGENTS.md", "CONTRIBUTING.md"]
+
+
+def test_build_repo_context_reuses_provider_cache_for_same_config(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md", "CONTRIBUTING.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    provider = FakeProvider({
+        "AGENTS.md": "Repo purpose",
+        "CONTRIBUTING.md": "Keep PRs small.",
+    })
+
+    first_context = build_repo_context(provider)
+    second_context = build_repo_context(provider)
+
+    assert second_context == first_context
+    assert provider.requested_paths == ["AGENTS.md", "CONTRIBUTING.md"]
+
+
+def test_build_repo_context_reuses_process_cache_for_same_pr_url(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    first_provider = FakeProvider({"AGENTS.md": "Repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+    second_provider = FakeProvider({"AGENTS.md": "Changed repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+
+    first_context = build_repo_context(first_provider)
+    second_context = build_repo_context(second_provider)
+
+    assert second_context == first_context
+    assert "Repo purpose" in second_context
+    assert "Changed repo purpose" not in second_context
+    assert first_provider.requested_paths == ["AGENTS.md"]
+    assert second_provider.requested_paths == []
+
+
+def test_build_repo_context_refreshes_process_cache_after_ttl(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    first_provider = FakeProvider({"AGENTS.md": "Repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+    second_provider = FakeProvider({"AGENTS.md": "Changed repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+
+    with patch("pr_agent.algo.repo_context.time.monotonic", side_effect=[100, 100, 2000, 2000, 2000, 2000]):
+        first_context = build_repo_context(first_provider)
+        second_context = build_repo_context(second_provider)
+
+    assert "Repo purpose" in first_context
+    assert "Changed repo purpose" in second_context
+    assert first_provider.requested_paths == ["AGENTS.md"]
+    assert second_provider.requested_paths == ["AGENTS.md"]
+
+
+def test_build_repo_context_refreshes_empty_process_cache_after_ttl(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    first_provider = FakeProvider({}, pr_url="https://example.com/org/repo/pull/1")
+    second_provider = FakeProvider({"AGENTS.md": "Repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+
+    with patch("pr_agent.algo.repo_context.time.monotonic", side_effect=[100, 100, 2000, 2000, 2000, 2000]):
+        first_context = build_repo_context(first_provider)
+        second_context = build_repo_context(second_provider)
+
+    assert first_context == ""
+    assert "Repo purpose" in second_context
+    assert first_provider.requested_paths == ["AGENTS.md"]
+    assert second_provider.requested_paths == ["AGENTS.md"]
+
+
+def test_repo_context_cache_evicts_oldest_entry_when_full():
+    cache = repo_context._RepoContextCache(max_size=2, ttl_seconds=900)
+    missing = object()
+
+    with patch("pr_agent.algo.repo_context.time.monotonic", return_value=100):
+        cache["first"] = "one"
+        cache["second"] = "two"
+        cache["third"] = "three"
+
+        assert cache.get("first", missing) is missing
+        assert cache.get("second", missing) == "two"
+        assert cache.get("third", missing) == "three"
+
+
+def test_get_repo_context_config_normalizes_inputs(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", "AGENTS.md")
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", "12")
+
+    assert repo_context._get_repo_context_config() == (["AGENTS.md"], 12)
+
+
+def test_get_repo_context_config_rejects_non_list_container(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", {"AGENTS.md": True})
+
+    assert repo_context._get_repo_context_config() is None
+
+
+def test_provider_supports_repo_context_warns_once_for_unsupported_provider(repo_context_settings):
+    provider = UnsupportedProvider()
+
+    with patch("pr_agent.algo.repo_context.get_logger") as mock_get_logger:
+        assert repo_context._provider_supports_repo_context(provider) is False
+        assert repo_context._provider_supports_repo_context(provider) is False
+
+    mock_get_logger.return_value.warning.assert_called_once_with(
+        "repo_context_files is configured, but UnsupportedProvider does not support repository file fetching; "
+        "skipping repo context"
+    )
+
+
+def test_load_repo_context_files_normalizes_fetch_results():
+    provider = FakeProvider({
+        "AGENTS.md": b"Repo purpose",
+        "EMPTY.md": "",
+        "MISSING.md": None,
+    })
+
+    files, had_fetch_error = repo_context._load_repo_context_files(
+        provider, ["AGENTS.md", "EMPTY.md", "MISSING.md", " "]
+    )
+
+    assert files == {"AGENTS.md": "Repo purpose"}
+    assert had_fetch_error is False
+    assert provider.requested_paths == ["AGENTS.md", "EMPTY.md", "MISSING.md"]
+
+
+def test_load_repo_context_files_reports_fetch_errors():
+    provider = FakeProvider({})
+    provider.get_repo_file_content = Mock(side_effect=Exception("temporary outage"))
+
+    files, had_fetch_error = repo_context._load_repo_context_files(provider, ["AGENTS.md"])
+
+    assert files == {}
+    assert had_fetch_error is True
+
+
+def test_build_repo_context_process_cache_invalidates_when_config_changes(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    first_provider = FakeProvider({
+        "AGENTS.md": "Repo purpose",
+        "CONTRIBUTING.md": "Keep PRs small.",
+    }, pr_url="https://example.com/org/repo/pull/1")
+    second_provider = FakeProvider({
+        "AGENTS.md": "Repo purpose",
+        "CONTRIBUTING.md": "Keep PRs small.",
+    }, pr_url="https://example.com/org/repo/pull/1")
+
+    first_context = build_repo_context(first_provider)
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["CONTRIBUTING.md"])
+    second_context = build_repo_context(second_provider)
+
+    assert "Repo purpose" in first_context
+    assert "Keep PRs small." in second_context
+    assert first_provider.requested_paths == ["AGENTS.md"]
+    assert second_provider.requested_paths == ["CONTRIBUTING.md"]
+
+
+def test_build_repo_context_does_not_cache_empty_context_after_fetch_error(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    provider = FakeProvider({"AGENTS.md": "Repo purpose"}, pr_url="https://example.com/org/repo/pull/1")
+    provider.get_repo_file_content = Mock(side_effect=[Exception("temporary outage"), "Repo purpose"])
+
+    first_context = build_repo_context(provider)
+    second_context = build_repo_context(provider)
+
+    assert first_context == ""
+    assert "Repo purpose" in second_context
+    assert provider.get_repo_file_content.call_count == 2
+
+
+def test_build_repo_context_cache_invalidates_when_repo_context_files_change(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    provider = FakeProvider({
+        "AGENTS.md": "Repo purpose",
+        "CONTRIBUTING.md": "Keep PRs small.",
+    })
+
+    first_context = build_repo_context(provider)
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["CONTRIBUTING.md"])
+    second_context = build_repo_context(provider)
+
+    assert "Repo purpose" in first_context
+    assert "Keep PRs small." in second_context
+    assert provider.requested_paths == ["AGENTS.md", "CONTRIBUTING.md"]
+
+
+def test_build_repo_context_cache_invalidates_when_line_budget_changes(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 9)
+    provider = FakeProvider({"AGENTS.md": "one\ntwo\nthree"})
+
+    truncated_context = build_repo_context(provider)
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    full_context = build_repo_context(provider)
+
+    assert TRUNCATION_MARKER in truncated_context
+    assert "one\ntwo\nthree" in full_context
+    assert provider.requested_paths == ["AGENTS.md", "AGENTS.md"]
+
+
+def test_render_instruction_files_escapes_path_and_derives_scope():
+    context = render_instruction_files({
+        'docs/Agent "Notes".md': "Use <literal> markers.\n",
+    })
+
+    assert context == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="docs/Agent &quot;Notes&quot;.md" scope="docs">\n'
+        "`````markdown\n"
+        "Use <literal> markers.\n"
+        "`````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+
+
+def test_render_instruction_files_uses_longer_fence_when_content_contains_default_fence():
+    context = render_instruction_files({
+        "AGENTS.md": "Avoid closing this fence:\n`````",
+    })
+
+    assert context == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="AGENTS.md" scope="repo-root">\n'
+        "``````markdown\n"
+        "Avoid closing this fence:\n"
+        "`````\n"
+        "``````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+
+
+def test_render_instruction_files_with_line_budget_uses_longer_fence_for_conflicting_content():
+    context = render_instruction_files_with_line_budget({
+        "AGENTS.md": "Avoid closing this fence:\n`````",
+    }, max_lines=500)
+
+    assert context == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="AGENTS.md" scope="repo-root">\n'
+        "``````markdown\n"
+        "Avoid closing this fence:\n"
+        "`````\n"
+        "``````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+
+
+def test_build_repo_context_skips_invalid_missing_and_empty_files(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["", 7, "MISSING.md", "EMPTY.md", "AGENTS.md"])
+    provider = FakeProvider({"EMPTY.md": "", "AGENTS.md": "Loaded context"})
+
+    assert build_repo_context(provider) == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="AGENTS.md" scope="repo-root">\n'
+        "`````markdown\n"
+        "Loaded context\n"
+        "`````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+    assert provider.requested_paths == ["MISSING.md", "EMPTY.md", "AGENTS.md"]
+
+
+def test_build_repo_context_enforces_total_line_cap(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md", "CONTRIBUTING.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 4)
+    provider = FakeProvider({
+        "AGENTS.md": "one\ntwo\nthree",
+        "CONTRIBUTING.md": "four\nfive",
+    })
+
+    context = build_repo_context(provider)
+
+    assert context == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        "</instruction_files>"
+    )
+    assert len(context.splitlines()) <= 4
+
+
+def test_render_instruction_files_with_line_budget_returns_empty_when_wrapper_exceeds_budget():
+    context = render_instruction_files_with_line_budget({
+        "AGENTS.md": "one",
+    }, max_lines=2)
+
+    assert context == ""
+
+
+@pytest.mark.parametrize("max_lines", range(0, 12))
+def test_render_instruction_files_with_line_budget_never_exceeds_configured_budget(max_lines):
+    context = render_instruction_files_with_line_budget({
+        "AGENTS.md": "one\ntwo\nthree",
+        "CONTRIBUTING.md": "four\nfive",
+    }, max_lines=max_lines)
+
+    assert len(context.splitlines()) <= max_lines
+
+
+def test_build_repo_context_returns_empty_when_no_files_configured(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", [])
+
+    assert build_repo_context(FakeProvider({"AGENTS.md": "repo purpose"})) == ""
+
+
+def test_build_repo_context_treats_string_config_as_single_file(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", "AGENTS.md")
+    provider = FakeProvider({"AGENTS.md": "repo purpose"})
+
+    assert build_repo_context(provider) == (
+        "You are being given instruction files. Follow them as project-specific guidance when reviewing code.\n"
+        "<instruction_files>\n"
+        '<file path="AGENTS.md" scope="repo-root">\n'
+        "`````markdown\n"
+        "repo purpose\n"
+        "`````\n"
+        "</file>\n\n"
+        "</instruction_files>"
+    )
+    assert provider.requested_paths == ["AGENTS.md"]
+
+
+def test_build_repo_context_skips_non_list_container(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", {"AGENTS.md": True})
+    provider = FakeProvider({"AGENTS.md": "repo purpose"})
+
+    assert build_repo_context(provider) == ""
+    assert provider.requested_paths == []
+
+
+def test_build_repo_context_warns_once_for_provider_without_repo_file_fetching(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    provider = UnsupportedProvider()
+
+    with patch("pr_agent.algo.repo_context.get_logger") as mock_get_logger:
+        context = build_repo_context(provider)
+        second_context = build_repo_context(provider)
+
+    assert context == ""
+    assert second_context == ""
+    mock_get_logger.return_value.warning.assert_called_once_with(
+        "repo_context_files is configured, but UnsupportedProvider does not support repository file fetching; "
+        "skipping repo context"
+    )
+
+
+def test_github_provider_decodes_repo_context_files_and_treats_failures_as_missing():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo_obj = Mock()
+    provider.repo_obj.get_contents.return_value.decoded_content = b"repo context"
+
+    assert provider.get_repo_file_content("AGENTS.md") == "repo context"
+
+    provider.repo_obj.get_contents.side_effect = Exception("not found")
+
+    assert provider.get_repo_file_content("MISSING.md") == ""
+
+
+def test_github_provider_reads_repo_context_files_from_pr_base_ref():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo_obj = Mock()
+    provider.repo_obj.get_contents.return_value.decoded_content = b"repo context"
+    provider.pr = Mock(base=Mock(sha="base-sha", ref="release/1.0"))
+
+    assert provider.get_repo_file_content("AGENTS.md") == "repo context"
+    provider.repo_obj.get_contents.assert_called_once_with("AGENTS.md", ref="base-sha")
+
+
+def test_github_provider_falls_back_to_default_branch_without_pr_base():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo_obj = Mock()
+    provider.repo_obj.get_contents.return_value.decoded_content = b"repo context"
+    provider.pr = None
+
+    assert provider.get_repo_file_content("AGENTS.md") == "repo context"
+    provider.repo_obj.get_contents.assert_called_once_with("AGENTS.md")
+
+
+@pytest.mark.parametrize(
+    "prompt_name,variables",
+    [
+        (
+            "pr_review_prompt",
+            {
+                "extra_instructions": "",
+                "repo_context": render_instruction_files({"AGENTS.md": "Repo purpose"}),
+                "skills_context": "",
+                "require_can_be_split_review": False,
+                "related_tickets": "",
+                "require_estimate_contribution_time_cost": False,
+                "require_score": False,
+                "require_tests": True,
+                "question_str": "",
+                "require_security_review": True,
+                "require_todo_scan": False,
+                "require_estimate_effort_to_review": True,
+                "num_max_findings": 3,
+                "num_pr_files": 1,
+                "is_ai_metadata": False,
+            },
+        ),
+        (
+            "pr_description_prompt",
+            {
+                "extra_instructions": "",
+                "repo_context": render_instruction_files({"AGENTS.md": "Repo purpose"}),
+                "skills_context": "",
+                "enable_custom_labels": False,
+                "custom_labels_class": "",
+                "enable_semantic_files_types": True,
+                "include_file_summary_changes": True,
+                "enable_pr_diagram": False,
+            },
+        ),
+        (
+            "pr_code_suggestions_prompt",
+            {
+                "extra_instructions": "",
+                "repo_context": render_instruction_files({"AGENTS.md": "Repo purpose"}),
+                "skills_context": "",
+                "focus_only_on_problems": True,
+                "num_code_suggestions": 3,
+                "is_ai_metadata": False,
+            },
+        ),
+        (
+            "pr_code_suggestions_prompt_not_decoupled",
+            {
+                "extra_instructions": "",
+                "repo_context": render_instruction_files({"AGENTS.md": "Repo purpose"}),
+                "skills_context": "",
+                "focus_only_on_problems": True,
+                "num_code_suggestions": 3,
+                "is_ai_metadata": False,
+            },
+        ),
+    ],
+)
+def test_prompt_templates_render_configured_repo_context(prompt_name, variables):
+    template = getattr(get_settings(), prompt_name).system
+
+    # select_autoescape() leaves string templates unescaped (matching production prompt rendering)
+    # while avoiding the hard-coded autoescape=False that static analysis flags.
+    environment = Environment(autoescape=select_autoescape(default_for_string=False), undefined=StrictUndefined)
+    rendered = environment.from_string(template).render(variables)
+
+    assert "Repository context:" in rendered
+    assert '<file path="AGENTS.md" scope="repo-root">' in rendered

--- a/tests/unittest/test_repo_context.py
+++ b/tests/unittest/test_repo_context.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from github import GithubException
 from jinja2 import Environment, StrictUndefined, select_autoescape
 
 from pr_agent.algo import repo_context
@@ -83,6 +84,27 @@ def test_build_repo_context_reads_from_target_branch_when_disabled(repo_context_
     build_repo_context(provider)
 
     assert provider.from_default_branch_calls == [False]
+
+
+@pytest.mark.parametrize(
+    "config_value,expected",
+    [
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("true", True),
+        ("1", True),
+        ("maybe", True),  # unparseable -> secure default
+    ],
+)
+def test_build_repo_context_parses_string_default_branch_flag(repo_context_settings, config_value, expected):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FROM_DEFAULT_BRANCH", config_value)
+    provider = FakeProvider({"AGENTS.md": "Repo purpose"})
+
+    build_repo_context(provider)
+
+    assert provider.from_default_branch_calls == [expected]
 
 
 def test_build_repo_context_fetches_and_formats_configured_files(repo_context_settings):
@@ -463,16 +485,28 @@ def test_build_repo_context_warns_once_for_provider_without_repo_file_fetching(r
     )
 
 
-def test_github_provider_decodes_repo_context_files_and_treats_failures_as_missing():
+def test_github_provider_decodes_repo_context_files_and_treats_404_as_missing():
     provider = GithubProvider.__new__(GithubProvider)
     provider.repo_obj = Mock()
     provider.repo_obj.get_contents.return_value.decoded_content = b"repo context"
 
     assert provider.get_repo_file_content("AGENTS.md") == "repo context"
 
-    provider.repo_obj.get_contents.side_effect = Exception("not found")
+    # A genuine 404 (missing file) is treated as "no context".
+    provider.repo_obj.get_contents.side_effect = GithubException(404, {"message": "Not Found"}, {})
 
     assert provider.get_repo_file_content("MISSING.md") == ""
+
+
+def test_github_provider_propagates_transient_fetch_errors():
+    # Transient/unexpected errors must propagate (not be swallowed as "missing"), so the
+    # repo-context loader flags a fetch error and does not cache an empty result.
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo_obj = Mock()
+    provider.repo_obj.get_contents.side_effect = GithubException(500, {"message": "Server Error"}, {})
+
+    with pytest.raises(GithubException):
+        provider.get_repo_file_content("AGENTS.md")
 
 
 def test_github_provider_reads_repo_context_files_from_pr_base_ref():

--- a/tests/unittest/test_repo_context.py
+++ b/tests/unittest/test_repo_context.py
@@ -20,9 +20,11 @@ class FakeProvider:
         self.files = files
         self.pr_url = pr_url
         self.requested_paths = []
+        self.from_default_branch_calls = []
 
-    def get_repo_file_content(self, file_path: str):
+    def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         self.requested_paths.append(file_path)
+        self.from_default_branch_calls.append(from_default_branch)
         return self.files.get(file_path)
 
 
@@ -35,6 +37,7 @@ def repo_context_settings():
     settings = get_settings()
     original_files = settings.config.get("repo_context_files", [])
     original_max_lines = settings.config.get("repo_context_max_lines", 500)
+    original_from_default_branch = settings.config.get("repo_context_from_default_branch", True)
     original_warned_provider_classes = repo_context._unsupported_repo_context_provider_classes.copy()
     original_process_cache = repo_context._repo_context_process_cache.copy()
 
@@ -42,6 +45,7 @@ def repo_context_settings():
 
     settings.set("CONFIG.REPO_CONTEXT_FILES", original_files)
     settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", original_max_lines)
+    settings.set("CONFIG.REPO_CONTEXT_FROM_DEFAULT_BRANCH", original_from_default_branch)
     repo_context._unsupported_repo_context_provider_classes = original_warned_provider_classes
     repo_context._repo_context_process_cache = original_process_cache
 
@@ -57,6 +61,28 @@ def test_default_config_ships_agents_md_as_repo_context():
         config = tomllib.load(config_file)
 
     assert config["config"]["repo_context_files"] == ["AGENTS.md"]
+    # Reading from the default branch is the secure default.
+    assert config["config"]["repo_context_from_default_branch"] is True
+
+
+def test_build_repo_context_reads_from_default_branch_by_default(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FROM_DEFAULT_BRANCH", True)
+    provider = FakeProvider({"AGENTS.md": "Repo purpose"})
+
+    build_repo_context(provider)
+
+    assert provider.from_default_branch_calls == [True]
+
+
+def test_build_repo_context_reads_from_target_branch_when_disabled(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FROM_DEFAULT_BRANCH", False)
+    provider = FakeProvider({"AGENTS.md": "Repo purpose"})
+
+    build_repo_context(provider)
+
+    assert provider.from_default_branch_calls == [False]
 
 
 def test_build_repo_context_fetches_and_formats_configured_files(repo_context_settings):
@@ -467,6 +493,17 @@ def test_github_provider_falls_back_to_default_branch_without_pr_base():
 
     assert provider.get_repo_file_content("AGENTS.md") == "repo context"
     provider.repo_obj.get_contents.assert_called_once_with("AGENTS.md")
+
+
+def test_github_provider_reads_from_default_branch_when_requested():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo_obj = Mock()
+    provider.repo_obj.get_contents.return_value.decoded_content = b"repo context"
+    # Even with a PR base ref available, from_default_branch must ignore it.
+    provider.pr = Mock(base=Mock(sha="base-sha", ref="release/1.0"))
+
+    assert provider.get_repo_file_content("AGENTS.md", from_default_branch=True) == "repo context"
+    provider.repo_obj.get_contents.assert_called_once_with("AGENTS.md")  # no ref -> default branch
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### **User description**

I backed out my [other PR](https://github.com/The-PR-Agent/pr-agent/pull/2358) because it was too many changes (previously included "de-dupe inline comments") in one PR.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add support for per-repository context files (AGENTS.md, CLAUDE.md, etc.) included in AI prompts

- Allow overriding Claude extended thinking models via configuration

- Support GitHub organization-level global settings repository

- Implement repo context caching with TTL and size limits

- Add repo file fetching for Gitea, GitLab, and GitHub providers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration"] -->|repo_context_files| B["Repo Context Builder"]
  B -->|fetch files| C["Git Providers"]
  C -->|AGENTS.md, CLAUDE.md| D["Instruction Files Renderer"]
  D -->|formatted context| E["AI Prompts"]
  F["Claude Models Override"] -->|claude_extended_thinking_models_override| G["LiteLLM Handler"]
  G -->|extended thinking| E
  H["GitHub Org Settings"] -->|global .pr_agent.toml| I["Settings Merger"]
  I -->|merged config| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Expand Claude extended thinking model support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>litellm_ai_handler.py</strong><dd><code>Add configurable Claude extended thinking model override</code>&nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repo_context.py</strong><dd><code>New module for repository context file handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-13c79bd37b82d9bd07f7d4c64c0bd29a7ca00182bf702a71f23a96fd91cacec2">+265/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>git_provider.py</strong><dd><code>Add base method for repository file content retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-52d45f12b836f77ed1aef86e972e65404634ea4e2a6083fb71a9b0f9bb9e062f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gitea_provider.py</strong><dd><code>Implement repository file content fetching for Gitea</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>github_provider.py</strong><dd><code>Add GitHub org-level settings and repo file fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gitlab_provider.py</strong><dd><code>Implement repository file content fetching for GitLab</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.py</strong><dd><code>Support multiple repository settings files with merging</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-314199df3610cf35a472e952294faf0f5fbb516a2bd217e891a510fd1a698bca">+29/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pr_code_suggestions.py</strong><dd><code>Include repository context in code suggestions prompts</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_description.py</strong><dd><code>Include repository context in description prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_reviewer.py</strong><dd><code>Include repository context in review prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_code_suggestions_prompts.toml</strong><dd><code>Add repository context section to code suggestions template</code></dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-2c15653dcc18b3b1bdc1022699b8ddfe1dc98e3463aa81a67f064c26238fb006">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_code_suggestions_prompts_not_decoupled.toml</strong><dd><code>Add repository context section to non-decoupled template</code>&nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-6a060c7790e0b4427bb8e6d7c8f60303accd2e2445dbc12274788bfb6afebd45">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_description_prompts.toml</strong><dd><code>Add repository context section to description template</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_reviewer_prompts.toml</strong><dd><code>Add repository context section to review template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>configuration.toml</strong><dd><code>Add repo context and Claude model override configuration options</code></dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_git_provider_utils.py</strong><dd><code>Add tests for merged global and local settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-0b039faa5e9ca6798a515aea405f84a1ff86d9b1f7a01dcc1ec743c92203308b">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gitea_provider.py</strong><dd><code>Add tests for Gitea repository file content fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-ba40939d8f8ee99dd52ee0fcf6906d8bf99111463f39a4068c9b90e556e35580">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_github_provider_settings.py</strong><dd><code>New tests for GitHub org-level settings support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-56320a224df4b48a1f13dbb6839188bba691437e948ef8d491bee0fb914a923c">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gitlab_provider.py</strong><dd><code>Add tests for GitLab repository file content fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-c238be75ae92bb320f78fd1ba04127d984c65bc7adb6e68cafc34b03a798857b">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_litellm_claude_extended_thinking.py</strong><dd><code>New tests for Claude extended thinking model override</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-c394f74e42afeba9bb9caaeef032ca5525baa9c70c463b841a11ef999e3365b0">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_repo_context.py</strong><dd><code>Comprehensive tests for repository context functionality</code>&nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-04b63729e1b74c266c6bc5d64a1129caf6fee586a85a540d76684f7ead9d880e">+501/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>github.md</strong><dd><code>Document GitHub organization-level settings support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-e73a6a650491a94e59d2b22db828e80548158694e07b521342f7dfe6fa3f1866">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration_options.md</strong><dd><code>Document global settings and GitHub Enterprise support</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/The-PR-Agent/pr-agent/pull/2387/files#diff-5b3d743def9f77f0b3ac72c61a3eec1418f87313b285ca3926b196828d8ecc2d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

