### PR TITLE
chore(deps): upgrade LiteLLM from v1.83.14 to v1.84.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-cloud-aiplatform==1.38.0
 google-generativeai==0.8.3
 google-cloud-storage==2.10.0
 Jinja2==3.1.6
-litellm==1.83.14
+litellm==1.84.0
 loguru==0.7.2
 msrest==0.7.1
 openai>=1.55.3


### PR DESCRIPTION
## What

Bumps `litellm` from `1.83.14` to `1.84.0` in `requirements.txt`.

## Why

`litellm` 1.83.13 and 1.83.14 ship an **exact pin** `pydantic==2.12.5`. This silently puts a hard ceiling on `pydantic` for the entire project — any PR that touches `pydantic` fails CI with `ResolutionImpossible`. For example, #2374 (`pydantic==2.13.3`) currently fails its `build-and-test` job for exactly this reason:

```
pr-agent depends on pydantic==2.13.3
litellm 1.83.14 depends on pydantic==2.12.5
ERROR: ResolutionImpossible
```

For comparison:

| litellm | pydantic constraint |
|---|---|
| 1.81.12 (previous) | `>=2.5.0,<3.0.0` (loose) |
| 1.83.14 (current) | `==2.12.5` (hard pin) |
| 1.84.0 (this PR) | `>=2.10.0,<3.0.0` (loose) |

1.84.0 restores a loose constraint, removing the ceiling and unblocking dependency updates.

## Verification

`pip install --dry-run -r requirements.txt` resolves cleanly with no conflicts (exit 0).