### PR TITLE
Replace old qodo-ai/pr-agent refs with new the-pr-agent/pr-agent

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 version: 0.1
 contact_links:
   - name: Discussions
-    url: https://github.com/qodo-ai/pr-agent/discussions
+    url: https://github.com/the-pr-agent/pr-agent/discussions
     about: GitHub Discussions
 
   - name: Discord community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ Thank you for your interest in contributing to the PR-Agent project!
 
 - Join our [Discord community](https://discord.com/channels/1057273017547378788/1126104260430528613) for questions and discussions
 - Check the [documentation](https://qodo-merge-docs.qodo.ai/) for detailed information
-- Report bugs or request features through [GitHub Issues](https://github.com/qodo-ai/pr-agent/issues)
+- Report bugs or request features through [GitHub Issues](https://github.com/the-pr-agent/pr-agent/issues)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pr-agent --pr_url https://github.com/owner/repo/pull/123 review
 [//]: # (## Jun 21, 2025)
 
 [//]: # ()
-[//]: # (v0.30 was [released]&#40;https://github.com/qodo-ai/pr-agent/releases&#41;)
+[//]: # (v0.30 was [released]&#40;https://github.com/the-pr-agent/pr-agent/releases&#41;)
 
 [//]: # ()
 [//]: # ()
@@ -231,7 +231,7 @@ https://openai.com/enterprise-privacy
 
 ## Contributing
 
-To contribute to the project, get started by reading our [Contributing Guide](https://github.com/qodo-ai/pr-agent/blob/b09eec265ef7d36c232063f76553efb6b53979ff/CONTRIBUTING.md).
+To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/b09eec265ef7d36c232063f76553efb6b53979ff/CONTRIBUTING.md).
 
 
 ## ❤️ Community

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,13 +27,13 @@ This section outlines which versions of PR-Agent are currently supported with se
 For the most recent updates, use our latest Docker image which is automatically built nightly:
 
 ```yaml
-uses: qodo-ai/pr-agent@main
+uses: the-pr-agent/pr-agent@main
 ```
 
 #### Specific Release Version
 
 For a fixed version, you can pin your action to a specific release version. Browse available releases at:
-[PR-Agent Releases](https://github.com/qodo-ai/pr-agent/releases)
+[PR-Agent Releases](https://github.com/the-pr-agent/pr-agent/releases)
 
 For example, to github action:
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -111,7 +111,7 @@ class GithubProvider(GitProvider):
         return f"{self.base_url_html}/{repo_path}.git" #https://github.com / <OWNER>/<REPO>.git
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
-    # Example: https://github.com/qodo-ai/pr-agent.git and branch: v0.8 -> prefix: "https://github.com/qodo-ai/pr-agent/blob/v0.8", suffix: ""
+    # Example: https://github.com/the-pr-agent/pr-agent.git and branch: v0.8 -> prefix: "https://github.com/the-pr-agent/pr-agent/blob/v0.8", suffix: ""
     # In case git url is not provided, provider will use PR context (which includes branch) to determine the prefix and suffix.
     def get_canonical_url_parts(self, repo_git_url:str, desired_branch:str) -> Tuple[str, str]:
         owner = None

--- a/tests/unittest/test_fetching_sub_issues.py
+++ b/tests/unittest/test_fetching_sub_issues.py
@@ -101,7 +101,7 @@
 #         Test fetch_sub_issues() to ensure an empty set is returned for an issue with no sub-issues.
 #         """
 #         github_provider = GithubProvider()
-#         issue_url = "https://github.com/qodo-ai/pr-agent/issues/1499"  # Likely non-existent issue
+#         issue_url = "https://github.com/the-pr-agent/pr-agent/issues/1499"  # Likely non-existent issue
 #         result = github_provider.fetch_sub_issues(issue_url)
 #
 #         print("Fetched sub-issues for non-existent issue:", result)

--- a/tests/unittest/test_fresh_vars_functionality.py
+++ b/tests/unittest/test_fresh_vars_functionality.py
@@ -6,7 +6,7 @@ particularly for the GitLab credentials use case where values should be reloaded
 on each access rather than being cached.
 
 The tests are designed to detect if fresh_vars is broken due to custom loader changes,
-such as those introduced in https://github.com/qodo-ai/pr-agent/pull/2087.
+such as those introduced in https://github.com/the-pr-agent/pr-agent/pull/2087.
 """
 
 import os


### PR DESCRIPTION
Use the lowercase namespace to match existing docs and action examples.

GitHub displays the owner as The-PR-Agent, but repository paths are case-insensitive, so this keeps the tree consistent without relying on redirects.

## GitHub Copilot PR Summary

> This pull request updates all references from the old `qodo-ai/pr-agent` repository to the new `the-pr-agent/pr-agent` repository across documentation, configuration files, code comments, and tests. This ensures consistency and prevents confusion for contributors and users by pointing to the correct repository and community resources.
> 
> Repository reference updates:
> 
> * Updated all URLs in documentation files (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`) to use `https://github.com/the-pr-agent/pr-agent` instead of the old `qodo-ai/pr-agent` links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R115) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L234-R234) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L38-R38) [[4]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L30-R36)
> * Changed the GitHub Discussions and Issues links in `.github/ISSUE_TEMPLATE/config.yml` and documentation to the new repository. [[1]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L5-R5) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L38-R38)
> 
> Code and test updates:
> 
> * Updated example repository URLs and comments in code and test files (`github_provider.py`, `test_fetching_sub_issues.py`, `test_fresh_vars_functionality.py`) to reference `the-pr-agent/pr-agent`. [[1]](diffhunk://#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11L114-R114) [[2]](diffhunk://#diff-00367d20ab0d561e72d6bffc80a7e49d418c126630adadc839a9323a34aa420fL104-R104) [[3]](diffhunk://#diff-2456489bc78d19363089551d45728b9d6dac9c50e130e3f1d1003f3e37228b3fL9-R9)