### PR TITLE
ci: publish multi-arch (arm64) Docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,6 +151,11 @@ jobs:
       - name: Set version in pyproject.toml
         run: python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
 
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
+        with:
+          # amd64 is the runner's native arch; only arm64 needs emulation.
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
@@ -179,6 +184,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=${{ matrix.suffix || 'cli' }}


### PR DESCRIPTION
## Problem

Published Docker images (e.g. `pragent/pr-agent:<v>-github_app`) ship only a `linux/amd64` manifest. On ARM64 hosts `docker pull` fails with `no matching manifest for linux/arm64/v8`, and forcing `--platform linux/amd64` then fails at runtime in rootless Docker/Podman with `exec format error`. This blocks out-of-the-box self-hosted deployment on ARM64 VPS hosts.

The `publish-docker` job never set `platforms:`, so every image was built only for the runner's native architecture.

## Change

`.github/workflows/publish.yml`, `publish-docker` job:

- Add a `docker/setup-qemu-action` step so the amd64 runner can emit arm64 layers.
- Add `platforms: linux/amd64,linux/arm64` to `docker/build-push-action`, so all 11 image targets publish a multi-arch manifest list.

No Dockerfile or dependency changes — the base images (`python:3.12-slim`, `public.ecr.aws/lambda/python:3.12`) are already multi-arch and all deps install from prebuilt arm64 wheels.

## Verification

Ran locally with no push:

```
docker buildx build --platform linux/amd64,linux/arm64 --target github_app -f docker/Dockerfile .
```

Both platforms built cleanly with no native compilation, and Buildx exported a manifest list containing both platform manifests.

## Note for maintainers

The two Lambda matrix entries (`github_lambda`, `gitlab_lambda`) install `gcc`/`python3-devel` via `dnf` in `docker/Dockerfile.lambda`, which runs slower under QEMU emulation. Worth watching the first release run's timing for those entries; `fail-fast: false` already isolates them, and they can be moved to a native arm64 runner in a follow-up if needed.

Fixes #2386, #1939