### PR TITLE
feat: add GLM model support from Z.AI

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -69,9 +69,10 @@ MAX_TOKENS = {
     # GLM models from Z.AI (OpenAI-compatible API)
     # Context window: ~200K tokens (204,800 for GLM-5.1, 202,752 for GLM-4.7/5-Turbo)
     # Max output: 128K tokens
-    'glm-5-turbo': 200000,  # ~200K context, but may be limited by config.max_model_tokens
-    'glm-4.7': 200000,  # ~200K context, but may be limited by config.max_model_tokens
-    'glm-5.1': 200000,  # ~200K context, but may be limited by config.max_model_tokens
+    # Note: Some tools may use MAX_TOKENS directly, bypassing config.max_model_tokens cap
+    "glm-5-turbo": 200000,  # ~200K context, but may be limited by config.max_model_tokens
+    "glm-4.7": 200000,  # ~200K context, but may be limited by config.max_model_tokens
+    "glm-5.1": 200000,  # ~200K context, but may be limited by config.max_model_tokens
     'deepseek/deepseek-chat': 128000,  # 128K, but may be limited by config.max_model_tokens
     'deepseek/deepseek-reasoner': 64000,  # 64K, but may be limited by config.max_model_tokens
     'openai/qwq-plus': 131072,  # 131K context length, but may be limited by config.max_model_tokens

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -66,6 +66,12 @@ MAX_TOKENS = {
     'claude-instant-1': 100000,
     'claude-2': 100000,
     'command-nightly': 4096,
+    # GLM models from Z.AI (OpenAI-compatible API)
+    # Context window: ~200K tokens (204,800 for GLM-5.1, 202,752 for GLM-4.7/5-Turbo)
+    # Max output: 128K tokens
+    'glm-5-turbo': 200000,  # ~200K context, but may be limited by config.max_model_tokens
+    'glm-4.7': 200000,  # ~200K context, but may be limited by config.max_model_tokens
+    'glm-5.1': 200000,  # ~200K context, but may be limited by config.max_model_tokens
     'deepseek/deepseek-chat': 128000,  # 128K, but may be limited by config.max_model_tokens
     'deepseek/deepseek-reasoner': 64000,  # 64K, but may be limited by config.max_model_tokens
     'openai/qwq-plus': 131072,  # 131K context length, but may be limited by config.max_model_tokens


### PR DESCRIPTION
## Summary

Adds support for GLM models (glm-5-turbo, glm-4.7, glm-5.1) from Z.AI to PR Agent's MAX_TOKENS registry.

## Problem

Users trying to use Z.AI's GLM models through PR Agent were experiencing failures with inline code suggestions. The error "Failed to generate code suggestions for PR" would appear, with no inline comments being generated.

## Root Cause

GLM models were not registered in PR Agent's MAX_TOKENS dictionary (`pr_agent/algo/__init__.py`), causing response parsing failures when these models were used through Z.AI's OpenAI-compatible API.

## Solution

Added GLM models to the MAX_TOKENS registry with accurate context window specifications:

- `glm-5-turbo`: ~200K context window (202,752 actual), 128K max output
- `glm-4.7`: ~200K context window (202,752 actual), 128K max output
- `glm-5.1`: ~200K context window (204,800 actual), 131,072 max output

## Specifications (Verified)

From official Z.AI documentation and independent sources:

**GLM-5.1**:
- Context Window: 204,800 tokens
- Max Output: 131,072 tokens
- Source: https://docs.z.ai/guides/llm/glm-5.1

**GLM-4.7**:
- Context Length: 200K tokens
- Maximum Output Tokens: 128K
- Source: https://docs.z.ai/guides/llm/glm-4.7

**GLM-5-Turbo**:
- Context Length: 200K tokens
- Maximum Output Tokens: 128K
- Source: https://docs.z.ai/guides/llm/glm-5-turbo

## Testing

Tested with PR #188 in cjunxiang/til repository using Z.AI's OpenAI-compatible API endpoint. After this fix, inline code suggestions are now successfully generated.

## Configuration Example

Users can now configure GLM models in their workflow:

```yaml
env:
  OPENAI.API_BASE: https://api.z.ai/v1
  config.model: "glm-5.1"
  config.fallback_models: '["glm-5.1", "glm-4.7", "glm-5-turbo"]'
  config.custom_model_max_tokens: "200000"
```

## Impact

- ✅ Enables PR Agent to work with GLM models from Z.AI
- ✅ Maintains backward compatibility (no changes to existing models)
- ✅ Follows existing pattern for custom model registration
- ✅ Uses conservative context window estimates to avoid token limit issues

## Sources

- [GLM-4.7 Overview - Z.AI Developer Docs](https://docs.z.ai/guides/llm/glm-4.7)
- [GLM-5-Turbo Overview - Z.AI Developer Docs](https://docs.z.ai/guides/llm/glm-5-turbo)
- [GLM-5.1 API - Together AI](https://www.together.ai/models/glm-51)
- [GLM 5.1 Context Window Verification - UniFuncs](https://unifuncs.com/s/azT3mQWC)