### PR TITLE
Fix: Add claude-opus-4-7 to NO_SUPPORT_TEMPERATURE_MODELS (#2400)

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -292,7 +292,18 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.1-codex-mini",
     "gpt-5.2-codex",
     "gpt-5.3-codex",
-    "gpt-5-mini"
+    "gpt-5-mini",
+
+    # Anthropic Claude Opus 4-7 - temperature is deprecated by Anthropic
+    "claude-opus-4-7",
+    "claude-3-7-opus",
+    "claude-opus-4.7",
+    "vertex_ai/claude-opus-4-7",
+    "anthropic/claude-opus-4-7",
+    "bedrock/anthropic.claude-opus-4-7",
+    "bedrock/anthropic.claude-opus-4-7-v1:0",
+    "bedrock/us.anthropic.claude-opus-4-7",
+    "bedrock/global.anthropic.claude-opus-4-7",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [


### PR DESCRIPTION
# Fix: Add claude-opus-4-7 to NO_SUPPORT_TEMPERATURE_MODELS

## Problem Description

Fixes issue #2400

When using Claude Opus 4-7 models (via Vertex AI, Anthropic, or Bedrock), PR-Agent fails with a 400 error because Anthropic has deprecated the `temperature` parameter for these models.

Error message: itellm.BadRequestError: Vertex_aiException BadRequestError -
{"type":"error","error":{"type":"invalid_request_error","message":"temperature is deprecated for this model."}}


Affected models:
- claude-opus-4-7
- vertex_ai/claude-opus-4-7
- anthropic/claude-opus-4-7
- bedrock/anthropic.claude-opus-4-7

## Solution

Added all Claude Opus 4-7 model variants to the existing `NO_SUPPORT_TEMPERATURE_MODELS` list in `pr_agent/algo/__init__.py`.

This follows the same pattern used for other models that don't support temperature (o1, o3, gpt-5-mini, etc.). The `LiteLLMAIHandler` already has logic to skip sending the temperature parameter for any model in this list.

## Changes Made

File changed: `pr_agent/algo/__init__.py`

Added to `NO_SUPPORT_TEMPERATURE_MODELS`:

```python
# Anthropic Claude Opus 4-7 - temperature is deprecated (Issue #2400)
"claude-opus-4-7",
"claude-3-7-opus",
"vertex_ai/claude-opus-4-7",
"anthropic/claude-opus-4-7",
"bedrock/anthropic.claude-opus-4-7",
"bedrock/anthropic.claude-opus-4-7-v1:0",
"bedrock/us.anthropic.claude-opus-4-7",
"bedrock/global.anthropic.claude-opus-4-7",