### PR TITLE
fix: run gitlab_webhook under gunicorn for worker isolation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ CMD ["python", "pr_agent/servers/github_polling.py"]
 
 FROM base AS gitlab_webhook
 ADD pr_agent pr_agent
-CMD ["python", "pr_agent/servers/gitlab_webhook.py"]
+CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py", "--forwarded-allow-ips", "*", "pr_agent.servers.gitlab_webhook:app"]
 
 FROM base AS azure_devops_webhook
 ADD pr_agent pr_agent


### PR DESCRIPTION
## What

Switch the `gitlab_webhook` Docker stage from a single uvicorn process to gunicorn + `UvicornWorker`, matching `github_app` and `gitea_app`. The gunicorn pattern was introduced for `github_app` in #983.

```diff
-CMD ["python", "pr_agent/servers/gitlab_webhook.py"]
+CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py", "--forwarded-allow-ips", "*", "pr_agent.servers.gitlab_webhook:app"]
```

## Why

`gitlab_webhook` runs a single uvicorn process. `/webhook` returns `200` immediately and offloads the actual work via Starlette `BackgroundTasks`, which run on the **same asyncio event loop** as the `GET /` health endpoint.

A slow LLM call starves that one loop — litellm's `acompletion` hands the blocking call to a threadpool, and `config.fallback_models` are tried serially (each with its own timeout), so a single logical call can block for minutes. While the loop is busy, `GET /` blocks; under Kubernetes the liveness probe then times out and the container is killed (exit 137), producing a restart loop.

With gunicorn running ≥2 workers, a worker blocked on a background task no longer fails the health check served by another worker, so the server stays responsive. This is the same rationale and pattern as #983 for the GitHub app. Worker count stays controllable via the existing `GUNICORN_WORKERS` env read by `gunicorn_config.py`.

## Related

- #2100, #2151 — "can't start new thread" on the GitLab webhook: the same event-loop / threadpool pressure under load.
- #983 — introduced the gunicorn + `UvicornWorker` pattern for `github_app`.

## Notes

- No new dependencies: `gunicorn==23.0.0`, `uvicorn==0.22.0`, and `pr_agent/servers/gunicorn_config.py` are already present.
- Dockerfile-only change (run mode), so no unit test applies. Validated by running the stage locally (`GET /` → `200`, webhooks processed) and in a multi-replica deployment, where the previously-recurring liveness restart loop stopped — 0 restarts over several hours of real webhook traffic, versus restarts every few minutes before.