### PR TITLE
docs: Fix broken list markup in gitea installation document

### DIFF
--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -6,15 +6,15 @@
 
 3. Generate a random secret for your app, and save it for later (`webhook_secret`). For example, you can use:
 
-```bash
-WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
-```
+    ```bash
+    WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
+    ```
 
 4. Clone this repository:
 
-```bash
-git clone https://github.com/the-pr-agent/pr-agent.git
-```
+    ```bash
+    git clone https://github.com/the-pr-agent/pr-agent.git
+    ```
 
 5. Prepare variables and secrets. Skip this step if you plan on setting these as environment variables when running the agent:
     - In the configuration file/variables:
@@ -25,22 +25,22 @@ git clone https://github.com/the-pr-agent/pr-agent.git
 
 6. Build a Docker image for the app and optionally push it to a Docker repository. We'll use Dockerhub as an example:
 
-```bash
-docker build -f /docker/Dockerfile -t pr-agent:gitea_app --target gitea_app .
-docker push pragent/pr-agent:gitea_webhook  # Push to your Docker repository
-```
+    ```bash
+    docker build -f /docker/Dockerfile -t pr-agent:gitea_app --target gitea_app .
+    docker push pragent/pr-agent:gitea_webhook  # Push to your Docker repository
+    ```
 
 7. Set the environmental variables, the method depends on your docker runtime. Skip this step if you included your secrets/configuration directly in the Docker image.
 
-```bash
-CONFIG__GIT_PROVIDER=gitea
-GITEA__PERSONAL_ACCESS_TOKEN=<personal_access_token>
-GITEA__WEBHOOK_SECRET=<webhook_secret>
-GITEA__URL=https://gitea.com # Or self host
-OPENAI__KEY=<your_openai_api_key>
-GITEA__SKIP_SSL_VERIFICATION=false # or true
-GITEA__SSL_CA_CERT=/path/to/cacert.pem
-```
+    ```bash
+    CONFIG__GIT_PROVIDER=gitea
+    GITEA__PERSONAL_ACCESS_TOKEN=<personal_access_token>
+    GITEA__WEBHOOK_SECRET=<webhook_secret>
+    GITEA__URL=https://gitea.com # Or self host
+    OPENAI__KEY=<your_openai_api_key>
+    GITEA__SKIP_SSL_VERIFICATION=false # or true
+    GITEA__SSL_CA_CERT=/path/to/cacert.pem
+    ```
 
 8. Create a webhook in your Gitea project. Set the URL to `http[s]://<PR_AGENT_HOSTNAME>/api/v1/gitea_webhooks`, the secret token to the generated secret from step 3, and enable the triggers `push`, `comments` and `merge request events`.
 


### PR DESCRIPTION
This patch fixes the following undesired order list render result:

<img width="355" height="479" alt="Screenshot" src="https://github.com/user-attachments/assets/674b099d-8b4a-4628-b1e1-c62acbf0dda2" />
