### PR TITLE
fix: make GitHub PR-description ticket selection deterministic

### DIFF
--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -39,31 +39,40 @@ def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url
     """
     Extract all ticket links from PR description
     """
-    github_tickets = set()
+    # Preserve first-seen order while de-duplicating, so the cap below selects a
+    # deterministic subset (a plain set would slice an arbitrary, run-varying one).
+    seen = set()
+    github_tickets = []
+
+    def _add(url):
+        if url not in seen:
+            seen.add(url)
+            github_tickets.append(url)
+
     try:
         # Use the updated pattern to find matches
         matches = GITHUB_TICKET_PATTERN.findall(pr_description)
 
         for match in matches:
             if match[0]:  # Full URL match
-                github_tickets.add(match[0])
+                _add(match[0])
             elif match[1]:  # Shorthand notation match: owner/repo#issue_number
                 owner, repo, issue_number = match[2], match[3], match[4]
-                github_tickets.add(f'{base_url_html.strip("/")}/{owner}/{repo}/issues/{issue_number}')
+                _add(f"{base_url_html.strip('/')}/{owner}/{repo}/issues/{issue_number}")
             else:  # #123 format
                 issue_number = match[5][1:]  # remove #
                 if issue_number.isdigit() and len(issue_number) < 5 and repo_path:
-                    github_tickets.add(f'{base_url_html.strip("/")}/{repo_path}/issues/{issue_number}')
+                    _add(f"{base_url_html.strip('/')}/{repo_path}/issues/{issue_number}")
 
         if len(github_tickets) > 3:
             get_logger().info(f"Too many tickets found in PR description: {len(github_tickets)}")
             # Limit the number of tickets to 3
-            github_tickets = set(list(github_tickets)[:3])
+            github_tickets = github_tickets[:3]
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",
                            artifact={"traceback": traceback.format_exc()})
 
-    return list(github_tickets)
+    return github_tickets
 
 def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html="https://github.com"):
     """

--- a/tests/unittest/test_extract_issue_from_branch.py
+++ b/tests/unittest/test_extract_issue_from_branch.py
@@ -1,6 +1,12 @@
 import pytest
 
-from pr_agent.tools.ticket_pr_compliance_check import extract_ticket_links_from_branch_name
+from pr_agent.tools.ticket_pr_compliance_check import (
+    extract_ticket_links_from_branch_name,
+    extract_ticket_links_from_pr_description,
+)
+
+# The PR-description extractor caps results at 3 (hardcoded in the function).
+MAX_TICKETS = 3
 
 
 class TestExtractTicketsLinkFromBranchName:
@@ -110,3 +116,36 @@ class TestExtractTicketsLinkFromBranchName:
             "https://github.com/org/repo/issues/1",
             "https://github.com/org/repo/issues/2",
         }
+
+
+class TestExtractTicketLinksFromPrDescription:
+    """GitHub issue extraction from the PR description."""
+
+    def test_preserves_first_seen_order(self):
+        """Issues are returned in first-seen order, de-duplicated.
+
+        Note: this documents the intended ordered behaviour. It does not reliably fail
+        against the old set-based code, because set iteration order is randomised per
+        process (PYTHONHASHSEED) and may coincidentally match insertion order for a
+        small input. test_cap_selects_deterministic_first_seen_subset is the reliable
+        regression guard (see its note)."""
+        desc = "Fixes #3, relates to #1, also #3 again and #2"
+        result = extract_ticket_links_from_pr_description(desc, "org/repo", "https://github.com")
+        assert result == [
+            "https://github.com/org/repo/issues/3",
+            "https://github.com/org/repo/issues/1",
+            "https://github.com/org/repo/issues/2",
+        ]
+
+    def test_cap_selects_deterministic_first_seen_subset(self):
+        """When more than MAX_TICKETS issues are present, the first MAX_TICKETS in
+        first-seen order are kept (not an arbitrary subset from a set).
+
+        This is the reliable regression guard for the bug: with > MAX_TICKETS issues,
+        the old code sliced list(set)[:MAX_TICKETS], so it returned an arbitrary subset
+        that (essentially) never equals the first-seen subset, on any hash seed."""
+        nums = list(range(1, MAX_TICKETS + 4))
+        desc = " ".join(f"#{n}" for n in nums)
+        result = extract_ticket_links_from_pr_description(desc, "org/repo", "https://github.com")
+        expected = [f"https://github.com/org/repo/issues/{n}" for n in nums[:MAX_TICKETS]]
+        assert result == expected


### PR DESCRIPTION
Fixes #2421

## Summary

`extract_ticket_links_from_pr_description()` in `pr_agent/tools/ticket_pr_compliance_check.py` accumulates GitHub issue URLs in a `set`, then enforces the 3-ticket cap by slicing a list built from that set:

```python
github_tickets = set()
...
if len(github_tickets) > 3:
    github_tickets = set(list(github_tickets)[:3])
...
return list(github_tickets)
```

Because a `set` has no defined iteration order (and Python randomizes string hashing per process via `PYTHONHASHSEED`), `list(github_tickets)[:3]` selects an **arbitrary** 3 of the referenced issues, and the selection can vary between runs. When a PR description references more than 3 issues, which issues get fetched for review context is therefore nondeterministic.

## Fix

Track URLs in first-seen order while de-duplicating (a `seen` set plus an ordered list), then apply the cap by slicing the ordered list — mirroring what `find_jira_tickets()` in the same file already does. Selection is now stable and predictable. Behaviour is unchanged for 3 or fewer issues.

## Tests

Structured as two commits — failing tests first, then the fix:

1. `test:` adds `TestExtractTicketLinksFromPrDescription` with two tests.
2. `fix:` makes them pass.

`test_cap_selects_deterministic_first_seen_subset` is the reliable regression guard: with more than 3 issues, the old set-based code returns an arbitrary subset that does not equal the first-seen subset. I verified it fails against the previous implementation on every hash seed `PYTHONHASHSEED` 0–11, and passes with the fix on all of them. (`test_preserves_first_seen_order` documents the intended ordering; its docstring notes it is not a reliable seed-independent guard on its own, which is why the cap test exists.)

## Notes

This was originally surfaced by the Qodo review bot on a separate Jira-support PR, but the function predates that work and is unrelated to Jira, so it is raised here on its own.

## Test plan

- [x] `pytest tests/unittest/test_extract_issue_from_branch.py`
- [x] New tests fail on the pre-fix code (verified across `PYTHONHASHSEED` 0–11) and pass with the fix

Co-Authored-By: Claude
