### PR TITLE
fix: update reference link to configuration.toml

### DIFF
--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -9,7 +9,7 @@ In terms of precedence, wiki configurations will override local configurations, 
 
 
 For a list of all possible configurations, see the [configuration options](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) page.
-In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L66) section in the configuration file.
+In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L76) section in the configuration file.
 
 !!! tip "Tip1: Edit only what you need"
     Your configuration file should be minimal, and edit only the relevant values. Don't copy the entire configuration options, since it can lead to legacy problems when something changes.


### PR DESCRIPTION
While reviewing the documentation at https://docs.pr-agent.ai/usage-guide/configuration_options/, I noticed that the link for 'pr_reviewer' was broken. It was pointing to a location ten lines above the actual definition. This was likely caused by changes in the configuration.toml structure that were not reflected in the documentation's anchor links.

I fixed the line number in this PR.