### PR TITLE
fix: preserve target indentation in improve suggestions

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -609,10 +609,26 @@ class PRCodeSuggestions:
                 original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip()) # lstrip works both for spaces and tabs
                 suggested_initial_spaces = len(suggested_initial_line) - len(suggested_initial_line.lstrip())
                 delta_spaces = original_initial_spaces - suggested_initial_spaces
+                # Detect indentation character from original line
+                indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                 if delta_spaces > 0:
-                    # Detect indentation character from original line
-                    indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                     new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * indent_char).rstrip('\n')
+                elif delta_spaces < 0:
+                    new_code_snippet = textwrap.dedent(new_code_snippet).rstrip('\n')
+                # Normalize all lines in the suggestion to use the original's
+                # indentation character. This fixes the bug where /improve
+                # replaces tabs with spaces in Go, Makefile, and other
+                # tab-indented codebases (#1858).
+                if indent_char == '\t':
+                    new_lines = []
+                    for line in new_code_snippet.split('\n'):
+                        stripped = line.lstrip(' ')
+                        leading_spaces = len(line) - len(stripped)
+                        if leading_spaces > 0:
+                            new_lines.append('\t' * (leading_spaces // 4) + stripped)
+                        else:
+                            new_lines.append(line)
+                    new_code_snippet = '\n'.join(new_lines)
         except Exception as e:
             get_logger().error(f"Error when dedenting code snippet for file {relevant_file}, error: {e}")
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -785,6 +785,142 @@ class PRCodeSuggestions:
         return self._suggestion_applyability(relevant_file, relevant_lines_start,
                                              relevant_lines_end, existing_code)[0]
 
+    @staticmethod
+    def _shift_code_indentation(code_snippet: str, delta_spaces: int) -> str:
+        shifted_lines = []
+        for line in code_snippet.splitlines():
+            if not line.strip():
+                shifted_lines.append("")
+                continue
+            if delta_spaces > 0:
+                shifted_lines.append(" " * delta_spaces + line)
+            elif delta_spaces < 0:
+                shift = -delta_spaces
+                leading_whitespace = len(line) - len(line.lstrip())
+                shifted_lines.append(line[min(shift, leading_whitespace):])
+            else:
+                shifted_lines.append(line)
+        return "\n".join(shifted_lines)
+
+    @staticmethod
+    def _infer_space_indentation_unit(space_deltas: list[int]) -> int:
+        if not space_deltas:
+            return 1
+        unique_deltas = sorted(set(space_deltas))
+        for delta in unique_deltas:
+            if delta * 2 in unique_deltas:
+                return delta
+        return unique_deltas[0]
+
+    @staticmethod
+    def _continuation_space_adjustments(
+        lines: list[str],
+        leading_whitespace: list[str],
+    ) -> list[int]:
+        openers = []
+        adjustments = [0] * len(lines)
+        closer_for = {"(": ")", "[": "]"}
+        for index, (line, prefix) in enumerate(
+            zip(lines, leading_whitespace, strict=True)
+        ):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            for opener_position in range(len(openers) - 1, -1, -1):
+                opener_index, opener_prefix, closer = openers[opener_position]
+                if prefix == opener_prefix and stripped.startswith(closer):
+                    interior_indexes = [
+                        line_index
+                        for line_index in range(opener_index + 1, index)
+                        if lines[line_index].strip()
+                    ]
+                    opener_spaces = opener_prefix.count(" ")
+                    positive_offsets = [
+                        leading_whitespace[line_index].count(" ") - opener_spaces
+                        for line_index in interior_indexes
+                        if leading_whitespace[line_index].count(" ") > opener_spaces
+                    ]
+                    if positive_offsets:
+                        continuation_offset = min(positive_offsets)
+                        for line_index in interior_indexes:
+                            if leading_whitespace[line_index].count(" ") > opener_spaces:
+                                adjustments[line_index] += continuation_offset
+                    del openers[opener_position:]
+                    break
+            if stripped[-1] in closer_for:
+                openers.append((index, prefix, closer_for[stripped[-1]]))
+        return adjustments
+
+    @staticmethod
+    def _align_code_with_tabs(code_snippet: str, anchor_prefix: str) -> str:
+        lines = code_snippet.splitlines()
+        if not lines:
+            return code_snippet
+        leading_whitespace = [line[:len(line) - len(line.lstrip())] for line in lines]
+        anchor_depth = len(anchor_prefix) - len(anchor_prefix.lstrip("\t"))
+        anchor_alignment = anchor_prefix[anchor_depth:]
+        initial_index, initial_prefix = next(
+            (
+                (index, prefix)
+                for index, (line, prefix) in enumerate(
+                    zip(lines, leading_whitespace, strict=True)
+                )
+                if line.strip()
+            ),
+            (0, ""),
+        )
+        initial_spaces = initial_prefix.count(" ")
+        initial_tabs = initial_prefix.count("\t")
+        continuation_adjustments = PRCodeSuggestions._continuation_space_adjustments(
+            lines,
+            leading_whitespace,
+        )
+        initial_continuation_adjustment = continuation_adjustments[initial_index]
+        adjusted_initial_spaces = initial_spaces - initial_continuation_adjustment
+        space_deltas = [
+            abs(
+                prefix.count(" ")
+                - continuation_adjustments[index]
+                - adjusted_initial_spaces
+            )
+            for index, (line, prefix) in enumerate(
+                zip(lines, leading_whitespace, strict=True)
+            )
+            if (
+                line.strip()
+                and prefix.count(" ") - continuation_adjustments[index]
+                != adjusted_initial_spaces
+            )
+        ]
+        space_unit = PRCodeSuggestions._infer_space_indentation_unit(space_deltas)
+        aligned_lines = []
+        for index, (line, prefix) in enumerate(
+            zip(lines, leading_whitespace, strict=True)
+        ):
+            if not line.strip():
+                aligned_lines.append("")
+                continue
+            continuation_alignment = (
+                continuation_adjustments[index] - initial_continuation_adjustment
+            )
+            relative_space_depth, alignment_spaces = divmod(
+                prefix.count(" ")
+                - initial_spaces
+                - continuation_alignment,
+                space_unit,
+            )
+            relative_depth = (
+                prefix.count("\t") - initial_tabs
+                + relative_space_depth
+            )
+            aligned_lines.append(
+                "\t" * max(0, anchor_depth + relative_depth)
+                + anchor_alignment
+                + " " * (alignment_spaces + continuation_alignment)
+                + line[len(prefix):]
+            )
+        return "\n".join(aligned_lines).rstrip("\n")
+
     def dedent_code(self, relevant_file, relevant_lines_start, new_code_snippet):
         try:  # dedent code snippet
             self.diff_files = getattr(self.git_provider, "diff_files", None)
@@ -793,7 +929,7 @@ class PRCodeSuggestions:
             original_initial_line = None
             for file in self.diff_files:
                 if file.filename.strip() == relevant_file:
-                    if file.head_file:
+                    if file.head_file and getattr(file, "head_file_is_complete", True):
                         file_lines = file.head_file.splitlines()
                         if relevant_lines_start > len(file_lines):
                             get_logger().warning(
@@ -818,14 +954,18 @@ class PRCodeSuggestions:
                         original_initial_line = patch_lines[0]
                     break
             if original_initial_line:
-                suggested_initial_line = new_code_snippet.splitlines()[0]
-                original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip()) # lstrip works both for spaces and tabs
+                suggested_initial_line = next(
+                    (line for line in new_code_snippet.splitlines() if line.strip()),
+                    "",
+                )
+                original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip())
                 suggested_initial_spaces = len(suggested_initial_line) - len(suggested_initial_line.lstrip())
-                delta_spaces = original_initial_spaces - suggested_initial_spaces
-                if delta_spaces > 0:
-                    # Detect indentation character from original line
-                    indent_char = '\t' if original_initial_line.startswith('\t') else ' '
-                    new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * indent_char).rstrip('\n')
+                if original_initial_line.startswith("\t"):
+                    original_prefix = original_initial_line[:original_initial_spaces]
+                    new_code_snippet = self._align_code_with_tabs(new_code_snippet, original_prefix)
+                else:
+                    delta_spaces = original_initial_spaces - suggested_initial_spaces
+                    new_code_snippet = self._shift_code_indentation(new_code_snippet, delta_spaces)
         except Exception as e:
             get_logger().error(f"Error when dedenting code snippet for file {relevant_file}, error: {e}")
 
@@ -1046,8 +1186,14 @@ class PRCodeSuggestions:
                     CHAR_LIMIT_PER_LINE = 84
                     suggestion_content = insert_br_after_x_chars(suggestion_content, CHAR_LIMIT_PER_LINE)
                     # pr_body += f"<tr><td><details><summary>{suggestion_content}</summary>"
-                    existing_code = suggestion['existing_code'].rstrip() + "\n"
-                    improved_code = suggestion['improved_code'].rstrip() + "\n"
+                    existing_code = suggestion["existing_code"].rstrip()
+                    if existing_code:
+                        existing_code = self.dedent_code(relevant_file, relevant_lines_start, existing_code)
+                    existing_code += "\n"
+                    improved_code = suggestion["improved_code"].rstrip()
+                    if improved_code:
+                        improved_code = self.dedent_code(relevant_file, relevant_lines_start, improved_code)
+                    improved_code += "\n"
 
                     diff = difflib.unified_diff(existing_code.split('\n'),
                                                 improved_code.split('\n'), n=999)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -129,6 +129,273 @@ def test_dedent_code_matches_target_file_indentation():
     assert tool.dedent_code("app.py", 2, "return new()") == "    return new()"
 
 
+def test_dedent_code_preserves_relative_indentation_across_anchor_and_snippet_styles():
+    anchors = [
+        ("", "spaces", 0),
+        ("  ", "spaces", 2),
+        ("    ", "spaces", 4),
+        ("\t", "tabs", 1),
+        ("\t\t", "tabs", 2),
+    ]
+    indentation_units = [1, 2, 4]
+    initial_depths = [0, 1, 2]
+    relative_depth_patterns = [(0, 1, 0), (0, 1, 2)]
+    checked_cases = 0
+
+    for anchor, anchor_style, anchor_depth in anchors:
+        for indentation_unit in indentation_units:
+            for initial_depth in initial_depths:
+                for relative_depths in relative_depth_patterns:
+                    snippet = "\n".join(
+                        " " * ((initial_depth + relative_depth) * indentation_unit) + f"line_{index}"
+                        for index, relative_depth in enumerate(relative_depths)
+                    )
+                    if anchor_style == "tabs":
+                        expected = "\n".join(
+                            "\t" * (anchor_depth + relative_depth) + f"line_{index}"
+                            for index, relative_depth in enumerate(relative_depths)
+                        )
+                    else:
+                        expected = "\n".join(
+                            " " * (anchor_depth + relative_depth * indentation_unit) + f"line_{index}"
+                            for index, relative_depth in enumerate(relative_depths)
+                        )
+
+                    git_provider = MagicMock()
+                    git_provider.diff_files = [FilePatchInfo(
+                        base_file="",
+                        head_file=f"{anchor}anchor\n",
+                        patch="",
+                        filename="app.py",
+                    )]
+                    tool = _make_tool(git_provider)
+
+                    actual = tool.dedent_code("app.py", 1, snippet)
+
+                    assert actual == expected, (
+                        anchor, indentation_unit, initial_depth, relative_depths, actual, expected
+                    )
+                    checked_cases += 1
+
+    assert checked_cases == 90
+
+
+def test_dedent_code_preserves_existing_tab_indentation_levels():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\t\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, "\touter\n\t\tinner\n\touter") == (
+        "\t\touter\n\t\t\tinner\n\t\touter"
+    )
+
+
+@pytest.mark.parametrize("snippet", [
+    " outer\n   inner\n outer",
+    "   outer\n     inner\n   outer",
+    "\t outer\n\t   inner\n\t outer",
+])
+def test_dedent_code_infers_tab_depth_from_relative_widths(snippet):
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, snippet) == "\touter\n\t\tinner\n\touter"
+
+
+def test_dedent_code_preserves_alignment_spaces_after_the_tab_anchor():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\t    anchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, "outer\n    inner\nouter") == (
+        "\t    outer\n\t\t    inner\n\t    outer"
+    )
+
+
+@pytest.mark.parametrize("alignment_spaces", [1, 2])
+def test_dedent_code_preserves_continuation_alignment_spaces(alignment_spaces):
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "outer\n    inner\n        deeper\n" + " " * (8 + alignment_spaces) + "aligned"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\touter\n\t\tinner\n\t\t\tdeeper\n\t\t\t" + " " * alignment_spaces + "aligned"
+    )
+
+
+def test_dedent_code_preserves_alignment_without_adjacent_depths():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "outer\n    inner\n            deeper\n              aligned"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\touter\n\t\tinner\n\t\t\t\tdeeper\n\t\t\t\t  aligned"
+    )
+
+
+def test_dedent_code_excludes_closed_continuations_from_unit_inference():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "outer(\n  arg\n)\nif cond:\n    inner\n        deeper"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\touter(\n\t  arg\n\t)\n\tif cond:\n\t\tinner\n\t\t\tdeeper"
+    )
+
+
+def test_dedent_code_infers_structure_inside_a_closed_continuation():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "outer(\n  function() {\n      if (cond) {\n          work()\n      }\n  }\n)"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\touter(\n\t  function() {\n\t\t  if (cond) {\n"
+        "\t\t\t  work()\n\t\t  }\n\t  }\n\t)"
+    )
+
+
+def test_dedent_code_preserves_spaces_in_a_pure_continuation():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "call(\n    arg\n)"
+    assert tool.dedent_code("app.py", 1, snippet) == "\tcall(\n\t    arg\n\t)"
+
+
+def test_dedent_code_keeps_two_space_structural_indentation():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "if outer:\n  if inner:\n    work()"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\tif outer:\n\t\tif inner:\n\t\t\twork()"
+    )
+
+
+def test_dedent_code_infers_structure_across_outdents_and_continuations():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\t\t\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    snippet = "        deep()\n    call(\n      arg\n    )\nouter()"
+    assert tool.dedent_code("app.py", 1, snippet) == (
+        "\t\t\tdeep()\n\t\tcall(\n\t\t  arg\n\t\t)\n\touter()"
+    )
+
+
+def test_dedent_code_removes_whitespace_from_blank_lines_when_shifting_left():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="    anchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, "        outer\n          \n            inner") == (
+        "    outer\n\n        inner"
+    )
+
+
+def test_dedent_code_ignores_blank_line_width_when_inferring_tab_depth():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, " outer\n       \n   inner\n outer") == (
+        "\touter\n\n\t\tinner\n\touter"
+    )
+
+
+def test_dedent_code_ignores_leading_blank_line_when_inferring_tab_depth():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="\tanchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, "\n  return new()") == "\n\treturn new()"
+
+
+def test_dedent_code_ignores_leading_blank_line_when_shifting_spaces():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="    anchor\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 1, "\n        return new()") == "\n    return new()"
+
+
 def test_dedent_code_uses_patch_when_file_content_is_unavailable():
     git_provider = MagicMock()
     git_provider.diff_files = [FilePatchInfo(
@@ -140,6 +407,20 @@ def test_dedent_code_uses_patch_when_file_content_is_unavailable():
     tool = _make_tool(git_provider)
 
     assert tool.dedent_code("app.py", 2, "return new()") == "    return new()"
+
+
+def test_dedent_code_uses_patch_when_head_file_is_partial():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="def f():\n    return older()\n",
+        head_file="def f():\n    return old()\n",
+        patch="@@ -19,2 +19,2 @@\n def f():\n-\told()\n+\told()\n",
+        filename="app.py",
+        head_file_is_complete=False,
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 20, "new()") == "\tnew()"
 
 
 @pytest.mark.asyncio
@@ -237,6 +518,75 @@ def _published_suggestion(git_provider):
     published = git_provider.publish_code_suggestions.call_args_list[0].args[0]
     assert len(published) == 1
     return published[0]
+
+
+def test_summarized_suggestions_use_the_target_file_indentation():
+    git_provider = _provider_with_file("func f() {\n\told()\n}\n", filename="main.go")
+    git_provider.get_line_link.return_value = "https://example.com/main.go#L2"
+    tool = _make_tool(git_provider)
+    suggestion = _valid_suggestion(
+        relevant_file="main.go",
+        relevant_lines_start=2,
+        relevant_lines_end=2,
+        existing_code="old()",
+        improved_code="replacement() {\n    nested()\n}",
+        score=8,
+    )
+
+    summary = tool.generate_summarized_suggestions({"code_suggestions": [suggestion]})
+
+    assert "+\treplacement() {" in summary
+    assert "+\t\tnested()" in summary
+    assert "+\t}" in summary
+
+
+def test_summarized_suggestions_use_patch_anchor_for_partial_head_file():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="func f() {\n\tolder()\n",
+        head_file="func f() {\n\told()\n",
+        patch="@@ -19,2 +19,2 @@\n func f() {\n-\tolder()\n+\told()\n",
+        filename="main.go",
+        head_file_is_complete=False,
+    )]
+    git_provider.get_line_link.return_value = "https://example.com/main.go#L20"
+    tool = _make_tool(git_provider)
+    suggestion = _valid_suggestion(
+        relevant_file="main.go",
+        relevant_lines_start=20,
+        relevant_lines_end=20,
+        existing_code="old()",
+        improved_code="replacement() {\n    nested()\n}",
+        score=8,
+    )
+
+    summary = tool.generate_summarized_suggestions({"code_suggestions": [suggestion]})
+
+    assert "+\treplacement() {" in summary
+    assert "+\t\tnested()" in summary
+    assert "+\t}" in summary
+
+
+def test_summarized_suggestions_normalize_both_sides_of_the_diff():
+    git_provider = _provider_with_file(
+        "func f() {\n\tif old() {\n\t\tkeep()\n\t}\n}\n",
+        filename="main.go",
+    )
+    git_provider.get_line_link.return_value = "https://example.com/main.go#L2-L4"
+    tool = _make_tool(git_provider)
+    suggestion = _valid_suggestion(
+        relevant_file="main.go",
+        relevant_lines_start=2,
+        relevant_lines_end=4,
+        existing_code="if old() {\n    keep()\n}",
+        improved_code="if new() {\n    keep()\n}",
+        score=8,
+    )
+
+    summary = tool.generate_summarized_suggestions({"code_suggestions": [suggestion]})
+
+    diff_block = summary.split("```diff\n", 1)[1].split("\n```", 1)[0]
+    assert diff_block == "-\tif old() {\n+\tif new() {\n \t\tkeep()\n \t}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes #1858 — `/improve` now preserves the target file's indentation in both summarized and committable suggestions.

## Root Cause

Indentation correction only ran for committable suggestions, while the default summary path rendered the model output unchanged. The previous correction also treated raw whitespace counts as indentation levels and removed the entire common prefix when a snippet was over-indented.

## Fix

- Shift space-indented snippets by the exact anchor delta.
- Infer tab-indented structural depth while preserving residual continuation-alignment spaces.
- Use patch anchors when a provider exposes only partial reconstructed file content.
- Normalize both sides of summarized diffs with the same target anchor.
- Add regression coverage for tab and space anchors, multiple indentation widths, common offsets, mixed prefixes, blank lines, continuation alignment, partial content, and summary rendering.

## Verification

- Focused suggestion tests: 61 passed.
- Full unit suite: 2,470 passed, 1 skipped, 1 xfailed.
- Diff formatting check: passed.
