### PR TITLE
feat: add Asana ticket detection to ticket compliance check

### DIFF
--- a/docs/docs/core-abilities/fetching_ticket_context.md
+++ b/docs/docs/core-abilities/fetching_ticket_context.md
@@ -98,14 +98,13 @@ Since PR-Agent is integrated with GitHub, it doesn't require any additional conf
 
 PR-Agent can detect Asana task references in PR descriptions and include them in the ticket compliance check.
 
-**Supported reference formats:**
+**Supported reference format:**
 
 - Full Asana URLs: `https://app.asana.com/0/{project_id}/{task_id}`
-- Shorthand format: `ASANA-123456789012` (case-insensitive, with or without a hyphen between "ASANA" and the task ID)
 
 **How to link a PR to an Asana task:**
 
-Include an Asana task reference in your PR description using either the full URL or the shorthand format. PR-Agent will detect it automatically and include it in the related tickets list.
+Include an Asana task URL in your PR description. PR-Agent will detect it automatically and include it in the related tickets list.
 
 !!! note "Asana content fetching"
     Asana task references are included for visibility and ticket compliance checking, but PR-Agent does **not** fetch the full task details from Asana (unlike GitHub and Jira tickets, which are fetched via API). The compliance check will note the reference and suggest reviewing the task in Asana for full context.

--- a/docs/docs/core-abilities/fetching_ticket_context.md
+++ b/docs/docs/core-abilities/fetching_ticket_context.md
@@ -14,6 +14,7 @@ This integration enriches the review process by automatically surfacing relevant
 
 - [GitHub/Gitlab Issues](#githubgitlab-issues-integration)
 - [Jira](#jira-integration)
+- [Asana](#asana-integration)
 
 **Ticket data fetched:**
 
@@ -30,6 +31,7 @@ Ticket Recognition Requirements:
 
 - The PR description should contain a link to the ticket or if the branch name starts with the ticket id / number.
 - For Jira tickets, you should follow the instructions in [Jira Integration](#jira-integration) in order to authenticate with Jira.
+- For Asana tickets, see [Asana Integration](#asana-integration).
 
 ### Describe tool
 
@@ -91,6 +93,24 @@ Branch names can also be used to link issues, for example:
 This branch-name detection applies **only when the git provider is GitHub**. Support for other platforms is planned for later.
 
 Since PR-Agent is integrated with GitHub, it doesn't require any additional configuration to fetch GitHub issues.
+
+## Asana Integration
+
+PR-Agent can detect Asana task references in PR descriptions and include them in the ticket compliance check.
+
+**Supported reference formats:**
+
+- Full Asana URLs: `https://app.asana.com/0/{project_id}/{task_id}`
+- Shorthand format: `ASANA-123456789012` (case-insensitive, with or without a hyphen between "ASANA" and the task ID)
+
+**How to link a PR to an Asana task:**
+
+Include an Asana task reference in your PR description using either the full URL or the shorthand format. PR-Agent will detect it automatically and include it in the related tickets list.
+
+!!! note "Asana content fetching"
+    Asana task references are included for visibility and ticket compliance checking, but PR-Agent does **not** fetch the full task details from Asana (unlike GitHub and Jira tickets, which are fetched via API). The compliance check will note the reference and suggest reviewing the task in Asana for full context.
+
+No additional configuration is required for Asana detection — it works out of the box.
 
 ## Jira Integration
 

--- a/docs/docs/core-abilities/fetching_ticket_context.md
+++ b/docs/docs/core-abilities/fetching_ticket_context.md
@@ -133,6 +133,18 @@ The token is sent only to Asana's fixed task API endpoint as a Bearer token. Whe
 not accessible to that token, PR-Agent skips that Asana task instead of evaluating compliance against placeholder
 content. API request timeout can be adjusted with `asana.request_timeout` (10 seconds by default, capped at 60 seconds).
 
+### Ticket limits
+
+PR-Agent fetches the first three detected Asana tasks at most, preserving their description order. This is an
+additive, provider-specific limit, with native tickets listed before Asana tasks:
+
+- On GitHub, the existing limit of three GitHub issues is preserved, plus up to three Asana tasks.
+- On Azure DevOps, all linked work items are preserved, plus up to three Asana tasks.
+- On other providers, up to three detected Asana tasks can supply ticket context.
+
+Keeping these limits separate prevents Asana references from silently displacing native tickets and avoids changing
+the established ticket-extraction behavior of existing providers.
+
 ## Jira Integration
 
 We support both Jira Cloud and Jira Server/Data Center.

--- a/docs/docs/core-abilities/fetching_ticket_context.md
+++ b/docs/docs/core-abilities/fetching_ticket_context.md
@@ -14,6 +14,7 @@ This integration enriches the review process by automatically surfacing relevant
 
 - [GitHub/Gitlab Issues](#githubgitlab-issues-integration)
 - [Jira](#jira-integration)
+- [Asana](#asana-integration)
 
 **Ticket data fetched:**
 
@@ -30,6 +31,7 @@ Ticket Recognition Requirements:
 
 - The PR description should contain a link to the ticket or if the branch name starts with the ticket id / number.
 - For Jira tickets, you should follow the instructions in [Jira Integration](#jira-integration) in order to authenticate with Jira.
+- For Asana tickets, see [Asana Integration](#asana-integration).
 
 ### Describe tool
 
@@ -91,6 +93,45 @@ Branch names can also be used to link issues, for example:
 This branch-name detection applies **only when the git provider is GitHub**. Support for other platforms is planned for later.
 
 Since PR-Agent is integrated with GitHub, it doesn't require any additional configuration to fetch GitHub issues.
+
+## Asana Integration
+
+PR-Agent can detect Asana task references in PR descriptions, fetch the referenced tasks through the
+[Asana API](https://developers.asana.com/reference/gettask), and include their titles, descriptions, and tags in the
+ticket compliance check.
+
+**Supported reference formats:**
+
+- Legacy links: `https://app.asana.com/0/{project_gid}/{task_gid}`
+- Current permalinks: `https://app.asana.com/1/{workspace_gid}/task/{task_gid}`
+- Current project links: `https://app.asana.com/1/{workspace_gid}/project/{project_gid}/task/{task_gid}`
+- Current Home links: `https://app.asana.com/1/{workspace_gid}/home/task/{task_gid}`
+- Task comment links ending in `/comment/{comment_gid}` (the parent task is fetched)
+
+**How to link a PR to an Asana task:**
+
+Include an Asana task URL in your PR description. PR-Agent will detect it automatically and include it in the related
+tickets list.
+
+### Authentication
+
+Create an [Asana personal access token](https://developers.asana.com/docs/personal-access-token) with access to the
+tasks that PR-Agent should read. Configure it in `.secrets.toml`:
+
+```toml
+[asana]
+api_token = "YOUR_PERSONAL_ACCESS_TOKEN"
+```
+
+For environment-based deployments, set the equivalent Dynaconf environment variable:
+
+```bash
+ASANA__API_TOKEN="YOUR_PERSONAL_ACCESS_TOKEN"
+```
+
+The token is sent only to Asana's fixed task API endpoint as a Bearer token. When no token is configured or a task is
+not accessible to that token, PR-Agent skips that Asana task instead of evaluating compliance against placeholder
+content. API request timeout can be adjusted with `asana.request_timeout` (10 seconds by default, capped at 60 seconds).
 
 ## Jira Integration
 

--- a/pr_agent/settings/.secrets_template.toml
+++ b/pr_agent/settings/.secrets_template.toml
@@ -104,6 +104,10 @@ webhook_secret = ""
 app_key = ""
 url = ""
 
+[asana]
+# Bearer token used to fetch task details from the Asana API.
+api_token = ""
+
 [azure_devops]
 # For Azure devops personal access token
 org = ""

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -84,6 +84,7 @@ require_security_review=true
 require_estimate_contribution_time_cost=false
 require_todo_scan=false
 require_ticket_analysis_review=true
+max_related_tickets=3
 # general options
 publish_output_no_suggestions=true # Set to "false" if you only need the reviewer's remarks (not labels, not "security audit", etc.) and want to avoid noisy "No major issues detected" comments.
 persistent_comment=true

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -443,6 +443,9 @@ target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
 # Max artifact size in characters (content is truncated if exceeded)
 max_artifact_size = 50000
 
+[asana]
+request_timeout = 10 # seconds allowed for each Asana task API request
+
 [azure_devops]
 default_comment_status = "closed"
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -614,7 +614,18 @@ class PRCodeSuggestions:
                 if delta_spaces > 0:
                     new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * indent_char).rstrip('\n')
                 elif delta_spaces < 0:
-                    new_code_snippet = textwrap.dedent(new_code_snippet).rstrip('\n')
+                    # Remove exactly -delta_spaces leading spaces from each
+                    # non-empty line.  textwrap.dedent() strips the *common*
+                    # indent which may remove too much when lines have
+                    # varying indentation levels (Qodo bug #3).
+                    remove_count = -delta_spaces
+                    dedented_lines = []
+                    for dline in new_code_snippet.split('\n'):
+                        if dline.strip():
+                            dedented_lines.append(dline[remove_count:])
+                        else:
+                            dedented_lines.append(dline)
+                    new_code_snippet = '\n'.join(dedented_lines).rstrip('\n')
                 # Normalize all lines in the suggestion to use the original's
                 # indentation character. This fixes the bug where /improve
                 # replaces tabs with spaces in Go, Makefile, and other
@@ -625,7 +636,13 @@ class PRCodeSuggestions:
                         stripped = line.lstrip(' ')
                         leading_spaces = len(line) - len(stripped)
                         if leading_spaces > 0:
-                            new_lines.append('\t' * (leading_spaces // 4) + stripped)
+                            # Preserve remainder spaces when converting
+                            # to tabs.  e.g. 6 spaces → 1 tab + 2 spaces
+                            # instead of silently dropping 2 spaces
+                            # (Qodo bug #3).
+                            tabs = leading_spaces // 4
+                            remainder = leading_spaces % 4
+                            new_lines.append('\t' * tabs + ' ' * remainder + stripped)
                         else:
                             new_lines.append(line)
                     new_code_snippet = '\n'.join(new_lines)

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -609,10 +609,26 @@ class PRCodeSuggestions:
                 original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip()) # lstrip works both for spaces and tabs
                 suggested_initial_spaces = len(suggested_initial_line) - len(suggested_initial_line.lstrip())
                 delta_spaces = original_initial_spaces - suggested_initial_spaces
+                # Detect indentation character from original line
+                indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                 if delta_spaces > 0:
-                    # Detect indentation character from original line
-                    indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                     new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * indent_char).rstrip('\n')
+                elif delta_spaces < 0:
+                    new_code_snippet = textwrap.dedent(new_code_snippet).rstrip('\n')
+                # Normalize all lines in the suggestion to use the original's
+                # indentation character. This fixes the bug where /improve
+                # replaces tabs with spaces in Go, Makefile, and other
+                # tab-indented codebases (#1858).
+                if indent_char == '\t':
+                    new_lines = []
+                    for line in new_code_snippet.split('\n'):
+                        stripped = line.lstrip(' ')
+                        leading_spaces = len(line) - len(stripped)
+                        if leading_spaces > 0:
+                            new_lines.append('\t' * (leading_spaces // 4) + stripped)
+                        else:
+                            new_lines.append(line)
+                    new_code_snippet = '\n'.join(new_lines)
         except Exception as e:
             get_logger().error(f"Error when dedenting code snippet for file {relevant_file}, error: {e}")
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -622,7 +622,8 @@ class PRCodeSuggestions:
                     dedented_lines = []
                     for dline in new_code_snippet.split('\n'):
                         if dline.strip():
-                            dedented_lines.append(dline[remove_count:])
+                            leading = len(dline) - len(dline.lstrip())
+                            dedented_lines.append(dline[min(remove_count, leading):])
                         else:
                             dedented_lines.append(dline)
                     new_code_snippet = '\n'.join(dedented_lines).rstrip('\n')

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -609,44 +609,10 @@ class PRCodeSuggestions:
                 original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip()) # lstrip works both for spaces and tabs
                 suggested_initial_spaces = len(suggested_initial_line) - len(suggested_initial_line.lstrip())
                 delta_spaces = original_initial_spaces - suggested_initial_spaces
-                # Detect indentation character from original line
-                indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                 if delta_spaces > 0:
+                    # Detect indentation character from original line
+                    indent_char = '\t' if original_initial_line.startswith('\t') else ' '
                     new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * indent_char).rstrip('\n')
-                elif delta_spaces < 0:
-                    # Remove exactly -delta_spaces leading spaces from each
-                    # non-empty line.  textwrap.dedent() strips the *common*
-                    # indent which may remove too much when lines have
-                    # varying indentation levels (Qodo bug #3).
-                    remove_count = -delta_spaces
-                    dedented_lines = []
-                    for dline in new_code_snippet.split('\n'):
-                        if dline.strip():
-                            leading = len(dline) - len(dline.lstrip())
-                            dedented_lines.append(dline[min(remove_count, leading):])
-                        else:
-                            dedented_lines.append(dline)
-                    new_code_snippet = '\n'.join(dedented_lines).rstrip('\n')
-                # Normalize all lines in the suggestion to use the original's
-                # indentation character. This fixes the bug where /improve
-                # replaces tabs with spaces in Go, Makefile, and other
-                # tab-indented codebases (#1858).
-                if indent_char == '\t':
-                    new_lines = []
-                    for line in new_code_snippet.split('\n'):
-                        stripped = line.lstrip(' ')
-                        leading_spaces = len(line) - len(stripped)
-                        if leading_spaces > 0:
-                            # Preserve remainder spaces when converting
-                            # to tabs.  e.g. 6 spaces → 1 tab + 2 spaces
-                            # instead of silently dropping 2 spaces
-                            # (Qodo bug #3).
-                            tabs = leading_spaces // 4
-                            remainder = leading_spaces % 4
-                            new_lines.append('\t' * tabs + ' ' * remainder + stripped)
-                        else:
-                            new_lines.append(line)
-                    new_code_snippet = '\n'.join(new_lines)
         except Exception as e:
             get_logger().error(f"Error when dedenting code snippet for file {relevant_file}, error: {e}")
 

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -300,8 +300,7 @@ async def extract_tickets(git_provider):
             asana_tickets_to_include,
             max_tickets,
         )
-        if tickets_content:
-            return tickets_content
+        return tickets_content
 
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -306,6 +306,7 @@ async def extract_tickets(git_provider):
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",
                            artifact={"traceback": traceback.format_exc()})
+    return []
 
 
 async def extract_and_cache_pr_tickets(git_provider, vars):

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -74,9 +74,15 @@ def _make_asana_ticket_content(ticket: str) -> dict:
     }
 
 
-def _append_asana_ticket_content(tickets_content: list, asana_tickets: list) -> None:
+def _append_asana_ticket_content(
+    tickets_content: list,
+    asana_tickets: list,
+    max_tickets: int,
+) -> None:
     seen_ticket_urls = {ticket.get("ticket_url") for ticket in tickets_content}
     for ticket in asana_tickets:
+        if len(tickets_content) >= max_tickets:
+            break
         if ticket not in seen_ticket_urls:
             tickets_content.append(_make_asana_ticket_content(ticket))
             seen_ticket_urls.add(ticket)
@@ -154,15 +160,12 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
 
 async def extract_tickets(git_provider):
     MAX_TICKET_CHARACTERS = 10000
+    MAX_TICKETS = 3
     try:
-        user_description = ""
-        try:
-            user_description = git_provider.get_user_description()
-        except Exception as e:
-            get_logger().warning(
-                f"Failed to get PR description for Asana ticket detection: {e}"
-            )
+        user_description = git_provider.get_user_description()
         asana_tickets = find_asana_tickets(user_description)
+        tickets_content = []
+        asana_tickets_to_include = asana_tickets
 
         if isinstance(git_provider, GithubProvider):
             description_tickets = extract_ticket_links_from_pr_description(
@@ -180,20 +183,20 @@ async def extract_tickets(git_provider):
                     merged.append(link)
 
             total_tickets = len(merged) + len(asana_tickets)
-            asana_tickets_to_include = asana_tickets
-            if total_tickets > 3:
+            if total_tickets > MAX_TICKETS:
                 get_logger().info(
                     f"Too many tickets (description + branch + Asana): {total_tickets}"
                 )
                 # Reserve at least one slot for an Asana reference when
                 # present so it is not systematically dropped.
                 reserved_asana_slots = 1 if asana_tickets else 0
-                github_slots = 3 - reserved_asana_slots
+                github_slots = MAX_TICKETS - reserved_asana_slots
                 tickets = merged[:github_slots]
-                asana_tickets_to_include = asana_tickets[: 3 - len(tickets)]
+                asana_tickets_to_include = asana_tickets[
+                    : MAX_TICKETS - len(tickets)
+                ]
             else:
                 tickets = merged
-            tickets_content = []
 
             if tickets:
 
@@ -253,13 +256,8 @@ async def extract_tickets(git_provider):
                         'sub_issues': sub_issues_content  # Store sub-issues content
                     })
 
-            _append_asana_ticket_content(tickets_content, asana_tickets_to_include)
-            if tickets_content:
-                return tickets_content
-
         elif isinstance(git_provider, AzureDevopsProvider):
             tickets_info = git_provider.get_linked_work_items()
-            tickets_content = []
             for ticket in tickets_info:
                 try:
                     ticket_body_str = ticket.get("body", "")
@@ -281,11 +279,16 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
-            _append_asana_ticket_content(tickets_content, asana_tickets)
-            return tickets_content
+            if asana_tickets and len(tickets_content) >= MAX_TICKETS:
+                tickets_content = tickets_content[: MAX_TICKETS - 1]
 
-        if asana_tickets:
-            return [_make_asana_ticket_content(ticket) for ticket in asana_tickets]
+        _append_asana_ticket_content(
+            tickets_content,
+            asana_tickets_to_include,
+            MAX_TICKETS,
+        )
+        if tickets_content:
+            return tickets_content
 
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -35,6 +35,37 @@ def find_jira_tickets(text):
     return list(tickets)
 
 
+# Compiled Asana task patterns
+_ASANA_TASK_URL_PATTERN = re.compile(
+    r'https://app\.asana\.com/0/(\d+)/(\d+)'
+)
+_ASANA_TASK_SHORT_PATTERN = re.compile(
+    r'\b(?:ASANA|asana)[- ]?(\d{12,20})\b'
+    r'|https://app\.asana\.com/0/\d+/\d+'
+)
+
+
+def find_asana_tickets(text: str) -> list:
+    """Extract Asana task references from text.
+
+    Supports both full Asana URLs and shorthand ``ASANA-123456789012``
+    format.  Returns a list of unique task URLs.
+
+    Args:
+        text: The text to scan for Asana task references.
+
+    Returns:
+        A list of Asana task URLs.
+    """
+    tickets = set()
+    for match in re.finditer(r'https://app\.asana\.com/0/(\d+)/(\d+)', text):
+        tickets.add(match.group(0))
+    for match in re.finditer(r'(?:^|[^A-Za-z0-9])(?:ASANA|asana)[- ]?(\d{12,20})', text):
+        task_id = match.group(1)
+        tickets.add(f"https://app.asana.com/0/0/{task_id}")
+    return sorted(tickets)
+
+
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
     """
     Extract all ticket links from PR description
@@ -123,6 +154,13 @@ async def extract_tickets(git_provider):
                 if link not in seen:
                     seen.add(link)
                     merged.append(link)
+
+            # Also detect Asana ticket references in the PR description
+            asana_tickets = find_asana_tickets(user_description)
+            for link in asana_tickets:
+                if link not in seen:
+                    seen.add(link)
+                    merged.append(link)
             if len(merged) > 3:
                 get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
                 tickets = merged[:3]
@@ -133,6 +171,17 @@ async def extract_tickets(git_provider):
             if tickets:
 
                 for ticket in tickets:
+                    # Skip Asana URLs — these are external references,
+                    # included for visibility but cannot be fetched via GitHub API.
+                    if "app.asana.com" in ticket:
+                        tickets_content.append({
+                            "title": f"Asana Task: {ticket}",
+                            "url": ticket,
+                            "body": ("Asana task referenced in PR description. "
+                                     "Fetch task details from Asana for full context."),
+                        })
+                        continue
+
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
 
                     try:

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -175,10 +175,12 @@ async def extract_tickets(git_provider):
                     # included for visibility but cannot be fetched via GitHub API.
                     if "app.asana.com" in ticket:
                         tickets_content.append({
+                            "ticket_id": ticket,
+                            "ticket_url": ticket,
                             "title": f"Asana Task: {ticket}",
-                            "url": ticket,
                             "body": ("Asana task referenced in PR description. "
                                      "Fetch task details from Asana for full context."),
+                            "labels": "",
                         })
                         continue
 

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -40,8 +40,8 @@ _ASANA_TASK_URL_PATTERN = re.compile(
     r'https://app\.asana\.com/0/(\d+)/(\d+)'
 )
 _ASANA_TASK_SHORT_PATTERN = re.compile(
-    r'\b(?:ASANA|asana)[- ]?(\d{12,20})\b'
-    r'|https://app\.asana\.com/0/\d+/\d+'
+    r'(?:^|[^A-Za-z0-9])(?:ASANA|asana)[- ]?(\d{12,20})',
+    re.IGNORECASE,
 )
 
 
@@ -58,11 +58,12 @@ def find_asana_tickets(text: str) -> list:
         A list of Asana task URLs.
     """
     tickets = set()
-    for match in re.finditer(r'https://app\.asana\.com/0/(\d+)/(\d+)', text):
+    for match in _ASANA_TASK_URL_PATTERN.finditer(text):
         tickets.add(match.group(0))
-    for match in re.finditer(r'(?:^|[^A-Za-z0-9])(?:ASANA|asana)[- ]?(\d{12,20})', text):
+    for match in _ASANA_TASK_SHORT_PATTERN.finditer(text):
         task_id = match.group(1)
-        tickets.add(f"https://app.asana.com/0/0/{task_id}")
+        if task_id:
+            tickets.add(f"https://app.asana.com/0/0/{task_id}")
     return sorted(tickets)
 
 
@@ -161,9 +162,15 @@ async def extract_tickets(git_provider):
                 if link not in seen:
                     seen.add(link)
                     merged.append(link)
+            asana_links = [t for t in merged if t.startswith("https://app.asana.com/")]
+            github_like = [t for t in merged if not t.startswith("https://app.asana.com/")]
             if len(merged) > 3:
                 get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
-                tickets = merged[:3]
+                # Reserve at least one slot for an Asana reference when
+                # present so it is not systematically dropped.
+                asana_slot = asana_links[:1]
+                gh_slots = 3 - len(asana_slot)
+                tickets = github_like[:gh_slots] + asana_slot
             else:
                 tickets = merged
             tickets_content = []
@@ -173,7 +180,7 @@ async def extract_tickets(git_provider):
                 for ticket in tickets:
                     # Skip Asana URLs — these are external references,
                     # included for visibility but cannot be fetched via GitHub API.
-                    if "app.asana.com" in ticket:
+                    if ticket.startswith("https://app.asana.com/"):
                         tickets_content.append({
                             "ticket_id": ticket,
                             "ticket_url": ticket,

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -205,9 +205,6 @@ async def extract_tickets(git_provider):
                 reserved_asana_slots = 1 if asana_tickets else 0
                 github_slots = max_tickets - reserved_asana_slots
                 tickets = merged[:github_slots]
-                asana_tickets_to_include = asana_tickets[
-                    : max_tickets - len(tickets)
-                ]
             else:
                 tickets = merged
 

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -2,8 +2,7 @@ import re
 import traceback
 
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import GithubProvider
-from pr_agent.git_providers import AzureDevopsProvider
+from pr_agent.git_providers import AzureDevopsProvider, GithubProvider
 from pr_agent.log import get_logger
 
 # Compile the regex pattern once, outside the function
@@ -36,8 +35,9 @@ def find_jira_tickets(text):
 
 
 _ASANA_TASK_URL_PATTERN = re.compile(
-    r'https://app\.asana\.com/0/(\d+)/(\d+)'
+    r"https://app\.asana\.com/0/(\d+)/(\d+)"
 )
+DEFAULT_MAX_RELATED_TICKETS = 3
 
 
 def find_asana_tickets(text: str | None) -> list:
@@ -86,6 +86,18 @@ def _append_asana_ticket_content(
         if ticket not in seen_ticket_urls:
             tickets_content.append(_make_asana_ticket_content(ticket))
             seen_ticket_urls.add(ticket)
+
+
+def _get_max_related_tickets() -> int:
+    max_tickets = get_settings().get(
+        "pr_reviewer.max_related_tickets",
+        DEFAULT_MAX_RELATED_TICKETS,
+    )
+    try:
+        max_tickets = int(max_tickets)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_RELATED_TICKETS
+    return max(max_tickets, 1)
 
 
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
@@ -138,7 +150,8 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
             pattern = re.compile(custom_regex_str)
             if pattern.groups < 1:
                 get_logger().error(
-                    "branch_issue_regex must contain at least one capturing group for the issue number; using default pattern."
+                    "branch_issue_regex must contain at least one capturing group for the issue number; "
+                    "using default pattern."
                 )
                 pattern = BRANCH_ISSUE_PATTERN
         except re.error as e:
@@ -160,7 +173,7 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
 
 async def extract_tickets(git_provider):
     MAX_TICKET_CHARACTERS = 10000
-    MAX_TICKETS = 3
+    max_tickets = _get_max_related_tickets()
     try:
         user_description = git_provider.get_user_description()
         asana_tickets = find_asana_tickets(user_description)
@@ -183,17 +196,17 @@ async def extract_tickets(git_provider):
                     merged.append(link)
 
             total_tickets = len(merged) + len(asana_tickets)
-            if total_tickets > MAX_TICKETS:
+            if total_tickets > max_tickets:
                 get_logger().info(
                     f"Too many tickets (description + branch + Asana): {total_tickets}"
                 )
                 # Reserve at least one slot for an Asana reference when
                 # present so it is not systematically dropped.
                 reserved_asana_slots = 1 if asana_tickets else 0
-                github_slots = MAX_TICKETS - reserved_asana_slots
+                github_slots = max_tickets - reserved_asana_slots
                 tickets = merged[:github_slots]
                 asana_tickets_to_include = asana_tickets[
-                    : MAX_TICKETS - len(tickets)
+                    : max_tickets - len(tickets)
                 ]
             else:
                 tickets = merged
@@ -279,13 +292,13 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
-            if asana_tickets and len(tickets_content) >= MAX_TICKETS:
-                tickets_content = tickets_content[: MAX_TICKETS - 1]
+            azure_slots = max_tickets - (1 if asana_tickets else 0)
+            tickets_content = tickets_content[:azure_slots]
 
         _append_asana_ticket_content(
             tickets_content,
             asana_tickets_to_include,
-            MAX_TICKETS,
+            max_tickets,
         )
         if tickets_content:
             return tickets_content

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -61,6 +61,23 @@ def find_asana_tickets(text: str | None) -> list:
     return sorted(tickets)
 
 
+def _is_asana_ticket(ticket: str) -> bool:
+    return ticket.startswith("https://app.asana.com/")
+
+
+def _make_asana_ticket_content(ticket: str) -> dict:
+    return {
+        "ticket_id": ticket,
+        "ticket_url": ticket,
+        "title": f"Asana Task: {ticket}",
+        "body": (
+            "Asana task referenced in PR description. "
+            "Fetch task details from Asana for full context."
+        ),
+        "labels": "",
+    }
+
+
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
     """
     Extract all ticket links from PR description
@@ -134,8 +151,16 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
 async def extract_tickets(git_provider):
     MAX_TICKET_CHARACTERS = 10000
     try:
-        if isinstance(git_provider, GithubProvider):
+        user_description = ""
+        try:
             user_description = git_provider.get_user_description()
+        except Exception as e:
+            get_logger().warning(
+                f"Failed to get PR description for Asana ticket detection: {e}"
+            )
+        asana_tickets = find_asana_tickets(user_description)
+
+        if isinstance(git_provider, GithubProvider):
             description_tickets = extract_ticket_links_from_pr_description(
                 user_description, git_provider.repo, git_provider.base_url_html
             )
@@ -150,14 +175,12 @@ async def extract_tickets(git_provider):
                     seen.add(link)
                     merged.append(link)
 
-            # Also detect Asana ticket references in the PR description
-            asana_tickets = find_asana_tickets(user_description)
             for link in asana_tickets:
                 if link not in seen:
                     seen.add(link)
                     merged.append(link)
-            asana_links = [t for t in merged if t.startswith("https://app.asana.com/")]
-            github_like = [t for t in merged if not t.startswith("https://app.asana.com/")]
+            asana_links = [t for t in merged if _is_asana_ticket(t)]
+            github_like = [t for t in merged if not _is_asana_ticket(t)]
             if len(merged) > 3:
                 get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
                 # Reserve at least one slot for an Asana reference when
@@ -174,15 +197,8 @@ async def extract_tickets(git_provider):
                 for ticket in tickets:
                     # Skip Asana URLs — these are external references,
                     # included for visibility but cannot be fetched via GitHub API.
-                    if ticket.startswith("https://app.asana.com/"):
-                        tickets_content.append({
-                            "ticket_id": ticket,
-                            "ticket_url": ticket,
-                            "title": f"Asana Task: {ticket}",
-                            "body": ("Asana task referenced in PR description. "
-                                     "Fetch task details from Asana for full context."),
-                            "labels": "",
-                        })
+                    if _is_asana_ticket(ticket):
+                        tickets_content.append(_make_asana_ticket_content(ticket))
                         continue
 
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
@@ -266,7 +282,14 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
+            seen_ticket_urls = {ticket.get("ticket_url") for ticket in tickets_content}
+            for ticket in asana_tickets:
+                if ticket not in seen_ticket_urls:
+                    tickets_content.append(_make_asana_ticket_content(ticket))
             return tickets_content
+
+        if asana_tickets:
+            return [_make_asana_ticket_content(ticket) for ticket in asana_tickets]
 
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -40,7 +40,7 @@ _ASANA_TASK_URL_PATTERN = re.compile(
 )
 
 
-def find_asana_tickets(text: str) -> list:
+def find_asana_tickets(text: str | None) -> list:
     """Extract Asana task references from text.
 
     Supports full Asana URLs (``https://app.asana.com/0/{project_id}/{task_id}``).
@@ -52,6 +52,9 @@ def find_asana_tickets(text: str) -> list:
     Returns:
         A list of Asana task URLs.
     """
+    if not isinstance(text, str) or not text:
+        return []
+
     tickets = set()
     for match in _ASANA_TASK_URL_PATTERN.finditer(text):
         tickets.add(match.group(0))
@@ -159,9 +162,9 @@ async def extract_tickets(git_provider):
                 get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
                 # Reserve at least one slot for an Asana reference when
                 # present so it is not systematically dropped.
-                asana_slot = asana_links[:1]
-                gh_slots = 3 - len(asana_slot)
-                tickets = github_like[:gh_slots] + asana_slot
+                reserved_asana_slots = 1 if asana_links else 0
+                github_slots = 3 - reserved_asana_slots
+                tickets = (github_like[:github_slots] + asana_links)[:3]
             else:
                 tickets = merged
             tickets_content = []

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -35,21 +35,16 @@ def find_jira_tickets(text):
     return list(tickets)
 
 
-# Compiled Asana task patterns
 _ASANA_TASK_URL_PATTERN = re.compile(
     r'https://app\.asana\.com/0/(\d+)/(\d+)'
-)
-_ASANA_TASK_SHORT_PATTERN = re.compile(
-    r'(?:^|[^A-Za-z0-9])(?:ASANA|asana)[- ]?(\d{12,20})',
-    re.IGNORECASE,
 )
 
 
 def find_asana_tickets(text: str) -> list:
     """Extract Asana task references from text.
 
-    Supports both full Asana URLs and shorthand ``ASANA-123456789012``
-    format.  Returns a list of unique task URLs.
+    Supports full Asana URLs (``https://app.asana.com/0/{project_id}/{task_id}``).
+    Returns a list of unique task URLs.
 
     Args:
         text: The text to scan for Asana task references.
@@ -60,10 +55,6 @@ def find_asana_tickets(text: str) -> list:
     tickets = set()
     for match in _ASANA_TASK_URL_PATTERN.finditer(text):
         tickets.add(match.group(0))
-    for match in _ASANA_TASK_SHORT_PATTERN.finditer(text):
-        task_id = match.group(1)
-        if task_id:
-            tickets.add(f"https://app.asana.com/0/0/{task_id}")
     return sorted(tickets)
 
 

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -61,10 +61,6 @@ def find_asana_tickets(text: str | None) -> list:
     return sorted(tickets)
 
 
-def _is_asana_ticket(ticket: str) -> bool:
-    return ticket.startswith("https://app.asana.com/")
-
-
 def _make_asana_ticket_content(ticket: str) -> dict:
     return {
         "ticket_id": ticket,
@@ -76,6 +72,14 @@ def _make_asana_ticket_content(ticket: str) -> dict:
         ),
         "labels": "",
     }
+
+
+def _append_asana_ticket_content(tickets_content: list, asana_tickets: list) -> None:
+    seen_ticket_urls = {ticket.get("ticket_url") for ticket in tickets_content}
+    for ticket in asana_tickets:
+        if ticket not in seen_ticket_urls:
+            tickets_content.append(_make_asana_ticket_content(ticket))
+            seen_ticket_urls.add(ticket)
 
 
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
@@ -175,19 +179,18 @@ async def extract_tickets(git_provider):
                     seen.add(link)
                     merged.append(link)
 
-            for link in asana_tickets:
-                if link not in seen:
-                    seen.add(link)
-                    merged.append(link)
-            asana_links = [t for t in merged if _is_asana_ticket(t)]
-            github_like = [t for t in merged if not _is_asana_ticket(t)]
-            if len(merged) > 3:
-                get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
+            total_tickets = len(merged) + len(asana_tickets)
+            asana_tickets_to_include = asana_tickets
+            if total_tickets > 3:
+                get_logger().info(
+                    f"Too many tickets (description + branch + Asana): {total_tickets}"
+                )
                 # Reserve at least one slot for an Asana reference when
                 # present so it is not systematically dropped.
-                reserved_asana_slots = 1 if asana_links else 0
+                reserved_asana_slots = 1 if asana_tickets else 0
                 github_slots = 3 - reserved_asana_slots
-                tickets = (github_like[:github_slots] + asana_links)[:3]
+                tickets = merged[:github_slots]
+                asana_tickets_to_include = asana_tickets[: 3 - len(tickets)]
             else:
                 tickets = merged
             tickets_content = []
@@ -195,12 +198,6 @@ async def extract_tickets(git_provider):
             if tickets:
 
                 for ticket in tickets:
-                    # Skip Asana URLs — these are external references,
-                    # included for visibility but cannot be fetched via GitHub API.
-                    if _is_asana_ticket(ticket):
-                        tickets_content.append(_make_asana_ticket_content(ticket))
-                        continue
-
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
 
                     try:
@@ -256,6 +253,8 @@ async def extract_tickets(git_provider):
                         'sub_issues': sub_issues_content  # Store sub-issues content
                     })
 
+            _append_asana_ticket_content(tickets_content, asana_tickets_to_include)
+            if tickets_content:
                 return tickets_content
 
         elif isinstance(git_provider, AzureDevopsProvider):
@@ -282,10 +281,7 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
-            seen_ticket_urls = {ticket.get("ticket_url") for ticket in tickets_content}
-            for ticket in asana_tickets:
-                if ticket not in seen_ticket_urls:
-                    tickets_content.append(_make_asana_ticket_content(ticket))
+            _append_asana_ticket_content(tickets_content, asana_tickets)
             return tickets_content
 
         if asana_tickets:

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -1,10 +1,12 @@
+import math
 import re
 import traceback
 from urllib.parse import urlparse
 
+import aiohttp
+
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import GithubProvider
-from pr_agent.git_providers import AzureDevopsProvider
+from pr_agent.git_providers import AzureDevopsProvider, GithubProvider
 from pr_agent.log import get_logger
 
 # Compile the regex pattern once, outside the function
@@ -13,6 +15,7 @@ GITHUB_TICKET_PATTERN = re.compile(
 )
 # Option A: issue number at start of branch or after /, followed by - or end (e.g. feature/1-test-issue, 123-fix)
 BRANCH_ISSUE_PATTERN = re.compile(r"(?:^|/)(\d{1,6})(?=-|$)")
+
 
 def find_jira_tickets(text):
     # Regular expression patterns for JIRA tickets
@@ -34,6 +37,140 @@ def find_jira_tickets(text):
                 tickets.add(ticket)
 
     return list(tickets)
+
+
+_ASANA_TASK_URL_PATTERN = re.compile(
+    r"https://app\.asana\.com/(?:"
+    r"0/\d+/(?P<legacy_task_gid>\d+)(?:/f)?"
+    r"|1/\d+/(?:project/\d+/|home/)?task/(?P<current_task_gid>\d+)(?:/comment/\d+)?"
+    r")/?(?=$|[^\w/])"
+)
+ASANA_TASK_API_URL = "https://app.asana.com/api/1.0/tasks/{task_gid}"
+ASANA_TASK_OPT_FIELDS = "gid,name,notes,permalink_url,tags.name"
+DEFAULT_ASANA_REQUEST_TIMEOUT = 10
+MAX_ASANA_REQUEST_TIMEOUT = 60
+MAX_RELATED_TICKETS = 3
+
+
+def find_asana_tickets(text: str | None) -> list:
+    """Extract Asana task references from text.
+
+    Supports legacy ``/0/{project_gid}/{task_gid}`` links and current ``/1/.../task/{task_gid}``
+    permalinks. Tasks are de-duplicated by GID while preserving their first-seen order.
+
+    Args:
+        text: The text to scan for Asana task references.
+
+    Returns:
+        A list of Asana task URLs.
+    """
+    if not isinstance(text, str) or not text:
+        return []
+
+    seen_task_gids = set()
+    tickets = []
+    for match in _ASANA_TASK_URL_PATTERN.finditer(text):
+        task_gid = match.group("legacy_task_gid") or match.group("current_task_gid")
+        if task_gid not in seen_task_gids:
+            seen_task_gids.add(task_gid)
+            tickets.append(match.group(0))
+    return tickets
+
+
+def _get_asana_task_gid(ticket_url: str) -> str:
+    match = _ASANA_TASK_URL_PATTERN.fullmatch(ticket_url)
+    if not match:
+        raise ValueError("Invalid Asana task URL")
+    return match.group("legacy_task_gid") or match.group("current_task_gid")
+
+
+def _get_asana_request_timeout() -> float:
+    timeout = get_settings().get("asana.request_timeout", DEFAULT_ASANA_REQUEST_TIMEOUT)
+    try:
+        timeout = float(timeout)
+    except (OverflowError, TypeError, ValueError):
+        return DEFAULT_ASANA_REQUEST_TIMEOUT
+    if not math.isfinite(timeout) or timeout <= 0:
+        return DEFAULT_ASANA_REQUEST_TIMEOUT
+    return min(timeout, MAX_ASANA_REQUEST_TIMEOUT)
+
+
+async def _fetch_asana_ticket_content(session, ticket_url: str, max_body_characters: int) -> dict:
+    task_gid = _get_asana_task_gid(ticket_url)
+    request_url = ASANA_TASK_API_URL.format(task_gid=task_gid)
+    async with session.get(request_url, params={"opt_fields": ASANA_TASK_OPT_FIELDS}) as response:
+        if response.status != 200:
+            raise RuntimeError(f"Asana API returned HTTP {response.status}")
+        payload = await response.json()
+
+    task = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(task, dict):
+        raise ValueError("Asana API response did not contain task data")
+
+    body = task.get("notes") if isinstance(task.get("notes"), str) else ""
+    if len(body) > max_body_characters:
+        body = body[:max_body_characters] + "..."
+
+    labels = []
+    tags = task.get("tags")
+    if isinstance(tags, list):
+        labels = [tag["name"] for tag in tags if isinstance(tag, dict) and isinstance(tag.get("name"), str)]
+
+    return {
+        "ticket_id": str(task.get("gid") or task_gid),
+        "ticket_url": task.get("permalink_url") or ticket_url,
+        "title": task.get("name") or f"Asana task {task_gid}",
+        "body": body,
+        "labels": ", ".join(labels),
+    }
+
+
+async def _fetch_asana_ticket_contents(
+    ticket_urls: list,
+    max_tickets: int,
+    max_body_characters: int,
+) -> list:
+    if not ticket_urls or max_tickets <= 0:
+        return []
+
+    api_token = get_settings().get("asana.api_token", "")
+    if not isinstance(api_token, str) or not api_token.strip():
+        get_logger().warning("Asana task references found, but asana.api_token is not configured")
+        return []
+
+    timeout = aiohttp.ClientTimeout(total=_get_asana_request_timeout())
+    headers = {"Authorization": f"Bearer {api_token.strip()}"}
+    tickets_content = []
+    async with aiohttp.ClientSession(headers=headers, timeout=timeout) as session:
+        # Bound attempts as well as successful results so invalid references cannot
+        # multiply request latency, rate-limit usage, or warning logs.
+        for ticket_url in ticket_urls[:max_tickets]:
+            if len(tickets_content) >= max_tickets:
+                break
+            task_gid = _get_asana_task_gid(ticket_url)
+            try:
+                ticket_content = await _fetch_asana_ticket_content(
+                    session,
+                    ticket_url,
+                    max_body_characters,
+                )
+            except Exception as e:
+                get_logger().warning(f"Failed to fetch Asana task {task_gid}: {e}")
+                continue
+            tickets_content.append(ticket_content)
+    return tickets_content
+
+
+def _get_user_description_for_asana(git_provider) -> str:
+    get_user_description = getattr(git_provider, "get_user_description", None)
+    if not callable(get_user_description):
+        return ""
+    try:
+        description = get_user_description()
+    except Exception as e:
+        get_logger().warning(f"Failed to read PR description for Asana references: {e}")
+        return ""
+    return description if isinstance(description, str) else ""
 
 
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
@@ -75,6 +212,7 @@ def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url
 
     return github_tickets
 
+
 def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html="https://github.com"):
     """
     Extract GitHub issue URLs from branch name. Numbers are matched at start of branch or after /,
@@ -95,7 +233,8 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
             pattern = re.compile(custom_regex_str)
             if pattern.groups < 1:
                 get_logger().error(
-                    "branch_issue_regex must contain at least one capturing group for the issue number; using default pattern."
+                    "branch_issue_regex must contain at least one capturing group for the issue number; "
+                    "using default pattern."
                 )
                 pattern = BRANCH_ISSUE_PATTERN
         except re.error as e:
@@ -183,8 +322,19 @@ def _get_repo_obj_for_ticket(git_provider, ticket_url, repo_name, repo_obj_cache
 async def extract_tickets(git_provider):
     MAX_TICKET_CHARACTERS = 10000
     try:
+        user_description = _get_user_description_for_asana(git_provider)
+        asana_ticket_urls = find_asana_tickets(user_description)
+        try:
+            asana_tickets_content = await _fetch_asana_ticket_contents(
+                asana_ticket_urls,
+                MAX_RELATED_TICKETS,
+                MAX_TICKET_CHARACTERS,
+            )
+        except Exception as e:
+            get_logger().warning(f"Failed to initialize Asana task fetching: {e}")
+            asana_tickets_content = []
+
         if isinstance(git_provider, GithubProvider):
-            user_description = git_provider.get_user_description()
             description_tickets = extract_ticket_links_from_pr_description(
                 user_description, git_provider.repo, git_provider.base_url_html
             )
@@ -198,17 +348,25 @@ async def extract_tickets(git_provider):
                 if link not in seen:
                     seen.add(link)
                     merged.append(link)
-            if len(merged) > 3:
-                get_logger().info(f"Too many tickets (description + branch): {len(merged)}")
-                tickets = merged[:3]
-            else:
-                tickets = merged
+
+            reserved_asana_slots = 1 if asana_tickets_content else 0
+            github_slots = MAX_RELATED_TICKETS - reserved_asana_slots
+            total_tickets = len(merged) + len(asana_tickets_content)
+            if total_tickets > MAX_RELATED_TICKETS:
+                get_logger().info(
+                    f"Too many tickets (description + branch + Asana): {total_tickets}"
+                )
+            # Keep the existing three-candidate GitHub attempt budget. Stop after
+            # enough successful issues are collected, leaving room for Asana.
+            tickets = merged[:MAX_RELATED_TICKETS]
             tickets_content = []
             repo_obj_cache = {}
 
             if tickets:
 
                 for ticket in tickets:
+                    if len(tickets_content) >= github_slots:
+                        break
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
 
                     try:
@@ -277,7 +435,9 @@ async def extract_tickets(git_provider):
                         'sub_issues': sub_issues_content  # Store sub-issues content
                     })
 
-                return tickets_content
+            remaining_slots = MAX_RELATED_TICKETS - len(tickets_content)
+            tickets_content.extend(asana_tickets_content[:remaining_slots])
+            return tickets_content
 
         elif isinstance(git_provider, AzureDevopsProvider):
             tickets_info = git_provider.get_linked_work_items()
@@ -303,11 +463,20 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
+            # Preserve the existing Azure work-item result set; Asana references add context
+            # without imposing a new global cap on another provider's established behaviour.
+            tickets_content.extend(asana_tickets_content)
             return tickets_content
+
+        if asana_ticket_urls:
+            return asana_tickets_content
 
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",
                            artifact={"traceback": traceback.format_exc()})
+        return []
+
+    return None
 
 
 async def extract_and_cache_pr_tickets(git_provider, vars):

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -45,11 +45,13 @@ _ASANA_TASK_URL_PATTERN = re.compile(
     r"|1/\d+/(?:project/\d+/|home/)?task/(?P<current_task_gid>\d+)(?:/comment/\d+)?"
     r")/?(?=$|[^\w/])"
 )
+# Security boundary: keep the token-bearing request target fixed to Asana rather than making it configurable.
 ASANA_TASK_API_URL = "https://app.asana.com/api/1.0/tasks/{task_gid}"
 ASANA_TASK_OPT_FIELDS = "gid,name,notes,permalink_url,tags.name"
 DEFAULT_ASANA_REQUEST_TIMEOUT = 10
 MAX_ASANA_REQUEST_TIMEOUT = 60
-MAX_RELATED_TICKETS = 3
+MAX_ASANA_TICKETS = 3
+MAX_GITHUB_TICKETS = 3
 
 
 def find_asana_tickets(text: str | None) -> list:
@@ -147,15 +149,17 @@ async def _fetch_asana_ticket_contents(
         for ticket_url in ticket_urls[:max_tickets]:
             if len(tickets_content) >= max_tickets:
                 break
-            task_gid = _get_asana_task_gid(ticket_url)
+            task_gid = None
             try:
+                task_gid = _get_asana_task_gid(ticket_url)
                 ticket_content = await _fetch_asana_ticket_content(
                     session,
                     ticket_url,
                     max_body_characters,
                 )
             except Exception as e:
-                get_logger().warning(f"Failed to fetch Asana task {task_gid}: {e}")
+                task_label = task_gid or "invalid reference"
+                get_logger().warning(f"Failed to fetch Asana task {task_label}: {e}")
                 continue
             tickets_content.append(ticket_content)
     return tickets_content
@@ -202,10 +206,9 @@ def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url
                 if issue_number.isdigit() and len(issue_number) < 5 and repo_path:
                     _add(f"{base_url_html.strip('/')}/{repo_path}/issues/{issue_number}")
 
-        if len(github_tickets) > 3:
+        if len(github_tickets) > MAX_GITHUB_TICKETS:
             get_logger().info(f"Too many tickets found in PR description: {len(github_tickets)}")
-            # Limit the number of tickets to 3
-            github_tickets = github_tickets[:3]
+            github_tickets = github_tickets[:MAX_GITHUB_TICKETS]
     except Exception as e:
         get_logger().error(f"Error extracting tickets error= {e}",
                            artifact={"traceback": traceback.format_exc()})
@@ -327,7 +330,7 @@ async def extract_tickets(git_provider):
         try:
             asana_tickets_content = await _fetch_asana_ticket_contents(
                 asana_ticket_urls,
-                MAX_RELATED_TICKETS,
+                MAX_ASANA_TICKETS,
                 MAX_TICKET_CHARACTERS,
             )
         except Exception as e:
@@ -349,24 +352,17 @@ async def extract_tickets(git_provider):
                     seen.add(link)
                     merged.append(link)
 
-            reserved_asana_slots = 1 if asana_tickets_content else 0
-            github_slots = MAX_RELATED_TICKETS - reserved_asana_slots
-            total_tickets = len(merged) + len(asana_tickets_content)
-            if total_tickets > MAX_RELATED_TICKETS:
-                get_logger().info(
-                    f"Too many tickets (description + branch + Asana): {total_tickets}"
-                )
-            # Keep the existing three-candidate GitHub attempt budget. Stop after
-            # enough successful issues are collected, leaving room for Asana.
-            tickets = merged[:MAX_RELATED_TICKETS]
+            if len(merged) > MAX_GITHUB_TICKETS:
+                get_logger().info(f"Too many GitHub tickets (description + branch): {len(merged)}")
+            # Preserve GitHub's established three-candidate budget. Asana tasks use
+            # their own bounded budget and therefore do not displace GitHub issues.
+            tickets = merged[:MAX_GITHUB_TICKETS]
             tickets_content = []
             repo_obj_cache = {}
 
             if tickets:
 
                 for ticket in tickets:
-                    if len(tickets_content) >= github_slots:
-                        break
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
 
                     try:
@@ -435,8 +431,7 @@ async def extract_tickets(git_provider):
                         'sub_issues': sub_issues_content  # Store sub-issues content
                     })
 
-            remaining_slots = MAX_RELATED_TICKETS - len(tickets_content)
-            tickets_content.extend(asana_tickets_content[:remaining_slots])
+            tickets_content.extend(asana_tickets_content)
             return tickets_content
 
         elif isinstance(git_provider, AzureDevopsProvider):
@@ -463,8 +458,8 @@ async def extract_tickets(git_provider):
                         f"Error processing Azure DevOps ticket: {e}",
                         artifact={"traceback": traceback.format_exc()},
                     )
-            # Preserve the existing Azure work-item result set; Asana references add context
-            # without imposing a new global cap on another provider's established behaviour.
+            # Preserve the existing Azure work-item result set. The independently bounded
+            # Asana results add context without imposing a new cap on Azure's established behaviour.
             tickets_content.extend(asana_tickets_content)
             return tickets_content
 

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -43,6 +43,17 @@ class _GithubProvider(GithubProvider):
         return []
 
 
+class _GenericProvider:
+    def __init__(self, description):
+        self.description = description
+
+    def get_user_description(self):
+        return self.description
+
+    def get_pr_branch(self):
+        return ""
+
+
 class TestFindAsanaTickets:
     """Tests for find_asana_tickets()."""
 
@@ -166,3 +177,24 @@ class TestFindAsanaTickets:
             ticket["ticket_url"].startswith("https://app.asana.com/")
             for ticket in tickets
         )
+
+    async def test_extract_tickets_includes_asana_for_non_github_provider(self):
+        """Asana detection should not be limited to the GitHub provider path."""
+        provider = _GenericProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert tickets == [
+            {
+                "ticket_id": "https://app.asana.com/0/99/888888888888",
+                "ticket_url": "https://app.asana.com/0/99/888888888888",
+                "title": "Asana Task: https://app.asana.com/0/99/888888888888",
+                "body": (
+                    "Asana task referenced in PR description. "
+                    "Fetch task details from Asana for full context."
+                ),
+                "labels": "",
+            }
+        ]

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for Asana ticket detection in ticket_pr_compliance_check.py.
+
+Tests cover:
+- Full Asana URL detection
+- Shorthand ASANA- prefix detection
+- Edge cases (mixed content, no tickets, duplicates)
+"""
+import pytest
+from pr_agent.tools.ticket_pr_compliance_check import find_asana_tickets
+
+
+class TestFindAsanaTickets:
+    """Tests for find_asana_tickets()."""
+
+    def test_detects_full_asana_url(self):
+        """Full Asana task URLs should be detected."""
+        text = "See https://app.asana.com/0/123456/789012 for details"
+        tickets = find_asana_tickets(text)
+        assert "https://app.asana.com/0/123456/789012" in tickets
+
+    def test_detects_asana_shorthand(self):
+        """ASANA-123456789012 shorthand format should be detected."""
+        text = "Task ASANA-123456789012 is complete"
+        tickets = find_asana_tickets(text)
+        assert any("123456789012" in t for t in tickets)
+
+    def test_detects_multiple_tickets(self):
+        """Multiple Asana references should all be found."""
+        text = (
+            "See ASANA-111111111111 and https://app.asana.com/0/22/333333333333"
+        )
+        tickets = find_asana_tickets(text)
+        assert len(tickets) == 2
+
+    def test_deduplicates_identical_tickets(self):
+        """Duplicate references to the same task should be deduplicated."""
+        text = (
+            "ASANA-123456789012 mentioned twice: ASANA-123456789012 again"
+        )
+        tickets = find_asana_tickets(text)
+        assert len(tickets) == 1
+
+    def test_returns_empty_for_no_tickets(self):
+        """Text without Asana references returns an empty list."""
+        text = "No tickets here, just regular text"
+        tickets = find_asana_tickets(text)
+        assert tickets == []
+
+    def test_returns_empty_for_empty_string(self):
+        """Empty string returns an empty list."""
+        tickets = find_asana_tickets("")
+        assert tickets == []
+
+    def test_ignores_github_urls(self):
+        """GitHub issue URLs should not be mistaken for Asana tickets."""
+        text = "Fix https://github.com/owner/repo/issues/42"
+        tickets = find_asana_tickets(text)
+        assert tickets == []
+
+    def test_shorthand_is_case_insensitive(self):
+        """Both ASANA- and asana- should be detected."""
+        text = "asana-999999999999 lowercase works too"
+        tickets = find_asana_tickets(text)
+        assert len(tickets) == 1
+        assert "999999999999" in tickets[0]
+
+    def test_tickets_are_sorted(self):
+        """Returned list should be sorted alphabetically."""
+        text = "ASANA-222222222222 ASANA-111111111111"
+        tickets = find_asana_tickets(text)
+        assert tickets == sorted(tickets)
+
+    def test_tickets_in_pr_description_mixed_content(self):
+        """Asana tickets mixed with other content in a PR description."""
+        text = """## Summary
+        Fixes ASANA-123456789012
+        Related to https://app.asana.com/0/99/888888888888
+
+        Also see GitHub issue #42
+        """
+        tickets = find_asana_tickets(text)
+        assert len(tickets) == 2

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -81,6 +81,11 @@ class TestFindAsanaTickets:
         tickets = find_asana_tickets("")
         assert tickets == []
 
+    def test_returns_empty_for_none_input(self):
+        """None input returns an empty list."""
+        tickets = find_asana_tickets(None)
+        assert tickets == []
+
     def test_ignores_github_urls(self):
         """GitHub issue URLs should not be mistaken for Asana tickets."""
         text = "Fix https://github.com/owner/repo/issues/42"
@@ -143,3 +148,21 @@ class TestFindAsanaTickets:
             if ticket["ticket_url"].startswith("https://app.asana.com/")
         ]
         assert len(asana_tickets) == 1
+
+    async def test_extract_tickets_backfills_with_asana_when_truncated(self):
+        """Ticket truncation should still return up to 3 available Asana tickets."""
+        provider = _GithubProvider(
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333 "
+            "https://app.asana.com/0/99/444444444444"
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert all(
+            ticket["ticket_url"].startswith("https://app.asana.com/")
+            for ticket in tickets
+        )

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -24,13 +24,22 @@ class _Repo:
         return _Issue(number)
 
 
+class _PartiallyFailingRepo:
+    def get_issue(self, number):
+        if number == 2:
+            raise RuntimeError("issue unavailable")
+        return _Issue(number)
+
+
 class _GithubProvider(GithubProvider):
     repo = "owner/repo"
     base_url_html = "https://github.com"
     repo_obj = _Repo()
 
-    def __init__(self, description):
+    def __init__(self, description, repo_obj=None):
         self.description = description
+        if repo_obj is not None:
+            self.repo_obj = repo_obj
 
     def get_user_description(self):
         return self.description
@@ -196,6 +205,28 @@ class TestFindAsanaTickets:
             ticket["ticket_url"].startswith("https://app.asana.com/")
             for ticket in tickets
         )
+
+    async def test_extract_tickets_backfills_asana_after_github_fetch_failure(self):
+        """Asana tickets should fill available slots after GitHub issue fetch failures."""
+        provider = _GithubProvider(
+            "Fixes #1 and #2. "
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333",
+            repo_obj=_PartiallyFailingRepo(),
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert tickets[0]["ticket_url"] == "https://github.com/owner/repo/issues/1"
+        assert [
+            ticket["ticket_url"] for ticket in tickets[1:]
+        ] == [
+            "https://app.asana.com/0/99/111111111111",
+            "https://app.asana.com/0/99/222222222222",
+        ]
 
     async def test_extract_tickets_includes_asana_for_non_github_provider(self):
         """Asana detection should not be limited to the GitHub provider path."""

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -5,6 +5,7 @@ Tests cover:
 - Full Asana URL detection
 - Edge cases (mixed content, no tickets, duplicates)
 """
+from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import AzureDevopsProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.tools.ticket_pr_compliance_check import extract_tickets, find_asana_tickets
@@ -265,4 +266,66 @@ class TestFindAsanaTickets:
         tickets = await extract_tickets(provider)
 
         assert len(tickets) == 3
+        assert tickets[-1]["ticket_url"] == "https://app.asana.com/0/99/888888888888"
+
+    async def test_extract_tickets_caps_azure_work_items_without_asana(self):
+        """Azure-only work items should also respect the configured ticket cap."""
+        provider = _AzureProvider(
+            "",
+            [
+                {
+                    "id": 1,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/1",
+                    "title": "Issue 1",
+                    "body": "Issue 1 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 2,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/2",
+                    "title": "Issue 2",
+                    "body": "Issue 2 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 3,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/3",
+                    "title": "Issue 3",
+                    "body": "Issue 3 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 4,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/4",
+                    "title": "Issue 4",
+                    "body": "Issue 4 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+            ],
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert [ticket["ticket_id"] for ticket in tickets] == [1, 2, 3]
+
+    async def test_extract_tickets_uses_configured_ticket_cap(self):
+        """The ticket cap should be configurable via pr_reviewer.max_related_tickets."""
+        previous_max = get_settings().get("pr_reviewer.max_related_tickets", 3)
+        get_settings().set("pr_reviewer.max_related_tickets", 4)
+        try:
+            provider = _GithubProvider(
+                "Fixes #1, #2 and #3. "
+                "Related Asana task: https://app.asana.com/0/99/888888888888"
+            )
+
+            tickets = await extract_tickets(provider)
+        finally:
+            get_settings().set("pr_reviewer.max_related_tickets", previous_max)
+
+        assert len(tickets) == 4
         assert tickets[-1]["ticket_url"] == "https://app.asana.com/0/99/888888888888"

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -5,6 +5,7 @@ Tests cover:
 - Full Asana URL detection
 - Edge cases (mixed content, no tickets, duplicates)
 """
+from pr_agent.git_providers import AzureDevopsProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.tools.ticket_pr_compliance_check import extract_tickets, find_asana_tickets
 
@@ -52,6 +53,18 @@ class _GenericProvider:
 
     def get_pr_branch(self):
         return ""
+
+
+class _AzureProvider(AzureDevopsProvider):
+    def __init__(self, description, work_items):
+        self.description = description
+        self.work_items = work_items
+
+    def get_user_description(self):
+        return self.description
+
+    def get_linked_work_items(self):
+        return self.work_items
 
 
 class TestFindAsanaTickets:
@@ -198,3 +211,58 @@ class TestFindAsanaTickets:
                 "labels": "",
             }
         ]
+
+    async def test_extract_tickets_caps_non_github_asana_references(self):
+        """Provider-agnostic Asana fallback should keep ticket context bounded."""
+        provider = _GenericProvider(
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333 "
+            "https://app.asana.com/0/99/444444444444"
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert all(
+            ticket["ticket_url"].startswith("https://app.asana.com/")
+            for ticket in tickets
+        )
+
+    async def test_extract_tickets_caps_azure_asana_references(self):
+        """Azure work items and Asana references should share the ticket cap."""
+        provider = _AzureProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888",
+            [
+                {
+                    "id": 1,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/1",
+                    "title": "Issue 1",
+                    "body": "Issue 1 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 2,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/2",
+                    "title": "Issue 2",
+                    "body": "Issue 2 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 3,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/3",
+                    "title": "Issue 3",
+                    "body": "Issue 3 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+            ],
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert tickets[-1]["ticket_url"] == "https://app.asana.com/0/99/888888888888"

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -56,6 +56,11 @@ class _GenericProvider:
         return ""
 
 
+class _FailingProvider:
+    def get_user_description(self):
+        raise RuntimeError("description unavailable")
+
+
 class _AzureProvider(AzureDevopsProvider):
     def __init__(self, description, work_items):
         self.description = description
@@ -212,6 +217,20 @@ class TestFindAsanaTickets:
                 "labels": "",
             }
         ]
+
+    async def test_extract_tickets_returns_empty_list_when_no_tickets_found(self):
+        """No detected tickets should return an empty list rather than None."""
+        provider = _GenericProvider("No related ticket references.")
+
+        tickets = await extract_tickets(provider)
+
+        assert tickets == []
+
+    async def test_extract_tickets_returns_empty_list_on_provider_error(self):
+        """Provider errors should not make extract_tickets() return None."""
+        tickets = await extract_tickets(_FailingProvider())
+
+        assert tickets == []
 
     async def test_extract_tickets_caps_non_github_asana_references(self):
         """Provider-agnostic Asana fallback should keep ticket context bounded."""

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -5,7 +5,42 @@ Tests cover:
 - Full Asana URL detection
 - Edge cases (mixed content, no tickets, duplicates)
 """
-from pr_agent.tools.ticket_pr_compliance_check import find_asana_tickets
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.tools.ticket_pr_compliance_check import extract_tickets, find_asana_tickets
+
+
+class _Issue:
+    def __init__(self, number):
+        self.number = number
+        self.title = f"Issue {number}"
+        self.body = f"Issue {number} body"
+        self.labels = []
+
+
+class _Repo:
+    def get_issue(self, number):
+        return _Issue(number)
+
+
+class _GithubProvider(GithubProvider):
+    repo = "owner/repo"
+    base_url_html = "https://github.com"
+    repo_obj = _Repo()
+
+    def __init__(self, description):
+        self.description = description
+
+    def get_user_description(self):
+        return self.description
+
+    def get_pr_branch(self):
+        return ""
+
+    def _parse_issue_url(self, ticket):
+        return self.repo, int(ticket.rsplit("/", 1)[-1])
+
+    def fetch_sub_issues(self, ticket):
+        return []
 
 
 class TestFindAsanaTickets:
@@ -71,3 +106,40 @@ class TestFindAsanaTickets:
         """
         tickets = find_asana_tickets(text)
         assert len(tickets) == 2
+
+    async def test_extract_tickets_includes_asana_reference(self):
+        """extract_tickets() should include Asana references in ticket content."""
+        provider = _GithubProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert tickets == [
+            {
+                "ticket_id": "https://app.asana.com/0/99/888888888888",
+                "ticket_url": "https://app.asana.com/0/99/888888888888",
+                "title": "Asana Task: https://app.asana.com/0/99/888888888888",
+                "body": (
+                    "Asana task referenced in PR description. "
+                    "Fetch task details from Asana for full context."
+                ),
+                "labels": "",
+            }
+        ]
+
+    async def test_extract_tickets_reserves_slot_for_asana_when_truncated(self):
+        """Asana references should not be dropped when the ticket list is capped."""
+        provider = _GithubProvider(
+            "Fixes #1 and #2 and #3. "
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await extract_tickets(provider)
+
+        assert len(tickets) == 3
+        asana_tickets = [
+            ticket for ticket in tickets
+            if ticket["ticket_url"].startswith("https://app.asana.com/")
+        ]
+        assert len(asana_tickets) == 1

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -3,7 +3,6 @@ Unit tests for Asana ticket detection in ticket_pr_compliance_check.py.
 
 Tests cover:
 - Full Asana URL detection
-- Shorthand ASANA- prefix detection
 - Edge cases (mixed content, no tickets, duplicates)
 """
 from pr_agent.tools.ticket_pr_compliance_check import find_asana_tickets
@@ -18,24 +17,20 @@ class TestFindAsanaTickets:
         tickets = find_asana_tickets(text)
         assert "https://app.asana.com/0/123456/789012" in tickets
 
-    def test_detects_asana_shorthand(self):
-        """ASANA-123456789012 shorthand format should be detected."""
-        text = "Task ASANA-123456789012 is complete"
-        tickets = find_asana_tickets(text)
-        assert any("123456789012" in t for t in tickets)
-
-    def test_detects_multiple_tickets(self):
-        """Multiple Asana references should all be found."""
+    def test_detects_multiple_urls(self):
+        """Multiple Asana URLs should all be found."""
         text = (
-            "See ASANA-111111111111 and https://app.asana.com/0/22/333333333333"
+            "See https://app.asana.com/0/11/111111111111"
+            " and https://app.asana.com/0/22/333333333333"
         )
         tickets = find_asana_tickets(text)
         assert len(tickets) == 2
 
-    def test_deduplicates_identical_tickets(self):
-        """Duplicate references to the same task should be deduplicated."""
+    def test_deduplicates_identical_urls(self):
+        """Duplicate references to the same URL should be deduplicated."""
         text = (
-            "ASANA-123456789012 mentioned twice: ASANA-123456789012 again"
+            "https://app.asana.com/0/1/123456789012"
+            " mentioned twice: https://app.asana.com/0/1/123456789012"
         )
         tickets = find_asana_tickets(text)
         assert len(tickets) == 1
@@ -57,38 +52,20 @@ class TestFindAsanaTickets:
         tickets = find_asana_tickets(text)
         assert tickets == []
 
-    def test_shorthand_is_case_insensitive(self):
-        """Both ASANA- and asana- should be detected."""
-        text = "asana-999999999999 lowercase works too"
-        tickets = find_asana_tickets(text)
-        assert len(tickets) == 1
-        assert "999999999999" in tickets[0]
-
-    def test_shorthand_mixed_case_asana(self):
-        """Mixed-case shorthand like Asana-123... should also be detected."""
-        text = "Asana-888888888888 mixed case"
-        tickets = find_asana_tickets(text)
-        assert len(tickets) == 1
-        assert "888888888888" in tickets[0]
-
-    def test_shorthand_respects_word_boundary(self):
-        """Text preceding the shorthand must not be alphanumeric.
-        NOTASANA-123 (no delimiter before ASANA) should not match."""
-        text = "Check NOTASANA-123456789012 in logs"
-        tickets = find_asana_tickets(text)
-        assert tickets == []
-
     def test_tickets_are_sorted(self):
         """Returned list should be sorted alphabetically."""
-        text = "ASANA-222222222222 ASANA-111111111111"
+        text = (
+            "https://app.asana.com/0/2/222222222222"
+            " https://app.asana.com/0/1/111111111111"
+        )
         tickets = find_asana_tickets(text)
         assert tickets == sorted(tickets)
 
     def test_tickets_in_pr_description_mixed_content(self):
         """Asana tickets mixed with other content in a PR description."""
         text = """## Summary
-        Fixes ASANA-123456789012
         Related to https://app.asana.com/0/99/888888888888
+        and https://app.asana.com/0/77/777777777777
 
         Also see GitHub issue #42
         """

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -6,7 +6,6 @@ Tests cover:
 - Shorthand ASANA- prefix detection
 - Edge cases (mixed content, no tickets, duplicates)
 """
-import pytest
 from pr_agent.tools.ticket_pr_compliance_check import find_asana_tickets
 
 
@@ -64,6 +63,20 @@ class TestFindAsanaTickets:
         tickets = find_asana_tickets(text)
         assert len(tickets) == 1
         assert "999999999999" in tickets[0]
+
+    def test_shorthand_mixed_case_asana(self):
+        """Mixed-case shorthand like Asana-123... should also be detected."""
+        text = "Asana-888888888888 mixed case"
+        tickets = find_asana_tickets(text)
+        assert len(tickets) == 1
+        assert "888888888888" in tickets[0]
+
+    def test_shorthand_respects_word_boundary(self):
+        """Text preceding the shorthand must not be alphanumeric.
+        NOTASANA-123 (no delimiter before ASANA) should not match."""
+        text = "Check NOTASANA-123456789012 in logs"
+        tickets = find_asana_tickets(text)
+        assert tickets == []
 
     def test_tickets_are_sorted(self):
         """Returned list should be sorted alphabetically."""

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -242,8 +242,8 @@ class TestFindAsanaTickets:
             }
         ]
 
-    async def test_extract_tickets_reserves_slot_for_asana_when_truncated(self):
-        """Asana references should not be dropped when the ticket list is capped."""
+    async def test_extract_tickets_adds_asana_without_displacing_github(self):
+        """Asana context should not displace GitHub's three existing ticket slots."""
         provider = _GithubProvider(
             "Fixes #1 and #2 and #3. "
             "Related Asana task: https://app.asana.com/0/99/888888888888"
@@ -251,12 +251,12 @@ class TestFindAsanaTickets:
 
         tickets = await tpc.extract_tickets(provider)
 
-        assert len(tickets) == 3
-        asana_tickets = [
-            ticket for ticket in tickets
-            if ticket["ticket_url"].startswith("https://app.asana.com/")
+        assert [ticket["ticket_url"] for ticket in tickets] == [
+            "https://github.com/owner/repo/issues/1",
+            "https://github.com/owner/repo/issues/2",
+            "https://github.com/owner/repo/issues/3",
+            "https://app.asana.com/0/99/888888888888",
         ]
-        assert len(asana_tickets) == 1
 
     async def test_extract_tickets_backfills_with_asana_when_truncated(self):
         """Ticket truncation should still return up to 3 available Asana tickets."""
@@ -289,17 +289,18 @@ class TestFindAsanaTickets:
 
         tickets = await tpc.extract_tickets(provider)
 
-        assert len(tickets) == 3
+        assert len(tickets) == 4
         assert tickets[0]["ticket_url"] == "https://github.com/owner/repo/issues/1"
         assert [
             ticket["ticket_url"] for ticket in tickets[1:]
         ] == [
             "https://app.asana.com/0/99/111111111111",
             "https://app.asana.com/0/99/222222222222",
+            "https://app.asana.com/0/99/333333333333",
         ]
 
-    async def test_asana_slot_does_not_skip_later_github_candidate(self):
-        """A reserved Asana slot must not reduce the existing GitHub attempt budget."""
+    async def test_asana_addition_does_not_skip_later_github_candidate(self):
+        """Adding Asana must not reduce the existing GitHub attempt budget."""
         provider = _GithubProvider(
             "Fixes #1 and #2 and #3. "
             "Related Asana task: https://app.asana.com/0/99/111111111111",
@@ -364,9 +365,13 @@ class TestFindAsanaTickets:
         )
 
     async def test_extract_tickets_adds_asana_without_truncating_azure(self):
-        """Asana context must not impose a new cap on Azure work items."""
+        """Azure work items remain intact while Asana additions keep their own cap."""
         provider = _AzureProvider(
-            "Related Asana task: https://app.asana.com/0/99/888888888888",
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333 "
+            "https://app.asana.com/0/99/444444444444",
             [
                 {
                     "id": 1,
@@ -392,13 +397,26 @@ class TestFindAsanaTickets:
                     "acceptance_criteria": "",
                     "labels": [],
                 },
+                {
+                    "id": 4,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/4",
+                    "title": "Issue 4",
+                    "body": "Issue 4 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
             ],
         )
 
         tickets = await tpc.extract_tickets(provider)
 
-        assert len(tickets) == 4
-        assert tickets[-1]["ticket_url"] == "https://app.asana.com/0/99/888888888888"
+        assert len(tickets) == 7
+        assert [ticket["ticket_id"] for ticket in tickets[:4]] == [1, 2, 3, 4]
+        assert [ticket["ticket_url"] for ticket in tickets[-3:]] == [
+            "https://app.asana.com/0/99/111111111111",
+            "https://app.asana.com/0/99/222222222222",
+            "https://app.asana.com/0/99/333333333333",
+        ]
 
     async def test_extract_tickets_preserves_all_azure_work_items_without_asana(self):
         """Azure-only extraction should preserve its pre-Asana behavior."""
@@ -484,6 +502,32 @@ class TestFindAsanaTickets:
 
         assert tickets == []
         assert attempted_urls == ticket_urls[:3]
+
+    async def test_invalid_asana_url_does_not_abort_valid_batch_entry(self, monkeypatch):
+        attempted_urls = []
+
+        async def _recording_fetch(_session, ticket_url, _max_body_characters):
+            attempted_urls.append(ticket_url)
+            task_gid = tpc._get_asana_task_gid(ticket_url)
+            return {
+                "ticket_id": task_gid,
+                "ticket_url": ticket_url,
+                "title": f"Asana task {task_gid}",
+                "body": "",
+                "labels": "",
+            }
+
+        monkeypatch.setattr(tpc, "_fetch_asana_ticket_content", _recording_fetch)
+        valid_url = "https://app.asana.com/0/99/888888888888"
+
+        tickets = await tpc._fetch_asana_ticket_contents(
+            ["https://app.asana.com/not-a-task", valid_url],
+            2,
+            10000,
+        )
+
+        assert [ticket["ticket_id"] for ticket in tickets] == ["888888888888"]
+        assert attempted_urls == [valid_url]
 
     async def test_asana_api_uses_bearer_token(self, monkeypatch):
         captured = {}

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -42,27 +42,19 @@ class _FirstTwoFailingRepo:
         return _Issue(number)
 
 
-class _GithubProvider(GithubProvider):
-    repo = "owner/repo"
-    base_url_html = "https://github.com"
-    repo_obj = _Repo()
-
-    def __init__(self, description, repo_obj=None):
-        self.description = description
-        if repo_obj is not None:
-            self.repo_obj = repo_obj
-
-    def get_user_description(self):
-        return self.description
-
-    def get_pr_branch(self):
-        return ""
-
-    def _parse_issue_url(self, ticket):
-        return self.repo, int(ticket.rsplit("/", 1)[-1])
-
-    def fetch_sub_issues(self, ticket):
-        return []
+def _make_github_provider(description, repo_obj=None):
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo = "owner/repo"
+    provider.base_url_html = "https://github.com"
+    provider.repo_obj = repo_obj if repo_obj is not None else _Repo()
+    provider.get_user_description = lambda: description
+    provider.get_pr_branch = lambda: ""
+    provider._parse_issue_url = lambda ticket: (
+        provider.repo,
+        int(ticket.rsplit("/", 1)[-1]),
+    )
+    provider.fetch_sub_issues = lambda _ticket: []
+    return provider
 
 
 class _GenericProvider:
@@ -81,16 +73,11 @@ class _FailingProvider:
         raise RuntimeError("description unavailable")
 
 
-class _AzureProvider(AzureDevopsProvider):
-    def __init__(self, description, work_items):
-        self.description = description
-        self.work_items = work_items
-
-    def get_user_description(self):
-        return self.description
-
-    def get_linked_work_items(self):
-        return self.work_items
+def _make_azure_provider(description, work_items):
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.get_user_description = lambda: description
+    provider.get_linked_work_items = lambda: work_items
+    return provider
 
 
 @pytest.fixture
@@ -224,9 +211,10 @@ class TestFindAsanaTickets:
         tickets = tpc.find_asana_tickets(text)
         assert len(tickets) == 2
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_includes_asana_reference(self):
         """extract_tickets() should include Asana references in ticket content."""
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Related Asana task: https://app.asana.com/0/99/888888888888"
         )
 
@@ -242,9 +230,10 @@ class TestFindAsanaTickets:
             }
         ]
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_adds_asana_without_displacing_github(self):
         """Asana context should not displace GitHub's three existing ticket slots."""
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Fixes #1 and #2 and #3. "
             "Related Asana task: https://app.asana.com/0/99/888888888888"
         )
@@ -258,9 +247,10 @@ class TestFindAsanaTickets:
             "https://app.asana.com/0/99/888888888888",
         ]
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_backfills_with_asana_when_truncated(self):
         """Ticket truncation should still return up to 3 available Asana tickets."""
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Related Asana tasks: "
             "https://app.asana.com/0/99/111111111111 "
             "https://app.asana.com/0/99/222222222222 "
@@ -276,9 +266,10 @@ class TestFindAsanaTickets:
             for ticket in tickets
         )
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_backfills_asana_after_github_fetch_failure(self):
         """Asana tickets should fill available slots after GitHub issue fetch failures."""
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Fixes #1 and #2. "
             "Related Asana tasks: "
             "https://app.asana.com/0/99/111111111111 "
@@ -299,9 +290,10 @@ class TestFindAsanaTickets:
             "https://app.asana.com/0/99/333333333333",
         ]
 
+    @pytest.mark.asyncio
     async def test_asana_addition_does_not_skip_later_github_candidate(self):
         """Adding Asana must not reduce the existing GitHub attempt budget."""
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Fixes #1 and #2 and #3. "
             "Related Asana task: https://app.asana.com/0/99/111111111111",
             repo_obj=_FirstTwoFailingRepo(),
@@ -314,6 +306,7 @@ class TestFindAsanaTickets:
             "https://app.asana.com/0/99/111111111111",
         ]
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_includes_asana_for_non_github_provider(self):
         """Asana detection should not be limited to the GitHub provider path."""
         provider = _GenericProvider(
@@ -332,6 +325,7 @@ class TestFindAsanaTickets:
             }
         ]
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_preserves_unsupported_provider_contract(self):
         """A non-ticket provider without Asana references remains unsupported."""
         provider = _GenericProvider("No related ticket references.")
@@ -340,12 +334,14 @@ class TestFindAsanaTickets:
 
         assert tickets is None
 
+    @pytest.mark.asyncio
     async def test_asana_description_error_is_isolated(self):
         """An optional Asana scan failure should not invent provider support."""
         tickets = await tpc.extract_tickets(_FailingProvider())
 
         assert tickets is None
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_caps_non_github_asana_references(self):
         """Provider-agnostic Asana fallback should keep ticket context bounded."""
         provider = _GenericProvider(
@@ -364,9 +360,10 @@ class TestFindAsanaTickets:
             for ticket in tickets
         )
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_adds_asana_without_truncating_azure(self):
         """Azure work items remain intact while Asana additions keep their own cap."""
-        provider = _AzureProvider(
+        provider = _make_azure_provider(
             "Related Asana tasks: "
             "https://app.asana.com/0/99/111111111111 "
             "https://app.asana.com/0/99/222222222222 "
@@ -418,9 +415,10 @@ class TestFindAsanaTickets:
             "https://app.asana.com/0/99/333333333333",
         ]
 
+    @pytest.mark.asyncio
     async def test_extract_tickets_preserves_all_azure_work_items_without_asana(self):
         """Azure-only extraction should preserve its pre-Asana behavior."""
-        provider = _AzureProvider(
+        provider = _make_azure_provider(
             "",
             [
                 {
@@ -463,6 +461,7 @@ class TestFindAsanaTickets:
         assert len(tickets) == 4
         assert [ticket["ticket_id"] for ticket in tickets] == [1, 2, 3, 4]
 
+    @pytest.mark.asyncio
     async def test_missing_token_does_not_create_placeholder_ticket(self):
         get_settings().set("asana.api_token", "")
         provider = _GenericProvider(
@@ -471,12 +470,13 @@ class TestFindAsanaTickets:
 
         assert await tpc.extract_tickets(provider) == []
 
+    @pytest.mark.asyncio
     async def test_asana_fetch_failure_does_not_displace_github_ticket(self, monkeypatch):
         async def _failing_fetch(*_args, **_kwargs):
             raise RuntimeError("task unavailable")
 
         monkeypatch.setattr(tpc, "_fetch_asana_ticket_content", _failing_fetch)
-        provider = _GithubProvider(
+        provider = _make_github_provider(
             "Fixes #1 and #2 and #3. "
             "Related Asana task: https://app.asana.com/0/99/888888888888"
         )
@@ -485,6 +485,7 @@ class TestFindAsanaTickets:
 
         assert [ticket["ticket_id"] for ticket in tickets] == [1, 2, 3]
 
+    @pytest.mark.asyncio
     async def test_asana_fetch_attempts_are_bounded_when_tasks_fail(self, monkeypatch):
         attempted_urls = []
 
@@ -503,6 +504,7 @@ class TestFindAsanaTickets:
         assert tickets == []
         assert attempted_urls == ticket_urls[:3]
 
+    @pytest.mark.asyncio
     async def test_invalid_asana_url_does_not_abort_valid_batch_entry(self, monkeypatch):
         attempted_urls = []
 
@@ -529,6 +531,7 @@ class TestFindAsanaTickets:
         assert [ticket["ticket_id"] for ticket in tickets] == ["888888888888"]
         assert attempted_urls == [valid_url]
 
+    @pytest.mark.asyncio
     async def test_asana_api_uses_bearer_token(self, monkeypatch):
         captured = {}
 
@@ -602,6 +605,7 @@ class _AsanaSession:
 
 
 class TestFetchAsanaTicketContent:
+    @pytest.mark.asyncio
     async def test_maps_real_task_fields_and_truncates_notes(self):
         response = _AsanaResponse(
             200,
@@ -633,6 +637,7 @@ class TestFetchAsanaTicketContent:
             "labels": "backend, urgent",
         }
 
+    @pytest.mark.asyncio
     async def test_non_success_response_raises_without_placeholder(self):
         session = _AsanaSession(_AsanaResponse(403, {"errors": []}))
 

--- a/tests/unittest/test_ticket_compliance.py
+++ b/tests/unittest/test_ticket_compliance.py
@@ -1,0 +1,600 @@
+"""
+Unit tests for Asana ticket detection in ticket_pr_compliance_check.py.
+
+Tests cover:
+- Legacy and current Asana URL detection
+- Authenticated task fetching and provider integration
+- Edge cases (mixed content, no tickets, duplicates, API failures)
+"""
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import AzureDevopsProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.tools import ticket_pr_compliance_check as tpc
+from tests.unittest import _settings_helpers
+
+
+class _Issue:
+    def __init__(self, number):
+        self.number = number
+        self.title = f"Issue {number}"
+        self.body = f"Issue {number} body"
+        self.labels = []
+
+
+class _Repo:
+    def get_issue(self, number):
+        return _Issue(number)
+
+
+class _PartiallyFailingRepo:
+    def get_issue(self, number):
+        if number == 2:
+            raise RuntimeError("issue unavailable")
+        return _Issue(number)
+
+
+class _FirstTwoFailingRepo:
+    def get_issue(self, number):
+        if number in {1, 2}:
+            raise RuntimeError("issue unavailable")
+        return _Issue(number)
+
+
+class _GithubProvider(GithubProvider):
+    repo = "owner/repo"
+    base_url_html = "https://github.com"
+    repo_obj = _Repo()
+
+    def __init__(self, description, repo_obj=None):
+        self.description = description
+        if repo_obj is not None:
+            self.repo_obj = repo_obj
+
+    def get_user_description(self):
+        return self.description
+
+    def get_pr_branch(self):
+        return ""
+
+    def _parse_issue_url(self, ticket):
+        return self.repo, int(ticket.rsplit("/", 1)[-1])
+
+    def fetch_sub_issues(self, ticket):
+        return []
+
+
+class _GenericProvider:
+    def __init__(self, description):
+        self.description = description
+
+    def get_user_description(self):
+        return self.description
+
+    def get_pr_branch(self):
+        return ""
+
+
+class _FailingProvider:
+    def get_user_description(self):
+        raise RuntimeError("description unavailable")
+
+
+class _AzureProvider(AzureDevopsProvider):
+    def __init__(self, description, work_items):
+        self.description = description
+        self.work_items = work_items
+
+    def get_user_description(self):
+        return self.description
+
+    def get_linked_work_items(self):
+        return self.work_items
+
+
+@pytest.fixture
+def asana_fetch_stub(monkeypatch):
+    settings_snapshot = _settings_helpers.snapshot_settings(
+        ["asana.api_token", "asana.request_timeout"]
+    )
+    get_settings().set("asana.api_token", "test-token")
+
+    async def _fake_fetch(_session, ticket_url, _max_body_characters):
+        task_gid = tpc._get_asana_task_gid(ticket_url)
+        return {
+            "ticket_id": task_gid,
+            "ticket_url": ticket_url,
+            "title": f"Asana task {task_gid}",
+            "body": f"Task notes {task_gid}",
+            "labels": "backend",
+        }
+
+    monkeypatch.setattr(tpc, "_fetch_asana_ticket_content", _fake_fetch)
+    try:
+        yield
+    finally:
+        _settings_helpers.restore_settings(settings_snapshot)
+
+
+@pytest.mark.usefixtures("asana_fetch_stub")
+class TestFindAsanaTickets:
+    """Tests for find_asana_tickets()."""
+
+    def test_detects_full_asana_url(self):
+        """Legacy Asana task URLs should be detected."""
+        text = "See https://app.asana.com/0/123456/789012 for details"
+        tickets = tpc.find_asana_tickets(text)
+        assert "https://app.asana.com/0/123456/789012" in tickets
+
+    def test_detects_current_asana_permalinks(self):
+        text = (
+            "See https://app.asana.com/1/12345/task/111111 "
+            "and https://app.asana.com/1/12345/project/98765/task/222222 "
+            "and https://app.asana.com/1/12345/home/task/333333 "
+            "and https://app.asana.com/1/12345/project/98765/task/444444/comment/555555"
+        )
+
+        assert tpc.find_asana_tickets(text) == [
+            "https://app.asana.com/1/12345/task/111111",
+            "https://app.asana.com/1/12345/project/98765/task/222222",
+            "https://app.asana.com/1/12345/home/task/333333",
+            "https://app.asana.com/1/12345/project/98765/task/444444/comment/555555",
+        ]
+
+    def test_detects_focus_query_and_trailing_slash(self):
+        text = (
+            "https://app.asana.com/1/12345/home/task/111111/?focus=true "
+            "https://app.asana.com/1/12345/task/222222?focus=true"
+        )
+
+        assert tpc.find_asana_tickets(text) == [
+            "https://app.asana.com/1/12345/home/task/111111/",
+            "https://app.asana.com/1/12345/task/222222",
+        ]
+
+    def test_detects_multiple_urls(self):
+        """Multiple Asana URLs should all be found."""
+        text = (
+            "See https://app.asana.com/0/11/111111111111"
+            " and https://app.asana.com/0/22/333333333333"
+        )
+        tickets = tpc.find_asana_tickets(text)
+        assert len(tickets) == 2
+
+    def test_deduplicates_identical_urls(self):
+        """Duplicate references to the same URL should be deduplicated."""
+        text = (
+            "https://app.asana.com/0/1/123456789012"
+            " mentioned twice: https://app.asana.com/0/1/123456789012"
+        )
+        tickets = tpc.find_asana_tickets(text)
+        assert len(tickets) == 1
+
+    def test_deduplicates_same_task_across_url_formats(self):
+        text = (
+            "https://app.asana.com/0/111/999999 first, "
+            "https://app.asana.com/0/222/999999 second, "
+            "https://app.asana.com/1/333/task/999999 third"
+        )
+
+        assert tpc.find_asana_tickets(text) == ["https://app.asana.com/0/111/999999"]
+
+    def test_returns_empty_for_no_tickets(self):
+        """Text without Asana references returns an empty list."""
+        text = "No tickets here, just regular text"
+        tickets = tpc.find_asana_tickets(text)
+        assert tickets == []
+
+    def test_returns_empty_for_empty_string(self):
+        """Empty string returns an empty list."""
+        tickets = tpc.find_asana_tickets("")
+        assert tickets == []
+
+    def test_returns_empty_for_none_input(self):
+        """None input returns an empty list."""
+        tickets = tpc.find_asana_tickets(None)
+        assert tickets == []
+
+    def test_ignores_github_urls(self):
+        """GitHub issue URLs should not be mistaken for Asana tickets."""
+        text = "Fix https://github.com/owner/repo/issues/42"
+        tickets = tpc.find_asana_tickets(text)
+        assert tickets == []
+
+    def test_tickets_preserve_first_seen_order(self):
+        text = (
+            "https://app.asana.com/0/2/222222222222"
+            " https://app.asana.com/0/1/111111111111"
+        )
+        tickets = tpc.find_asana_tickets(text)
+        assert tickets == [
+            "https://app.asana.com/0/2/222222222222",
+            "https://app.asana.com/0/1/111111111111",
+        ]
+
+    def test_tickets_in_pr_description_mixed_content(self):
+        """Asana tickets mixed with other content in a PR description."""
+        text = """## Summary
+        Related to https://app.asana.com/0/99/888888888888
+        and https://app.asana.com/0/77/777777777777
+
+        Also see GitHub issue #42
+        """
+        tickets = tpc.find_asana_tickets(text)
+        assert len(tickets) == 2
+
+    async def test_extract_tickets_includes_asana_reference(self):
+        """extract_tickets() should include Asana references in ticket content."""
+        provider = _GithubProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert tickets == [
+            {
+                "ticket_id": "888888888888",
+                "ticket_url": "https://app.asana.com/0/99/888888888888",
+                "title": "Asana task 888888888888",
+                "body": "Task notes 888888888888",
+                "labels": "backend",
+            }
+        ]
+
+    async def test_extract_tickets_reserves_slot_for_asana_when_truncated(self):
+        """Asana references should not be dropped when the ticket list is capped."""
+        provider = _GithubProvider(
+            "Fixes #1 and #2 and #3. "
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 3
+        asana_tickets = [
+            ticket for ticket in tickets
+            if ticket["ticket_url"].startswith("https://app.asana.com/")
+        ]
+        assert len(asana_tickets) == 1
+
+    async def test_extract_tickets_backfills_with_asana_when_truncated(self):
+        """Ticket truncation should still return up to 3 available Asana tickets."""
+        provider = _GithubProvider(
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333 "
+            "https://app.asana.com/0/99/444444444444"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert all(
+            ticket["ticket_url"].startswith("https://app.asana.com/")
+            for ticket in tickets
+        )
+
+    async def test_extract_tickets_backfills_asana_after_github_fetch_failure(self):
+        """Asana tickets should fill available slots after GitHub issue fetch failures."""
+        provider = _GithubProvider(
+            "Fixes #1 and #2. "
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333",
+            repo_obj=_PartiallyFailingRepo(),
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert tickets[0]["ticket_url"] == "https://github.com/owner/repo/issues/1"
+        assert [
+            ticket["ticket_url"] for ticket in tickets[1:]
+        ] == [
+            "https://app.asana.com/0/99/111111111111",
+            "https://app.asana.com/0/99/222222222222",
+        ]
+
+    async def test_asana_slot_does_not_skip_later_github_candidate(self):
+        """A reserved Asana slot must not reduce the existing GitHub attempt budget."""
+        provider = _GithubProvider(
+            "Fixes #1 and #2 and #3. "
+            "Related Asana task: https://app.asana.com/0/99/111111111111",
+            repo_obj=_FirstTwoFailingRepo(),
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert [ticket["ticket_url"] for ticket in tickets] == [
+            "https://github.com/owner/repo/issues/3",
+            "https://app.asana.com/0/99/111111111111",
+        ]
+
+    async def test_extract_tickets_includes_asana_for_non_github_provider(self):
+        """Asana detection should not be limited to the GitHub provider path."""
+        provider = _GenericProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert tickets == [
+            {
+                "ticket_id": "888888888888",
+                "ticket_url": "https://app.asana.com/0/99/888888888888",
+                "title": "Asana task 888888888888",
+                "body": "Task notes 888888888888",
+                "labels": "backend",
+            }
+        ]
+
+    async def test_extract_tickets_preserves_unsupported_provider_contract(self):
+        """A non-ticket provider without Asana references remains unsupported."""
+        provider = _GenericProvider("No related ticket references.")
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert tickets is None
+
+    async def test_asana_description_error_is_isolated(self):
+        """An optional Asana scan failure should not invent provider support."""
+        tickets = await tpc.extract_tickets(_FailingProvider())
+
+        assert tickets is None
+
+    async def test_extract_tickets_caps_non_github_asana_references(self):
+        """Provider-agnostic Asana fallback should keep ticket context bounded."""
+        provider = _GenericProvider(
+            "Related Asana tasks: "
+            "https://app.asana.com/0/99/111111111111 "
+            "https://app.asana.com/0/99/222222222222 "
+            "https://app.asana.com/0/99/333333333333 "
+            "https://app.asana.com/0/99/444444444444"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 3
+        assert all(
+            ticket["ticket_url"].startswith("https://app.asana.com/")
+            for ticket in tickets
+        )
+
+    async def test_extract_tickets_adds_asana_without_truncating_azure(self):
+        """Asana context must not impose a new cap on Azure work items."""
+        provider = _AzureProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888",
+            [
+                {
+                    "id": 1,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/1",
+                    "title": "Issue 1",
+                    "body": "Issue 1 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 2,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/2",
+                    "title": "Issue 2",
+                    "body": "Issue 2 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 3,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/3",
+                    "title": "Issue 3",
+                    "body": "Issue 3 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+            ],
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 4
+        assert tickets[-1]["ticket_url"] == "https://app.asana.com/0/99/888888888888"
+
+    async def test_extract_tickets_preserves_all_azure_work_items_without_asana(self):
+        """Azure-only extraction should preserve its pre-Asana behavior."""
+        provider = _AzureProvider(
+            "",
+            [
+                {
+                    "id": 1,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/1",
+                    "title": "Issue 1",
+                    "body": "Issue 1 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 2,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/2",
+                    "title": "Issue 2",
+                    "body": "Issue 2 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 3,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/3",
+                    "title": "Issue 3",
+                    "body": "Issue 3 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+                {
+                    "id": 4,
+                    "url": "https://dev.azure.com/org/project/_workitems/edit/4",
+                    "title": "Issue 4",
+                    "body": "Issue 4 body",
+                    "acceptance_criteria": "",
+                    "labels": [],
+                },
+            ],
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert len(tickets) == 4
+        assert [ticket["ticket_id"] for ticket in tickets] == [1, 2, 3, 4]
+
+    async def test_missing_token_does_not_create_placeholder_ticket(self):
+        get_settings().set("asana.api_token", "")
+        provider = _GenericProvider(
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        assert await tpc.extract_tickets(provider) == []
+
+    async def test_asana_fetch_failure_does_not_displace_github_ticket(self, monkeypatch):
+        async def _failing_fetch(*_args, **_kwargs):
+            raise RuntimeError("task unavailable")
+
+        monkeypatch.setattr(tpc, "_fetch_asana_ticket_content", _failing_fetch)
+        provider = _GithubProvider(
+            "Fixes #1 and #2 and #3. "
+            "Related Asana task: https://app.asana.com/0/99/888888888888"
+        )
+
+        tickets = await tpc.extract_tickets(provider)
+
+        assert [ticket["ticket_id"] for ticket in tickets] == [1, 2, 3]
+
+    async def test_asana_fetch_attempts_are_bounded_when_tasks_fail(self, monkeypatch):
+        attempted_urls = []
+
+        async def _failing_fetch(_session, ticket_url, _max_body_characters):
+            attempted_urls.append(ticket_url)
+            raise RuntimeError("task unavailable")
+
+        monkeypatch.setattr(tpc, "_fetch_asana_ticket_content", _failing_fetch)
+        ticket_urls = [
+            f"https://app.asana.com/0/99/{task_gid}"
+            for task_gid in range(111111111111, 111111111119)
+        ]
+
+        tickets = await tpc._fetch_asana_ticket_contents(ticket_urls, 3, 10000)
+
+        assert tickets == []
+        assert attempted_urls == ticket_urls[:3]
+
+    async def test_asana_api_uses_bearer_token(self, monkeypatch):
+        captured = {}
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+        def _client_session(*, headers, timeout):
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _Session()
+
+        monkeypatch.setattr(tpc.aiohttp, "ClientSession", _client_session)
+
+        tickets = await tpc._fetch_asana_ticket_contents(
+            ["https://app.asana.com/0/99/888888888888"],
+            1,
+            10000,
+        )
+
+        assert tickets[0]["ticket_id"] == "888888888888"
+        assert captured["headers"] == {"Authorization": "Bearer test-token"}
+        assert captured["timeout"].total == 10
+
+    @pytest.mark.parametrize(
+        ("configured_timeout", "expected_timeout"),
+        [
+            (float("inf"), tpc.DEFAULT_ASANA_REQUEST_TIMEOUT),
+            (float("nan"), tpc.DEFAULT_ASANA_REQUEST_TIMEOUT),
+            (-1, tpc.DEFAULT_ASANA_REQUEST_TIMEOUT),
+            (10**1000, tpc.DEFAULT_ASANA_REQUEST_TIMEOUT),
+            (600, tpc.MAX_ASANA_REQUEST_TIMEOUT),
+        ],
+    )
+    def test_asana_request_timeout_is_finite_and_bounded(
+        self, configured_timeout, expected_timeout
+    ):
+        get_settings().set("asana.request_timeout", configured_timeout)
+
+        assert tpc._get_asana_request_timeout() == expected_timeout
+
+
+class _AsanaResponse:
+    def __init__(self, status, payload):
+        self.status = status
+        self.payload = payload
+
+    async def json(self):
+        return self.payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _AsanaSession:
+    def __init__(self, response):
+        self.response = response
+        self.request_url = None
+        self.request_params = None
+
+    def get(self, request_url, params):
+        self.request_url = request_url
+        self.request_params = params
+        return self.response
+
+
+class TestFetchAsanaTicketContent:
+    async def test_maps_real_task_fields_and_truncates_notes(self):
+        response = _AsanaResponse(
+            200,
+            {
+                "data": {
+                    "gid": "888888888888",
+                    "name": "Fix login race",
+                    "notes": "x" * 25,
+                    "permalink_url": "https://app.asana.com/1/42/task/888888888888",
+                    "tags": [{"name": "backend"}, {"name": "urgent"}],
+                }
+            },
+        )
+        session = _AsanaSession(response)
+
+        ticket = await tpc._fetch_asana_ticket_content(
+            session,
+            "https://app.asana.com/0/99/888888888888",
+            20,
+        )
+
+        assert session.request_url == "https://app.asana.com/api/1.0/tasks/888888888888"
+        assert session.request_params == {"opt_fields": tpc.ASANA_TASK_OPT_FIELDS}
+        assert ticket == {
+            "ticket_id": "888888888888",
+            "ticket_url": "https://app.asana.com/1/42/task/888888888888",
+            "title": "Fix login race",
+            "body": "x" * 20 + "...",
+            "labels": "backend, urgent",
+        }
+
+    async def test_non_success_response_raises_without_placeholder(self):
+        session = _AsanaSession(_AsanaResponse(403, {"errors": []}))
+
+        with pytest.raises(RuntimeError, match="HTTP 403"):
+            await tpc._fetch_asana_ticket_content(
+                session,
+                "https://app.asana.com/1/42/task/888888888888",
+                10000,
+            )


### PR DESCRIPTION
## What

Fixes #2002 — adds authenticated Asana task fetching to the ticket compliance check.

## Problem

The ticket compliance check could use GitHub and Azure DevOps ticket content, but Asana references did not provide real task context for compliance analysis.

## Solution

- Detect full Asana task URLs in both legacy and current permalink formats.
- Fetch each referenced task through `GET /api/1.0/tasks/{task_gid}` using a configured Bearer token.
- Keep the token-bearing request target fixed to Asana's official API as a security boundary.
- Include the task name, notes, tags, and canonical permalink in ticket context.
- Deduplicate references by task GID while preserving their first-seen order.
- Bound Asana fetch attempts and isolate invalid, missing, inaccessible, or failed tasks so one bad reference cannot abort the batch.
- Preserve native provider behavior: GitHub keeps its existing three-issue limit, Azure keeps all linked work items, and each path appends at most three Asana tasks.

## Configuration

Configure an Asana personal access token in `.secrets.toml`:

```toml
[asana]
api_token = "YOUR_PERSONAL_ACCESS_TOKEN"
```

Environment-based deployments can use `ASANA__API_TOKEN`. The default per-task request timeout is 10 seconds, can be changed with `asana.request_timeout`, and is capped at 60 seconds.

## Local verification

- Focused ticket-compliance and extraction tests: 64 passed.
- Full unit suite with coverage: 1783 passed, 1 skipped, 1 xfailed.
- Ruff, flake8, isort, pre-commit hooks, and diff whitespace checks passed.
- MkDocs site build passed.
- No live Asana credentials were used; API behavior is covered with mocked responses.
