### PR TITLE
fix(gitea): return repo settings as bytes so .pr_agent.toml loads

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -605,11 +605,11 @@ class GiteaProvider(GitProvider):
 
         return [label.name for label in labels]
 
-    def get_repo_settings(self) -> str:
+    def get_repo_settings(self) -> bytes:
         """Get repository settings"""
         if not self.repo_settings:
             self.logger.error("Repository settings not found")
-            return ""
+            return b""
 
         response = self.repo_api.get_file_content(
             owner=self.owner,
@@ -619,9 +619,13 @@ class GiteaProvider(GitProvider):
         )
         if not response:
             self.logger.error("Failed to get repository settings")
-            return ""
+            return b""
 
-        return response
+        # utils.apply_repo_settings() writes this via os.write() and later
+        # calls .decode() on it, so it must be bytes to match the GitHub/
+        # GitLab/Bitbucket contract. get_file_content() decodes the raw bytes
+        # to str, so re-encode here (see issue #2347).
+        return response.encode('utf-8')
 
     def get_user_id(self) -> str:
         """Get the ID of the authenticated user"""

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -103,3 +103,48 @@ class TestGiteaProvider:
         args, kwargs = mock_api_client.call_api.call_args
         assert args[0] == '/repos/owner/repo/pulls/123/commits'
         assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+
+    def test_get_repo_settings_returns_bytes(self):
+        """Regression for #2347: get_repo_settings must return bytes so that
+        utils.apply_repo_settings can os.write() it and later .decode() it. The
+        Gitea raw-file API yields str (unlike GitHub/GitLab/Bitbucket, which hand
+        back bytes), so the provider must encode before returning."""
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        toml = '[pr_reviewer]\nnum_code_suggestions = 4\n'
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.sha = 'sha1'
+        provider.repo_settings = '.pr_agent.toml'
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_file_content.return_value = toml  # API decodes to str
+
+        result = provider.get_repo_settings()
+
+        assert isinstance(result, bytes)
+        assert result == toml.encode('utf-8')
+        # The bytes must survive the exact operations utils.py performs on them.
+        assert result.decode() == toml
+
+    def test_get_repo_settings_empty_bytes_when_unset_or_missing(self):
+        """No settings path configured, or empty/absent file: return empty
+        bytes, so every code path honours the -> bytes contract (not just the
+        success path) and a caller can never receive a str."""
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        unset = GiteaProvider.__new__(GiteaProvider)
+        unset.logger = MagicMock()
+        unset.repo_settings = None
+        assert unset.get_repo_settings() == b""
+
+        empty = GiteaProvider.__new__(GiteaProvider)
+        empty.logger = MagicMock()
+        empty.owner = 'owner'
+        empty.repo = 'repo'
+        empty.sha = 'sha1'
+        empty.repo_settings = '.pr_agent.toml'
+        empty.repo_api = MagicMock()
+        empty.repo_api.get_file_content.return_value = ''
+        assert empty.get_repo_settings() == b""


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Gitea repo settings to return bytes so .pr_agent.toml loads
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

`GiteaProvider.get_repo_settings()` returned a `str`, but `utils.apply_repo_settings()` writes the value with `os.write(fd, repo_settings)` and `handle_configurations_errors()` later calls `.decode()` on it — both require `bytes`. This is the contract the GitHub (`decoded_content`), GitLab (python-gitlab `.decode()`) and Bitbucket (`response.text.encode('utf-8')`) providers already follow.

As a result, loading a repo-level `.pr_agent.toml` on Gitea failed with `a bytes-like object is required, not 'str'`, and the error handler then crashed in turn with `'str' object has no attribute 'decode'`, so repo-level configuration was effectively unusable.

## Fix

Encode the content to `bytes` in `get_repo_settings()` before returning, mirroring the Bitbucket provider (which also starts from a `str`). `RepoApi.get_file_content()` is intentionally left returning `str`, since its other callers (diff and language analysis) legitimately consume text.

## Tests

Added regression tests in `tests/unittest/test_gitea_provider.py`:

- `test_get_repo_settings_returns_bytes` — asserts the return is `bytes` and round-trips through the exact `os.write` / `.decode` operations `utils.py` performs.
- `test_get_repo_settings_falsy_when_unset_or_missing` — locks the falsy-on-missing behaviour shared with the other providers.

Fixes #2347.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fix Gitea provider to return repo settings as bytes, matching other providers.
• Prevent .pr_agent.toml loading failures caused by os.write/.decode bytes contract.
• Add regression tests for bytes return and falsy behavior when settings are missing.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A[GiteaProvider] --> B["get_repo_settings()"] --> C[RepoApi] --> D["get_file_content()"] --> E["encode('utf-8')"] --> F["utils.apply_repo_settings()"]
  subgraph Legend
    direction LR
    _mod([Module/Class]) ~~~ _fn[Function] ~~~ _ext[[External/Helper]]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Make utils.apply_repo_settings accept str as well as bytes</b></summary>

- ➕ Avoids re-encoding in providers that return decoded text
- ➕ Centralizes the type-handling logic in one place
- ➖ Expands the utils contract and increases branching/complexity there
- ➖ Diverges from the established cross-provider expectation that repo settings are bytes

</details>

<details>
<summary><b>2. Return empty bytes (b&#x27;&#x27;) consistently on error/missing settings</b></summary>

- ➕ Keeps the get_repo_settings() return type consistent (always bytes or falsy bytes)
- ➕ Avoids mixed-type falsy returns (&#x27;&#x27; vs b&#x27;&#x27;) in callers
- ➖ Slight behavior change if any caller distinguishes &#x27;&#x27; from b&#x27;&#x27;
- ➖ Not strictly required to fix the reported crash if callers only check truthiness

</details>

**Recommendation:** The chosen approach (encode to bytes in GiteaProvider.get_repo_settings) is the best fit because it restores the existing provider contract relied upon by utils.apply_repo_settings and aligns Gitea with GitHub/GitLab/Bitbucket behavior. Consider a follow-up to return b&#x27;&#x27; (instead of &#x27;&#x27;) on failure/missing cases to fully match the new bytes return annotation and avoid mixed-type falsy values.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>gitea_provider.py</strong> <code>Encode repo settings content to bytes in get_repo_settings()</code> <code>+6/-2</code></summary>

<br/>

>Encode repo settings content to bytes in get_repo_settings()
>
><pre>
>• Changes GiteaProvider.get_repo_settings() to return bytes by UTF-8 encoding the decoded file content. Adds inline documentation explaining the bytes contract expected by utils.apply_repo_settings() and why re-encoding is required for Gitea.
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2435/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc'>pr_agent/git_providers/gitea_provider.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_gitea_provider.py</strong> <code>Add regression tests for Gitea repo settings bytes contract</code> <code>+44/-0</code></summary>

<br/>

>Add regression tests for Gitea repo settings bytes contract
>
><pre>
>• Adds unit tests asserting get_repo_settings() returns bytes and round-trips through decode, matching the downstream os.write/.decode usage. Adds coverage for falsy returns when repo settings are unset or the file content is empty.
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2435/files#diff-ba40939d8f8ee99dd52ee0fcf6906d8bf99111463f39a4068c9b90e556e35580'>tests/unittest/test_gitea_provider.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>