### PR TITLE
fix(github_action): skip bot-sender comments to avoid feedback loop

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -146,6 +146,14 @@ async def run_action():
     elif GITHUB_EVENT_NAME == "issue_comment" or GITHUB_EVENT_NAME == "pull_request_review_comment":
         action = event_payload.get("action")
         if action in ["created", "edited"]:
+            # Skip comments authored by bots (including pr-agent's own
+            # "Preparing review..." messages), which would otherwise re-fire
+            # the action and be parsed as a command, causing a feedback loop.
+            # Mirrors the `if: github.event.sender.type != 'Bot'` workflow
+            # guard so users don't have to add it themselves. See issue #2398.
+            if event_payload.get("sender", {}).get("type") == "Bot":
+                get_logger().info("Skipping comment event from a bot sender to avoid a feedback loop")
+                return
             comment_body = event_payload.get("comment", {}).get("body")
             try:
                 if GITHUB_EVENT_NAME == "pull_request_review_comment":

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -103,3 +103,86 @@ async def test_run_action_invokes_enabled_auto_tools_for_pull_request_event(monk
             settings.set("GITHUB_ACTION_CONFIG", original_github_action_config)
         else:
             settings.unset("GITHUB_ACTION_CONFIG", force=True)
+
+
+@pytest.fixture
+def restore_github_settings():
+    """run_action mutates global GITHUB/GITHUB_ACTION_CONFIG settings; snapshot
+    and restore them so these tests don't leak state into others."""
+    settings = get_settings()
+    had_github = "GITHUB" in settings
+    original_github = copy.deepcopy(settings.get("GITHUB", None))
+    had_cfg = "GITHUB_ACTION_CONFIG" in settings
+    original_cfg = copy.deepcopy(settings.get("GITHUB_ACTION_CONFIG", None))
+    yield
+    if had_github:
+        settings.set("GITHUB", original_github)
+    else:
+        settings.unset("GITHUB", force=True)
+    if had_cfg:
+        settings.set("GITHUB_ACTION_CONFIG", original_cfg)
+    else:
+        settings.unset("GITHUB_ACTION_CONFIG", force=True)
+
+
+def _write_issue_comment_event(tmp_path, sender_type):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({
+        "action": "created",
+        "comment": {"body": "/review", "id": 123},
+        "issue": {
+            "pull_request": {"url": "https://api.github.com/repos/org/repo/pulls/1"},
+            "url": "https://api.github.com/repos/org/repo/issues/1",
+        },
+        "sender": {"type": sender_type},
+    }))
+    return event_path
+
+
+def _patch_issue_comment_deps(monkeypatch, handled):
+    monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda pr_url: None)
+
+    class FakeProvider:
+        def __init__(self, pr_url=None):
+            self.pr_url = pr_url
+
+        def add_eyes_reaction(self, comment_id, disable_eyes=False):
+            return None
+
+    monkeypatch.setattr(github_action_runner, "get_git_provider", lambda: FakeProvider)
+
+    class FakeAgent:
+        async def handle_request(self, url, body, notify=None):
+            handled.append((url, body))
+
+    monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_from_bot_sender_is_skipped(monkeypatch, tmp_path, restore_github_settings):
+    """Regression for #2398: a comment authored by a bot (e.g. pr-agent's own
+    'Preparing review...' message) must not be parsed as a command, which would
+    re-trigger the action in a feedback loop."""
+    handled = []
+    _patch_issue_comment_deps(monkeypatch, handled)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_issue_comment_event(tmp_path, "Bot")))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    await github_action_runner.run_action()
+
+    assert handled == []  # bot comment skipped; no command handled
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_from_user_is_processed(monkeypatch, tmp_path, restore_github_settings):
+    """The bot guard must not over-skip: a human comment is still handled."""
+    handled = []
+    _patch_issue_comment_deps(monkeypatch, handled)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_issue_comment_event(tmp_path, "User")))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    await github_action_runner.run_action()
+
+    assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Skip bot-authored GitHub Action comments to prevent issue_comment feedback loops
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

When pr-agent runs as a GitHub Action on `issue_comment` events, it re-fires on the comments it posts itself (e.g. "Preparing review..."). Each bot comment triggers another `issue_comment` run, which parses the comment body as a command and fails with `Unknown command: preparing`, as described in #2398.

## Fix

Skip processing in the `issue_comment` / `pull_request_review_comment` handler when the comment's sender is a Bot. This mirrors the `if: github.event.sender.type != 'Bot'` guard the docs already recommend, so users no longer have to add it to every workflow themselves.

Behaviour note: this skips all bot-authored comments. That matches the documented `sender.type != 'Bot'` recommendation; if someone intentionally drives pr-agent from another bot, they'd need a different trigger. Happy to gate it behind a config flag instead if you'd prefer.

## Tests

- `test_issue_comment_from_bot_sender_is_skipped` — a bot-authored comment is not handled.
- `test_issue_comment_from_user_is_processed` — a human comment is still handled (the guard doesn't over-skip).

Fixes #2398.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Skip issue_comment processing when the comment sender is a GitHub Bot
• Prevent pr-agent from re-triggering on its own status comments and failing command parsing
• Add regression tests ensuring bot comments are skipped while human comments still run
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A{{"GitHub comment event"}} --> B["github_action_runner.run_action"] --> C{"sender.type == Bot?"}
  C -- "yes" --> D["Log + return"]
  C -- "no" --> E["Parse body + URL"] --> F["PRAgent.handle_request"] --> G["GitHub API"]
  subgraph Legend
    direction LR
    _evt{{"Event"}} ~~~ _handler["Handler"] ~~~ _dec{"Decision"}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Workflow-level guard only (docs approach)</b></summary>

- ➕ Keeps library behavior unchanged
- ➕ Allows users to decide whether other bots should be able to trigger pr-agent
- ➖ Easy to miss; every workflow must remember to add it
- ➖ Doesn’t help users already experiencing the loop until they change workflows

</details>

<details>
<summary><b>2. Config flag (e.g., skip_bot_senders=true by default)</b></summary>

- ➕ Maintains safe default while allowing opt-out for bot-driven automations
- ➕ Makes behavior explicit and discoverable in configuration
- ➖ Adds configuration surface area and support burden
- ➖ Requires documenting and threading config through the action runner

</details>

<details>
<summary><b>3. Allowlist/denylist by sender.login (skip only pr-agent bot)</b></summary>

- ➕ Preserves ability to trigger from other bots
- ➕ More targeted than sender.type == Bot
- ➖ Brittle across installations/forks/renamed apps
- ➖ Still risks loops if other bot comments trigger self-replies

</details>

**Recommendation:** The current `sender.type == &#x27;Bot&#x27;` short-circuit is a solid default because it matches GitHub’s documented workflow guard and prevents a high-impact feedback loop out of the box. If there is a real use case for bot-driven commands, consider a follow-up that adds a config toggle or allowlist; otherwise keep the minimal guard for safety and simplicity.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>github_action_runner.py</strong> <code>Skip bot-authored comment events in GitHub Action runner</code> <code>+8/-0</code></summary>

<br/>

>Skip bot-authored comment events in GitHub Action runner
>
><pre>
>• Adds an early-return guard in the issue_comment / pull_request_review_comment handler when the event sender is a Bot. This prevents pr-agent from re-triggering on its own comments and entering a command-parsing feedback loop (issue #2398).
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2438/files#diff-15f9c11da031449998128bdbba057d768853e836eedf44563be71b3847be80e0'>pr_agent/servers/github_action_runner.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_github_action_runner_core.py</strong> <code>Add regression tests for bot-sender skip behavior</code> <code>+83/-0</code></summary>

<br/>

>Add regression tests for bot-sender skip behavior
>
><pre>
>• Introduces fixtures/helpers to isolate global settings mutations and to stub dependencies for issue_comment handling. Adds async tests verifying bot-authored comments are skipped and human comments still invoke PRAgent handling.
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2438/files#diff-e93e360a73b73f49118e702afcd44d6e6294f808f55e8565034eb17f0caf16d6'>tests/unittest/test_github_action_runner_core.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>