### PR TITLE
docs: use shell-portable env var names in install examples

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -546,13 +546,13 @@ For more detailed configuration options, see:
 ### Action for GitHub enterprise server
 
 !!! tip ""
-    To use the action with a GitHub enterprise server, add an environment variable `GITHUB.BASE_URL` with the API URL of your GitHub server.
+    To use the action with a GitHub enterprise server, add an environment variable `GITHUB__BASE_URL` with the API URL of your GitHub server.
 
     For example, if your GitHub server is at `https://github.mycompany.com`, add the following to your workflow file:
     ```yaml
           env:
             # ... previous environment values
-            GITHUB.BASE_URL: "https://github.mycompany.com/api/v3"
+            GITHUB__BASE_URL: "https://github.mycompany.com/api/v3"
     ```
 
 ---

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -12,48 +12,48 @@ To invoke a tool (for example `review`), you can run PR-Agent directly from the 
 - For GitHub:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your_openai_key> -e GITHUB.USER_TOKEN=<your_github_token> pragent/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI__KEY=<your_openai_key> -e GITHUB__USER_TOKEN=<your_github_token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you are using GitHub enterprise server, you need to specify the custom url as variable.
     For example, if your GitHub server is at `https://github.mycompany.com`, add the following to the command:
 
     ```bash
-    -e GITHUB.BASE_URL=https://github.mycompany.com/api/v3
+    -e GITHUB__BASE_URL=https://github.mycompany.com/api/v3
     ```
 
 - For GitLab:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitlab -e GITLAB.PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI__KEY=<your key> -e CONFIG__GIT_PROVIDER=gitlab -e GITLAB__PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you have a dedicated GitLab instance, you need to specify the custom url as variable:
 
     ```bash
-    -e GITLAB.URL=<your gitlab instance url>
+    -e GITLAB__URL=<your gitlab instance url>
     ```
 
 - For BitBucket:
 
     ```bash
-    docker run --rm -it -e CONFIG.GIT_PROVIDER=bitbucket -e OPENAI.KEY=$OPENAI_API_KEY -e BITBUCKET.BEARER_TOKEN=$BITBUCKET_BEARER_TOKEN pragent/pr-agent:latest --pr_url=<pr_url> review
+    docker run --rm -it -e CONFIG__GIT_PROVIDER=bitbucket -e OPENAI__KEY=$OPENAI_API_KEY -e BITBUCKET__BEARER_TOKEN=$BITBUCKET_BEARER_TOKEN pragent/pr-agent:latest --pr_url=<pr_url> review
     ```
 
 - For Gitea:
 
     ```bash
-    docker run --rm -it -e OPENAI.KEY=<your key> -e CONFIG.GIT_PROVIDER=gitea -e GITEA.PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
+    docker run --rm -it -e OPENAI__KEY=<your key> -e CONFIG__GIT_PROVIDER=gitea -e GITEA__PERSONAL_ACCESS_TOKEN=<your token> pragent/pr-agent:latest --pr_url <pr_url> review
     ```
 
     If you have a dedicated Gitea instance, you need to specify the custom url as variable:
 
     ```bash
-    -e GITEA.URL=<your gitea instance url>
+    -e GITEA__URL=<your gitea instance url>
     ```
 
 
-For other git providers, update `CONFIG.GIT_PROVIDER` accordingly and check the [`pr_agent/settings/.secrets_template.toml`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/.secrets_template.toml) file for environment variables expected names and values.
+For other git providers, update `CONFIG__GIT_PROVIDER` accordingly and check the [`pr_agent/settings/.secrets_template.toml`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/.secrets_template.toml) file for environment variables expected names and values.
 
 ### Utilizing environment variables
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Docs: use shell-portable double-underscore env var names in install examples
<code>📝 Documentation</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

The install docs document env vars in the dotted form (`GITHUB.BASE_URL`, `OPENAI.KEY`, ...). Dynaconf accepts both the dotted and double-underscore forms, but most shells can't `export` a name containing a dot, and a GitHub Actions `env:` block with a dotted key is similarly problematic, so users copying these examples hit failures (#2310).

## Fix

Switch the example commands in `installation/locally.md` (the `docker -e` examples) and `installation/github.md` (the GitHub-enterprise `env:` block) to the equivalent double-underscore form (`GITHUB__BASE_URL`), which works everywhere and which the existing `.env` example and `help_docs.md` already use. The convention note that documents both forms is left intact, since both remain valid at the config layer.

Fixes #2310.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Replace dotted env var names with double-underscore equivalents in install examples.
• Fix copy/paste failures in shells and GitHub Actions <b><i>env:</i></b> blocks.
• Keep configuration convention unchanged (both forms still supported by Dynaconf).
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  U(["User"]) --> D["Installation docs"] --> R(["Docker run / GitHub Action"]) --> E{{"Environment variables"}} --> A["PR-Agent"]

  subgraph Legend
    direction LR
    _user(["Actor"]) ~~~ _step["Step/Component"] ~~~ _cfg{{"Config"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The chosen approach is optimal: standardize docs examples on the double-underscore form that works in shells and GitHub Actions while remaining equivalent in Dynaconf. Considered alternatives (keeping dotted examples with warnings, or mixing both forms inline) add confusion and still lead to copy/paste failures.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>github.md</strong> <code>Fix GitHub Enterprise env var example to use &#x27;GITHUB__BASE_URL&#x27;</code> <code>+2/-2</code></summary>

<br/>

>Fix GitHub Enterprise env var example to use &#x27;GITHUB__BASE_URL&#x27;
>
><pre>
>• Updates the GitHub Enterprise Server setup instructions to use the shell/GitHub-Actions-safe double-underscore env var name. Adjusts both the narrative text and the YAML &#x27;env:&#x27; example key accordingly.
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2439/files#diff-e73a6a650491a94e59d2b22db828e80548158694e07b521342f7dfe6fa3f1866'>docs/docs/installation/github.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>locally.md</strong> <code>Make Docker &#x27;-e&#x27; install examples shell-portable (double-underscore env vars)</code> <code>+8/-8</code></summary>

<br/>

>Make Docker &#x27;-e&#x27; install examples shell-portable (double-underscore env vars)
>
><pre>
>• Replaces dotted env var names in &#x27;docker run -e ...&#x27; examples across GitHub/GitLab/Bitbucket/Gitea sections with double-underscore equivalents. Also updates the generic guidance line to reference &#x27;CONFIG__GIT_PROVIDER&#x27; consistently.
></pre>
>
><a href='https://github.com/The-PR-Agent/pr-agent/pull/2439/files#diff-eb5faafeb31ee35a5ac52ada7f6449d0bd142b3be46df74262c0490190b43481'>docs/docs/installation/locally.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>