### PR TITLE
fix: remove closed Discord community links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,3 @@ contact_links:
   - name: Discussions
     url: https://github.com/the-pr-agent/pr-agent/discussions
     about: GitHub Discussions
-
-  - name: Discord community
-    url: https://discord.com/channels/1057273017547378788/1126104260430528613
-    about: Join our discord community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,6 @@ Thank you for your interest in contributing to the PR-Agent project!
 
 ## Questions or Need Help?
 
-- Join our [Discord community](https://discord.com/channels/1057273017547378788/1126104260430528613) for questions and discussions
+- Ask questions or start a discussion in [GitHub Discussions](https://github.com/the-pr-agent/pr-agent/discussions)
 - Check the [documentation](https://qodo-merge-docs.qodo.ai/) for detailed information
 - Report bugs or request features through [GitHub Issues](https://github.com/the-pr-agent/pr-agent/issues)


### PR DESCRIPTION
The Discord community is closed, and these links point to a channel deep-link (`discord.com/channels/...`) rather than a public invite, so they do not work for anyone outside the server in any case.

This removes the Discord contact link from the issue-template config (GitHub Discussions, already listed there, stays as the community channel) and replaces the Discord pointer in `CONTRIBUTING.md` with the existing GitHub Discussions link.

The `codium.ai` links elsewhere in the docs are intentionally left untouched: they still redirect to qodo.ai and work, so updating them would be a separate cosmetic change rather than a dead-link fix.
