### PR TITLE
fix: add claude-opus-4-7 to NO_SUPPORT_TEMPERATURE_MODELS (#2400)

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -167,6 +167,7 @@ MAX_TOKENS = {
     'bedrock/anthropic.claude-opus-4-6-20260120-v1:0': 200000,
     'bedrock/anthropic.claude-opus-4-6-v1:0': 200000,
     'bedrock/anthropic.claude-opus-4-7': 1000000,
+    'bedrock/anthropic.claude-opus-4-7-v1:0': 1000000,
     'bedrock/anthropic.claude-opus-4-8': 1000000,
     'bedrock/anthropic.claude-3-haiku-20240307-v1:0': 100000,
     'bedrock/anthropic.claude-3-5-haiku-20241022-v1:0': 100000,
@@ -309,7 +310,15 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.1-codex-mini",
     "gpt-5.2-codex",
     "gpt-5.3-codex",
-    "gpt-5-mini"
+    "gpt-5-mini",
+    # Anthropic Claude Opus 4-7 — temperature is deprecated (Issue #2400)
+    "claude-opus-4-7",
+    "vertex_ai/claude-opus-4-7",
+    "anthropic/claude-opus-4-7",
+    "bedrock/anthropic.claude-opus-4-7",
+    "bedrock/anthropic.claude-opus-4-7-v1:0",
+    "bedrock/us.anthropic.claude-opus-4-7",
+    "bedrock/global.anthropic.claude-opus-4-7",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [


### PR DESCRIPTION
Fixes #2400

## Description

When using Claude Opus 4-7 models (via Anthropic, Vertex AI, or Bedrock), PR-Agent sends the `temperature` parameter which Anthropic has deprecated for these models, causing every command to fail with a 400 error:

> `temperature` is deprecated for this model.

## Changes Made

1. Added all Claude Opus 4-7 model variants to `NO_SUPPORT_TEMPERATURE_MODELS` in `pr_agent/algo/__init__.py`:
   - `claude-opus-4-7`
   - `vertex_ai/claude-opus-4-7`
   - `anthropic/claude-opus-4-7`
   - `bedrock/anthropic.claude-opus-4-7`
   - `bedrock/anthropic.claude-opus-4-7-v1:0`
   - `bedrock/us.anthropic.claude-opus-4-7`
   - `bedrock/global.anthropic.claude-opus-4-7`

2. Added `bedrock/anthropic.claude-opus-4-7-v1:0` to `MAX_TOKENS` (same token limit as the non-`-v1:0` variant) so that `get_max_tokens()` does not crash when this model ID is configured.

The fix follows the existing pattern used for the Claude Opus 4-8 variants already in `NO_SUPPORT_TEMPERATURE_MODELS`. The `LiteLLMAIHandler` already skips sending the `temperature` parameter for any model in this list.
