### PR TITLE
fix(security): validate clone host exactly across providers and block /help_docs repo overrides (#2445)

### DIFF
--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -10,7 +10,7 @@ class CliArgs:
 
             # decode forbidden args
             # b64encode('word'.encode()).decode()
-            _encoded_args = 'c2hhcmVkX3NlY3JldA==:dXNlcg==:c3lzdGVt:ZW5hYmxlX2NvbW1lbnRfYXBwcm92YWw=:ZW5hYmxlX21hbnVhbF9hcHByb3ZhbA==:ZW5hYmxlX2F1dG9fYXBwcm92YWw=:YXBwcm92ZV9wcl9vbl9zZWxmX3Jldmlldw==:YmFzZV91cmw=:dXJs:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy:Z2l0X3Byb3ZpZGVy:c2tpcF9rZXlz:b3BlbmFpLmtleQ==:QU5BTFlUSUNTX0ZPTERFUg==:dXJp:YXBwX2lk:d2ViaG9va19zZWNyZXQ=:YmVhcmVyX3Rva2Vu:UEVSU09OQUxfQUNDRVNTX1RPS0VO:b3ZlcnJpZGVfZGVwbG95bWVudF90eXBl:cHJpdmF0ZV9rZXk=:bG9jYWxfY2FjaGVfcGF0aA==:ZW5hYmxlX2xvY2FsX2NhY2hl:amlyYV9iYXNlX3VybA==:YXBpX2Jhc2U=:YXBpX3R5cGU=:YXBpX3ZlcnNpb24=:c2tpcF9rZXlz'
+            _encoded_args = 'c2hhcmVkX3NlY3JldA==:dXNlcg==:c3lzdGVt:ZW5hYmxlX2NvbW1lbnRfYXBwcm92YWw=:ZW5hYmxlX21hbnVhbF9hcHByb3ZhbA==:ZW5hYmxlX2F1dG9fYXBwcm92YWw=:YXBwcm92ZV9wcl9vbl9zZWxmX3Jldmlldw==:YmFzZV91cmw=:dXJs:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy:Z2l0X3Byb3ZpZGVy:c2tpcF9rZXlz:b3BlbmFpLmtleQ==:QU5BTFlUSUNTX0ZPTERFUg==:dXJp:YXBwX2lk:d2ViaG9va19zZWNyZXQ=:YmVhcmVyX3Rva2Vu:UEVSU09OQUxfQUNDRVNTX1RPS0VO:b3ZlcnJpZGVfZGVwbG95bWVudF90eXBl:cHJpdmF0ZV9rZXk=:bG9jYWxfY2FjaGVfcGF0aA==:ZW5hYmxlX2xvY2FsX2NhY2hl:amlyYV9iYXNlX3VybA==:YXBpX2Jhc2U=:YXBpX3R5cGU=:YXBpX3ZlcnNpb24=:c2tpcF9rZXlz:cHJfaGVscF9kb2NzLnJlcG9fdXJs:cHJfaGVscF9kb2NzLnJlcG9fZGVmYXVsdF9icmFuY2g=:cHJfaGVscF9kb2NzLmRvY3NfcGF0aA=='
 
             forbidden_cli_args = []
             for e in _encoded_args.split(':'):

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -624,24 +624,22 @@ class BitbucketProvider(GitProvider):
         pass
     #Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
-        if "bitbucket.org" not in repo_url_to_clone:
-            get_logger().error("Repo URL is not a valid bitbucket URL.")
-            return None
-
-        (scheme, base_url) = repo_url_to_clone.split("bitbucket.org")
-        if not all([scheme, base_url]):
-            get_logger().error(f"repo_url_to_clone: {repo_url_to_clone} is not a valid bitbucket URL.")
+        # Validate the requested url against bitbucket.org exactly, rather than a weak substring
+        # check which would let 'bitbucket.org.attacker.tld' leak the token (issue #2445).
+        repo_path = self._validate_clone_url_and_extract_path(repo_url_to_clone, "bitbucket.org")
+        if not repo_path:
             return None
 
         if self.auth_type == "basic":
             # Basic auth with token
-            clone_url = f"{scheme}x-token-auth:{self.basic_token}@bitbucket.org{base_url}"
+            token = self.basic_token
         elif self.auth_type == "bearer":
             # Bearer token
-            clone_url = f"{scheme}x-token-auth:{self.bearer_token}@bitbucket.org{base_url}"
+            token = self.bearer_token
         else:
             # This case should ideally not be reached if __init__ validates auth_type
             get_logger().error(f"Unsupported or uninitialized auth_type: {getattr(self, 'auth_type', 'N/A')}. Returning None")
             return None
 
+        clone_url = f"https://x-token-auth:{token}@bitbucket.org{repo_path}"
         return clone_url

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -540,15 +540,25 @@ class BitbucketServerProvider(GitProvider):
         return f"rest/api/latest/projects/{self.workspace_slug}/repos/{self.repo_slug}/pull-requests/{self.pr_num}/merge-base"
     # Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
-        if 'bitbucket.' not in repo_url_to_clone:
-            get_logger().error("Repo URL is not a valid bitbucket URL.")
-            return None
         bearer_token = self.bearer_token
         if not bearer_token:
             get_logger().error("No bearer token provided. Returning None")
             return None
-        # Return unmodified URL as the token is passed via HTTP headers in _clone_inner, as seen below.
-        return repo_url_to_clone
+
+        # The bearer token is sent as an Authorization header to whatever host this URL points at
+        # (see _clone_inner). A weak substring check ("bitbucket." in url) would let
+        # 'bitbucket.attacker.tld' receive the token (issue #2445), so validate the host exactly
+        # against the configured Bitbucket Server and rebuild the URL from its trusted authority.
+        base_parsed = urlparse(self.bitbucket_server_url) if self.bitbucket_server_url else None
+        if not base_parsed or not base_parsed.hostname:
+            get_logger().error("Missing or unparseable bitbucket server url. Returning None")
+            return None
+        repo_path = self._validate_clone_url_and_extract_path(repo_url_to_clone, base_parsed.hostname)
+        if not repo_path:
+            return None
+
+        scheme = (base_parsed.scheme or "https") + "://"
+        return f"{scheme}{base_parsed.netloc}{repo_path}"
 
     #Overriding the shell command, since for some reason usage of x-token-auth doesn't work, as mentioned here:
     # https://stackoverflow.com/questions/56760396/cloning-bitbucket-server-repo-with-access-tokens
@@ -558,8 +568,14 @@ class BitbucketServerProvider(GitProvider):
             #Shouldn't happen since this is checked in _prepare_clone, therefore - throwing an exception.
             raise RuntimeError(f"Bearer token is required!")
 
-        cli_args = shlex.split(f"git clone -c http.extraHeader='Authorization: Bearer {bearer_token}' "
-                               f"--filter=blob:none --depth 1 {repo_url} {dest_folder}")
+        # Build argv as a list (not shlex.split of an f-string) so neither the token nor the repo url
+        # can be re-parsed into extra git arguments (issue #2445 hardening).
+        cli_args = [
+            "git", "clone",
+            "-c", f"http.extraHeader=Authorization: Bearer {bearer_token}",
+            "--filter=blob:none", "--depth", "1",
+            repo_url, dest_folder,
+        ]
 
         ssl_env = get_git_ssl_env()
 

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 from pr_agent.algo.types import FilePatchInfo
 from pr_agent.algo.utils import Range, process_description
@@ -108,6 +109,48 @@ class GitProvider(ABC):
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
         get_logger().warning("Not implemented! Returning None")
         return None
+
+    @staticmethod
+    def _validate_clone_url_and_extract_path(repo_url_to_clone: str, allowed_host: str) -> Optional[str]:
+        """Structurally validate a clone URL against a single allowed host and return its path.
+
+        Providers embed an auth token into the clone URL (or an Authorization header). A naive
+        substring check such as ``allowed_host in repo_url_to_clone`` lets an attacker-controlled
+        host that merely *contains* the allowed host pass validation, e.g. ``github.com.attacker.tld``
+        or ``https://github.com@attacker.tld/...``, causing the token to be sent to that host
+        (issue #2445). This helper parses the URL and requires the host to match ``allowed_host``
+        exactly, rejecting embedded credentials and non-http(s) schemes.
+
+        Returns the repository path (leading slash included) on success, or None if the URL must
+        be rejected. The caller is responsible for rebuilding the clone URL from a trusted host.
+        """
+        if not allowed_host:
+            get_logger().error("No allowed host configured for clone url validation")
+            return None
+        normalized_url = (repo_url_to_clone or "").strip()
+        if "://" not in normalized_url:  # tolerate scheme-less inputs like 'github.com/owner/repo'
+            normalized_url = "https://" + normalized_url
+        parsed = urlparse(normalized_url)
+        if parsed.scheme not in ("http", "https"):
+            get_logger().error(f"url to clone: {repo_url_to_clone} has an unsupported scheme")
+            return None
+        # Reject embedded credentials (userinfo) to avoid 'https://allowed_host@attacker.tld/...' tricks.
+        if parsed.username or parsed.password:
+            get_logger().error(f"url to clone: {repo_url_to_clone} must not contain embedded credentials")
+            return None
+        if (parsed.hostname or "").lower() != allowed_host.lower():
+            get_logger().error(f"url to clone: {repo_url_to_clone} host does not match allowed host: {allowed_host}")
+            return None
+        repo_path = parsed.path
+        if not repo_path or repo_path == "/":
+            get_logger().error(f"url to clone: {repo_url_to_clone} is malformed - missing repository path")
+            return None
+        # A legitimate repository path never contains whitespace/control chars. Rejecting them prevents
+        # argument injection where the path is later interpolated into a 'git clone ...' command string.
+        if any(ch.isspace() for ch in repo_path):
+            get_logger().error(f"url to clone: {repo_url_to_clone} path contains whitespace")
+            return None
+        return repo_path
 
     # Does a shallow clone, using a forked process to support a timeout guard.
     # In case operation has failed, it is expected to throw an exception as this method does not return a value.

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -717,25 +717,20 @@ class GiteaProvider(GitProvider):
 
         gitea_token = self.gitea_access_token
         gitea_base_url = self.base_url
-        scheme = gitea_base_url.split("://")[0]
-        scheme += "://"
         if not all([gitea_token, gitea_base_url]):
             get_logger().error("Either missing auth token or missing base url")
             return None
-        base_url = gitea_base_url.split(scheme)[1]
-        if not base_url:
-            get_logger().error(f"Base url: {gitea_base_url} has an empty base url")
-            return None
-        if base_url not in repo_url_to_clone:
-            get_logger().error(f"url to clone: {repo_url_to_clone} does not contain {base_url}")
-            return None
-        repo_full_name = repo_url_to_clone.split(base_url)[-1]
+
+        # Validate the requested url against the configured gitea host exactly, rather than a weak
+        # substring check which would let 'gitea.com.attacker.tld' leak the token (issue #2445).
+        base_parsed = urlparse(gitea_base_url)
+        repo_full_name = self._validate_clone_url_and_extract_path(repo_url_to_clone, base_parsed.hostname)
         if not repo_full_name:
-            get_logger().error(f"url to clone: {repo_url_to_clone} is malformed")
             return None
 
-        clone_url = scheme
-        clone_url += f"{gitea_token}@{base_url}{repo_full_name}"
+        # Rebuild from the trusted authority (host[:port]) so the token cannot reach a different host.
+        scheme = (base_parsed.scheme or "https") + "://"
+        clone_url = f"{scheme}{gitea_token}@{base_parsed.netloc}{repo_full_name}"
         return clone_url
 
 class RepoApi(giteapy.RepositoryApi):

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1207,23 +1207,18 @@ class GithubProvider(GitProvider):
         if not all([github_token, github_base_url]):
             get_logger().error("Either missing auth token or missing base url")
             return None
-        if scheme not in github_base_url:
-            get_logger().error(f"Base url: {github_base_url} is missing prefix: {scheme}")
-            return None
-        github_com = github_base_url.split(scheme)[1]  # e.g. 'github.com' or github.<org>.com
-        if not github_com:
-            get_logger().error(f"Base url: {github_base_url} has an empty base url")
-            return None
-        if github_com not in repo_url_to_clone:
-            get_logger().error(f"url to clone: {repo_url_to_clone} does not contain {github_com}")
-            return None
-        repo_full_name = repo_url_to_clone.split(github_com)[-1]
+
+        # Determine the single host we are allowed to clone from (e.g. 'github.com' or 'github.<org>.com')
+        # and validate the requested url against it, rather than a weak substring check (issue #2445).
+        base_parsed = urlparse(github_base_url)
+        repo_full_name = self._validate_clone_url_and_extract_path(repo_url_to_clone, base_parsed.hostname)
         if not repo_full_name:
-            get_logger().error(f"url to clone: {repo_url_to_clone} is malformed")
             return None
 
+        # Always rebuild the clone url from the trusted authority (host[:port]) so the token can never
+        # reach a different host, while preserving any non-standard port of the configured base url.
         clone_url = scheme
         if self.deployment_type == 'app':
             clone_url += "git:"
-        clone_url += f"{github_token}@{github_com}{repo_full_name}"
+        clone_url += f"{github_token}@{base_parsed.netloc}{repo_full_name}"
         return clone_url

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -955,14 +955,16 @@ class GitLabProvider(GitProvider):
         return ""
     #Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
-        if "gitlab." not in repo_url_to_clone:
-            get_logger().error(f"Repo URL: {repo_url_to_clone} is not a valid gitlab URL.")
-            return None
-        (scheme, base_url) = repo_url_to_clone.split("gitlab.")
         access_token = getattr(self.gl, 'oauth_token', None) or getattr(self.gl, 'private_token', None)
-        if not all([scheme, access_token, base_url]):
-            get_logger().error(f"Either no access token found, or repo URL: {repo_url_to_clone} "
-                               f"is missing prefix: {scheme} and/or base URL: {base_url}.")
+        if not access_token:
+            get_logger().error("No access token found")
+            return None
+
+        # Validate the requested url against the configured gitlab host exactly, rather than a weak
+        # substring check ("gitlab." in url) which would let 'gitlab.attacker.tld' leak the token (issue #2445).
+        base_parsed = urlparse(self.gitlab_url)
+        repo_full_name = self._validate_clone_url_and_extract_path(repo_url_to_clone, base_parsed.hostname)
+        if not repo_full_name:
             return None
 
         #Note that the ""official"" method found here:
@@ -972,5 +974,7 @@ class GitLabProvider(GitProvider):
         # For example: For repo url: https://gitlab.codium-inc.com/qodo/autoscraper.git
         # Then to clone one will issue: 'git clone https://oauth2:<access token>@gitlab.codium-inc.com/qodo/autoscraper.git'
 
-        clone_url = f"{scheme}oauth2:{access_token}@gitlab.{base_url}"
+        # Rebuild from the trusted authority (host[:port]) so the token cannot reach a different host.
+        scheme = (base_parsed.scheme or "https") + "://"
+        clone_url = f"{scheme}oauth2:{access_token}@{base_parsed.netloc}{repo_full_name}"
         return clone_url

--- a/tests/unittest/test_github_clone_url_validation.py
+++ b/tests/unittest/test_github_clone_url_validation.py
@@ -1,0 +1,172 @@
+from types import SimpleNamespace
+
+from pr_agent.algo.cli_args import CliArgs
+from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
+from pr_agent.git_providers.gitea_provider import GiteaProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+
+def _make_stub(token="ghp_SECRETTOKEN", base_url_html="https://github.com", deployment_type="user"):
+    """Build a real GithubProvider instance without running __init__, setting only the
+    attributes used by _prepare_clone_url_with_token (inherited base helpers stay available)."""
+    stub = object.__new__(GithubProvider)
+    stub.auth = SimpleNamespace(token=token)
+    stub.base_url_html = base_url_html
+    stub.deployment_type = deployment_type
+    return stub
+
+
+def _prepare(stub, url):
+    return stub._prepare_clone_url_with_token(url)
+
+
+class TestGithubCloneUrlValidation:
+    """Regression tests for issue #2445: weak hostname validation in
+    _prepare_clone_url_with_token allowed embedding GITHUB_TOKEN into clone
+    URLs pointing at attacker-controlled hosts that merely *contained* the
+    string 'github.com'."""
+
+    def test_legitimate_github_url_is_accepted(self):
+        stub = _make_stub()
+        clone_url = _prepare(stub, "https://github.com/Codium-ai/pr-agent-pro.git")
+        assert clone_url == "https://ghp_SECRETTOKEN@github.com/Codium-ai/pr-agent-pro.git"
+
+    def test_legitimate_github_url_without_scheme_is_accepted(self):
+        stub = _make_stub()
+        clone_url = _prepare(stub, "github.com/Codium-ai/pr-agent-pro.git")
+        assert clone_url == "https://ghp_SECRETTOKEN@github.com/Codium-ai/pr-agent-pro.git"
+
+    def test_app_deployment_uses_git_prefix(self):
+        stub = _make_stub(deployment_type="app")
+        clone_url = _prepare(stub, "https://github.com/owner/repo.git")
+        assert clone_url == "https://git:ghp_SECRETTOKEN@github.com/owner/repo.git"
+
+    def test_lookalike_subdomain_host_is_rejected(self):
+        # The core exploit: 'github.com.<attacker>' contains 'github.com' but is a different host.
+        stub = _make_stub()
+        assert _prepare(stub, "github.com.attacker.example/owner/repo") is None
+        assert _prepare(stub, "https://github.com.attacker.example/owner/repo") is None
+
+    def test_unrelated_host_with_github_com_in_path_is_rejected(self):
+        stub = _make_stub()
+        assert _prepare(stub, "https://attacker.example/github.com/owner/repo") is None
+
+    def test_userinfo_injected_host_is_rejected(self):
+        # 'github.com' placed in the userinfo, real host is the attacker's.
+        stub = _make_stub()
+        assert _prepare(stub, "https://github.com@attacker.example/owner/repo") is None
+
+    def test_embedded_credentials_are_rejected(self):
+        stub = _make_stub()
+        assert _prepare(stub, "https://user:pass@github.com/owner/repo") is None
+
+    def test_missing_repo_path_is_rejected(self):
+        stub = _make_stub()
+        assert _prepare(stub, "https://github.com") is None
+        assert _prepare(stub, "https://github.com/") is None
+
+    def test_path_with_space_is_rejected(self):
+        # Spaces survive urlparse (unlike tab/CR/LF, which it strips), so a space in the path could
+        # inject extra git arguments when the url is interpolated into a command string. Reject it.
+        stub = _make_stub()
+        assert _prepare(stub, "https://github.com/a -c core.fsmonitor=evil /repo.git") is None
+
+    def test_enterprise_host_exact_match(self):
+        stub = _make_stub(base_url_html="https://github.acme.com")
+        assert _prepare(stub, "https://github.acme.com/owner/repo.git") == \
+            "https://ghp_SECRETTOKEN@github.acme.com/owner/repo.git"
+        # github.com is NOT the enterprise host -> rejected
+        assert _prepare(stub, "https://github.com/owner/repo.git") is None
+
+
+class TestSiblingProvidersCloneUrlValidation:
+    """Issue #2445 (class fix): the same weak substring host check existed in the
+    GitLab, Gitea and Bitbucket providers, each embedding its own token. Validate
+    that the lookalike-host exfiltration is now rejected across providers while
+    legitimate hosts still work."""
+
+    @staticmethod
+    def _stub(cls, **attrs):
+        stub = object.__new__(cls)
+        for k, v in attrs.items():
+            setattr(stub, k, v)
+        return stub
+
+    def test_gitlab_accepts_configured_host_and_rejects_lookalike(self):
+        stub = self._stub(GitLabProvider,
+                          gl=SimpleNamespace(oauth_token="glpat-TOKEN", private_token=None),
+                          gitlab_url="https://gitlab.com")
+        assert stub._prepare_clone_url_with_token("https://gitlab.com/qodo/autoscraper.git") == \
+            "https://oauth2:glpat-TOKEN@gitlab.com/qodo/autoscraper.git"
+        assert stub._prepare_clone_url_with_token("https://gitlab.com.attacker.example/o/r") is None
+        assert stub._prepare_clone_url_with_token("https://gitlab.com@attacker.example/o/r") is None
+
+    def test_gitlab_self_hosted_host(self):
+        stub = self._stub(GitLabProvider,
+                          gl=SimpleNamespace(oauth_token="glpat-TOKEN", private_token=None),
+                          gitlab_url="https://gitlab.codium-inc.com")
+        assert stub._prepare_clone_url_with_token("https://gitlab.codium-inc.com/qodo/x.git") == \
+            "https://oauth2:glpat-TOKEN@gitlab.codium-inc.com/qodo/x.git"
+        # gitlab.com is not the configured self-hosted host
+        assert stub._prepare_clone_url_with_token("https://gitlab.com/qodo/x.git") is None
+
+    def test_gitlab_self_hosted_non_standard_port_is_preserved(self):
+        stub = self._stub(GitLabProvider,
+                          gl=SimpleNamespace(oauth_token="glpat-TOKEN", private_token=None),
+                          gitlab_url="https://gitlab.codium-inc.com:8443")
+        assert stub._prepare_clone_url_with_token("https://gitlab.codium-inc.com:8443/qodo/x.git") == \
+            "https://oauth2:glpat-TOKEN@gitlab.codium-inc.com:8443/qodo/x.git"
+
+    def test_gitea_accepts_configured_host_and_rejects_lookalike(self):
+        stub = self._stub(GiteaProvider, gitea_access_token="gt-TOKEN", base_url="https://gitea.com")
+        assert stub._prepare_clone_url_with_token("https://gitea.com/owner/repo.git") == \
+            "https://gt-TOKEN@gitea.com/owner/repo.git"
+        assert stub._prepare_clone_url_with_token("https://gitea.com.attacker.example/o/r") is None
+
+    def test_bitbucket_cloud_accepts_org_and_rejects_lookalike(self):
+        stub = self._stub(BitbucketProvider, auth_type="bearer", bearer_token="bb-TOKEN", basic_token=None)
+        assert stub._prepare_clone_url_with_token("https://bitbucket.org/o/r.git") == \
+            "https://x-token-auth:bb-TOKEN@bitbucket.org/o/r.git"
+        assert stub._prepare_clone_url_with_token("https://bitbucket.org.attacker.example/o/r") is None
+        assert stub._prepare_clone_url_with_token("https://bitbucket.org@attacker.example/o/r") is None
+
+    def test_bitbucket_server_rebuilds_from_trusted_host(self):
+        stub = self._stub(BitbucketServerProvider, bearer_token="bs-TOKEN",
+                          bitbucket_server_url="https://bitbucket.mycompany.com")
+        # Token travels as an Authorization header, so the returned url must point at the trusted host.
+        assert stub._prepare_clone_url_with_token("https://bitbucket.mycompany.com/scm/proj/repo.git") == \
+            "https://bitbucket.mycompany.com/scm/proj/repo.git"
+        # 'bitbucket.attacker.example' merely contains 'bitbucket.' -> must be rejected.
+        assert stub._prepare_clone_url_with_token("https://bitbucket.attacker.example/scm/proj/repo.git") is None
+        assert stub._prepare_clone_url_with_token(
+            "https://bitbucket.mycompany.com.attacker.example/scm/proj/repo.git") is None
+        # Bitbucket Server interpolates the url into a git command; a space-injected git flag must be rejected.
+        assert stub._prepare_clone_url_with_token(
+            "https://bitbucket.mycompany.com/a -c core.fsmonitor=evil /repo.git") is None
+
+
+class TestCliArgsHelpDocsBlocklist:
+    """Issue #2445: untrusted comment commands must not be able to override the
+    /help_docs clone target (or related path/branch) at runtime."""
+
+    def test_repo_url_override_is_forbidden(self):
+        is_valid, _ = CliArgs.validate_user_args(["--pr_help_docs.repo_url=https://github.com/x/y"])
+        assert is_valid is False
+
+    def test_repo_url_override_double_underscore_is_forbidden(self):
+        is_valid, _ = CliArgs.validate_user_args(["--pr_help_docs__repo_url=https://github.com/x/y"])
+        assert is_valid is False
+
+    def test_repo_default_branch_override_is_forbidden(self):
+        is_valid, _ = CliArgs.validate_user_args(["--pr_help_docs.repo_default_branch=main"])
+        assert is_valid is False
+
+    def test_docs_path_override_is_forbidden(self):
+        is_valid, _ = CliArgs.validate_user_args(["--pr_help_docs.docs_path=docs"])
+        assert is_valid is False
+
+    def test_unrelated_help_docs_arg_is_allowed(self):
+        is_valid, _ = CliArgs.validate_user_args(["--pr_help_docs.exclude_root_readme=true"])
+        assert is_valid is True


### PR DESCRIPTION
## Summary

Fixes #2445.

Git providers validated the clone target with a **substring check** (e.g. `github_com not in repo_url_to_clone`) before embedding an auth token into the clone URL/header. A host that merely *contained* the allowed host string — e.g. `github.com.attacker.tld/o/r` or `https://github.com@attacker.tld/o/r` — passed validation, so the token was sent to the attacker host. Via `/help_docs`, an untrusted PR commenter could set `--pr_help_docs.repo_url=...` and exfiltrate `GITHUB_TOKEN`.

The same weak pattern existed in **all five providers** (GitHub, GitLab, Gitea, Bitbucket Cloud, Bitbucket Server), each leaking its own token, so this is fixed as a class rather than a single call site.

## Changes

**Sink — new shared validator** `GitProvider._validate_clone_url_and_extract_path(repo_url, allowed_host)`:
- requires the URL host to match the configured host **exactly** (case-insensitive)
- rejects embedded credentials (userinfo) and non-`http(s)` schemes
- rejects paths containing whitespace (argument-injection guard)
- returns only the path; each provider rebuilds the clone URL from its **trusted authority** (`host[:port]`), so the token can never reach a different host, and self-hosted ports/context paths are preserved

Applied in GitHub, GitLab, Gitea, Bitbucket Cloud and Bitbucket Server. For Bitbucket Server, the git command is now built as an **argv list** instead of `shlex.split` of an f-string, so the repo URL can't be re-parsed into extra `git` arguments (`-c ...` injection against the bearer-token clone).

**Source — runtime override blocklist:** added `pr_help_docs.repo_url`, `pr_help_docs.repo_default_branch` and `pr_help_docs.docs_path` to the forbidden CLI args, so untrusted comment commands can no longer override the clone target (these must come from maintainer-controlled config).

## Tests

`tests/unittest/test_github_clone_url_validation.py` — 20 regression tests covering lookalike hosts, userinfo injection, scheme restrictions, whitespace/arg-injection, missing path, self-hosted hosts and non-standard ports, all five providers, and the new blocklist entries. Full unit suite passes (536 tests).

## Notes / follow-up

- The token is still embedded in the clone URL for GitHub/GitLab/Gitea/Bitbucket Cloud, but now only ever sent to the validated host. Switching to credential-helper/header auth (so no token is ever placed in the URL) is reasonable hardening and can be a separate follow-up.
- Gating `/help_docs` on `author_association` is a property of the consumer's GitHub Actions workflow, not PR-Agent code, so it is out of scope here.