### PR TITLE
fix(security)!: temporarily disable /help_docs command (#2445)

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -13,7 +13,6 @@ from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_config import PRConfig
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_generate_labels import PRGenerateLabels
-from pr_agent.tools.pr_help_docs import PRHelpDocs
 from pr_agent.tools.pr_help_message import PRHelpMessage
 from pr_agent.tools.pr_line_questions import PR_LineQuestions
 from pr_agent.tools.pr_questions import PRQuestions
@@ -40,7 +39,9 @@ command2class = {
     "similar_issue": PRSimilarIssue,
     "add_docs": PRAddDocs,
     "generate_labels": PRGenerateLabels,
-    "help_docs": PRHelpDocs,
+    # SECURITY: "/help_docs" is temporarily disabled while the clone-target validation
+    # fix is reviewed (see issue #2445). Re-enable by restoring `"help_docs": PRHelpDocs`
+    # and its import once the hardening PR is merged.
 }
 
 commands = list(command2class.keys())

--- a/tests/unittest/test_help_docs_disabled.py
+++ b/tests/unittest/test_help_docs_disabled.py
@@ -1,0 +1,25 @@
+import pytest
+
+import pr_agent.agent.pr_agent as pr_agent_module
+from pr_agent.agent.pr_agent import PRAgent, command2class
+
+
+def test_help_docs_is_not_registered():
+    """Security stopgap for issue #2445: the /help_docs command must be disabled
+    (unregistered) until the clone-target validation fix is merged."""
+    assert "help_docs" not in command2class
+    assert "help_docs" not in pr_agent_module.commands
+
+
+@pytest.mark.asyncio
+async def test_help_docs_command_is_not_routed(monkeypatch):
+    """An incoming /help_docs command resolves to an unknown command and is rejected."""
+    monkeypatch.setattr(pr_agent_module, "apply_repo_settings", lambda pr_url: None)
+    monkeypatch.setattr(pr_agent_module.CliArgs, "validate_user_args", lambda args: (True, ""))
+    monkeypatch.setattr(pr_agent_module, "update_settings_from_args", lambda args: args)
+
+    handled = await PRAgent()._handle_request(
+        "https://github.com/owner/repo/pull/1",
+        "/help_docs \"what docs exist\" --pr_help_docs.repo_url=https://github.com/x/y",
+    )
+    assert handled is False


### PR DESCRIPTION
## Summary

Immediate mitigation for #2445.

`/help_docs` accepts an untrusted runtime override of the clone target (`--pr_help_docs.repo_url=...`) and, because the clone-URL host validation only checks substring containment, the git provider token can be embedded into a clone URL pointing at an attacker-controlled host (e.g. `github.com.attacker.tld`) — leaking `GITHUB_TOKEN`.

This PR is a **stopgap**: it unregisters the `/help_docs` command so it can no longer be invoked, to be merged ahead of the full fix. An incoming `/help_docs` now resolves to an unknown command and is rejected.

The complete hardening (exact host validation across all providers + blocking the runtime override) is in **#2450**; this command should be re-enabled as part of that work.

## Changes

- Remove the `help_docs` entry (and its import) from `command2class` in `pr_agent/agent/pr_agent.py`, with a comment pointing at #2445 / re-enable instructions.
- Add `tests/unittest/test_help_docs_disabled.py` asserting the command is unregistered and not routed.

## Re-enable

Restore `"help_docs": PRHelpDocs` and its import, and delete the stopgap test, once #2450 (or equivalent) lands.