### PR TITLE
Update NO_SUPPORT_TEMPERATURE_MODELS for newer opus models

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -319,7 +319,6 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "claude-fable-5",  
     "anthropic/claude-fable-5",
     "vertex_ai/claude-opus-4-7",
-    "anthropic/claude-opus-4-7",
     "bedrock/anthropic.claude-opus-4-7",
     "bedrock/anthropic.claude-opus-4-7-v1:0",
     "bedrock/us.anthropic.claude-opus-4-7",

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -311,8 +311,13 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.2-codex",
     "gpt-5.3-codex",
     "gpt-5-mini",
-    # Anthropic Claude Opus 4-7 — temperature is deprecated (Issue #2400)
+    # Anthropic Claude Opus 4-7 — temperature is deprecated (Issue #2400), (Issue #2449)
     "claude-opus-4-7",
+    "anthropic/claude-opus-4-7",
+    "claude-opus-4-8",
+    "anthropic/claude-opus-4-8",
+    "claude-fable-5",  
+    "anthropic/claude-fable-5",
     "vertex_ai/claude-opus-4-7",
     "anthropic/claude-opus-4-7",
     "bedrock/anthropic.claude-opus-4-7",

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -316,7 +316,7 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "anthropic/claude-opus-4-7",
     "claude-opus-4-8",
     "anthropic/claude-opus-4-8",
-    "claude-fable-5",  
+    "claude-fable-5",
     "anthropic/claude-fable-5",
     "vertex_ai/claude-opus-4-7",
     "bedrock/anthropic.claude-opus-4-7",


### PR DESCRIPTION
Added
"claude-opus-4-7", "anthropic/claude-opus-4-7",
"claude-opus-4-8", "anthropic/claude-opus-4-8",
"claude-fable-5",  "anthropic/claude-fable-5"
to NO_SUPPORT_TEMPERATURE_MODELS

I am unsure about updating equivalent of these
"vertex_ai/claude-opus-4-7",
"anthropic/claude-opus-4-7",
"bedrock/anthropic.claude-opus-4-7",
"bedrock/anthropic.claude-opus-4-7-v1:0",
"bedrock/us.anthropic.claude-opus-4-7",
"bedrock/global.anthropic.claude-opus-4-7",



#2449 