### PR TITLE
fix (A2A): fetch public diff for PR URLs and report failed state to Langfuse

### DIFF
--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -12,8 +12,12 @@ Three paths:
 Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", "")
 (several tool paths never set it, and handle_request swallows exceptions -> False).
 route_and_run NEVER raises; on failure/empty it returns an honest fallback string."""
+import asyncio
+import ipaddress
 import re
+import socket
 from typing import NamedTuple, Optional
+from urllib.parse import urljoin, urlparse
 
 import aiohttp
 
@@ -26,6 +30,7 @@ _DEFAULT_VERB = "review"
 
 _DIFF_FETCH_TIMEOUT_S = 20
 _DIFF_FETCH_MAX_BYTES = 4_000_000  # ~4 MB; larger diffs exceed model context anyway
+_DIFF_FETCH_MAX_REDIRECTS = 5
 
 # PR-URL detection: github/gitlab/bitbucket/azure-style hosts with a PR/MR path.
 _PR_URL_RE = re.compile(
@@ -113,32 +118,85 @@ def _ask_needs_context_fallback() -> str:
     return "PR-Agent requires a PR URL or a supplied diff."
 
 
+def _ip_is_blocked(addr) -> bool:
+    """Reject non-public IP ranges (SSRF guard): private/loopback/link-local (incl. cloud
+    metadata 169.254.0.0/16), reserved, multicast, unspecified."""
+    return (addr.is_private or addr.is_loopback or addr.is_link_local
+            or addr.is_reserved or addr.is_multicast or addr.is_unspecified)
+
+
+async def _host_resolves_public(host: str) -> bool:
+    """True only if `host` resolves and EVERY resolved IP is public. DNS runs in a thread
+    so it does not block the event loop. Any failure -> False (fail closed)."""
+    if not host:
+        return False
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, host, None)
+    except Exception:
+        return False
+    saw = False
+    for info in infos:
+        ip = info[4][0].split("%")[0]  # strip IPv6 zone id
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            return False
+        saw = True
+        if _ip_is_blocked(addr):
+            return False
+    return saw
+
+
+async def _url_is_safe(url: str) -> bool:
+    """SSRF gate for one URL: https scheme + a hostname that resolves only to public IPs."""
+    try:
+        u = urlparse(url)
+    except Exception:
+        return False
+    if u.scheme != "https" or not u.hostname:
+        return False
+    return await _host_resolves_public(u.hostname)
+
+
 async def _fetch_public_diff(pr_url: str) -> Optional[str]:
     """Fetch the public unified diff for a GitHub/GitLab PR/MR URL by appending '.diff'.
-    Returns the diff text, or None on any failure (private/404, network, non-200, oversize,
-    empty). No auth - public repos only; degrades to None so the caller fails honestly."""
+    Returns the diff text, or None on any failure. No auth - public repos only. SSRF-guarded:
+    https-only and the host (and every redirect hop) must resolve to public IPs; degrades to
+    None so the caller fails honestly."""
     diff_url = pr_url + ".diff"
     headers = {"User-Agent": "pr-agent-mosaico"}
     try:
         timeout = aiohttp.ClientTimeout(total=_DIFF_FETCH_TIMEOUT_S)
         async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
-            async with session.get(diff_url, allow_redirects=True) as resp:
-                if resp.status != 200:
-                    get_logger().info(f"MOSAICO: diff fetch {diff_url} -> HTTP {resp.status}")
+            url = diff_url
+            for _ in range(_DIFF_FETCH_MAX_REDIRECTS + 1):
+                if not await _url_is_safe(url):
+                    get_logger().info(f"MOSAICO: diff fetch blocked unsafe/non-public URL: {url}")
                     return None
-                # StreamReader.read(n) returns only the currently-buffered bytes, so it
-                # cannot bound the body. Drain in chunks with a hard size cap instead.
-                chunks = []
-                total = 0
-                async for chunk in resp.content.iter_chunked(65536):
-                    total += len(chunk)
-                    if total > _DIFF_FETCH_MAX_BYTES:
-                        get_logger().info(f"MOSAICO: diff fetch {diff_url} exceeds size cap; skipping.")
+                async with session.get(url, allow_redirects=False) as resp:
+                    if resp.status in (301, 302, 303, 307, 308):
+                        loc = resp.headers.get("Location")
+                        if not loc:
+                            return None
+                        url = urljoin(url, loc)
+                        continue
+                    if resp.status != 200:
+                        get_logger().info(f"MOSAICO: diff fetch {url} -> HTTP {resp.status}")
                         return None
-                    chunks.append(chunk)
-        raw = b"".join(chunks)
-        text = raw.decode("utf-8", errors="replace")
-        return text if text.strip() else None
+                    # StreamReader.read(n) returns only buffered bytes; drain in chunks with a cap.
+                    chunks = []
+                    total = 0
+                    async for chunk in resp.content.iter_chunked(65536):
+                        total += len(chunk)
+                        if total > _DIFF_FETCH_MAX_BYTES:
+                            get_logger().info(f"MOSAICO: diff fetch {url} exceeds size cap; skipping.")
+                            return None
+                        chunks.append(chunk)
+                    raw = b"".join(chunks)
+                    text = raw.decode("utf-8", errors="replace")
+                    return text if text.strip() else None
+            get_logger().info(f"MOSAICO: diff fetch exceeded redirect limit: {diff_url}")
+            return None
     except Exception as e:
         get_logger().info(f"MOSAICO: diff fetch failed for {diff_url}: {e}")
         return None

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -2,7 +2,9 @@
 rendered markdown.
 
 Three paths:
-  (a) a host PR URL  -> run the verb via the host provider (URL drives provider).
+  (a) a host PR URL  -> fetch the public unified diff by appending '.diff', then
+      route through the token-free mosaico_diff provider.  Fails honestly if the
+      repo is private / host unsupported.
   (b) a supplied unified diff -> set MOSAICO.INPUT + CONFIG.GIT_PROVIDER="mosaico_diff"
       on the context settings, run the verb via DiffInputProvider.
   (c) free-text with no PR URL and no diff -> honest guidance (ask needs a PR/diff).
@@ -11,6 +13,9 @@ Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", 
 (several tool paths never set it, and handle_request swallows exceptions -> False).
 route_and_run NEVER raises; on failure/empty it returns an honest fallback string."""
 import re
+from typing import NamedTuple, Optional
+
+import aiohttp
 
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
@@ -18,6 +23,9 @@ from pr_agent.mosaico.diff_provider import parse_unified_diff
 
 _VALID_VERBS = ("review", "improve", "describe", "ask")
 _DEFAULT_VERB = "review"
+
+_DIFF_FETCH_TIMEOUT_S = 20
+_DIFF_FETCH_MAX_BYTES = 4_000_000  # ~4 MB; larger diffs exceed model context anyway
 
 # PR-URL detection: github/gitlab/bitbucket/azure-style hosts with a PR/MR path.
 _PR_URL_RE = re.compile(
@@ -29,6 +37,12 @@ _PR_URL_RE = re.compile(
 _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
+
+
+class RouteResult(NamedTuple):
+    """Routing outcome: rendered text + whether it succeeded (drives A2A complete vs failed)."""
+    text: str
+    ok: bool
 
 
 def _detect_verb(text: str) -> str:
@@ -99,7 +113,45 @@ def _ask_needs_context_fallback() -> str:
     return "PR-Agent requires a PR URL or a supplied diff."
 
 
-async def _run_pr_agent(target: str, verb: str) -> str:
+async def _fetch_public_diff(pr_url: str) -> Optional[str]:
+    """Fetch the public unified diff for a GitHub/GitLab PR/MR URL by appending '.diff'.
+    Returns the diff text, or None on any failure (private/404, network, non-200, oversize,
+    empty). No auth - public repos only; degrades to None so the caller fails honestly."""
+    diff_url = pr_url + ".diff"
+    headers = {"User-Agent": "pr-agent-mosaico"}
+    try:
+        timeout = aiohttp.ClientTimeout(total=_DIFF_FETCH_TIMEOUT_S)
+        async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+            async with session.get(diff_url, allow_redirects=True) as resp:
+                if resp.status != 200:
+                    get_logger().info(f"MOSAICO: diff fetch {diff_url} -> HTTP {resp.status}")
+                    return None
+                # StreamReader.read(n) returns only the currently-buffered bytes, so it
+                # cannot bound the body. Drain in chunks with a hard size cap instead.
+                chunks = []
+                total = 0
+                async for chunk in resp.content.iter_chunked(65536):
+                    total += len(chunk)
+                    if total > _DIFF_FETCH_MAX_BYTES:
+                        get_logger().info(f"MOSAICO: diff fetch {diff_url} exceeds size cap; skipping.")
+                        return None
+                    chunks.append(chunk)
+        raw = b"".join(chunks)
+        text = raw.decode("utf-8", errors="replace")
+        return text if text.strip() else None
+    except Exception as e:
+        get_logger().info(f"MOSAICO: diff fetch failed for {diff_url}: {e}")
+        return None
+
+
+def _pr_fetch_failed_fallback(pr_url: str) -> str:
+    return (f"PR-Agent could not fetch a public diff for {pr_url} "
+            f"(private repo, unsupported host such as Azure DevOps/Bitbucket, "
+            f"or the host blocked the request). "
+            f"Paste the unified diff directly, or supply a git access token.")
+
+
+async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
     """Run a review/improve/describe verb via PRAgent.handle_request, defensively.
     Force non-publishing output capture: the tools render into get_settings().data only
     when publish_output is False; with the default True they'd publish to the real PR and
@@ -110,12 +162,12 @@ async def _run_pr_agent(target: str, verb: str) -> str:
         ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false"],
     )
     if ok is False:
-        return _error_fallback(verb)
+        return RouteResult(_error_fallback(verb), ok=False)
     artifact = _capture_artifact()
-    return artifact if artifact else _empty_fallback(verb)
+    return RouteResult(artifact, ok=True) if artifact else RouteResult(_empty_fallback(verb), ok=True)
 
 
-async def _run_ask(target: str, question: str) -> str:
+async def _run_ask(target: str, question: str) -> "RouteResult":
     """Run the ask path directly via PRQuestions (it uses get_git_provider()(pr_url),
     not the with-context variant). PRQuestions.run() is NOT wrapped by handle_request's
     try/except, so wrap it here and treat an exception like a swallowed failure.
@@ -134,9 +186,9 @@ async def _run_ask(target: str, question: str) -> str:
         await q.run()
     except Exception:
         get_logger().exception("MOSAICO: ask path failed")
-        return _error_fallback("ask")
+        return RouteResult(_error_fallback("ask"), ok=False)
     answer = (q.prediction or "").strip()
-    return answer if answer else _empty_fallback("ask")
+    return RouteResult(answer, ok=True) if answer else RouteResult(_empty_fallback("ask"), ok=True)
 
 
 def _simple_languages(files) -> dict:
@@ -151,41 +203,53 @@ def _simple_languages(files) -> dict:
     return langs
 
 
-async def route_and_run(user_text: str) -> str:
-    """Route inbound text to a pr-agent command and return rendered markdown. Never raises."""
+async def _run_on_diff(diff_body: str, verb: str, text: str, title: str) -> "RouteResult":
+    """Parse a unified diff, install it as MOSAICO.INPUT under the mosaico_diff provider,
+    and run the verb (token-free). Empty parse -> empty fallback (ok=True)."""
+    parsed = parse_unified_diff(diff_body)
+    if not parsed:
+        return RouteResult(_empty_fallback(verb), ok=True)
+    settings = get_settings()
+    settings.set("MOSAICO.INPUT", {
+        "files": parsed,
+        "languages": _simple_languages(parsed),
+        "title": title,
+    })
+    settings.set("CONFIG.GIT_PROVIDER", "mosaico_diff")
+    if verb == "ask":
+        return await _run_ask("mosaico://supplied-diff", text)
+    return await _run_pr_agent("mosaico://supplied-diff", verb)
+
+
+async def route_and_run_result(user_text: str) -> "RouteResult":
+    """Route inbound text to a pr-agent command and return a RouteResult. Never raises."""
     try:
         text = user_text or ""
         verb = _detect_verb(text)
 
-        # Path (a): a host PR URL — run via the host provider (URL drives provider).
+        # Path (a): a host PR URL — fetch the public unified diff and route through
+        # the token-free mosaico_diff provider.
         pr_url = _find_pr_url(text)
         if pr_url:
-            if verb == "ask":
-                return await _run_ask(pr_url, text)
-            return await _run_pr_agent(pr_url, verb)
+            diff_body = await _fetch_public_diff(pr_url)
+            if not diff_body:
+                return RouteResult(_pr_fetch_failed_fallback(pr_url), ok=False)
+            return await _run_on_diff(diff_body, verb, text, title=pr_url)
 
         # Path (b): a supplied unified diff.
         if _looks_like_diff(text):
-            diff_body = _extract_diff(text)
             # Detect the verb from the prose only: a '?' in the patch body must not flip review to ask.
             verb = _detect_verb(_diff_prose(text))
-            parsed = parse_unified_diff(diff_body)
-            if not parsed:
-                return _empty_fallback(verb)
-            settings = get_settings()
-            settings.set("MOSAICO.INPUT", {
-                "files": parsed,
-                "languages": _simple_languages(parsed),
-                "title": "Supplied diff",
-            })
-            settings.set("CONFIG.GIT_PROVIDER", "mosaico_diff")
-            if verb == "ask":
-                return await _run_ask("mosaico://supplied-diff", text)
-            return await _run_pr_agent("mosaico://supplied-diff", verb)
+            return await _run_on_diff(_extract_diff(text), verb, text, title="Supplied diff")
 
         # Path (c): free-text with no PR URL and no supplied diff. PRQuestions needs a
         # diff/PR to answer, so return honest guidance rather than a false internal error.
-        return _ask_needs_context_fallback()
+        return RouteResult(_ask_needs_context_fallback(), ok=True)
     except Exception:
-        get_logger().exception("MOSAICO: route_and_run failed")
-        return _error_fallback("request")
+        get_logger().exception("MOSAICO: route_and_run_result failed")
+        return RouteResult(_error_fallback("request"), ok=False)
+
+
+async def route_and_run(user_text: str) -> str:
+    """Back-compat string wrapper around route_and_run_result (preserves existing callers/tests)."""
+    return (await route_and_run_result(user_text)).text

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -261,12 +261,16 @@ def _simple_languages(files) -> dict:
     return langs
 
 
-async def _run_on_diff(diff_body: str, verb: str, text: str, title: str) -> "RouteResult":
+async def _run_on_diff(diff_body: str, verb: str, text: str, title: str, empty_ok: bool = True) -> "RouteResult":
     """Parse a unified diff, install it as MOSAICO.INPUT under the mosaico_diff provider,
-    and run the verb (token-free). Empty parse -> empty fallback (ok=True)."""
+    and run the verb (token-free). Empty parse -> empty fallback (ok=True) when empty_ok is
+    True (supplied-diff path); failure (ok=False) when empty_ok is False (PR-URL path, where
+    an empty parse indicates the fetched body was not a real diff)."""
     parsed = parse_unified_diff(diff_body)
     if not parsed:
-        return RouteResult(_empty_fallback(verb), ok=True)
+        if empty_ok:
+            return RouteResult(_empty_fallback(verb), ok=True)
+        return RouteResult(_pr_fetch_failed_fallback(title), ok=False)
     settings = get_settings()
     settings.set("MOSAICO.INPUT", {
         "files": parsed,
@@ -292,7 +296,7 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
             diff_body = await _fetch_public_diff(pr_url)
             if not diff_body:
                 return RouteResult(_pr_fetch_failed_fallback(pr_url), ok=False)
-            return await _run_on_diff(diff_body, verb, text, title=pr_url)
+            return await _run_on_diff(diff_body, verb, text, title=pr_url, empty_ok=False)
 
         # Path (b): a supplied unified diff.
         if _looks_like_diff(text):

--- a/pr_agent/mosaico/env_bridge.py
+++ b/pr_agent/mosaico/env_bridge.py
@@ -16,6 +16,7 @@ ENV_LANGFUSE_HOST = "LANGFUSE_HOST"
 DEFAULT_CUSTOM_MODEL_MAX_TOKENS = 32000
 ENV_LANGFUSE_PUBLIC_KEY = "LANGFUSE_PUBLIC_KEY"
 ENV_LANGFUSE_SECRET_KEY = "LANGFUSE_SECRET_KEY"
+LANGFUSE_CALLBACK_NAME = "langfuse_otel"
 
 
 def langfuse_env_present() -> bool:
@@ -62,8 +63,8 @@ def apply_mosaico_env() -> None:
 def _register_langfuse_callback(settings) -> None:
     for key in ("LITELLM.SUCCESS_CALLBACK", "LITELLM.FAILURE_CALLBACK"):
         current = list(settings.get(key, []) or [])
-        if "langfuse" not in current:
-            current.append("langfuse")
+        if LANGFUSE_CALLBACK_NAME not in current:
+            current.append(LANGFUSE_CALLBACK_NAME)
             settings.set(key, current)
     settings.set("LITELLM.ENABLE_CALLBACKS", True)
     get_logger().info("MOSAICO: registered Langfuse litellm callback.")

--- a/pr_agent/mosaico/env_bridge.py
+++ b/pr_agent/mosaico/env_bridge.py
@@ -17,6 +17,7 @@ DEFAULT_CUSTOM_MODEL_MAX_TOKENS = 32000
 ENV_LANGFUSE_PUBLIC_KEY = "LANGFUSE_PUBLIC_KEY"
 ENV_LANGFUSE_SECRET_KEY = "LANGFUSE_SECRET_KEY"
 LANGFUSE_CALLBACK_NAME = "langfuse_otel"
+LEGACY_LANGFUSE_CALLBACK = "langfuse"
 
 
 def langfuse_env_present() -> bool:
@@ -62,9 +63,11 @@ def apply_mosaico_env() -> None:
 
 def _register_langfuse_callback(settings) -> None:
     for key in ("LITELLM.SUCCESS_CALLBACK", "LITELLM.FAILURE_CALLBACK"):
-        current = list(settings.get(key, []) or [])
+        # Drop the legacy 'langfuse' callback (incompatible with langfuse 3.x -> sdk_integration
+        # TypeError) and ensure exactly one 'langfuse_otel'.
+        current = [c for c in (settings.get(key, []) or []) if c != LEGACY_LANGFUSE_CALLBACK]
         if LANGFUSE_CALLBACK_NAME not in current:
             current.append(LANGFUSE_CALLBACK_NAME)
-            settings.set(key, current)
+        settings.set(key, current)
     settings.set("LITELLM.ENABLE_CALLBACKS", True)
     get_logger().info("MOSAICO: registered Langfuse litellm callback.")

--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -15,7 +15,7 @@ from starlette_context import context as sctx
 
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.log import get_logger
-from pr_agent.mosaico.dispatch import route_and_run
+from pr_agent.mosaico.dispatch import route_and_run_result
 from pr_agent.mosaico.observability import (langfuse_span,
                                             mosaico_log_context,
                                             parse_observability_metadata)
@@ -37,8 +37,12 @@ class PRAgentExecutor(AgentExecutor):
             user_text = context.get_user_input() or ""
             meta = parse_observability_metadata(context.metadata)
             with mosaico_log_context(meta, task.context_id), langfuse_span(meta, task.context_id):
-                markdown = await route_and_run(user_text)
-            await updater.complete(new_agent_text_message(markdown or "(no output produced)"))
+                result = await route_and_run_result(user_text)
+            message = new_agent_text_message(result.text or "(no output produced)")
+            if result.ok:
+                await updater.complete(message)
+            else:
+                await updater.failed(message)
         except Exception as e:
             get_logger().exception("MOSAICO task failed")
             await updater.failed(new_agent_text_message(f"Error: {e}"))

--- a/tests/unittest/test_mosaico_env_bridge.py
+++ b/tests/unittest/test_mosaico_env_bridge.py
@@ -90,8 +90,8 @@ class TestApplyMosaicoEnv:
         s = get_settings()
         success = list(s.get("LITELLM.SUCCESS_CALLBACK") or [])
         failure = list(s.get("LITELLM.FAILURE_CALLBACK") or [])
-        assert success.count("langfuse") == 1
-        assert failure.count("langfuse") == 1
+        assert success.count("langfuse_otel") == 1
+        assert failure.count("langfuse_otel") == 1
         assert s.get("LITELLM.ENABLE_CALLBACKS") is True
 
     def test_langfuse_not_registered_without_keys(self, restore_settings, clear_mosaico_env, monkeypatch):
@@ -146,8 +146,8 @@ class TestApplyMosaicoEnv:
 
         from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
         LiteLLMAIHandler()
-        assert litellm.success_callback == ["langfuse"]
-        assert litellm.failure_callback == ["langfuse"]
+        assert litellm.success_callback == ["langfuse_otel"]
+        assert litellm.failure_callback == ["langfuse_otel"]
 
 
 class TestParseObservabilityMetadata:

--- a/tests/unittest/test_mosaico_env_bridge.py
+++ b/tests/unittest/test_mosaico_env_bridge.py
@@ -94,6 +94,19 @@ class TestApplyMosaicoEnv:
         assert failure.count("langfuse_otel") == 1
         assert s.get("LITELLM.ENABLE_CALLBACKS") is True
 
+    def test_register_langfuse_callback_removes_legacy(self, restore_settings, clear_mosaico_env, monkeypatch):
+        """Legacy 'langfuse' entries must be stripped and replaced by exactly one 'langfuse_otel'."""
+        monkeypatch.setenv("LANGFUSE_HOST", "https://lf.example")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+        # Pre-seed legacy callback in both lists
+        global_settings.set("LITELLM.SUCCESS_CALLBACK", ["langfuse"])
+        global_settings.set("LITELLM.FAILURE_CALLBACK", ["langfuse"])
+        apply_mosaico_env()
+        s = get_settings()
+        assert list(s.get("LITELLM.SUCCESS_CALLBACK") or []) == ["langfuse_otel"]
+        assert list(s.get("LITELLM.FAILURE_CALLBACK") or []) == ["langfuse_otel"]
+
     def test_langfuse_not_registered_without_keys(self, restore_settings, clear_mosaico_env, monkeypatch):
         monkeypatch.setenv("API_BASE", "https://mosaico.example/v1")
         # snapshot/reset callbacks to empty so we observe no registration

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -7,6 +7,7 @@ from a2a.types import Message, Part, Role, TextPart
 from starlette_context import request_cycle_context
 
 import pr_agent.mosaico.executor as executor_mod
+from pr_agent.mosaico.dispatch import RouteResult
 from pr_agent.mosaico.executor import PRAgentExecutor
 
 
@@ -77,10 +78,10 @@ def spy_updater(monkeypatch):
 class TestExecute:
     @pytest.mark.asyncio
     async def test_completes_with_rendered_markdown(self, monkeypatch, spy_updater):
-        async def fake_route_and_run(text):
-            return "RENDERED"
+        async def fake_route_and_run_result(text):
+            return RouteResult("RENDERED", True)
 
-        monkeypatch.setattr(executor_mod, "route_and_run", fake_route_and_run)
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
 
         eq = _RecordingEventQueue()
         ctx = _FakeRequestContext("review this", metadata={})
@@ -94,10 +95,10 @@ class TestExecute:
 
     @pytest.mark.asyncio
     async def test_empty_render_uses_placeholder(self, monkeypatch, spy_updater):
-        async def fake_route_and_run(text):
-            return ""
+        async def fake_route_and_run_result(text):
+            return RouteResult("", True)
 
-        monkeypatch.setattr(executor_mod, "route_and_run", fake_route_and_run)
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
         with request_cycle_context({}):
             await PRAgentExecutor().execute(_FakeRequestContext("x"), _RecordingEventQueue())
         assert spy_updater.last.completed_with == "(no output produced)"
@@ -107,7 +108,7 @@ class TestExecute:
         async def boom(text):
             raise RuntimeError("kaboom")
 
-        monkeypatch.setattr(executor_mod, "route_and_run", boom)
+        monkeypatch.setattr(executor_mod, "route_and_run_result", boom)
 
         eq = _RecordingEventQueue()
         # Must not raise out of execute.
@@ -119,10 +120,10 @@ class TestExecute:
 
     @pytest.mark.asyncio
     async def test_existing_task_not_re_enqueued(self, monkeypatch, spy_updater):
-        async def fake_route_and_run(text):
-            return "R"
+        async def fake_route_and_run_result(text):
+            return RouteResult("R", True)
 
-        monkeypatch.setattr(executor_mod, "route_and_run", fake_route_and_run)
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
 
         from a2a.utils import new_task
         existing = new_task(_make_message("hi"))
@@ -133,6 +134,18 @@ class TestExecute:
         # current_task present -> no new Task enqueued
         assert eq.events == []
         assert spy_updater.last.completed_with == "R"
+
+    @pytest.mark.asyncio
+    async def test_failed_result_marks_failed(self, monkeypatch, spy_updater):
+        async def fake_route_and_run_result(text):
+            return RouteResult("boom", ok=False)
+
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
+
+        with request_cycle_context({}):
+            await PRAgentExecutor().execute(_FakeRequestContext("z"), _RecordingEventQueue())
+        assert spy_updater.last.failed_with == "boom"
+        assert spy_updater.last.completed_with is None
 
     @pytest.mark.asyncio
     async def test_cancel_raises_not_implemented(self):

--- a/tests/unittest/test_mosaico_isolation.py
+++ b/tests/unittest/test_mosaico_isolation.py
@@ -22,6 +22,7 @@ from starlette_context import request_cycle_context
 
 import pr_agent.mosaico.executor as executor_mod
 from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.mosaico.dispatch import RouteResult
 from pr_agent.mosaico.executor import PRAgentExecutor
 
 
@@ -97,7 +98,7 @@ async def _distinct_route_and_run(user_text):
     assert read["model"] == profile["model"], f"{user_text} saw model {read['model']}"
     assert read["provider"] == profile["provider"], f"{user_text} saw provider {read['provider']}"
     assert read["artifact"] == profile["artifact"], f"{user_text} saw artifact {read['artifact']}"
-    return profile["artifact"]
+    return RouteResult(profile["artifact"], ok=True)
 
 
 async def _run_one(text):
@@ -128,7 +129,7 @@ def snapshot_global():
 class TestConcurrencyIsolation:
     @pytest.mark.asyncio
     async def test_no_bleed_between_concurrent_requests(self, monkeypatch, snapshot_global):
-        monkeypatch.setattr(executor_mod, "route_and_run", _distinct_route_and_run)
+        monkeypatch.setattr(executor_mod, "route_and_run_result", _distinct_route_and_run)
         monkeypatch.setattr(executor_mod, "TaskUpdater", _SpyTaskUpdater)
 
         # Capture global_settings BEFORE for the unmutated check.

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -153,6 +153,21 @@ class TestPathPrUrl:
         await route_and_run(f"review {PR_URL}")
         assert global_settings.get("CONFIG.GIT_PROVIDER") == "mosaico_diff"
 
+    @pytest.mark.asyncio
+    async def test_pr_url_non_diff_body_marks_failed(self, monkeypatch, restore_settings):
+        """When _fetch_public_diff returns HTTP 200 but with non-diff content (e.g. an HTML
+        login page), parse_unified_diff yields [] and _run_on_diff must report ok=False with
+        the pr-fetch-failed fallback — NOT ok=True with the empty fallback."""
+
+        async def fake_fetch_public_diff(pr_url):
+            return "<html><body>Sign in</body></html>"
+
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
+
+        result = await route_and_run_result(f"review {PR_URL}")
+        assert result.ok is False
+        assert "could not fetch" in result.text
+
 
 # ---------------------------------------------------------------------------
 # Path (b): supplied diff

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -7,9 +7,13 @@ with no exception escaping.
 asyncio_mode=auto."""
 import pytest
 
+import aiohttp
+
 from pr_agent.config_loader import global_settings
+from pr_agent.mosaico import dispatch
 from pr_agent.mosaico.dispatch import (_detect_verb, _empty_fallback,
-                                       _error_fallback, route_and_run)
+                                       _error_fallback, route_and_run,
+                                       route_and_run_result, RouteResult)
 
 PR_URL = "https://github.com/org/repo/pull/123"
 
@@ -23,6 +27,17 @@ index 1111111..2222222 100644
 +x = 2
  y = 3
 ```"""
+
+# Raw (unfenced) unified diff used for mocking _fetch_public_diff responses.
+SAMPLE_RAW_DIFF = """diff --git a/foo.py b/foo.py
+index 1111111..2222222 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,2 +1,2 @@
+-x = 1
++x = 2
+ y = 3
+"""
 
 _SENTINEL = object()
 
@@ -90,12 +105,15 @@ class TestVerbDetection:
 
 
 # ---------------------------------------------------------------------------
-# Path (a): host PR URL
+# Path (a): host PR URL — now fetches diff and routes through mosaico_diff
 # ---------------------------------------------------------------------------
 class TestPathPrUrl:
     @pytest.mark.asyncio
     async def test_pr_url_runs_handle_request_and_returns_artifact(self, monkeypatch, restore_settings):
         captured = {}
+
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
 
         async def fake_handle_request(self, pr_url, request, notify=None):
             captured["pr_url"] = pr_url
@@ -103,32 +121,37 @@ class TestPathPrUrl:
             _set_artifact("REVIEW MARKDOWN")
             return True
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         from pr_agent.agent.pr_agent import PRAgent
         monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
 
         out = await route_and_run(f"review {PR_URL}")
         assert out == "REVIEW MARKDOWN"
-        assert captured["pr_url"] == PR_URL
-        # _run_pr_agent must inject the no-publish flags so tools write into
-        # data["artifact"] instead of publishing to the real PR.
+        # After Fix B path (a) routes through the supplied-diff target, not the raw PR URL.
+        assert captured["pr_url"] == "mosaico://supplied-diff"
+        assert global_settings.get("CONFIG.GIT_PROVIDER") == "mosaico_diff"
+        # _run_pr_agent must inject the no-publish flags.
         assert "--config.publish_output=false" in captured["request"]
         assert "--config.publish_output_progress=false" in captured["request"]
         assert "/review" in captured["request"]
 
     @pytest.mark.asyncio
-    async def test_pr_url_leaves_git_provider_default(self, monkeypatch, restore_settings):
-        global_settings.set("CONFIG.GIT_PROVIDER", "github")
+    async def test_pr_url_routes_through_mosaico_diff(self, monkeypatch, restore_settings):
+        """After Fix B, a PR URL must be routed through mosaico_diff (not the host provider)."""
+
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
 
         async def fake_handle_request(self, pr_url, request, notify=None):
             _set_artifact("OK")
             return True
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         from pr_agent.agent.pr_agent import PRAgent
         monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
 
         await route_and_run(f"review {PR_URL}")
-        # path (a) must NOT switch the provider to mosaico_diff
-        assert global_settings.get("CONFIG.GIT_PROVIDER") == "github"
+        assert global_settings.get("CONFIG.GIT_PROVIDER") == "mosaico_diff"
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +232,9 @@ class TestAskWithContext:
     async def test_pr_url_question_runs_prquestions(self, monkeypatch, restore_settings):
         captured = {}
 
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
         class FakePRQuestions:
             def __init__(self, pr_url, args=None, ai_handler=None):
                 captured["pr_url"] = pr_url
@@ -224,13 +250,16 @@ class TestAskWithContext:
             pr_agent_used["called"] = True
             return True
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         monkeypatch.setattr("pr_agent.tools.pr_questions.PRQuestions", FakePRQuestions)
         from pr_agent.agent.pr_agent import PRAgent
         monkeypatch.setattr(PRAgent, "handle_request", fail_handle_request)
 
         out = await route_and_run(f"what does this change? {PR_URL}")
         assert out == "URL ANSWER"
-        assert captured["pr_url"] == PR_URL  # path (a): URL drives the provider target
+        # After Fix B path (a) routes through supplied-diff target, not the raw PR URL.
+        assert captured["pr_url"] == "mosaico://supplied-diff"
+        assert global_settings.get("CONFIG.GIT_PROVIDER") == "mosaico_diff"
         assert pr_agent_used["called"] is False
 
     @pytest.mark.asyncio
@@ -301,9 +330,13 @@ class TestPathFreeText:
 class TestDefensiveCapture:
     @pytest.mark.asyncio
     async def test_handle_request_false_returns_error_fallback(self, monkeypatch, restore_settings):
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
         async def fake_handle_request(self, pr_url, request, notify=None):
             return False  # swallowed internal failure
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         from pr_agent.agent.pr_agent import PRAgent
         monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
 
@@ -312,10 +345,14 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_ok_but_no_artifact_returns_empty_fallback(self, monkeypatch, restore_settings):
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
         async def fake_handle_request(self, pr_url, request, notify=None):
             # ok=True but never sets data["artifact"] (early-return paths)
             return True
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         from pr_agent.agent.pr_agent import PRAgent
         monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
         # ensure no stale artifact from a prior test
@@ -326,6 +363,9 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_ask_that_raises_returns_error_fallback(self, monkeypatch, restore_settings):
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
         class RaisingPRQuestions:
             def __init__(self, pr_url, args=None, ai_handler=None):
                 self.prediction = None
@@ -333,6 +373,7 @@ class TestDefensiveCapture:
             async def run(self):
                 raise RuntimeError("boom")
 
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
         monkeypatch.setattr("pr_agent.tools.pr_questions.PRQuestions", RaisingPRQuestions)
         # Use a PR URL so the ask path (a) actually runs PRQuestions (free-text no longer
         # invokes it after Fix B); a raise there -> error fallback.
@@ -345,6 +386,81 @@ class TestDefensiveCapture:
         for text in ("", None, "   ", "random text with no url and no diff"):
             out = await route_and_run(text)
             assert isinstance(out, str)
+
+    @pytest.mark.asyncio
+    async def test_pr_url_fetch_failure_marks_failed(self, monkeypatch, restore_settings):
+        """When _fetch_public_diff returns None, route_and_run_result must report ok=False
+        and include the URL plus 'could not fetch' in the text."""
+
+        async def fake_fetch_public_diff(pr_url):
+            return None
+
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
+
+        result = await route_and_run_result(f"review {PR_URL}")
+        assert result.ok is False
+        assert PR_URL in result.text
+        assert "could not fetch" in result.text
+
+
+# ---------------------------------------------------------------------------
+# _fetch_public_diff unit tests (no network — fake aiohttp.ClientSession)
+# ---------------------------------------------------------------------------
+class _FakeResp:
+    def __init__(self, status, body):
+        self.status = status
+        self.content = self
+        self._body = body
+
+    async def iter_chunked(self, n):
+        for i in range(0, len(self._body), n):
+            yield self._body[i:i + n]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get(self, url, allow_redirects=True):
+        return self._resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class TestFetchPublicDiff:
+    @pytest.mark.asyncio
+    async def test_fetch_public_diff_non_200_returns_none(self, monkeypatch):
+        resp = _FakeResp(404, b"")
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
+        result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_public_diff_oversize_returns_none(self, monkeypatch):
+        resp = _FakeResp(200, b"x" * (dispatch._DIFF_FETCH_MAX_BYTES + 1))
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
+        result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_public_diff_assembles_multichunk_body(self, monkeypatch):
+        # Body larger than the 65536 chunk size but under the cap: the full body must be
+        # assembled across chunks, not truncated to the first read.
+        body = b"a" * 200000
+        resp = _FakeResp(200, body)
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
+        result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
+        assert len(result) == 200000
 
 
 # ---------------------------------------------------------------------------
@@ -377,7 +493,7 @@ class TestPublishOutputForced:
         global_settings.set("CONFIG.PUBLISH_OUTPUT", True)
         out = await _run_pr_agent(PR_URL, "review")
 
-        assert out == "REVIEW OUTPUT"
+        assert out.text == "REVIEW OUTPUT"
         assert "--config.publish_output=false" in captured_args["request"], (
             "Production path must inject --config.publish_output=false; "
             "without it the tool publishes to the real PR and returns nothing to MOSAICO."
@@ -415,7 +531,7 @@ class TestPublishOutputForced:
         global_settings.set("CONFIG.PUBLISH_OUTPUT", True)
         out = await _run_ask(PR_URL, "what does this change?")
 
-        assert out == "CAPTURED ANSWER"
+        assert out.text == "CAPTURED ANSWER"
         assert publish_output_at_run_time.get("value") is False, (
             "CONFIG.PUBLISH_OUTPUT must be False when PRQuestions.run() is called; "
             "without this, run()'s publish guards post comments to the real PR."

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -407,10 +407,11 @@ class TestDefensiveCapture:
 # _fetch_public_diff unit tests (no network — fake aiohttp.ClientSession)
 # ---------------------------------------------------------------------------
 class _FakeResp:
-    def __init__(self, status, body):
+    def __init__(self, status, body, headers=None):
         self.status = status
         self.content = self
         self._body = body
+        self.headers = headers if headers is not None else {}
 
     async def iter_chunked(self, n):
         for i in range(0, len(self._body), n):
@@ -437,10 +438,15 @@ class _FakeSession:
         return False
 
 
+async def _always_safe(url: str) -> bool:
+    return True
+
+
 class TestFetchPublicDiff:
     @pytest.mark.asyncio
     async def test_fetch_public_diff_non_200_returns_none(self, monkeypatch):
         resp = _FakeResp(404, b"")
+        monkeypatch.setattr(dispatch, "_url_is_safe", _always_safe)
         monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
         result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
         assert result is None
@@ -448,6 +454,7 @@ class TestFetchPublicDiff:
     @pytest.mark.asyncio
     async def test_fetch_public_diff_oversize_returns_none(self, monkeypatch):
         resp = _FakeResp(200, b"x" * (dispatch._DIFF_FETCH_MAX_BYTES + 1))
+        monkeypatch.setattr(dispatch, "_url_is_safe", _always_safe)
         monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
         result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
         assert result is None
@@ -458,9 +465,91 @@ class TestFetchPublicDiff:
         # assembled across chunks, not truncated to the first read.
         body = b"a" * 200000
         resp = _FakeResp(200, body)
+        monkeypatch.setattr(dispatch, "_url_is_safe", _always_safe)
         monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
         result = await dispatch._fetch_public_diff("https://github.com/o/r/pull/1")
         assert len(result) == 200000
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard unit tests
+# ---------------------------------------------------------------------------
+class TestFetchPublicDiffSSRF:
+    @pytest.mark.asyncio
+    async def test_non_https_blocked(self):
+        # http scheme is blocked before any DNS lookup
+        assert await dispatch._url_is_safe("http://github.com/o/r/pull/1.diff") is False
+
+    @pytest.mark.asyncio
+    async def test_private_ip_blocked(self, monkeypatch):
+        monkeypatch.setattr(dispatch.socket, "getaddrinfo",
+                            lambda *a, **k: [(2, 1, 6, "", ("10.0.0.5", 0))])
+        assert await dispatch._url_is_safe("https://internal.example/x/pull/1.diff") is False
+
+    @pytest.mark.asyncio
+    async def test_metadata_ip_blocked(self, monkeypatch):
+        monkeypatch.setattr(dispatch.socket, "getaddrinfo",
+                            lambda *a, **k: [(2, 1, 6, "", ("169.254.169.254", 0))])
+        assert await dispatch._url_is_safe("https://metadata.example/pull/1.diff") is False
+
+    @pytest.mark.asyncio
+    async def test_public_ip_allowed(self, monkeypatch):
+        # 140.82.121.4 is a public GitHub IP
+        monkeypatch.setattr(dispatch.socket, "getaddrinfo",
+                            lambda *a, **k: [(2, 1, 6, "", ("140.82.121.4", 0))])
+        assert await dispatch._url_is_safe("https://github.com/o/r/pull/1.diff") is True
+
+    @pytest.mark.asyncio
+    async def test_fetch_blocks_unsafe_without_request(self, monkeypatch):
+        # _url_is_safe returns False -> _fetch_public_diff must return None without calling GET
+        async def always_unsafe(url: str) -> bool:
+            return False
+
+        class _NeverCalledSession:
+            def get(self, url, allow_redirects=False):
+                raise AssertionError("GET must not be called when URL is unsafe")
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        monkeypatch.setattr(dispatch, "_url_is_safe", always_unsafe)
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _NeverCalledSession())
+        result = await dispatch._fetch_public_diff("https://169.254.169.254/x/pull/1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_internal_blocked(self, monkeypatch):
+        """A redirect whose Location resolves to a private IP must be blocked."""
+        PUBLIC_HOST = "github.com"
+        PRIVATE_IP = "10.0.0.9"
+
+        def fake_getaddrinfo(host, port, *a, **k):
+            if host == PUBLIC_HOST:
+                return [(2, 1, 6, "", ("140.82.121.4", 0))]
+            # Any other host (incl. the raw IP string) -> private
+            return [(2, 1, 6, "", (PRIVATE_IP, 0))]
+
+        monkeypatch.setattr(dispatch.socket, "getaddrinfo", fake_getaddrinfo)
+
+        # First GET returns a 302 pointing at an internal URL; second must never be reached.
+        redirect_resp = _FakeResp(302, b"", headers={"Location": f"https://{PRIVATE_IP}/evil"})
+
+        class _RedirectSession:
+            def get(self, url, allow_redirects=False):
+                return redirect_resp
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _RedirectSession())
+        result = await dispatch._fetch_public_diff(f"https://{PUBLIC_HOST}/o/r/pull/1")
+        assert result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When a PR URL is provided, fetch the public unified diff via `.diff` endpoint and route through mosaico_diff provider instead of using the host provider. This enables token-free operation for public repos while failing honestly for private repos or unsupported hosts.

- Add `_fetch_public_diff()` to retrieve public diffs with size/timeout limits
- Return `RouteResult(text, ok)` from routing to distinguish success/failure
- Mark tasks as failed (not completed) when diff fetch or routing fails
- Switch Langfuse callback from `langfuse` to `langfuse_otel` for OTEL support
- Update all tests to mock diff fetching and validate failed state handling