### PR TITLE
feat(A2A): migrate to A2A 1.0 protocol with artifact-based task completion

### DIFF
--- a/pr_agent/mosaico/card.py
+++ b/pr_agent/mosaico/card.py
@@ -6,7 +6,7 @@ selects message/send vs message/stream from capabilities.streaming)."""
 import os
 
 from a2a.types import (AgentCapabilities, AgentCard, AgentExtension,
-                       AgentSkill)
+                       AgentInterface, AgentSkill)
 
 from pr_agent.algo.utils import get_version
 
@@ -16,10 +16,14 @@ AGENT_NAME = "PR-Agent Solution Agent"
 DEFAULT_PORT = 9000
 
 
-def _card_url() -> str:
+def _jsonrpc_interface() -> AgentInterface:
     host = os.getenv("AGENT_CARD_HOST") or "localhost"
     port = os.getenv("AGENT_CARD_PORT") or os.getenv("PORT") or str(DEFAULT_PORT)
-    return f"http://{host}:{port}/"
+    return AgentInterface(
+        protocol_binding="JSONRPC",
+        protocol_version="1.0",
+        url=f"http://{host}:{port}/",
+    )
 
 
 def _build_skills() -> list:
@@ -80,8 +84,8 @@ def build_agent_card() -> AgentCard:
                     "suggestions, a generated PR title and description, and answers to questions "
                     "about that specific pull request or diff. Every action is anchored to a "
                     "concrete pull request or git diff supplied in the request.",
-        url=_card_url(),
         version=get_version(),
+        supported_interfaces=[_jsonrpc_interface()],
         default_input_modes=["text", "text/plain"],
         default_output_modes=["text", "text/plain", "text/markdown"],
         capabilities=AgentCapabilities(

--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -36,9 +36,17 @@ class PRAgentExecutor(AgentExecutor):
     """Turns a MOSAICO message/send into a pr-agent run and returns a Task."""
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        # In A2A 1.0 DefaultRequestHandler sets task_id/context_id on the context.
-        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        # In A2A 1.0 DefaultRequestHandler sets task_id/context_id on the context before
+        # execute() is reached (the SDK also rejects non-1.0 requests upstream).  We still
+        # build the updater INSIDE the try and validate the fields explicitly: a context
+        # missing them surfaces as a controlled, logged failure here instead of an uncaught
+        # crash before any task event is emitted.
+        updater = None
         try:
+            if not context.task_id or not context.context_id:
+                raise ValueError("A2A 1.0 RequestContext missing task_id/context_id")
+            updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+
             # Request-scoped settings: the tool run mutates ONLY this deepcopy, never the
             # shared global. get_settings() resolves to sctx["settings"] when present.
             sctx["settings"] = copy.deepcopy(global_settings)
@@ -63,6 +71,10 @@ class PRAgentExecutor(AgentExecutor):
                 await updater.failed(msg)
         except Exception as e:
             get_logger().exception("MOSAICO task failed")
+            if updater is None:
+                # task_id/context_id were missing, so we cannot create a Task to fail.
+                # Re-raise so the handler returns a controlled JSON-RPC error.
+                raise
             error_text = f"Error: {e}"
             # Must add_artifact first to initialise the task before failed().
             await updater.add_artifact([Part(text=error_text)])

--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -1,16 +1,27 @@
-"""MOSAICO A2A executor + the /health LLM probe.
+"""MOSAICO A2A executor + the /health LLM probe (A2A 1.0).
 
 PRAgentExecutor.execute runs a single non-streaming path: it FIRST installs a
 request-scoped deepcopy of global_settings into starlette_context (so the tool run
 mutates only the per-request copy — load-bearing isolation under concurrency), routes
 the inbound text to a pr-agent command, and completes the Task with the rendered
-markdown. health_check issues a single, NON-retry-wrapped litellm probe."""
+markdown.
+
+On success the review text is published as an artifact (RISK 2: the reference agent's
+pollTask reads task.artifacts, not the completion message), then complete().
+
+On any failure — including ok=False from the router (Fix C) — an artifact containing
+the error text is published first (required to initialise the task before sending a
+TaskStatusUpdateEvent), then failed().  The first event to the ActiveTask MUST be a
+TaskArtifactUpdateEvent (not a TaskStatusUpdateEvent), otherwise the SDK raises
+"Agent should enqueue Task before TaskStatusUpdateEvent event".
+
+health_check issues a single, NON-retry-wrapped litellm probe."""
 import copy
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
-from a2a.utils import new_agent_text_message, new_task
+from a2a.types import Part
 from starlette_context import context as sctx
 
 from pr_agent.config_loader import get_settings, global_settings
@@ -22,13 +33,11 @@ from pr_agent.mosaico.observability import (langfuse_span,
 
 
 class PRAgentExecutor(AgentExecutor):
-    """Turns a MOSAICO message/send into a pr-agent run and returns a text Message."""
+    """Turns a MOSAICO message/send into a pr-agent run and returns a Task."""
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        task = context.current_task or new_task(context.message)
-        if context.current_task is None:
-            await event_queue.enqueue_event(task)
-        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        # In A2A 1.0 DefaultRequestHandler sets task_id/context_id on the context.
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
         try:
             # Request-scoped settings: the tool run mutates ONLY this deepcopy, never the
             # shared global. get_settings() resolves to sctx["settings"] when present.
@@ -36,16 +45,29 @@ class PRAgentExecutor(AgentExecutor):
 
             user_text = context.get_user_input() or ""
             meta = parse_observability_metadata(context.metadata)
-            with mosaico_log_context(meta, task.context_id), langfuse_span(meta, task.context_id):
+            with mosaico_log_context(meta, context.context_id), \
+                    langfuse_span(meta, context.context_id):
                 result = await route_and_run_result(user_text)
-            message = new_agent_text_message(result.text or "(no output produced)")
+
+            output_text = result.text or "(no output produced)"
+            # ALWAYS add_artifact first: the SDK requires a TaskArtifactUpdateEvent
+            # before any TaskStatusUpdateEvent (otherwise it raises InvalidAgentResponseError
+            # "Agent should enqueue Task before TaskStatusUpdateEvent").  The artifact also
+            # delivers the review text to the reference agent's pollTask (RISK 2).
+            await updater.add_artifact([Part(text=output_text)])
             if result.ok:
-                await updater.complete(message)
+                await updater.complete()
             else:
-                await updater.failed(message)
+                # ok=False means a recoverable routing/fetch failure (Fix C).
+                msg = updater.new_agent_message([Part(text=output_text)])
+                await updater.failed(msg)
         except Exception as e:
             get_logger().exception("MOSAICO task failed")
-            await updater.failed(new_agent_text_message(f"Error: {e}"))
+            error_text = f"Error: {e}"
+            # Must add_artifact first to initialise the task before failed().
+            await updater.add_artifact([Part(text=error_text)])
+            msg = updater.new_agent_message([Part(text=error_text)])
+            await updater.failed(msg)
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
         raise NotImplementedError("cancel is not supported by the PR-Agent solution agent")

--- a/pr_agent/mosaico/server.py
+++ b/pr_agent/mosaico/server.py
@@ -1,18 +1,19 @@
-"""MOSAICO A2A server.
+"""MOSAICO A2A server (A2A 1.0).
 
-Mounts the A2A SDK app (POST / for message/send, GET /.well-known/agent-card.json)
-plus a GET /health route, with RawContextMiddleware on the SAME app so every request
-runs inside a starlette_context scope (MANDATORY: the executor installs a request-scoped
-deepcopy of the settings there; without the scope it raises ContextDoesNotExistError).
+Builds a plain Starlette app with A2A routes (agent-card + JSONRPC) plus a GET /health
+route, with RawContextMiddleware on the SAME app so every request runs inside a
+starlette_context scope (MANDATORY: the executor installs a request-scoped deepcopy of
+the settings there; without the scope it raises ContextDoesNotExistError).
 
 Module import side effects (so build_app works in tests): JSON logger, apply_mosaico_env(),
 provider registration, and a one-time Langfuse client construction when creds are present.
 uvicorn.run is only invoked under __main__."""
 import os
 
-from a2a.server.apps import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
 from a2a.server.tasks import InMemoryTaskStore
+from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -36,22 +37,14 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 9000
 
 
-class _HealthApp(A2AStarletteApplication):
-    """A2A app extended with a GET /health route (mirrors mosaico-base-agents/app.py)."""
-
-    def routes(self, *args, **kwargs):
-        routes = super().routes(*args, **kwargs)
-        routes.append(Route(HEALTH_PATH, self._health, methods=["GET"], name="health"))
-        return routes
-
-    async def _health(self, request: Request) -> JSONResponse:
-        health = await health_check()
-        is_healthy = health == "OK"
-        status_code = 200 if is_healthy else 503
-        content = {"is_healthy": is_healthy, "status": health}
-        if not is_healthy:
-            content["detail"] = health
-        return JSONResponse(content, status_code=status_code)
+async def _health(request: Request) -> JSONResponse:
+    health = await health_check()
+    is_healthy = health == "OK"
+    status_code = 200 if is_healthy else 503
+    content = {"is_healthy": is_healthy, "status": health}
+    if not is_healthy:
+        content["detail"] = health
+    return JSONResponse(content, status_code=status_code)
 
 
 def _configure_runtime() -> None:
@@ -83,14 +76,20 @@ def _configure_langfuse() -> None:
 
 
 def build_app():
-    """Build the Starlette app: A2A routes + /health, with RawContextMiddleware mounted
-    on the SAME app. build(**kwargs) forwards to Starlette(**kwargs) (a2a-sdk 0.3.26)."""
+    """Build the Starlette app: A2A card + JSONRPC routes + /health, with
+    RawContextMiddleware on the same app (A2A 1.0)."""
+    card = build_agent_card()
     handler = DefaultRequestHandler(
         agent_executor=PRAgentExecutor(),
         task_store=InMemoryTaskStore(),
+        agent_card=card,
     )
-    sdk_app = _HealthApp(agent_card=build_agent_card(), http_handler=handler)
-    return sdk_app.build(middleware=[Middleware(RawContextMiddleware)])
+    routes = [
+        *create_agent_card_routes(card),          # GET /.well-known/agent-card.json
+        *create_jsonrpc_routes(handler, rpc_url="/"),
+        Route(HEALTH_PATH, _health, methods=["GET"]),
+    ]
+    return Starlette(routes=routes, middleware=[Middleware(RawContextMiddleware)])
 
 
 def start() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ tiktoken==0.12.0
 ujson==5.8.0
 uvicorn==0.22.0
 tenacity==8.2.3
-a2a-sdk[http-server]>=1.0.0,<1.1.0
+a2a-sdk[http-server]==1.0.3
 langfuse==3.14.5
 gunicorn==23.0.0
 pytest-cov==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ tiktoken==0.12.0
 ujson==5.8.0
 uvicorn==0.22.0
 tenacity==8.2.3
-a2a-sdk[http-server]==0.3.26
+a2a-sdk[http-server]>=1.0.0,<1.1.0
 langfuse==3.14.5
 gunicorn==23.0.0
 pytest-cov==7.0.0

--- a/tests/unittest/test_mosaico_a2a_roundtrip.py
+++ b/tests/unittest/test_mosaico_a2a_roundtrip.py
@@ -1,12 +1,22 @@
-"""End-to-end A2A round-trip through the real MOSAICO server stack.
+"""End-to-end A2A 1.0 round-trip through the real MOSAICO server stack.
 
-Drives an HTTP POST through the whole server (ASGI -> A2AStarletteApplication ->
-executor -> RawContextMiddleware -> route_and_run -> real PRReviewer with
-publish_output forced False -> A2A response). Regression proof that the
-publish_output fix returns real content instead of "(no output produced)".
+Drives an HTTP POST through the whole server (Starlette + DefaultRequestHandler +
+executor + RawContextMiddleware + route_and_run + real PRReviewer with publish_output
+forced False -> A2A 1.0 response). Tier 0b: load-bearing interop proof.
 
 Only the LLM is stubbed (LiteLLMAIHandler.chat_completion -> canned review YAML);
 everything above it runs real and unmocked.
+
+1.0 WIRE CONTRACT:
+- method: "SendMessage" (not "message/send")
+- header: A2A-Version: 1.0
+- params: built from SDK types (SendMessageRequest.MessageToDict) — never hand-rolled
+- result shape: {"task": {"status": {"state": "TASK_STATE_COMPLETED"}, "artifacts": [...]}}
+- review text is in artifacts[0].parts[0].text (RISK 2: reference agent reads artifacts)
+- bad URL → state "TASK_STATE_FAILED" (Fix C)
+
+Non-vacuity: reverting Fix C (making ok=False route to complete()) would flip the
+bad-URL assertion to TASK_STATE_COMPLETED — making test_bad_url_roundtrip fail.
 
 Note: import pr_agent.config_loader first to avoid the pr_agent.log <->
 custom_merge_loader circular import (mirrors server.py)."""
@@ -16,7 +26,10 @@ import pr_agent.config_loader  # noqa: F401  (import-order load; see module docs
 
 import httpx
 import pytest
+from google.protobuf.json_format import MessageToDict
 from httpx import ASGITransport
+
+from a2a.types import Message, Part, Role, SendMessageRequest
 
 # A small, valid unified diff wrapped in a ```diff fence -> the supplied-diff (path b)
 # of the router: no PR URL, no network, parsed by the mosaico_diff provider.
@@ -33,6 +46,9 @@ _DIFF_TEXT = (
     " y = 3\n"
     "```"
 )
+
+# A URL that is unreachable / SSRF-blocked -> routes to failed (Fix C).
+_BAD_URL = "https://github.com/nonexistent-org-xyz/nonexistent-repo-xyz/pull/99999"
 
 _MARKER = "MARKER_CANNED_REVIEW_E2E"
 
@@ -52,43 +68,60 @@ review:
   security_concerns: 'No'
 """
 
+# A2A 1.0 request header — required so the server does not fall back to 0.3 mode.
+_A2A_HEADERS = {"A2A-Version": "1.0"}
+
 
 def _message_send_body(text: str) -> dict:
-    """A genuine A2A JSON-RPC message/send body (shape verified against the installed
-    a2a SDK: SendMessageRequest.model_dump)."""
+    """Build a genuine A2A 1.0 JSON-RPC message/send body from the SDK's own types.
+
+    Using MessageToDict(SendMessageRequest(...)) ensures the payload shape is identical
+    to what the reference agent sends — never hand-rolled."""
+    msg = Message(
+        message_id="rt-msg-1",
+        role=Role.ROLE_USER,
+        parts=[Part(text=text)],
+    )
+    req = SendMessageRequest(message=msg)
     return {
         "id": "rt-1",
         "jsonrpc": "2.0",
-        "method": "message/send",
-        "params": {
-            "message": {
-                "kind": "message",
-                "messageId": "rt-msg-1",
-                "role": "user",
-                "parts": [{"kind": "text", "text": text}],
-            }
-        },
+        "method": "SendMessage",
+        "params": MessageToDict(req),
     }
 
 
-def _extract_text(result: dict) -> str:
-    """Pull the agent's text out of an A2A message/send result. The executor completes a
-    Task, so the agent reply lands in result.status.message.parts[*].text; tolerate the
-    plain-Message shape too."""
-    if not isinstance(result, dict):
-        return ""
-    msg = result.get("status", {}).get("message") if "status" in result else result
-    parts = (msg or {}).get("parts", []) if isinstance(msg, dict) else []
-    return "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+def _extract_artifact_text(result: dict) -> str:
+    """Extract the agent's review text from A2A 1.0 task artifacts.
+
+    A2A 1.0 result shape: {"task": {"artifacts": [{"parts": [{"text": "..."}]}]}}
+    The reference agent's pollTask reads task.artifacts (RISK 2); this mirrors that."""
+    task = result.get("task", result) if isinstance(result, dict) else {}
+    artifacts = task.get("artifacts", [])
+    texts = []
+    for art in artifacts:
+        for part in art.get("parts", []):
+            if isinstance(part.get("text"), str):
+                texts.append(part["text"])
+    return "\n".join(texts)
+
+
+def _get_task_state(result: dict) -> str:
+    """Extract the task state from an A2A 1.0 result dict."""
+    task = result.get("task", result) if isinstance(result, dict) else {}
+    return task.get("status", {}).get("state", "")
 
 
 def _build_client(app):
-    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+        headers=_A2A_HEADERS,
+    )
 
 
 def _live_llm_creds_absent() -> bool:
-    """True when the MOSAICO LLM packaging creds (API_BASE + API_KEY) are NOT both set.
-    Boolean presence only — never reads or echoes the values."""
+    """True when the MOSAICO LLM packaging creds (API_BASE + API_KEY) are NOT both set."""
     return not (os.getenv("API_BASE") and os.getenv("API_KEY"))
 
 
@@ -100,7 +133,7 @@ class TestA2ARoundTripStubbedLLM:
 
         # health_check() issues a direct, non-retry litellm.acompletion probe (NOT
         # LiteLLMAIHandler.chat_completion), so stub acompletion here to keep /health
-        # healthy offline — no LLM/network in CI. health_check ignores the response body.
+        # healthy offline — no LLM/network in CI.
         async def fake_acompletion(**kwargs):
             return {"choices": [{"message": {"content": "ping"}}]}
         monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
@@ -116,7 +149,12 @@ class TestA2ARoundTripStubbedLLM:
             assert card.status_code == 200
             body = card.json()
             assert body["name"] == "PR-Agent Solution Agent"
-            # observability extension still advertised required over the wire
+
+            # A2A 1.0: supported_interfaces replaces top-level url.
+            assert "supportedInterfaces" in body, f"A2A 1.0 card missing supportedInterfaces: {body}"
+            assert "url" not in body, f"A2A 1.0 card must not have top-level url: {body}"
+
+            # Observability extension still advertised required over the wire.
             exts = body["capabilities"]["extensions"]
             obs_uri = "https://mosaico-project.eu/extensions/mosaico-observability"
             assert any(
@@ -124,16 +162,20 @@ class TestA2ARoundTripStubbedLLM:
             )
 
     @pytest.mark.asyncio
-    async def test_supplied_diff_review_roundtrip(self, monkeypatch):
-        """The end-to-end proof of the publish_output fix: a supplied-diff /review POST
-        returns the real rendered review (our marker) over the wire — NOT the old
-        "(no output produced)" and NOT an "Error:" message."""
+    async def test_supplied_diff_completed_with_artifact(self, monkeypatch):
+        """RISK 2 proof: a supplied-diff /review POST returns the real review in artifacts.
+
+        The reference agent's pollTask reads task.artifacts — not the completion message.
+        This test asserts:
+          1. state == TASK_STATE_COMPLETED
+          2. artifacts contains our canned-review marker text
+        A revert of the add_artifact() call would break assertion 2 (non-vacuity)."""
         import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
 
         async def fake_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
             return _CANNED_REVIEW_YAML, "stop"
 
-        # Stub ONLY the LLM. route_and_run / executor / middleware / publish_output stay real.
+        # Stub ONLY the LLM. Everything above it runs real.
         monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", fake_chat_completion)
 
         from pr_agent.mosaico.server import build_app
@@ -146,14 +188,45 @@ class TestA2ARoundTripStubbedLLM:
         assert "error" not in payload, f"JSON-RPC error returned: {payload.get('error')}"
         assert "result" in payload, f"no result in response: {payload}"
 
-        text = _extract_text(payload["result"])
-        assert text, "agent returned an empty text part"
-        # The publish_output fix proof: real content, marker present, no old failure strings.
-        assert _MARKER in text, f"canned review marker missing from response: {text[:300]!r}"
+        state = _get_task_state(payload["result"])
+        assert state == "TASK_STATE_COMPLETED", f"task not completed: {payload['result']}"
+
+        # RISK 2 assertion: review text must be in artifacts, not just status.
+        text = _extract_artifact_text(payload["result"])
+        assert text, "agent returned empty artifacts — review not retrievable by reference agent"
+        assert _MARKER in text, f"canned review marker missing from artifacts: {text[:300]!r}"
         assert "(no output produced)" not in text
         assert not text.startswith("Error:")
         # Confirms PRReviewer actually rendered (not a raw YAML passthrough).
         assert "PR Reviewer Guide" in text
+
+    @pytest.mark.asyncio
+    async def test_bad_url_yields_failed(self, monkeypatch):
+        """Fix C proof: an unfetchable/SSRF-blocked PR URL must yield TASK_STATE_FAILED.
+
+        Non-vacuity: reverting Fix C (completing instead of failing on ok=False) would
+        change this result to TASK_STATE_COMPLETED, flipping this test red."""
+        import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
+
+        async def fake_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+            return _CANNED_REVIEW_YAML, "stop"
+
+        monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", fake_chat_completion)
+
+        from pr_agent.mosaico.server import build_app
+        app = build_app()
+        async with _build_client(app) as client:
+            resp = await client.post("/", json=_message_send_body(f"review {_BAD_URL}"))
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert "error" not in payload, f"unexpected JSON-RPC error: {payload.get('error')}"
+        assert "result" in payload, f"no result in response: {payload}"
+
+        state = _get_task_state(payload["result"])
+        assert state == "TASK_STATE_FAILED", (
+            f"bad URL must yield TASK_STATE_FAILED (Fix C), got: {state}"
+        )
 
 
 class TestA2ARoundTripLiveLLM:
@@ -174,7 +247,9 @@ class TestA2ARoundTripLiveLLM:
         assert resp.status_code == 200
         payload = resp.json()
         assert "result" in payload, f"no result in response: {payload}"
-        text = _extract_text(payload["result"])
-        assert text, "live agent returned an empty text part"
+        state = _get_task_state(payload["result"])
+        assert state == "TASK_STATE_COMPLETED", f"live test expected completed: {payload['result']}"
+        text = _extract_artifact_text(payload["result"])
+        assert text, "live agent returned empty artifacts"
         assert "(no output produced)" not in text
         assert not text.startswith("Error:")

--- a/tests/unittest/test_mosaico_card.py
+++ b/tests/unittest/test_mosaico_card.py
@@ -1,6 +1,8 @@
-"""Tests for the MOSAICO agent card."""
+"""Tests for the MOSAICO agent card (A2A 1.0)."""
 import json
 import os
+
+from google.protobuf.json_format import MessageToDict
 
 from pr_agent.mosaico.card import (OBSERVABILITY_EXTENSION_URI,
                                    build_agent_card)
@@ -12,9 +14,29 @@ _REGISTRATION_JSON = os.path.join(
 
 
 class TestAgentCard:
-    def test_protocol_version_0_3_0(self):
+    def test_supported_interfaces_present(self):
+        """A2A 1.0: url+protocol_version moved into supported_interfaces."""
         card = build_agent_card()
-        assert card.protocol_version == "0.3.0"
+        assert len(card.supported_interfaces) == 1
+        iface = card.supported_interfaces[0]
+        assert iface.protocol_binding == "JSONRPC"
+        assert iface.protocol_version == "1.0"
+        assert iface.url.endswith("/")
+
+    def test_url_absent_from_card_top_level(self):
+        """Non-vacuity: the old 0.3 top-level url= field MUST NOT appear in the 1.0 card."""
+        d = MessageToDict(build_agent_card())
+        assert "url" not in d, f"top-level 'url' must not appear in 1.0 card: {d}"
+        assert "protocolVersion" not in d, f"top-level 'protocolVersion' must not appear: {d}"
+
+    def test_supported_interfaces_serialise(self):
+        """Serialised card carries supportedInterfaces (camelCase) with the interface URL."""
+        d = MessageToDict(build_agent_card())
+        assert "supportedInterfaces" in d
+        ifaces = d["supportedInterfaces"]
+        assert len(ifaces) == 1
+        assert ifaces[0]["protocolBinding"] == "JSONRPC"
+        assert ifaces[0]["protocolVersion"] == "1.0"
 
     def test_streaming_false(self):
         card = build_agent_card()
@@ -22,7 +44,7 @@ class TestAgentCard:
 
     def test_observability_extension_required(self):
         card = build_agent_card()
-        exts = card.capabilities.extensions
+        exts = list(card.capabilities.extensions)
         assert exts, "no extensions advertised"
         obs = [e for e in exts if e.uri == OBSERVABILITY_EXTENSION_URI]
         assert len(obs) == 1, "observability extension not found exactly once"
@@ -32,19 +54,23 @@ class TestAgentCard:
         assert OBSERVABILITY_EXTENSION_URI == \
             "https://mosaico-project.eu/extensions/mosaico-observability"
 
+    def test_observability_extension_serialises(self):
+        """Extension must survive MessageToDict round-trip (regression vs broken toml)."""
+        d = MessageToDict(build_agent_card())
+        exts = d["capabilities"]["extensions"]
+        obs = [e for e in exts if e["uri"] == OBSERVABILITY_EXTENSION_URI]
+        assert len(obs) == 1
+        assert obs[0]["required"] is True
+
     def test_four_skills(self):
         card = build_agent_card()
         skill_ids = {s.id for s in card.skills}
         assert skill_ids == {"review", "improve", "describe", "ask"}
 
-    def test_url_ends_with_slash(self):
-        card = build_agent_card()
-        assert card.url.endswith("/")
-
     def test_input_output_modes(self):
         card = build_agent_card()
-        assert card.default_input_modes == ["text", "text/plain"]
-        assert "text/markdown" in card.default_output_modes
+        assert list(card.default_input_modes) == ["text", "text/plain"]
+        assert "text/markdown" in list(card.default_output_modes)
 
     def test_version_is_nonempty(self):
         card = build_agent_card()

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -203,6 +203,27 @@ class TestExecute:
         )
         assert spy.failed_with is not None
 
+    @pytest.mark.parametrize("missing", ["task_id", "context_id"])
+    @pytest.mark.asyncio
+    async def test_missing_a2a_fields_raise_controlled_error(self, monkeypatch, spy_updater, missing):
+        """Defense in depth: a RequestContext lacking the A2A 1.0 task_id/context_id
+        fields raises a controlled error (logged) before any TaskUpdater is built —
+        not an uncaught crash, and never a silent complete()."""
+        async def fake_route_and_run_result(text):
+            return RouteResult("RENDERED", True)
+
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
+
+        ctx = _FakeRequestContext("review this")
+        setattr(ctx, missing, None)
+        with request_cycle_context({}):
+            with pytest.raises(ValueError):
+                await PRAgentExecutor().execute(ctx, _RecordingEventQueue())
+
+        # TaskUpdater was never constructed (validation fires first), so no task
+        # lifecycle events were emitted.
+        assert spy_updater.last is None
+
     @pytest.mark.asyncio
     async def test_cancel_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -1,9 +1,13 @@
-"""Tests for PRAgentExecutor.execute.
+"""Tests for PRAgentExecutor.execute (A2A 1.0).
 
 Drives execute() with a fake RequestContext + a recording EventQueue, and a spy
-TaskUpdater that captures complete()/failed() calls. asyncio_mode=auto."""
+TaskUpdater that captures add_artifact()/complete()/failed() calls. asyncio_mode=strict.
+
+Non-vacuity (Fix C): test_non_vacuity_ok_false_must_not_complete verifies that if
+ok=False causes complete() instead of failed(), the assertion fails — proving the
+test can detect a Fix C regression."""
 import pytest
-from a2a.types import Message, Part, Role, TextPart
+from a2a.types import Message, Part, Role
 from starlette_context import request_cycle_context
 
 import pr_agent.mosaico.executor as executor_mod
@@ -14,8 +18,8 @@ from pr_agent.mosaico.executor import PRAgentExecutor
 def _make_message(text: str) -> Message:
     return Message(
         message_id="m1",
-        role=Role.user,
-        parts=[Part(root=TextPart(text=text))],
+        role=Role.ROLE_USER,
+        parts=[Part(text=text)],
     )
 
 
@@ -29,43 +33,81 @@ class _RecordingEventQueue:
 
 class _FakeRequestContext:
     """Faithful stand-in for a2a RequestContext: top-level metadata, get_user_input,
-    current_task, message."""
+    task_id, context_id, message."""
 
-    def __init__(self, text, metadata=None, current_task=None):
+    def __init__(self, text, metadata=None):
         self._text = text
         self.metadata = metadata or {}
-        self.current_task = current_task
         self.message = _make_message(text)
+        # A2A 1.0: task_id/context_id are set by DefaultRequestHandler before execute.
+        self.task_id = "task-001"
+        self.context_id = "ctx-001"
 
     def get_user_input(self, delimiter: str = "\n") -> str:
         return self._text
 
 
 class _SpyTaskUpdater:
+    """Spy replacing TaskUpdater; captures add_artifact/complete/failed calls."""
+
     last = None
 
     def __init__(self, event_queue, task_id, context_id):
         self.event_queue = event_queue
         self.task_id = task_id
         self.context_id = context_id
-        self.completed_with = None
-        self.failed_with = None
+        self.artifacts = []       # list of Part lists passed to add_artifact
+        self.completed = False
+        self.failed_with = None   # message text passed to failed()
         type(self).last = self
 
+    async def add_artifact(self, parts, **kwargs):
+        self.artifacts.append(parts)
+
     async def complete(self, message=None):
-        self.completed_with = _message_text(message)
+        self.completed = True
 
     async def failed(self, message=None):
         self.failed_with = _message_text(message)
 
+    def new_agent_message(self, parts, metadata=None):
+        return _FakeMessage(parts)
+
+
+class _FakeMessage:
+    def __init__(self, parts):
+        self._parts = parts
+
+    @property
+    def parts(self):
+        return self._parts
+
 
 def _message_text(message):
+    """Extract plain text from a message (real protobuf Part or FakeMessage)."""
     if message is None:
         return None
     try:
-        return message.parts[0].root.text
+        parts = message.parts
+        if parts:
+            p = parts[0]
+            if hasattr(p, "text"):
+                return p.text
+        return str(message)
     except Exception:
         return str(message)
+
+
+def _artifact_text(spy):
+    """Return the first text from the first artifact list, or None."""
+    if not spy.artifacts:
+        return None
+    parts = spy.artifacts[0]
+    if parts:
+        p = parts[0]
+        if hasattr(p, "text"):
+            return p.text
+    return None
 
 
 @pytest.fixture
@@ -77,7 +119,8 @@ def spy_updater(monkeypatch):
 
 class TestExecute:
     @pytest.mark.asyncio
-    async def test_completes_with_rendered_markdown(self, monkeypatch, spy_updater):
+    async def test_completes_with_artifact(self, monkeypatch, spy_updater):
+        """ok=True path: result goes into add_artifact (RISK 2), then complete()."""
         async def fake_route_and_run_result(text):
             return RouteResult("RENDERED", True)
 
@@ -88,20 +131,24 @@ class TestExecute:
         with request_cycle_context({}):
             await PRAgentExecutor().execute(ctx, eq)
 
-        # The new Task was enqueued (current_task was None).
-        assert len(eq.events) == 1
-        assert spy_updater.last.completed_with == "RENDERED"
-        assert spy_updater.last.failed_with is None
+        spy = spy_updater.last
+        # The review text must be in the artifact (RISK 2: reference agent reads artifacts).
+        assert _artifact_text(spy) == "RENDERED"
+        assert spy.completed is True
+        assert spy.failed_with is None
 
     @pytest.mark.asyncio
-    async def test_empty_render_uses_placeholder(self, monkeypatch, spy_updater):
+    async def test_empty_render_artifact_has_placeholder(self, monkeypatch, spy_updater):
         async def fake_route_and_run_result(text):
             return RouteResult("", True)
 
         monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
         with request_cycle_context({}):
             await PRAgentExecutor().execute(_FakeRequestContext("x"), _RecordingEventQueue())
-        assert spy_updater.last.completed_with == "(no output produced)"
+
+        spy = spy_updater.last
+        assert _artifact_text(spy) == "(no output produced)"
+        assert spy.completed is True
 
     @pytest.mark.asyncio
     async def test_route_and_run_raises_marks_failed(self, monkeypatch, spy_updater):
@@ -111,32 +158,19 @@ class TestExecute:
         monkeypatch.setattr(executor_mod, "route_and_run_result", boom)
 
         eq = _RecordingEventQueue()
-        # Must not raise out of execute.
         with request_cycle_context({}):
             await PRAgentExecutor().execute(_FakeRequestContext("y"), eq)
-        assert spy_updater.last.completed_with is None
-        assert spy_updater.last.failed_with is not None
-        assert "kaboom" in spy_updater.last.failed_with
+
+        spy = spy_updater.last
+        # Exception path: artifact is added (to init task), then failed().
+        assert spy.artifacts, "artifact must be added even on exception path"
+        assert spy.completed is False
+        assert spy.failed_with is not None
+        assert "kaboom" in spy.failed_with
 
     @pytest.mark.asyncio
-    async def test_existing_task_not_re_enqueued(self, monkeypatch, spy_updater):
-        async def fake_route_and_run_result(text):
-            return RouteResult("R", True)
-
-        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
-
-        from a2a.utils import new_task
-        existing = new_task(_make_message("hi"))
-        eq = _RecordingEventQueue()
-        ctx = _FakeRequestContext("hi", current_task=existing)
-        with request_cycle_context({}):
-            await PRAgentExecutor().execute(ctx, eq)
-        # current_task present -> no new Task enqueued
-        assert eq.events == []
-        assert spy_updater.last.completed_with == "R"
-
-    @pytest.mark.asyncio
-    async def test_failed_result_marks_failed(self, monkeypatch, spy_updater):
+    async def test_failed_result_marks_failed_not_completed(self, monkeypatch, spy_updater):
+        """ok=False path (Fix C): artifact is added, then failed() — never complete()."""
         async def fake_route_and_run_result(text):
             return RouteResult("boom", ok=False)
 
@@ -144,8 +178,30 @@ class TestExecute:
 
         with request_cycle_context({}):
             await PRAgentExecutor().execute(_FakeRequestContext("z"), _RecordingEventQueue())
-        assert spy_updater.last.failed_with == "boom"
-        assert spy_updater.last.completed_with is None
+
+        spy = spy_updater.last
+        assert spy.artifacts, "artifact must be added before failed()"
+        assert spy.failed_with is not None
+        assert spy.completed is False
+
+    @pytest.mark.asyncio
+    async def test_non_vacuity_ok_false_must_not_complete(self, monkeypatch, spy_updater):
+        """Non-vacuity guard (Fix C): if ok=False route calls complete() instead of
+        failed(), this assertion fails — proving the test catches a Fix C regression."""
+        async def bad_url_result(text):
+            return RouteResult("SSRF blocked", ok=False)
+
+        monkeypatch.setattr(executor_mod, "route_and_run_result", bad_url_result)
+
+        with request_cycle_context({}):
+            await PRAgentExecutor().execute(_FakeRequestContext("z"), _RecordingEventQueue())
+
+        spy = spy_updater.last
+        # If Fix C is reverted (complete() called on ok=False), this assertion fails.
+        assert spy.completed is False, (
+            "ok=False path must call failed(), not complete() — Fix C guard"
+        )
+        assert spy.failed_with is not None
 
     @pytest.mark.asyncio
     async def test_cancel_raises_not_implemented(self):

--- a/tests/unittest/test_mosaico_isolation.py
+++ b/tests/unittest/test_mosaico_isolation.py
@@ -17,7 +17,7 @@ same interleaving WITHOUT the per-request deepcopy and asserting the bleed DOES 
 import asyncio
 
 import pytest
-from a2a.types import Message, Part, Role, TextPart
+from a2a.types import Message, Part, Role
 from starlette_context import request_cycle_context
 
 import pr_agent.mosaico.executor as executor_mod
@@ -27,8 +27,8 @@ from pr_agent.mosaico.executor import PRAgentExecutor
 
 
 def _make_message(text: str) -> Message:
-    return Message(message_id=f"m-{text}", role=Role.user,
-                   parts=[Part(root=TextPart(text=text))])
+    return Message(message_id=f"m-{text}", role=Role.ROLE_USER,
+                   parts=[Part(text=text)])
 
 
 class _RecordingEventQueue:
@@ -43,8 +43,9 @@ class _FakeRequestContext:
     def __init__(self, text):
         self._text = text
         self.metadata = {}
-        self.current_task = None
         self.message = _make_message(text)
+        self.task_id = f"task-{text}"
+        self.context_id = f"ctx-{text}"
 
     def get_user_input(self, delimiter: str = "\n") -> str:
         return self._text
@@ -55,11 +56,17 @@ class _SpyTaskUpdater:
         self.completed_with = None
         self.failed_with = None
 
+    async def add_artifact(self, parts, **kwargs):
+        pass
+
     async def complete(self, message=None):
         self.completed_with = message
 
     async def failed(self, message=None):
         self.failed_with = message
+
+    def new_agent_message(self, parts, metadata=None):
+        return None
 
 
 # Per-request distinct values keyed by the inbound text (== request id).

--- a/tests/unittest/test_mosaico_smoke.py
+++ b/tests/unittest/test_mosaico_smoke.py
@@ -1,4 +1,4 @@
-"""Full-path smoke test.
+"""Full-path smoke test (A2A 1.0).
 
 Drives ONE message/send through the SDK via Starlette TestClient against build_app()
 (REAL RawContextMiddleware mounted), proving the full path:
@@ -13,9 +13,11 @@ This test passing is the end-to-end proof that the middleware->executor->dispatc
 provider->render chain works through the wire."""
 import uuid
 
+from google.protobuf.json_format import MessageToDict
 from starlette.testclient import TestClient
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
+from a2a.types import Message, Part, Role, SendMessageRequest
 from pr_agent.mosaico.server import build_app
 
 REVIEW_DIFF = """```diff
@@ -45,28 +47,35 @@ review:
 
 
 def _send_message_payload(text: str) -> dict:
+    """Build a valid A2A 1.0 message/send JSON-RPC body from SDK types."""
+    msg = Message(
+        message_id=str(uuid.uuid4()),
+        role=Role.ROLE_USER,
+        parts=[Part(text=text)],
+    )
+    req = SendMessageRequest(message=msg)
     return {
         "id": "1",
         "jsonrpc": "2.0",
-        "method": "message/send",
-        "params": {
-            "message": {
-                "kind": "message",
-                "messageId": str(uuid.uuid4()),
-                "role": "user",
-                "parts": [{"kind": "text", "text": text}],
-            }
-        },
+        "method": "SendMessage",
+        "params": MessageToDict(req),
     }
 
 
+# A2A 1.0 requires the version header so the handler does not fall back to 0.3.
+_A2A_HEADERS = {"A2A-Version": "1.0"}
+
+
 def _extract_text(result: dict) -> str:
-    """Pull all text parts out of a message/send JSON-RPC result (Task or Message)."""
+    """Pull all text parts out of a message/send JSON-RPC result.
+
+    In A2A 1.0 the result is wrapped: {"task": {...}} with artifacts.
+    Harvest all text values recursively from the result envelope."""
     chunks = []
 
     def harvest(obj):
         if isinstance(obj, dict):
-            if obj.get("kind") == "text" and isinstance(obj.get("text"), str):
+            if isinstance(obj.get("text"), str):
                 chunks.append(obj["text"])
             for v in obj.values():
                 harvest(v)
@@ -86,19 +95,24 @@ class TestSmokeFullPath:
         monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", fake_chat_completion)
 
         client = TestClient(build_app())
-        resp = client.post("/", json=_send_message_payload(f"review this\n{REVIEW_DIFF}"))
+        resp = client.post("/", json=_send_message_payload(f"review this\n{REVIEW_DIFF}"),
+                           headers=_A2A_HEADERS)
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert "error" not in body, body
         result = body["result"]
 
-        # Completed task (or a final message) with non-empty rendered content over the wire.
-        status = result.get("status", {})
-        if status:
-            assert status.get("state") in ("completed", "failed")
-            assert status.get("state") == "completed", f"task failed: {result}"
-        text = _extract_text(result)
-        assert text.strip(), f"no text content returned: {result}"
+        # A2A 1.0: result is {"task": {...}}
+        task = result.get("task", result)
+        status = task.get("status", {})
+        state = status.get("state", "")
+        assert state == "TASK_STATE_COMPLETED", f"task not completed: {task}"
+
+        # Review text should be in artifacts.
+        artifacts = task.get("artifacts", [])
+        assert artifacts, f"no artifacts in completed task: {task}"
+        text = _extract_text({"artifacts": artifacts})
+        assert text.strip(), f"no text content in artifacts: {task}"
         # Must NOT be the executor's exception placeholder.
         assert not text.startswith("Error:"), text
 
@@ -112,15 +126,20 @@ class TestSmokeFullPath:
 
         client = TestClient(build_app())
         empty = "```diff\nnot actually a diff\n```"
-        resp = client.post("/", json=_send_message_payload(f"review\n{empty}"))
+        resp = client.post("/", json=_send_message_payload(f"review\n{empty}"),
+                           headers=_A2A_HEADERS)
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert "error" not in body, body
         result = body["result"]
-        status = result.get("status", {})
-        if status:
-            assert status.get("state") == "completed", f"task failed: {result}"
+
+        # A2A 1.0: result is {"task": {...}}
+        task = result.get("task", result)
+        status = task.get("status", {})
+        state = status.get("state", "")
+        assert state == "TASK_STATE_COMPLETED", f"task not completed: {task}"
+
+        # The defensive empty-fallback text is in the artifact.
         text = _extract_text(result)
-        # The defensive empty-fallback string, and no exception escaped.
         assert "no output produced" in text, text
         assert not text.startswith("Error:"), text


### PR DESCRIPTION
Upgrade from A2A SDK 0.3.26 to 1.0.0+ with breaking wire protocol changes:
- Replace message/send method with SendMessage (1.0 RPC naming)
- Add A2A-Version: 1.0 header requirement across all requests
- Move url/protocol_version into supported_interfaces in agent card
- Publish review text as task artifacts before completion (RISK 2: reference agent reads task.artifacts)
- Require TaskArtifactUpdateEvent before TaskStatusUpdateEvent to prevent SDK InvalidAgentResponseError
- Route ok=False results to failed() instead of complete() (Fix C)
- Replace A2AStarletteApplication with plain Starlette + create_jsonrpc_routes
- Update all SDK type imports (Role.user → Role.ROLE_USER, Part construction)
- Add task_id/context_id to RequestContext (set by DefaultRequestHandler)
