### PR TITLE
feat(sambanova): add MiniMax-M3, keep M2.5

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -164,12 +164,12 @@ key = ... # your Groq api key
 
 ### SambaNova
 
-To use MiniMax-M2.7 model with SambaNova, for example, set:
+To use MiniMax-M3 model with SambaNova, for example, set:
 
 ```toml
 [config] # in configuration.toml
-model = "sambanova/MiniMax-M2.7"
-fallback_models = ["sambanova/MiniMax-M2.5"]
+model = "sambanova/MiniMax-M3"
+fallback_models = ["sambanova/MiniMax-M2.7"]
 [sambanova] # in .secrets.toml
 key = ... # your SambaNova api key
 ```

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -244,6 +244,7 @@ MAX_TOKENS = {
     'groq/meta-llama/llama-4-scout-17b-16e-instruct': 131072,
     'groq/llama-3.3-70b-versatile': 128000,
     'groq/llama-3.1-8b-instant': 128000,
+    'sambanova/MiniMax-M3': 192000,
     'sambanova/MiniMax-M2.7': 192000,
     'sambanova/MiniMax-M2.5': 160000,
     'sambanova/Meta-Llama-3.3-70B-Instruct': 128000,

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -315,7 +315,7 @@ class TestApiKeyGuard:
 
             assert litellm.api_key == sambanova_key
             await handler.chat_completion(
-                model="sambanova/MiniMax-M2.7", system="sys", user="usr"
+                model="sambanova/MiniMax-M3", system="sys", user="usr"
             )
 
         assert mock_call.call_args[1].get("api_key") == sambanova_key


### PR DESCRIPTION
## Summary

Refresh the SambaNova MiniMax lineup so the listed defaults match what people are currently picking, while keeping `MiniMax-M2.5` available so existing configs that reference it keep working.

This is a re-do of #2418 that addresses my review comment there ([please bring back this model](https://github.com/The-PR-Agent/pr-agent/pull/2418#discussion_r-removed-m25)): instead of dropping `sambanova/MiniMax-M2.5`, this PR keeps it.

- Add `sambanova/MiniMax-M3` to `MAX_TOKENS` with a 192k context (same conservative cap already used for M2.7), placed right above the M2.7 entry so it's the first SambaNova MiniMax option in the list.
- **Keep** `sambanova/MiniMax-M2.5` in `MAX_TOKENS`. Removing it would make `get_max_tokens()` raise for any deployment still configured with that model id — the default `custom_model_max_tokens` is non-positive, so there is no fallback path and existing configs would fail fast at runtime.
- Keep `sambanova/MiniMax-M2.7` as a fallback option.
- Update the SambaNova snippet in `docs/docs/usage-guide/changing_a_model.md` to recommend M3 as the primary model and M2.7 as the fallback in the `fallback_models` example.
- Update the SambaNova key-forwarding test in `test_litellm_api_key_guard.py` to use `sambanova/MiniMax-M3` so the test exercises the model id we now recommend. The test still verifies the same key-forwarding behavior.

## Notes

- No API URL or provider plumbing changes — only the model id list, the docs example, and the test fixture string.
- 192k for M3 mirrors the value already in place for M2.7. SambaNova's M3 deployment may eventually expose a larger window, but matching M2.7 keeps this PR conservative; a follow-up can bump it once the deployed limit is confirmed.

## Test plan

- [x] `pr_agent/algo/__init__.py` parses cleanly; `MAX_TOKENS` contains `sambanova/MiniMax-M3`, `sambanova/MiniMax-M2.7`, and `sambanova/MiniMax-M2.5`.
- [x] M3 entry appears before M2.7 in the dict so it is the first SambaNova MiniMax model listed.
- [ ] `pytest tests/unittest/test_litellm_api_key_guard.py::TestApiKeyGuard::test_sambanova_key_forwarded_for_non_ollama_model` (CI to run; the test only swapped a model id string).