### PR TITLE
chore: let Qodo auto-approve PRs after self-review

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,3 +1,8 @@
+# NOTE: This file is consumed by Qodo's "free for open source" agent
+# (the `qodo-free-for-open-source-projects` bot) — a separate, hosted, closed-source
+# service. It is NOT read by the open-source pr-agent in this repository; some keys
+# below (e.g. the [review_agent] section) only exist in that hosted agent.
+
 [pr_reviewer]
 enable_review_labels_effort = true
 enable_auto_approval = true
@@ -18,3 +23,5 @@ push_commands = [
 [review_agent]
 enabled = true
 publish_output = true
+demand_self_review = true
+approve_pr_on_self_review = true


### PR DESCRIPTION
## What

Enable Qodo's review agent to **approve a PR once the author completes the self-review checkbox**, mirroring the setup used in the [`typeorm/typeorm`](https://github.com/typeorm/typeorm/blob/master/.pr_agent.toml) repository.

Changes to `.pr_agent.toml`:

- `[review_agent] demand_self_review = true` — adds a self-review checkbox the author must tick
- `[review_agent] approve_pr_on_self_review = true` — Qodo submits an approval once that box is checked

## Note on this file

Added a header comment clarifying that `.pr_agent.toml` in this repo is consumed by Qodo's hosted **"free for open source"** agent (the `qodo-free-for-open-source-projects` bot) — a separate, closed-source service. It is **not** read by the open-source `pr-agent` in this repository; keys like the `[review_agent]` section only exist in that hosted agent.