### PR TITLE
docs(readme): add Qodo as Gold tier sponsor; declutter top

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,7 @@ The Original Open-Source PR Reviewer
  This repository contains the open-source PR Agent Project. 
  It is not the Qodo free tier.
  
-Try the free version on our website.
-
-👉[Get Started Now](https://www.qodo.ai/get-started/)
-
 PR-Agent is an open-source, AI-powered code review agent and a community-maintained legacy project of Qodo. It is distinct from Qodo’s primary AI code review offering, which provides a feature-rich, context-aware experience. Qodo now offers a free tier that integrates seamlessly with GitHub, GitLab, Bitbucket, and Azure DevOps for high-quality automated reviews.
-
-
-## Big News for PR-Agent
-
-PR-Agent has a new home!
-
-After years of building this tool alongside the community, Qodo has donated PR-Agent to the open-source community - and we couldn't be more excited about what comes next.
-
-The project now lives in the PR-Agent org on GitHub, is fully community-owned, and is open for contributions and additional maintainers.
-
-What else changed: 
-- Docs moved to - www.pr-agent.ai
-- Qodo Merge (Qodo 1.0), the hosted URL, which was the enterprise version of PR-Agent, has been rebranded and evolved into Qodo (Qodo 2.0), a full AI code review platform.
 
 
 ## Table of Contents
@@ -53,6 +36,7 @@ What else changed:
 - [How It Works](#how-it-works)
 - [Data Privacy](#data-privacy)
 - [Contributing](#contributing)
+- [Sponsors](#sponsors)
 
 ## Getting Started
 
@@ -237,6 +221,30 @@ https://openai.com/enterprise-privacy
 
 To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/b09eec265ef7d36c232063f76553efb6b53979ff/CONTRIBUTING.md).
 
+
+## Sponsors
+
+PR-Agent is proudly supported by its sponsors.
+
+### 🥇 Gold
+
+<a href="https://www.qodo.ai" target="_blank">
+  <img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="200" alt="Qodo">
+</a>
+
+[Qodo — qodo.ai](https://www.qodo.ai/) · 👉 [Try the free version](https://www.qodo.ai/get-started/)
+
+## Big News for PR-Agent
+
+PR-Agent has a new home!
+
+After years of building this tool alongside the community, Qodo has donated PR-Agent to the open-source community - and we couldn't be more excited about what comes next.
+
+The project now lives in the PR-Agent org on GitHub, is fully community-owned, and is open for contributions and additional maintainers.
+
+What else changed: 
+- Docs moved to - www.pr-agent.ai
+- Qodo Merge (Qodo 1.0), the hosted URL, which was the enterprise version of PR-Agent, has been rebranded and evolved into Qodo (Qodo 2.0), a full AI code review platform.
 
 ## ❤️ Community
 


### PR DESCRIPTION
## What

- Adds a **Sponsors** section to the README with **Qodo as the Gold tier** sponsor (logo + links).
- Moves the Qodo website link out of the top intro and places it next to the sponsor entry.
- Relocates the **"Big News for PR-Agent"** block out of the prime top-of-README space down to sit alongside the Community section, where it reads naturally with the donation/community narrative.
- Adds **Sponsors** to the Table of Contents.

## Why

The top of the README was carrying the "Big News" announcement as noise above the fold. This declutters the intro, gives Qodo proper Gold-tier sponsor recognition, and keeps the Qodo website CTA grouped with that recognition.

## Notes

- Used Qodo's own logo (`qodo-logo.svg`) for the sponsor entry rather than the PR-Agent logo placeholder, since it represents Qodo as a sponsor.