### PR TITLE
docs(readme): move Sponsors section to the top 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ The Original Open-Source PR Reviewer
 PR-Agent is an open-source, AI-powered code review agent and a community-maintained legacy project of Qodo. It is distinct from Qodo’s primary AI code review offering, which provides a feature-rich, context-aware experience. Qodo now offers a free tier that integrates seamlessly with GitHub, GitLab, Bitbucket, and Azure DevOps for high-quality automated reviews.
 
 
+## Sponsors
+
+PR-Agent is a community-maintained open-source project, with its ongoing development supported by our sponsors. If you'd like to support the project, consider [becoming a sponsor](https://github.com/sponsors/naorpeled).
+
+<p align="center">
+  <h3 align="center">🥇 Gold Sponsor</h3>
+</p>
+
+<p align="center">
+  <a target="_blank" href="https://www.qodo.ai/">
+    <img alt="Qodo — Gold sponsor" src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="300">
+  </a>
+</p>
+
+<p align="center">
+  <a target="_blank" href="https://www.qodo.ai/get-started/">Try the free version of Qodo</a>
+</p>
+
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)
@@ -36,7 +55,6 @@ PR-Agent is an open-source, AI-powered code review agent and a community-maintai
 - [How It Works](#how-it-works)
 - [Data Privacy](#data-privacy)
 - [Contributing](#contributing)
-- [Sponsors](#sponsors)
 
 ## Getting Started
 
@@ -221,18 +239,6 @@ https://openai.com/enterprise-privacy
 
 To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/b09eec265ef7d36c232063f76553efb6b53979ff/CONTRIBUTING.md).
 
-
-## Sponsors
-
-PR-Agent is proudly supported by its sponsors.
-
-### 🥇 Gold
-
-<a href="https://www.qodo.ai" target="_blank">
-  <img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="200" alt="Qodo">
-</a>
-
-[Qodo — qodo.ai](https://www.qodo.ai/) · 👉 [Try the free version](https://www.qodo.ai/get-started/)
 
 ## Big News for PR-Agent
 


### PR DESCRIPTION
## What

Moves the **Sponsors** section from near the bottom of the README up to just below the intro paragraph (above the Table of Contents), so the Gold sponsor is prominent near the top.
- Sponsors is now the first `##` section, with a centered "🥇 Gold Sponsor" presentation (Qodo logo + links).
- Dropped the now-redundant `Sponsors` entry from the Table of Contents (the section sits above the TOC).