### PR TITLE
fix user bot permission in Docs

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -47,7 +47,7 @@ Note that if your base branches are not protected, don't set the variables as `p
 
 ## Run a GitLab webhook server
 
-1. In GitLab create a new user and give it "Reporter" role for the intended group or project.
+1. In GitLab create a new user and give it "Developer" role for the intended group or project. (Note: "Reporter" role is sufficient for adding comments for `/improve` or `/review` for example, but "Developer" role is required to update the Merge Request description when using the `/describe` command).
 
 2. For the user from step 1, generate a `personal_access_token` with `api` access.
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -9,7 +9,7 @@ In terms of precedence, wiki configurations will override local configurations, 
 
 
 For a list of all possible configurations, see the [configuration options](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) page.
-In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L66) section in the configuration file.
+In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L76) section in the configuration file.
 
 !!! tip "Tip1: Edit only what you need"
     Your configuration file should be minimal, and edit only the relevant values. Don't copy the entire configuration options, since it can lead to legacy problems when something changes.


### PR DESCRIPTION
based on the issue https://github.com/The-PR-Agent/pr-agent/issues/2468 the gitlab required permission for user while using the `/describe` must be developer at least. I fix it in this MR.