### PR TITLE
docs: update the configuration example of the Deepseek model

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -327,12 +327,12 @@ See [litellm](https://docs.litellm.ai/docs/providers/bedrock#usage) documentatio
 
 ### DeepSeek
 
-To use deepseek-chat model with DeepSeek, for example, set:
+To use deepseek-v4 model with DeepSeek, for example, set:
 
 ```toml
 [config] # in configuration.toml
-model = "deepseek/deepseek-chat"
-fallback_models=["deepseek/deepseek-chat"]
+model = "deepseek/deepseek-v4-pro"
+fallback_models=["deepseek/deepseek-v4-flash"]
 ```
 
 and fill up your key
@@ -342,7 +342,7 @@ and fill up your key
 key = ...
 ```
 
-(you can obtain a deepseek-chat key from [here](https://platform.deepseek.com))
+(you can obtain a deepseek-v4 key from [here](https://platform.deepseek.com/api_keys))
 
 ### DeepInfra
 


### PR DESCRIPTION
The two model names `deepseek-chat` and `deepseek-reasoner` will be deprecated at 2026/07/24 23:59 Beijing time, and should be updated to the new model names: `deepseek-v4-flash` and `deepseek-v4-pro`. In addition, this PR also updates the link to obtain the API key.

https://api-docs.deepseek.com/

<img width="2306" height="1439" alt="image" src="https://github.com/user-attachments/assets/04ff66f9-4422-4d17-b1bc-16314aec7c58" />
