### PR TITLE
fix: don't overwrite PR title in /describe when generate_ai_title is false

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -396,7 +396,8 @@ class AzureDevopsProvider(GitProvider):
                 get_logger().warning("PR description was truncated due to length limit")
         try:
             updated_pr = GitPullRequest()
-            updated_pr.title = pr_title
+            if pr_title is not None:
+                updated_pr.title = pr_title
             updated_pr.description = pr_body
             self.azure_devops_client.update_pull_request(
                 project=self.workspace_slug,

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -601,11 +601,10 @@ class BitbucketProvider(GitProvider):
 
     # bitbucket does not support labels
     def publish_description(self, pr_title: str, description: str):
-        payload = json.dumps({
-            "description": description,
-            "title": pr_title
-
-        })
+        payload_dict = {"description": description}
+        if pr_title is not None:
+            payload_dict["title"] = pr_title
+        payload = json.dumps(payload_dict)
 
         response = requests.request("PUT", self.bitbucket_pull_request_api_url, headers=self.headers, data=payload)
         try:

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -513,14 +513,19 @@ class BitbucketServerProvider(GitProvider):
 
     # bitbucket does not support labels
     def publish_description(self, pr_title: str, description: str):
+        pr = self.pr
+        if pr_title is None:
+            # The update replaces the PR, so an omitted title would be wiped.
+            # Re-fetch the latest PR so a title edited during the describe run is
+            # preserved instead of reverted to a stale cached value. This also
+            # refreshes version/reviewers, which the replace-style update needs.
+            pr = self._get_pr()
+            self.pr = pr
         payload = {
-            "version": self.pr.version,
+            "version": pr.version,
             "description": description,
-            # The update replaces the PR, so omitted fields get wiped. When
-            # pr_title is None (title not AI-generated) keep the existing title
-            # rather than blanking it.
-            "title": pr_title if pr_title is not None else self.pr.title,
-            "reviewers": self.pr.reviewers  # needs to be sent otherwise gets wiped
+            "title": pr_title if pr_title is not None else pr.title,
+            "reviewers": pr.reviewers  # needs to be sent otherwise gets wiped
         }
         try:
             self.bitbucket_client.update_pull_request(self.workspace_slug, self.repo_slug, str(self.pr_num), payload)

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -516,7 +516,10 @@ class BitbucketServerProvider(GitProvider):
         payload = {
             "version": self.pr.version,
             "description": description,
-            "title": pr_title,
+            # The update replaces the PR, so omitted fields get wiped. When
+            # pr_title is None (title not AI-generated) keep the existing title
+            # rather than blanking it.
+            "title": pr_title if pr_title is not None else self.pr.title,
             "reviewers": self.pr.reviewers  # needs to be sent otherwise gets wiped
         }
         try:

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -515,10 +515,8 @@ class BitbucketServerProvider(GitProvider):
     def publish_description(self, pr_title: str, description: str):
         pr = self.pr
         if pr_title is None:
-            # The update replaces the PR, so an omitted title would be wiped.
-            # Re-fetch the latest PR so a title edited during the describe run is
-            # preserved instead of reverted to a stale cached value. This also
-            # refreshes version/reviewers, which the replace-style update needs.
+            # Replace-style update: an omitted/stale title would be lost, so
+            # re-fetch to preserve a title edited during the describe run.
             pr = self._get_pr()
             self.pr = pr
         payload = {

--- a/pr_agent/git_providers/codecommit_client.py
+++ b/pr_agent/git_providers/codecommit_client.py
@@ -200,7 +200,6 @@ class CodeCommitClient:
             self._connect_boto_client()
 
         try:
-            # pr_title is None when the title was not AI-generated: leave it unchanged.
             if pr_title is not None:
                 self.boto_client.update_pull_request_title(pullRequestId=str(pr_number), title=pr_title)
             self.boto_client.update_pull_request_description(pullRequestId=str(pr_number), description=pr_body)

--- a/pr_agent/git_providers/codecommit_client.py
+++ b/pr_agent/git_providers/codecommit_client.py
@@ -200,7 +200,9 @@ class CodeCommitClient:
             self._connect_boto_client()
 
         try:
-            self.boto_client.update_pull_request_title(pullRequestId=str(pr_number), title=pr_title)
+            # pr_title is None when the title was not AI-generated: leave it unchanged.
+            if pr_title is not None:
+                self.boto_client.update_pull_request_title(pullRequestId=str(pr_number), title=pr_title)
             self.boto_client.update_pull_request_description(pullRequestId=str(pr_number), description=pr_body)
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == 'PullRequestDoesNotExistException':

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -368,7 +368,8 @@ class GerritProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str):
         msg = adopt_to_gerrit_message(pr_body)
-        add_comment(self.parsed_url, self.refspec, pr_title + '\n' + msg)
+        text = msg if pr_title is None else pr_title + '\n' + msg
+        add_comment(self.parsed_url, self.refspec, text)
 
     def publish_inline_comments(self, comments: list[dict]):
         raise NotImplementedError(

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -167,6 +167,9 @@ class GitProvider(ABC):
 
     @abstractmethod
     def publish_description(self, pr_title: str, pr_body: str):
+        # pr_title may be None, which means "leave the existing title unchanged"
+        # and update only the description. Implementations must not write the
+        # title in that case.
         pass
 
     @abstractmethod

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -640,13 +640,16 @@ class GiteaProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str) -> None:
         """Publish PR description"""
-        response = self.repo_api.edit_pull_request(
+        edit_kwargs = dict(
             owner=self.owner,
             repo=self.repo,
             pr_number=self.pr_number if self.enabled_pr else self.issue_number,
-            title=pr_title,
-            body=pr_body
+            body=pr_body,
         )
+        # Leave the existing title unchanged when it was not AI-generated.
+        if pr_title is not None:
+            edit_kwargs["title"] = pr_title
+        response = self.repo_api.edit_pull_request(**edit_kwargs)
 
         if not response:
             self.logger.error("Failed to publish PR description")

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -646,7 +646,6 @@ class GiteaProvider(GitProvider):
             pr_number=self.pr_number if self.enabled_pr else self.issue_number,
             body=pr_body,
         )
-        # Leave the existing title unchanged when it was not AI-generated.
         if pr_title is not None:
             edit_kwargs["title"] = pr_title
         response = self.repo_api.edit_pull_request(**edit_kwargs)

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -358,7 +358,11 @@ class GithubProvider(GitProvider):
             raise RateLimitExceeded("Rate limit exceeded for GitHub API.") from e
 
     def publish_description(self, pr_title: str, pr_body: str):
-        self.pr.edit(title=pr_title, body=pr_body)
+        if pr_title is None:
+            # Leave the existing title unchanged; update only the body.
+            self.pr.edit(body=pr_body)
+        else:
+            self.pr.edit(title=pr_title, body=pr_body)
 
     def get_latest_commit_url(self) -> str:
         return self.last_commit_id.html_url

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -359,7 +359,6 @@ class GithubProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str):
         if pr_title is None:
-            # Leave the existing title unchanged; update only the body.
             self.pr.edit(body=pr_body)
         else:
             self.pr.edit(title=pr_title, body=pr_body)

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -485,7 +485,8 @@ class GitLabProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str):
         try:
-            self.mr.title = pr_title
+            if pr_title is not None:
+                self.mr.title = pr_title
             self.mr.description = pr_body
             self.mr.save()
         except Exception as e:

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -111,9 +111,10 @@ class LocalGitProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str):
         with open(self.description_path, "w") as file:
-            # Write the string to the file
-            content = pr_body if pr_title is None else pr_title + '\n' + pr_body
-            file.write(content)
+            # When pr_title is None (title not AI-generated) keep the existing
+            # title rather than dropping the title line from the output.
+            title = self.get_pr_title() if pr_title is None else pr_title
+            file.write(title + '\n' + pr_body)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         with open(self.review_path, "w") as file:

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -111,8 +111,6 @@ class LocalGitProvider(GitProvider):
 
     def publish_description(self, pr_title: str, pr_body: str):
         with open(self.description_path, "w") as file:
-            # When pr_title is None (title not AI-generated) keep the existing
-            # title rather than dropping the title line from the output.
             title = self.get_pr_title() if pr_title is None else pr_title
             file.write(title + '\n' + pr_body)
 

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -112,7 +112,8 @@ class LocalGitProvider(GitProvider):
     def publish_description(self, pr_title: str, pr_body: str):
         with open(self.description_path, "w") as file:
             # Write the string to the file
-            file.write(pr_title + '\n' + pr_body)
+            content = pr_body if pr_title is None else pr_title + '\n' + pr_body
+            file.write(content)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         with open(self.review_path, "w") as file:

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -180,11 +180,8 @@ class PRDescription:
                     else:
                         self.git_provider.publish_comment(full_markdown_description)
                 else:
-                    # When the title was not AI-generated, pass None so the
-                    # provider leaves the existing title untouched. Re-writing the
-                    # original title on every run is normally a no-op, but it races
-                    # with a manual title edit made while describe is running and
-                    # reverts it. See issue #2474.
+                    # Pass None when the title is not AI-generated so the provider
+                    # leaves it untouched, avoiding reverting a manual edit (#2474).
                     title_to_publish = pr_title.strip() if get_settings().pr_description.generate_ai_title else None
                     self.git_provider.publish_description(title_to_publish, pr_body)
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -180,7 +180,13 @@ class PRDescription:
                     else:
                         self.git_provider.publish_comment(full_markdown_description)
                 else:
-                    self.git_provider.publish_description(pr_title.strip(), pr_body)
+                    # When the title was not AI-generated, pass None so the
+                    # provider leaves the existing title untouched. Re-writing the
+                    # original title on every run is normally a no-op, but it races
+                    # with a manual title edit made while describe is running and
+                    # reverts it. See issue #2474.
+                    title_to_publish = pr_title.strip() if get_settings().pr_description.generate_ai_title else None
+                    self.git_provider.publish_description(title_to_publish, pr_body)
 
                     # publish final update message
                     if (get_settings().pr_description.final_update_message and not get_settings().config.get('is_auto_command', False)):

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -232,3 +232,26 @@ class TestGitLabProvider:
         assert gitlab_provider.get_line_link("src/app.py", 10, 12) == (
             "https://gitlab.com/group/repo/-/blob/feature/cache/src/app.py?ref_type=heads#L10-12"
         )
+
+    def test_publish_description_with_none_title_leaves_title_unchanged(self, gitlab_provider):
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.title = "Original title"
+        gitlab_provider.id_mr = 1
+
+        gitlab_provider.publish_description(None, "Updated description")
+
+        # Title must not be overwritten when pr_title is None; only the body updates.
+        assert gitlab_provider.mr.title == "Original title"
+        assert gitlab_provider.mr.description == "Updated description"
+        gitlab_provider.mr.save.assert_called_once()
+
+    def test_publish_description_with_title_updates_both(self, gitlab_provider):
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.title = "Original title"
+        gitlab_provider.id_mr = 1
+
+        gitlab_provider.publish_description("AI title", "Updated description")
+
+        assert gitlab_provider.mr.title == "AI title"
+        assert gitlab_provider.mr.description == "Updated description"
+        gitlab_provider.mr.save.assert_called_once()


### PR DESCRIPTION
## What

`/describe` re-saved the PR/MR title on every run even when `generate_ai_title` is false (the default). The title is read at the start of the describe run and written back unconditionally, so a title edited by hand while describe is running gets reverted on publish. This affects every provider, since each one sets the title alongside the description in `publish_description`.

## Fix

When `generate_ai_title` is false, the describe flow now passes `pr_title=None`, and each provider treats `None` as "leave the existing title unchanged", updating only the description. When `generate_ai_title` is true, behaviour is unchanged. Bitbucket Server is special-cased: its update replaces the PR, so it preserves the existing title instead of blanking it.

## Tests

Added GitLab provider unit tests covering both the title-preserved (`None`) and title-updated paths.

Closes #2474
