### PR TITLE
fix(tickets): prevent /review and /describe crash on linked issues with sub-issues

### DIFF
--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -99,7 +99,7 @@ Related Ticket Info:
 {% for ticket in related_tickets %}
 =====
 Ticket Title: '{{ ticket.title }}'
-{%- if ticket.labels %}
+{%- if ticket.labels is defined and ticket.labels %}
 Ticket Labels: {{ ticket.labels }}
 {%- endif %}
 {%- if ticket.body %}

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -217,7 +217,7 @@ Ticket URL: '{{ ticket.ticket_url }}'
 
 Ticket Title: '{{ ticket.title }}'
 
-{%- if ticket.labels %}
+{%- if ticket.labels is defined and ticket.labels %}
 
 Ticket Labels: {{ ticket.labels }}
 

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -171,7 +171,8 @@ async def extract_tickets(git_provider):
                                 sub_issues_content.append({
                                     'ticket_url': sub_issue_url,
                                     'title': sub_issue.title,
-                                    'body': sub_body
+                                    'body': sub_body,
+                                    'labels': ""  # keep key present so StrictUndefined template render doesn't crash
                                 })
                             except Exception as e:
                                 get_logger().warning(f"Failed to fetch sub-issue content for {sub_issue_url}: {e}")

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -168,7 +168,7 @@ async def extract_tickets(git_provider):
                                 if len(sub_body) > MAX_TICKET_CHARACTERS:
                                     sub_body = sub_body[:MAX_TICKET_CHARACTERS] + "..."
 
-                                # Extract sub-issue labels (sub-issues are regular issues and can have labels)
+                                # Extract sub-issue labels
                                 sub_labels = []
                                 try:
                                     for label in sub_issue.labels:
@@ -181,7 +181,7 @@ async def extract_tickets(git_provider):
                                     'ticket_url': sub_issue_url,
                                     'title': sub_issue.title,
                                     'body': sub_body,
-                                    'labels': ", ".join(sub_labels)  # keep key present so StrictUndefined render doesn't crash
+                                    'labels': ", ".join(sub_labels)
                                 })
                             except Exception as e:
                                 get_logger().warning(f"Failed to fetch sub-issue content for {sub_issue_url}: {e}")

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -168,11 +168,20 @@ async def extract_tickets(git_provider):
                                 if len(sub_body) > MAX_TICKET_CHARACTERS:
                                     sub_body = sub_body[:MAX_TICKET_CHARACTERS] + "..."
 
+                                # Extract sub-issue labels (sub-issues are regular issues and can have labels)
+                                sub_labels = []
+                                try:
+                                    for label in sub_issue.labels:
+                                        sub_labels.append(label.name if hasattr(label, 'name') else label)
+                                except Exception as e:
+                                    get_logger().error(f"Error extracting labels error= {e}",
+                                                       artifact={"traceback": traceback.format_exc()})
+
                                 sub_issues_content.append({
                                     'ticket_url': sub_issue_url,
                                     'title': sub_issue.title,
                                     'body': sub_body,
-                                    'labels': ""  # keep key present so StrictUndefined template render doesn't crash
+                                    'labels': ", ".join(sub_labels)  # keep key present so StrictUndefined render doesn't crash
                                 })
                             except Exception as e:
                                 get_logger().warning(f"Failed to fetch sub-issue content for {sub_issue_url}: {e}")


### PR DESCRIPTION
## Problem

When `require_ticket_analysis_review` is enabled (the default) and a PR references an issue that has **sub-issues**, both `/review` and `/describe` crash *before any model call* with:

```
UndefinedError: 'dynaconf.utils.boxing.DynaBox object' has no attribute 'labels'
```

This leaves a stuck "Preparing review…" placeholder that never resolves. `/improve` is unaffected because it doesn't call ticket extraction.

## Root cause

In `extract_tickets()`, **main-issue** entries include a `labels` key but **sub-issue** entries (`sub_issues_content`) do not. `extract_and_cache_pr_tickets()` appends both into the same `related_tickets` list.

The reviewer/description prompts — and the token-counting pre-pass in `token_handler.py` — render this list under `Environment(undefined=StrictUndefined)`. Under `StrictUndefined`, `{% if ticket.labels %}` on a label-less sub-issue raises `UndefinedError` instead of evaluating falsy, aborting the entire prompt render before the LLM request.

## Fix

Two layers of defense:

1. **`ticket_pr_compliance_check.py`** — add `'labels': ""` to sub-issue entries so the key is always present.
2. **`pr_reviewer_prompts.toml` / `pr_description_prompts.toml`** — guard with `{% if ticket.labels is defined and ticket.labels %}`, matching the existing `ticket.requirements` pattern, so the templates are robust against any future label-less entry.

## Verification

Reproduced with the issue's pinned deps (`dynaconf==3.2.4`, `Jinja2==3.1.6`): the old template fragment crashes with `UndefinedError` on a label-less entry, while the new defensive template renders all entry shapes (with labels / missing key / empty string) cleanly.

Fixes #2471