### PR TITLE
feat(deepseek): register deepseek-v4-pro and deepseek-v4-flash models

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -68,6 +68,8 @@ MAX_TOKENS = {
     'command-nightly': 4096,
     'deepseek/deepseek-chat': 128000,  # 128K, but may be limited by config.max_model_tokens
     'deepseek/deepseek-reasoner': 64000,  # 64K, but may be limited by config.max_model_tokens
+    'deepseek/deepseek-v4-pro': 1000000,  # 1M, but may be limited by config.max_model_tokens
+    'deepseek/deepseek-v4-flash': 1000000,  # 1M, but may be limited by config.max_model_tokens
     'openai/qwq-plus': 131072,  # 131K context length, but may be limited by config.max_model_tokens
     'replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1': 4096,
     'meta-llama/Llama-2-7b-chat-hf': 4096,


### PR DESCRIPTION
## What

Adds the new DeepSeek V4 model names to the `MAX_TOKENS` registry in `pr_agent/algo/__init__.py`:

```python
'deepseek/deepseek-v4-pro': 1000000,    # 1M context
'deepseek/deepseek-v4-flash': 1000000,  # 1M context
```

## Why

DeepSeek is deprecating the `deepseek-chat` and `deepseek-reasoner` model names on **2026-07-24**, replacing them with `deepseek-v4-pro` and `deepseek-v4-flash` ([API docs](https://api-docs.deepseek.com/)). Both V4 models ship with a 1M-token context window.

Without these entries, `get_max_tokens()` raises an exception for the new model names unless the user manually sets `config.custom_model_max_tokens`. This complements the docs update in #2472, which points users at the `deepseek-v4-*` names — that example would otherwise fail out of the box.

The existing `deepseek-chat` / `deepseek-reasoner` entries are left in place for backward compatibility until the deprecation date.

## Notes

The V4 models are unified chat/reasoning models (standard ChatCompletions, support temperature), so unlike `deepseek-reasoner` they are intentionally **not** added to `USER_MESSAGE_ONLY_MODELS` or `NO_SUPPORT_TEMPERATURE_MODELS`.