### PR TITLE
fix(describe): guard pr_description config reads against missing keys (#2238)

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -259,7 +259,7 @@ def pr_generate_compressed_diff(top_langs: list, token_handler: TokenHandler, mo
 
     # additional iterations (if needed)
     if large_pr_handling:
-        NUMBER_OF_ALLOWED_ITERATIONS = get_settings().pr_description.max_ai_calls - 1 # one more call is to summarize
+        NUMBER_OF_ALLOWED_ITERATIONS = get_settings().pr_description.get("max_ai_calls", 4) - 1 # one more call is to summarize
         for i in range(NUMBER_OF_ALLOWED_ITERATIONS-1):
             if remaining_files_list:
                 total_tokens, patches, remaining_files_list, files_in_patch_list = generate_full_patch(convert_hunks_to_line_numbers,

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -208,7 +208,7 @@ class PRDescription:
             get_logger().info("Markers were enabled, but user description does not contain markers. Skipping AI prediction")
             return None
 
-        large_pr_handling = get_settings().pr_description.enable_large_pr_handling and "pr_description_only_files_prompts" in get_settings()
+        large_pr_handling = get_settings().pr_description.get("enable_large_pr_handling", True) and "pr_description_only_files_prompts" in get_settings()
         output = get_pr_diff(self.git_provider, self.token_handler, model, large_pr_handling=large_pr_handling, return_remaining_files=True)
         if isinstance(output, tuple):
             patches_diff, remaining_files_list = output
@@ -244,7 +244,7 @@ class PRDescription:
                 self.git_provider, token_handler_only_files_prompt, model)
 
             # get the files prediction for each patch
-            if not get_settings().pr_description.async_ai_calls:
+            if not get_settings().pr_description.get("async_ai_calls", True):
                 results = []
                 for i, patches in enumerate(patches_compressed_list):  # sync calls
                     patches_diff = "\n".join(patches)

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -131,3 +131,23 @@ def test_get_pr_multi_diffs_clips_large_patch_when_policy_is_clip(monkeypatch):
         settings.config.patch_extra_lines_after = original["patch_extra_lines_after"]
         settings.config.large_patch_policy = original["large_patch_policy"]
         settings.config.verbosity_level = original["verbosity_level"]
+
+
+def test_pr_description_reads_fall_back_when_keys_missing():
+    # Regression for "'DynaBox' object has no attribute 'enable_large_pr_handling'":
+    # custom_merge_loader replaces a section instead of merging it, so a custom
+    # .pr_agent.toml that defines [pr_description] without the large-PR keys drops
+    # their defaults. /describe must still work via .get(..., default) instead of crashing.
+    from dynaconf.utils.boxing import DynaBox
+
+    # A [pr_description] section overridden without the large-PR keys
+    pr_description = DynaBox({"publish_labels": False})
+
+    # Bare attribute access is what used to raise and abort the run
+    with pytest.raises(AttributeError):
+        _ = pr_description.enable_large_pr_handling
+
+    # Guarded reads (matching the call sites) resolve to the documented defaults
+    assert pr_description.get("enable_large_pr_handling", True) is True
+    assert pr_description.get("async_ai_calls", True) is True
+    assert pr_description.get("max_ai_calls", 4) == 4


### PR DESCRIPTION
## What

Fixes the `'DynaBox' object has no attribute 'enable_large_pr_handling'` crash on `/describe`.

Closes #2238

## Why it still happens after #2234

#2234 restored `enable_large_pr_handling` / `max_ai_calls` / `async_ai_calls` as defaults in `configuration.toml`, but the reads were left as direct attribute access. The catch is `custom_merge_loader` **replaces** a whole section instead of merging fields (it documents this in its own docstring). So any user whose custom `.pr_agent.toml` has a `[pr_description]` section that omits these keys loses the defaults at runtime, and the unguarded read throws. `retry_with_fallback_models` swallows it as a failed prediction and keeps trying models until the run fails - which is exactly what a v0.34 user with an older config reported.

## The fix

Read the three keys via `.get(..., default)` at the call sites, so the documented defaults apply even when a custom config replaces the section:

- `pr_agent/tools/pr_description.py:211` - `enable_large_pr_handling` (default `True`)
- `pr_agent/tools/pr_description.py:247` - `async_ai_calls` (default `True`)
- `pr_agent/algo/pr_processing.py:262` - `max_ai_calls` (default `4`)

Defaults match `configuration.toml`.

## Test

Added `test_pr_description_reads_fall_back_when_keys_missing`, which reproduces the overridden section with a `DynaBox` missing the keys, asserts bare attribute access raises the original error, and verifies the guarded reads fall back to the defaults.
