### PR TITLE
fix(azure): decode percent-encoded spaces in Azure DevOps PR URLs (#2080)

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -563,8 +563,10 @@ class AzureDevopsProvider(GitProvider):
         if path_parts[num_parts - 2] != "pullrequest":
             raise ValueError("The provided URL does not follow the expected Azure DevOps PR URL format")
 
-        workspace_slug = path_parts[num_parts - 5]
-        repo_slug = path_parts[num_parts - 3]
+        # Decode percent-encoding (e.g. %20) so project/repo names with spaces
+        # match what the Azure DevOps REST client expects (e.g. "Dev Project")
+        workspace_slug = unquote(path_parts[num_parts - 5])
+        repo_slug = unquote(path_parts[num_parts - 3])
         try:
             pr_number = int(path_parts[num_parts - 1])
         except ValueError as e:

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from typing import Optional, Tuple
-from urllib.parse import unquote, urlparse
+from urllib.parse import quote, unquote, urlparse
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -641,7 +641,11 @@ class AzureDevopsProvider(GitProvider):
     def get_latest_commit_url(self) -> str:
         commits = self.azure_devops_client.get_pull_request_commits(self.repo_slug, self.pr_num, self.workspace_slug)
         last = commits[0]
-        url = self.azure_devops_client.normalized_url + "/" + self.workspace_slug + "/_git/" + self.repo_slug + "/commit/" + last.commit_id
+        # workspace/repo slugs are stored decoded (e.g. "Dev Project") for the REST API,
+        # so re-encode them when building a web URL to avoid raw spaces in markdown output
+        workspace = quote(self.workspace_slug, safe='')
+        repo = quote(self.repo_slug, safe='')
+        url = self.azure_devops_client.normalized_url + "/" + workspace + "/_git/" + repo + "/commit/" + last.commit_id
         return url
 
     def get_linked_work_items(self) -> list:

--- a/tests/unittest/test_azure_devops_comment.py
+++ b/tests/unittest/test_azure_devops_comment.py
@@ -58,4 +58,26 @@ class TestAzureDevopsProviderPublishComment(unittest.TestCase):
         # Import get_settings directly to read from configuration.toml
         status = get_settings().azure_devops.default_comment_status
         # The expected value should match what's in your configuration.toml
-        self.assertEqual(status, "closed")        
+        self.assertEqual(status, "closed")
+
+
+class TestAzureDevopsProviderCommitUrl(unittest.TestCase):
+    def test_get_latest_commit_url_reencodes_spaces(self):
+        # workspace/repo slugs are stored decoded for the REST API; the web URL must
+        # re-encode them so project/repo names with spaces don't emit raw spaces
+        with patch.object(AzureDevopsProvider, "_get_azure_devops_client", return_value=(MagicMock(), MagicMock())):
+            provider = AzureDevopsProvider()
+            provider.workspace_slug = "Dev Project"
+            provider.repo_slug = "repo name"
+            provider.pr_num = 1234
+
+            client = provider.azure_devops_client
+            client.normalized_url = "https://dev.azure.com/org"
+            commit = MagicMock()
+            commit.commit_id = "abc123"
+            client.get_pull_request_commits.return_value = [commit]
+
+            url = provider.get_latest_commit_url()
+
+            assert url == "https://dev.azure.com/org/Dev%20Project/_git/repo%20name/commit/abc123"
+            assert " " not in url

--- a/tests/unittest/test_azure_devops_parsing.py
+++ b/tests/unittest/test_azure_devops_parsing.py
@@ -20,3 +20,11 @@ class TestAzureDevOpsParsing:
         # workspace_slug, repo_slug, pr_number
         assert AzureDevopsProvider._parse_pr_url(pr_url) == ("project", "repo", 1)
 
+    def test_address_with_encoded_spaces(self):
+        # project/repo names with spaces arrive percent-encoded and must be decoded
+        # so they match what the Azure DevOps REST client expects
+        pr_url = "https://dev.azure.com/organization/Dev%20Project/_git/repo%20name/pullrequest/1234"
+
+        # workspace_slug, repo_slug, pr_number
+        assert AzureDevopsProvider._parse_pr_url(pr_url) == ("Dev Project", "repo name", 1234)
+


### PR DESCRIPTION
## What

Fixes a 404 when running pr-agent against an Azure DevOps PR whose project or repo name contains a space.

Closes #2080

## Why

`AzureDevopsProvider._parse_pr_url` split the URL path and returned the raw segments, so a URL like:

```
https://dev.azure.com/org/Dev%20Project/_git/repo_name/pullrequest/1234
```

yielded `workspace_slug="Dev%20Project"`. The Azure DevOps REST client expects the decoded value (`Dev Project`), so the call returned a 404.

The webhook handler already decodes its URLs (#740), but that fix lived in `azuredevops_server_webhook.py` and never reached the provider class used by the CLI - which is where @jamesweale hit it.

## The fix

`unquote()` the workspace and repo slugs in `_parse_pr_url` (matching the `unquote` already used webhook-side).

## Test

Added `test_address_with_encoded_spaces` to `test_azure_devops_parsing.py`: a `%20`-encoded project and repo now parse to `("Dev Project", "repo name", 1234)`. Existing parsing tests still pass.

## Not covered here

The reporter also hit `RuntimeError: asyncio.run() cannot be called from a running event loop` when calling `cli.run_command` from inside an existing event loop. That's expected (`run_command` wraps `asyncio.run`); the fix is to await the async entrypoint or run the CLI as a separate process, so it's out of scope for this PR.
