### PR TITLE
feat(ask): add extra_instructions support for /ask (#2473)

### DIFF
--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -60,3 +60,35 @@ To get a direct link to an image, we recommend using the following scheme:
 ![Ask image5](https://codium.ai/images/pr_agent/ask_images5.png){width=512}
 
 See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_video.mov)
+
+## Configuration options
+
+???+ example "General options"
+
+    <table>
+      <tr>
+        <td><b>extra_instructions</b></td>
+        <td>Optional extra instructions to the tool. For example: "Do not answer questions that ask to rate PR quality on a scale of 1 to 10. Instead, tell the user this type of question is not allowed."</td>
+      </tr>
+      <tr>
+        <td><b>enable_help_text</b></td>
+        <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
+      </tr>
+      <tr>
+        <td><b>use_conversation_history</b></td>
+        <td>If set to true, the tool will use the conversation history when answering questions on specific code lines (GitHub only). Default is true.</td>
+      </tr>
+    </table>
+
+Example usage in a configuration file:
+
+```toml
+[pr_questions]
+extra_instructions = "Do not answer questions that ask to rate PR quality on a scale of 1 to 10."
+```
+
+Example usage in a PR comment:
+
+```
+/ask "What does this change do?" --pr_questions.extra_instructions="Answer in one short paragraph."
+```

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -129,6 +129,7 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
+extra_instructions = ""
 
 
 [pr_code_suggestions] # /improve #

--- a/pr_agent/settings/pr_line_questions_prompts.toml
+++ b/pr_agent/settings/pr_line_questions_prompts.toml
@@ -12,6 +12,7 @@ Extra instructions from the user:
 ======
 {{ extra_instructions }}
 ======
+Follow the extra instructions above; they take precedence over any conflicting guidance in this prompt.
 {%- endif %}
 
 Additional guidelines:

--- a/pr_agent/settings/pr_line_questions_prompts.toml
+++ b/pr_agent/settings/pr_line_questions_prompts.toml
@@ -5,6 +5,15 @@ Your goal is to answer questions\\tasks about specific lines of code in the PR, 
 Be informative, constructive, and give examples. Try to be as specific as possible.
 Don't avoid answering the questions. You must answer the questions, as best as you can, without adding any unrelated content.
 
+{%- if extra_instructions %}
+
+
+Extra instructions from the user:
+======
+{{ extra_instructions }}
+======
+{%- endif %}
+
 Additional guidelines:
 - When quoting variables or names from the code, use backticks (`) instead of single quote (').
 - If relevant, use bullet points.

--- a/pr_agent/settings/pr_questions_prompts.toml
+++ b/pr_agent/settings/pr_questions_prompts.toml
@@ -12,6 +12,7 @@ Extra instructions from the user:
 ======
 {{ extra_instructions }}
 ======
+Follow the extra instructions above; they take precedence over any conflicting guidance in this prompt.
 {%- endif %}
 """
 

--- a/pr_agent/settings/pr_questions_prompts.toml
+++ b/pr_agent/settings/pr_questions_prompts.toml
@@ -4,6 +4,15 @@ system="""You are PR-Reviewer, a language model designed to answer questions abo
 Your goal is to answer questions\\tasks about the new code introduced in the PR (lines starting with '+' in the 'PR Git Diff' section), and provide feedback.
 Be informative, constructive, and give examples. Try to be as specific as possible.
 Don't avoid answering the questions. You must answer the questions, as best as you can, without adding any unrelated content.
+
+{%- if extra_instructions %}
+
+
+Extra instructions from the user:
+======
+{{ extra_instructions }}
+======
+{%- endif %}
 """
 
 user="""PR Info:

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -35,7 +35,8 @@ class PR_LineQuestions:
             "question": self.question_str,
             "full_hunk": "",
             "selected_lines": "",
-            "conversation_history": "",  
+            "conversation_history": "",
+            "extra_instructions": get_settings().pr_questions.extra_instructions,
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -35,6 +35,7 @@ class PRQuestions:
             "diff": "",  # empty diff for initial calculation
             "questions": self.question_str,
             "commit_messages_str": self.git_provider.get_commit_messages(),
+            "extra_instructions": get_settings().pr_questions.extra_instructions,
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -340,3 +340,51 @@ def test_line_question_settings_teardown_restores_sentinel_for_missing_keys():
         restore_settings(saved)
 
     assert settings.get(key, SENTINEL) is SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# extra_instructions prompt rendering
+# ---------------------------------------------------------------------------
+
+class TestExtraInstructionsPromptRendering:
+    @pytest.fixture
+    def extra_instructions_settings(self):
+        keys = ("pr_questions.extra_instructions",)
+        saved = snapshot_settings(keys)
+        try:
+            yield get_settings()
+        finally:
+            restore_settings(saved)
+
+    def test_ask_system_prompt_includes_extra_instructions_when_set(self, extra_instructions_settings):
+        from jinja2 import Environment, StrictUndefined
+
+        extra_instructions_settings.set(
+            "pr_questions.extra_instructions",
+            "Do not answer questions that ask to rate PR quality.",
+        )
+        environment = Environment(undefined=StrictUndefined)
+        variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
+        system_prompt = environment.from_string(get_settings().pr_questions_prompt.system).render(variables)
+        assert "Do not answer questions that ask to rate PR quality." in system_prompt
+
+    def test_ask_system_prompt_omits_extra_instructions_block_when_empty(self, extra_instructions_settings):
+        from jinja2 import Environment, StrictUndefined
+
+        extra_instructions_settings.set("pr_questions.extra_instructions", "")
+        environment = Environment(undefined=StrictUndefined)
+        variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
+        system_prompt = environment.from_string(get_settings().pr_questions_prompt.system).render(variables)
+        assert "Extra instructions from the user" not in system_prompt
+
+    def test_ask_line_system_prompt_includes_extra_instructions_when_set(self, extra_instructions_settings):
+        from jinja2 import Environment, StrictUndefined
+
+        extra_instructions_settings.set(
+            "pr_questions.extra_instructions",
+            "Do not answer questions that ask to rate PR quality.",
+        )
+        environment = Environment(undefined=StrictUndefined)
+        variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
+        system_prompt = environment.from_string(get_settings().pr_line_questions_prompt.system).render(variables)
+        assert "Do not answer questions that ask to rate PR quality." in system_prompt

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -18,6 +18,13 @@ from pr_agent.tools.pr_questions import PRQuestions
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
 
 
+def _render_jinja_template(template: str, variables: dict) -> str:
+    from jinja2 import Environment, StrictUndefined
+
+    environment = Environment(undefined=StrictUndefined, autoescape=True)
+    return environment.from_string(template).render(variables)
+
+
 def _make_pr_questions(question_str: str = "", prediction: str = "", git_provider=None) -> PRQuestions:
     obj = PRQuestions.__new__(PRQuestions)
     obj.question_str = question_str
@@ -357,34 +364,25 @@ class TestExtraInstructionsPromptRendering:
             restore_settings(saved)
 
     def test_ask_system_prompt_includes_extra_instructions_when_set(self, extra_instructions_settings):
-        from jinja2 import Environment, StrictUndefined
-
         extra_instructions_settings.set(
             "pr_questions.extra_instructions",
             "Do not answer questions that ask to rate PR quality.",
         )
-        environment = Environment(undefined=StrictUndefined)
         variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
-        system_prompt = environment.from_string(get_settings().pr_questions_prompt.system).render(variables)
+        system_prompt = _render_jinja_template(get_settings().pr_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt
 
     def test_ask_system_prompt_omits_extra_instructions_block_when_empty(self, extra_instructions_settings):
-        from jinja2 import Environment, StrictUndefined
-
         extra_instructions_settings.set("pr_questions.extra_instructions", "")
-        environment = Environment(undefined=StrictUndefined)
         variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
-        system_prompt = environment.from_string(get_settings().pr_questions_prompt.system).render(variables)
+        system_prompt = _render_jinja_template(get_settings().pr_questions_prompt.system, variables)
         assert "Extra instructions from the user" not in system_prompt
 
     def test_ask_line_system_prompt_includes_extra_instructions_when_set(self, extra_instructions_settings):
-        from jinja2 import Environment, StrictUndefined
-
         extra_instructions_settings.set(
             "pr_questions.extra_instructions",
             "Do not answer questions that ask to rate PR quality.",
         )
-        environment = Environment(undefined=StrictUndefined)
         variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
-        system_prompt = environment.from_string(get_settings().pr_line_questions_prompt.system).render(variables)
+        system_prompt = _render_jinja_template(get_settings().pr_line_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -371,6 +371,7 @@ class TestExtraInstructionsPromptRendering:
         variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
         system_prompt = _render_jinja_template(get_settings().pr_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt
+        assert "take precedence over any conflicting guidance" in system_prompt
 
     def test_ask_system_prompt_omits_extra_instructions_block_when_empty(self, extra_instructions_settings):
         extra_instructions_settings.set("pr_questions.extra_instructions", "")
@@ -386,3 +387,4 @@ class TestExtraInstructionsPromptRendering:
         variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
         system_prompt = _render_jinja_template(get_settings().pr_line_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt
+        assert "take precedence over any conflicting guidance" in system_prompt


### PR DESCRIPTION
/ask didn’t support extra_instructions like /review and /improve. This adds it for PR-wide and line-level ask.

Set it in .pr_agent.toml or per comment, eg. to refuse certain questions (like “rate this PR 1–10”) and tell the user why.

Fixes #2473