### PR TITLE
fix(gitlab): preserve user-added labels in publish_labels and get_pr_…

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -964,23 +964,69 @@ def set_custom_labels(variables, git_provider=None):
         counter += 1
     variables["labels_minimal_to_labels_dict"] = labels_minimal_to_labels_dict
 
+def _describe_managed_label_names():
+    """Return the lowercase set of label names that ``/describe`` manages.
+
+    Centralized so callers in tools, providers, and helpers stay aligned. The
+    rules mirror ``set_custom_labels``:
+
+    * Always include the five base labels emitted by the default prompt
+      (``bug fix``, ``tests``, ``enhancement``, ``documentation``, ``other``).
+    * When ``enable_custom_labels`` is on and a ``custom_labels`` mapping is
+      configured, include its keys.
+    * When ``enable_custom_labels`` is on but no ``custom_labels`` are
+      configured, include the same default list that ``set_custom_labels``
+      injects in that case (notably ``Bug fix with tests``), otherwise that
+      label is published by ``/describe`` once and then sticks forever
+      because it gets misclassified as a user label.
+
+    All comparisons are case-insensitive; callers should call ``.lower()`` on
+    the label they are testing.
+    """
+    base = {"bug fix", "tests", "enhancement", "documentation", "other"}
+    try:
+        if not get_settings().config.get("enable_custom_labels", False):
+            return base
+        custom_labels = get_settings().get("custom_labels", [])
+        if not custom_labels:
+            # Mirror the default list injected by ``set_custom_labels`` when
+            # custom labels are enabled but none are configured.
+            base = base | {
+                "bug fix", "tests", "bug fix with tests",
+                "enhancement", "documentation", "other",
+            }
+            return base
+        # ``custom_labels`` may be a dict (the documented shape) or a list.
+        if isinstance(custom_labels, dict):
+            return base | {str(k).lower() for k in custom_labels.keys()}
+        return base | {str(label).lower() for label in custom_labels}
+    except Exception as e:
+        get_logger().exception(f"Failed to compute describe-managed label set: {e}")
+        return base
+
+
+def is_describe_managed_label(label):
+    """Return True when ``label`` belongs to the ``/describe``-managed namespace.
+
+    See :func:`_describe_managed_label_names` for the namespace definition.
+    """
+    if label is None:
+        return False
+    return label.lower() in _describe_managed_label_names()
+
+
 def get_user_labels(current_labels: List[str] = None):
     """
-    Only keep labels that has been added by the user
+    Only keep labels that have been added by the user.
+
+    A user label is any current label that is *not* in the ``/describe``-
+    managed namespace (see :func:`is_describe_managed_label`).
     """
     try:
-        enable_custom_labels = get_settings().config.get('enable_custom_labels', False)
-        custom_labels = get_settings().get('custom_labels', [])
         if current_labels is None:
             current_labels = []
-        user_labels = []
-        for label in current_labels:
-            if label.lower() in ['bug fix', 'tests', 'enhancement', 'documentation', 'other']:
-                continue
-            if enable_custom_labels:
-                if label in custom_labels:
-                    continue
-            user_labels.append(label)
+        managed = _describe_managed_label_names()
+        user_labels = [label for label in current_labels if label.lower() not in managed]
         if user_labels:
             get_logger().debug(f"Keeping user labels: {user_labels}")
     except Exception as e:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -71,6 +71,19 @@ def get_git_ssl_env() -> dict[str, str]:
     return returned_env
 
 
+
+class LabelRefreshError(RuntimeError):
+    """Raised when a managed-label refresh fails before a label diff is computed.
+
+    Callers (notably ``/describe`` and ``/review``) use this to log
+    refresh-failure-skipped runs distinctly from genuine no-ops where the
+    server-side label set already matches the desired set. The provider must
+    raise this *before* any ``save()`` is attempted; on save() failure the
+    provider remains free to raise the underlying transport exception or to
+    log-and-swallow as it does today.
+    """
+
+
 class GitProvider(ABC):
     @abstractmethod
     def is_supported(self, capability: str) -> bool:
@@ -393,13 +406,23 @@ class GitProvider(ABC):
         ``managed_labels + user_labels``, and write the diff under the same
         snapshot.
 
-        Returns the list of labels that were (or would be) published, or
-        ``None`` if the publish was skipped because nothing changed. Errors
-        from the underlying ``publish_labels`` are not caught here; callers
-        decide whether label failures should propagate.
+        Return value semantics:
+
+        * Returns the list of labels that were (or would be) published.
+        * Returns ``None`` *only* when nothing changed (desired set already
+          matches current).
+        * Raises ``LabelRefreshError`` if the pre-write refresh fails so
+          callers can log refresh failures distinctly from no-ops. Other
+          errors from ``publish_labels`` propagate unchanged so providers
+          can decide whether label failures should bubble up.
         """
         managed = list(managed_labels or [])
-        current = self.get_pr_labels(update=True) or []
+        try:
+            current = self.get_pr_labels(update=True) or []
+        except Exception as refresh_err:
+            raise LabelRefreshError(
+                f"failed to refresh labels before managed-label publish: {refresh_err}"
+            ) from refresh_err
         user_labels = [label for label in current if not is_managed_label(label)]
         new_labels = managed + user_labels
         if sorted(new_labels) == sorted(current):

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -371,6 +371,42 @@ class GitProvider(ABC):
     def get_repo_labels(self):
         pass
 
+    def publish_managed_labels(self, managed_labels, is_managed_label):
+        """Atomically update the agent-managed labels while preserving user labels.
+
+        ``managed_labels`` is the desired set of agent-managed labels for this run
+        (e.g. ``["Review effort 3/5"]``). ``is_managed_label`` is a callable that
+        returns ``True`` for any label that belongs to the agent's managed
+        namespace and should therefore be considered for removal when no longer
+        present in ``managed_labels``.
+
+        The default implementation performs the historical read-modify-write:
+        read the current labels (with refresh), keep everything that is **not**
+        managed, union with ``managed_labels``, and republish via
+        ``publish_labels``. This preserves existing behavior for providers that
+        do not support a server-side set-diff.
+
+        Providers that support an incremental label update (e.g. GitLab's
+        ``add_labels`` / ``remove_labels``) should override this to avoid the
+        cross-method snapshot race: refresh once, derive ``current`` from that
+        single snapshot, compute the add/remove diff against
+        ``managed_labels + user_labels``, and write the diff under the same
+        snapshot.
+
+        Returns the list of labels that were (or would be) published, or
+        ``None`` if the publish was skipped because nothing changed. Errors
+        from the underlying ``publish_labels`` are not caught here; callers
+        decide whether label failures should propagate.
+        """
+        managed = list(managed_labels or [])
+        current = self.get_pr_labels(update=True) or []
+        user_labels = [label for label in current if not is_managed_label(label)]
+        new_labels = managed + user_labels
+        if sorted(new_labels) == sorted(current):
+            return None
+        self.publish_labels(new_labels)
+        return new_labels
+
     @abstractmethod
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         pass

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -20,7 +20,7 @@ from ..algo.utils import (clip_tokens,
                           load_large_diff)
 from ..config_loader import get_settings
 from ..log import get_logger
-from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider
+from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, LabelRefreshError
 
 
 class DiffNotFoundError(Exception):
@@ -926,21 +926,36 @@ class GitLabProvider(GitProvider):
         snapshots, allowing a label added between them to be removed by
         ``current - desired``.
 
-        Returns the new label set that would be on the server after the
-        publish, or ``None`` if nothing changed / the refresh failed.
+        Return value semantics (intentionally distinct from earlier revisions
+        of this method so callers can log refresh failures separately from
+        no-ops):
+
+        * Returns the new label set that would be on the server after the
+          publish.
+        * Returns ``None`` *only* when the desired set already matches the
+          server snapshot, i.e. nothing needs to change.
+        * Raises ``LabelRefreshError`` when the pre-save MR refresh fails.
+          Callers should isolate the failure (log + continue) rather than
+          letting it abort the surrounding tool.
+        * Swallows downstream ``save()`` failures and logs a warning,
+          matching ``publish_labels`` semantics so a transient save failure
+          does not bubble up either.
         """
         try:
-            try:
-                self.mr = self._get_merge_request()
-            except Exception as refresh_err:
-                # Same strict policy as ``publish_labels``: a stale snapshot
-                # produces an incorrect diff. Abort and let the caller decide
-                # whether the run should continue.
-                get_logger().warning(
-                    f"publish_managed_labels: aborting, failed to refresh MR before save. "
-                    f"error: {refresh_err}"
-                )
-                return None
+            self.mr = self._get_merge_request()
+        except Exception as refresh_err:
+            # Strict policy: a stale snapshot would produce an incorrect diff
+            # and could clobber user labels. Surface the failure to the
+            # caller via a typed exception so it can be logged distinctly
+            # from a genuine no-op.
+            get_logger().warning(
+                f"publish_managed_labels: aborting, failed to refresh MR before save. "
+                f"error: {refresh_err}"
+            )
+            raise LabelRefreshError(
+                f"failed to refresh MR before managed-label publish: {refresh_err}"
+            ) from refresh_err
+        try:
             current_labels = list(self.mr.labels or [])
             user_labels = [label for label in current_labels if not is_managed_label(label)]
             new_labels = list(managed_labels or []) + user_labels
@@ -949,6 +964,10 @@ class GitLabProvider(GitProvider):
             self._publish_labels_against(self.mr, new_labels)
             return new_labels
         except Exception as e:
+            # Refresh succeeded but save() / diff computation failed. Match
+            # publish_labels semantics: log and continue without raising, so a
+            # transient post-refresh failure does not abort the surrounding
+            # tool. The refresh-failure path above is handled separately.
             get_logger().warning(f"Failed to publish managed labels, error: {e}")
             return None
 

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -886,8 +886,59 @@ class GitLabProvider(GitProvider):
 
     def publish_labels(self, pr_types):
         try:
-            self.mr.labels = list(set(pr_types))
-            self.mr.save()
+            # Race-safe label update.
+            #
+            # Previous behavior: ``self.mr.labels = list(set(pr_types))`` followed
+            # by ``self.mr.save()`` issued a full PUT on the labels array using
+            # whatever snapshot of ``self.mr`` was cached at provider-construction
+            # time. Any label a user added between webhook delivery and this save
+            # was silently dropped.
+            #
+            # New behavior: re-fetch the MR immediately before computing the
+            # delta, then use python-gitlab's ``add_labels`` / ``remove_labels``
+            # attributes on save. python-gitlab forwards those attributes to
+            # the matching ``add_labels`` / ``remove_labels`` parameters on
+            # ``PUT /projects/:id/merge_requests/:merge_request_iid`` so the
+            # server applies an incremental set-diff and concurrent additions
+            # outside the diff are preserved.
+            desired = set(pr_types)
+            try:
+                self.mr = self._get_merge_request()
+            except Exception as refresh_err:
+                # Strict policy: a stale snapshot can produce an incorrect
+                # add/remove diff that re-introduces the bug this method is
+                # meant to fix. Abort the publish, log, and leave server
+                # state untouched rather than risk clobbering user labels.
+                get_logger().warning(
+                    f"publish_labels: aborting, failed to refresh MR before save. error: {refresh_err}"
+                )
+                return
+            current = set(self.mr.labels or [])
+            to_add = sorted(desired - current)
+            to_remove = sorted(current - desired)
+            if not to_add and not to_remove:
+                return
+            # GitLab accepts comma-separated strings for these attributes.
+            # Wrap the save in try/finally so the transient add_labels /
+            # remove_labels attributes are always cleared from ``self.mr``,
+            # even on save() failure. Otherwise a later self.mr.save() call
+            # in an unrelated tool (e.g. publish_description) would resend
+            # the prior label diff and cause unexpected churn.
+            try:
+                if to_add:
+                    self.mr.add_labels = ",".join(to_add)
+                if to_remove:
+                    self.mr.remove_labels = ",".join(to_remove)
+                self.mr.save()
+            finally:
+                for attr in ("add_labels", "remove_labels"):
+                    try:
+                        delattr(self.mr, attr)
+                    except (AttributeError, KeyError):
+                        # Already absent (e.g. only one side of the diff was
+                        # set, or python-gitlab cleared it on save). Safe to
+                        # ignore.
+                        pass
         except Exception as e:
             get_logger().warning(f"Failed to publish labels, error: {e}")
 
@@ -895,6 +946,21 @@ class GitLabProvider(GitProvider):
         pass
 
     def get_pr_labels(self, update=False):
+        # The previous implementation ignored the ``update`` flag entirely and
+        # always returned the snapshot cached at provider construction. Callers
+        # such as ``PRReviewer.set_review_labels`` rely on a fresh read to
+        # preserve user-added labels in their read-modify-write cycle; without
+        # the refresh, any label added after the webhook fired would be missing
+        # from ``current_labels`` and dropped by the subsequent publish_labels.
+        #
+        # Strict policy on refresh failure: a stale snapshot will produce an
+        # incorrect diff in the caller's filter-and-republish cycle, so we
+        # surface the failure to the caller instead of silently returning
+        # cached data. ``set_review_labels`` already wraps this in a broad
+        # try/except, so the failure degrades into "skip the label update for
+        # this run" rather than breaking the whole review.
+        if update:
+            self.mr = self._get_merge_request()
         return self.mr.labels
 
     def get_repo_labels(self):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -901,7 +901,6 @@ class GitLabProvider(GitProvider):
             # ``PUT /projects/:id/merge_requests/:merge_request_iid`` so the
             # server applies an incremental set-diff and concurrent additions
             # outside the diff are preserved.
-            desired = set(pr_types)
             try:
                 self.mr = self._get_merge_request()
             except Exception as refresh_err:
@@ -913,34 +912,83 @@ class GitLabProvider(GitProvider):
                     f"publish_labels: aborting, failed to refresh MR before save. error: {refresh_err}"
                 )
                 return
-            current = set(self.mr.labels or [])
-            to_add = sorted(desired - current)
-            to_remove = sorted(current - desired)
-            if not to_add and not to_remove:
-                return
-            # GitLab accepts comma-separated strings for these attributes.
-            # Wrap the save in try/finally so the transient add_labels /
-            # remove_labels attributes are always cleared from ``self.mr``,
-            # even on save() failure. Otherwise a later self.mr.save() call
-            # in an unrelated tool (e.g. publish_description) would resend
-            # the prior label diff and cause unexpected churn.
-            try:
-                if to_add:
-                    self.mr.add_labels = ",".join(to_add)
-                if to_remove:
-                    self.mr.remove_labels = ",".join(to_remove)
-                self.mr.save()
-            finally:
-                for attr in ("add_labels", "remove_labels"):
-                    try:
-                        delattr(self.mr, attr)
-                    except (AttributeError, KeyError):
-                        # Already absent (e.g. only one side of the diff was
-                        # set, or python-gitlab cleared it on save). Safe to
-                        # ignore.
-                        pass
+            self._publish_labels_against(self.mr, pr_types)
         except Exception as e:
             get_logger().warning(f"Failed to publish labels, error: {e}")
+
+    def publish_managed_labels(self, managed_labels, is_managed_label):
+        """Atomic managed-label update.
+
+        Refresh the MR exactly once and compute both the user-label filter and
+        the add/remove diff against that single snapshot. This closes the
+        cross-method race where a caller's ``get_pr_labels(update=True)`` and
+        ``publish_labels()``'s internal refresh produced two different
+        snapshots, allowing a label added between them to be removed by
+        ``current - desired``.
+
+        Returns the new label set that would be on the server after the
+        publish, or ``None`` if nothing changed / the refresh failed.
+        """
+        try:
+            try:
+                self.mr = self._get_merge_request()
+            except Exception as refresh_err:
+                # Same strict policy as ``publish_labels``: a stale snapshot
+                # produces an incorrect diff. Abort and let the caller decide
+                # whether the run should continue.
+                get_logger().warning(
+                    f"publish_managed_labels: aborting, failed to refresh MR before save. "
+                    f"error: {refresh_err}"
+                )
+                return None
+            current_labels = list(self.mr.labels or [])
+            user_labels = [label for label in current_labels if not is_managed_label(label)]
+            new_labels = list(managed_labels or []) + user_labels
+            if sorted(new_labels) == sorted(current_labels):
+                return None
+            self._publish_labels_against(self.mr, new_labels)
+            return new_labels
+        except Exception as e:
+            get_logger().warning(f"Failed to publish managed labels, error: {e}")
+            return None
+
+    def _publish_labels_against(self, mr, desired_labels):
+        """Apply a set-diff publish against ``mr``'s already-refreshed snapshot.
+
+        Computes ``to_add`` / ``to_remove`` from ``mr.labels`` (the caller's
+        responsibility to have refreshed), writes the diff via
+        ``add_labels`` / ``remove_labels`` so the server applies an
+        incremental update, and clears the transient diff attributes in a
+        ``finally`` so a later unrelated ``mr.save()`` (e.g.
+        ``publish_description``) does not resend them.
+        """
+        desired = set(desired_labels)
+        current = set(mr.labels or [])
+        to_add = sorted(desired - current)
+        to_remove = sorted(current - desired)
+        if not to_add and not to_remove:
+            return
+        # GitLab accepts comma-separated strings for these attributes.
+        # Wrap the save in try/finally so the transient add_labels /
+        # remove_labels attributes are always cleared from ``mr``, even on
+        # save() failure. Otherwise a later mr.save() call in an unrelated
+        # tool (e.g. publish_description) would resend the prior label diff
+        # and cause unexpected churn.
+        try:
+            if to_add:
+                mr.add_labels = ",".join(to_add)
+            if to_remove:
+                mr.remove_labels = ",".join(to_remove)
+            mr.save()
+        finally:
+            for attr in ("add_labels", "remove_labels"):
+                try:
+                    delattr(mr, attr)
+                except (AttributeError, KeyError):
+                    # Already absent (e.g. only one side of the diff was
+                    # set, or python-gitlab cleared it on save). Safe to
+                    # ignore.
+                    pass
 
     def publish_inline_comments(self, comments: list[dict]):
         pass

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -16,7 +16,7 @@ from pr_agent.algo.pr_processing import (OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD,
                                          retry_with_fallback_models)
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRDescriptionHeader, clip_tokens,
-                                 get_max_tokens, get_user_labels, load_yaml,
+                                 get_max_tokens, load_yaml,
                                  set_custom_labels,
                                  show_relevant_configurations)
 from pr_agent.config_loader import get_settings
@@ -197,24 +197,46 @@ class PRDescription:
     def _safe_publish_labels(self, pr_labels: List[str]) -> None:
         """Publish labels in a failure-isolated way.
 
-        ``get_pr_labels(update=True)`` may raise on a refresh failure (e.g.
-        transient GitLab API error). For ``/describe`` the description itself
-        is the primary artifact: a label-update failure must not block the
-        description publish. Catch any exception here, log a warning, and
-        return so the caller continues to publish the description.
+        For ``/describe`` the description itself is the primary artifact: a
+        label-update failure must not block the description publish. Catch the
+        narrow set of expected provider/network errors here, log a warning,
+        and return so the caller continues to publish the description.
+
+        Uses ``publish_managed_labels`` so the provider (notably
+        ``GitLabProvider``) can refresh the MR exactly once and compute both
+        the user-label filter and the add/remove diff against a single
+        snapshot, eliminating the cross-method snapshot race where a label
+        added between the caller's read and ``publish_labels``'s internal
+        refresh could be removed.
         """
+        # ``get_user_labels`` defines "user label" as anything outside the
+        # /describe-managed namespace (the standard description labels and any
+        # configured custom_labels). The managed predicate must mirror that
+        # exclusion list so user-added labels stay on the MR.
+        enable_custom_labels = get_settings().config.get("enable_custom_labels", False)
+        custom_labels = get_settings().get("custom_labels", []) if enable_custom_labels else []
+        managed_default = {"bug fix", "tests", "enhancement", "documentation", "other"}
+
+        def _is_managed(label: str) -> bool:
+            if label is None:
+                return False
+            if label.lower() in managed_default:
+                return True
+            if enable_custom_labels and label in custom_labels:
+                return True
+            return False
+
         try:
-            original_labels = self.git_provider.get_pr_labels(update=True)
-            get_logger().debug("original labels", artifact=original_labels)
-            user_labels = get_user_labels(original_labels)
-            new_labels = pr_labels + user_labels
-            get_logger().debug("published labels", artifact=new_labels)
-            if set(new_labels) != set(original_labels):
-                get_logger().info(f"Setting describe labels:\n{new_labels}")
-                self.git_provider.publish_labels(new_labels)
+            get_logger().debug("describe labels", artifact={"managed": pr_labels})
+            new_labels = self.git_provider.publish_managed_labels(pr_labels, _is_managed)
+            if new_labels is None:
+                get_logger().debug("Labels unchanged, not updating")
             else:
-                get_logger().debug("Labels are the same, not updating")
-        except Exception as label_err:
+                get_logger().info(f"Setting describe labels:\n{new_labels}")
+        except (ConnectionError, TimeoutError, OSError, ValueError, KeyError, AttributeError) as label_err:
+            # Narrow set of expected failure modes from provider/network calls
+            # and predictable shape errors on the MR object. Anything else
+            # (e.g. programmer errors) should surface, not be swallowed.
             get_logger().warning(
                 f"Failed to update labels during PR description; "
                 f"continuing with description publish. error: {label_err}"

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -16,13 +16,13 @@ from pr_agent.algo.pr_processing import (OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD,
                                          retry_with_fallback_models)
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRDescriptionHeader, clip_tokens,
-                                 get_max_tokens, load_yaml,
-                                 set_custom_labels,
+                                 get_max_tokens, is_describe_managed_label,
+                                 load_yaml, set_custom_labels,
                                  show_relevant_configurations)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (GithubProvider, get_git_provider,
                                     get_git_provider_with_context)
-from pr_agent.git_providers.git_provider import get_main_pr_language
+from pr_agent.git_providers.git_provider import LabelRefreshError, get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.ticket_pr_compliance_check import (
@@ -208,31 +208,30 @@ class PRDescription:
         snapshot, eliminating the cross-method snapshot race where a label
         added between the caller's read and ``publish_labels``'s internal
         refresh could be removed.
+
+        The managed-label predicate is sourced from
+        ``is_describe_managed_label`` so the namespace is computed in exactly
+        one place (alongside ``get_user_labels``) and stays correct for every
+        configuration mode -- including the ``enable_custom_labels=True`` /
+        no-``custom_labels`` case where ``set_custom_labels`` injects defaults
+        such as ``Bug fix with tests``.
         """
-        # ``get_user_labels`` defines "user label" as anything outside the
-        # /describe-managed namespace (the standard description labels and any
-        # configured custom_labels). The managed predicate must mirror that
-        # exclusion list so user-added labels stay on the MR.
-        enable_custom_labels = get_settings().config.get("enable_custom_labels", False)
-        custom_labels = get_settings().get("custom_labels", []) if enable_custom_labels else []
-        managed_default = {"bug fix", "tests", "enhancement", "documentation", "other"}
-
-        def _is_managed(label: str) -> bool:
-            if label is None:
-                return False
-            if label.lower() in managed_default:
-                return True
-            if enable_custom_labels and label in custom_labels:
-                return True
-            return False
-
         try:
             get_logger().debug("describe labels", artifact={"managed": pr_labels})
-            new_labels = self.git_provider.publish_managed_labels(pr_labels, _is_managed)
+            new_labels = self.git_provider.publish_managed_labels(
+                pr_labels, is_describe_managed_label
+            )
             if new_labels is None:
                 get_logger().debug("Labels unchanged, not updating")
             else:
                 get_logger().info(f"Setting describe labels:\n{new_labels}")
+        except LabelRefreshError as refresh_err:
+            # Distinguish a real refresh failure from a no-op so the run
+            # can be diagnosed. /describe still continues to publish the
+            # description; only the label update is skipped.
+            get_logger().warning(
+                f"Skipping describe label update; MR refresh failed. error: {refresh_err}"
+            )
         except (ConnectionError, TimeoutError, OSError, ValueError, KeyError, AttributeError) as label_err:
             # Narrow set of expected failure modes from provider/network calls
             # and predictable shape errors on the MR object. Anything else

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -157,16 +157,7 @@ class PRDescription:
 
                 # publish labels
                 if get_settings().pr_description.publish_labels and pr_labels and self.git_provider.is_supported("get_labels"):
-                    original_labels = self.git_provider.get_pr_labels(update=True)
-                    get_logger().debug(f"original labels", artifact=original_labels)
-                    user_labels = get_user_labels(original_labels)
-                    new_labels = pr_labels + user_labels
-                    get_logger().debug(f"published labels", artifact=new_labels)
-                    if set(new_labels) != set(original_labels):
-                        get_logger().info(f"Setting describe labels:\n{new_labels}")
-                        self.git_provider.publish_labels(new_labels)
-                    else:
-                        get_logger().debug(f"Labels are the same, not updating")
+                    self._safe_publish_labels(pr_labels)
 
                 # publish description
                 if get_settings().pr_description.publish_description_as_comment:
@@ -202,6 +193,32 @@ class PRDescription:
                                artifact={"traceback": traceback.format_exc()})
 
         return ""
+
+    def _safe_publish_labels(self, pr_labels: List[str]) -> None:
+        """Publish labels in a failure-isolated way.
+
+        ``get_pr_labels(update=True)`` may raise on a refresh failure (e.g.
+        transient GitLab API error). For ``/describe`` the description itself
+        is the primary artifact: a label-update failure must not block the
+        description publish. Catch any exception here, log a warning, and
+        return so the caller continues to publish the description.
+        """
+        try:
+            original_labels = self.git_provider.get_pr_labels(update=True)
+            get_logger().debug("original labels", artifact=original_labels)
+            user_labels = get_user_labels(original_labels)
+            new_labels = pr_labels + user_labels
+            get_logger().debug("published labels", artifact=new_labels)
+            if set(new_labels) != set(original_labels):
+                get_logger().info(f"Setting describe labels:\n{new_labels}")
+                self.git_provider.publish_labels(new_labels)
+            else:
+                get_logger().debug("Labels are the same, not updating")
+        except Exception as label_err:
+            get_logger().warning(
+                f"Failed to update labels during PR description; "
+                f"continuing with description publish. error: {label_err}"
+            )
 
     async def _prepare_prediction(self, model: str) -> None:
         if get_settings().pr_description.use_description_markers and 'pr_agent:' not in self.user_description:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -20,6 +20,7 @@ from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (get_git_provider,
                                     get_git_provider_with_context)
 from pr_agent.git_providers.git_provider import (IncrementalPR,
+                                                 LabelRefreshError,
                                                  get_main_pr_language)
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
@@ -411,11 +412,22 @@ class PRReviewer:
                     return (lowered.startswith("review effort")
                             or lowered.startswith("possible security concern"))
 
-                published = self.git_provider.publish_managed_labels(review_labels, _is_review_managed)
-                if published is None:
-                    get_logger().info(f"Review labels are already set; managed set:\n{review_labels}")
+                try:
+                    published = self.git_provider.publish_managed_labels(
+                        review_labels, _is_review_managed
+                    )
+                except LabelRefreshError as refresh_err:
+                    # Distinguish a refresh failure from a no-op so the run
+                    # can be diagnosed instead of being mis-logged as
+                    # "already set / unchanged".
+                    get_logger().warning(
+                        f"Skipping review label update; MR refresh failed. error: {refresh_err}"
+                    )
                 else:
-                    get_logger().info(f"Setting review labels:\n{published}")
+                    if published is None:
+                        get_logger().info(f"Review labels are already set; managed set:\n{review_labels}")
+                    else:
+                        get_logger().info(f"Setting review labels:\n{published}")
             except Exception as e:
                 get_logger().error(f"Failed to set review labels, error: {e}")
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -395,22 +395,27 @@ class PRReviewer:
                     if security_concerns_bool:
                         review_labels.append('Possible security concern')
 
-                current_labels = self.git_provider.get_pr_labels(update=True)
-                if not current_labels:
-                    current_labels = []
-                get_logger().debug(f"Current labels:\n{current_labels}")
-                if current_labels:
-                    current_labels_filtered = [label for label in current_labels if
-                                               not label.lower().startswith('review effort') and not label.lower().startswith(
-                                                   'possible security concern')]
+                # The review-managed namespace is exactly the two prefixes
+                # below. Anything else (user-added labels like ``area/backend``
+                # or labels managed by /describe) must be preserved. Use
+                # ``publish_managed_labels`` so providers that support an
+                # atomic refresh+diff path (e.g. GitLab) can compute both the
+                # filter and the diff against a single MR snapshot, closing
+                # the cross-method race where a label added between the
+                # caller's read and ``publish_labels``'s internal refresh
+                # could be removed.
+                def _is_review_managed(label: str) -> bool:
+                    if label is None:
+                        return False
+                    lowered = label.lower()
+                    return (lowered.startswith('review effort')
+                            or lowered.startswith('possible security concern'))
+
+                published = self.git_provider.publish_managed_labels(review_labels, _is_review_managed)
+                if published is None:
+                    get_logger().info(f"Review labels are already set; managed set:\n{review_labels}")
                 else:
-                    current_labels_filtered = []
-                new_labels = review_labels + current_labels_filtered
-                if (current_labels or review_labels) and sorted(new_labels) != sorted(current_labels):
-                    get_logger().info(f"Setting review labels:\n{review_labels + current_labels_filtered}")
-                    self.git_provider.publish_labels(new_labels)
-                else:
-                    get_logger().info(f"Review labels are already set:\n{review_labels + current_labels_filtered}")
+                    get_logger().info(f"Setting review labels:\n{published}")
             except Exception as e:
                 get_logger().error(f"Failed to set review labels, error: {e}")
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -408,8 +408,8 @@ class PRReviewer:
                     if label is None:
                         return False
                     lowered = label.lower()
-                    return (lowered.startswith('review effort')
-                            or lowered.startswith('possible security concern'))
+                    return (lowered.startswith("review effort")
+                            or lowered.startswith("possible security concern"))
 
                 published = self.git_provider.publish_managed_labels(review_labels, _is_review_managed)
                 if published is None:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -255,3 +255,135 @@ class TestGitLabProvider:
         assert gitlab_provider.mr.title == "AI title"
         assert gitlab_provider.mr.description == "Updated description"
         gitlab_provider.mr.save.assert_called_once()
+
+    # ---- publish_labels / get_pr_labels tests ----
+
+    def _prime_mr_for_labels(self, gitlab_provider, server_labels):
+        """Install a mock MR with server_labels for label-publishing tests.
+
+        _get_merge_request is patched to return a fresh MagicMock with the
+        same label set, simulating a successful server refresh. spec=[...]
+        keeps MagicMock from silently auto-creating add_labels /
+        remove_labels attrs so tests can assert which side(s) of the diff
+        were written.
+        """
+        mr = MagicMock(spec=["labels", "save"])
+        mr.labels = list(server_labels)
+        gitlab_provider.mr = mr
+        gitlab_provider._get_merge_request = MagicMock(return_value=mr)
+        return mr
+
+    def test_publish_labels_noop_when_sets_equal(self, gitlab_provider):
+        mr = self._prime_mr_for_labels(gitlab_provider, ["bug", "review effort 3/5"])
+
+        gitlab_provider.publish_labels(["bug", "review effort 3/5"])
+
+        # No diff -> no save, no transient attributes touched.
+        mr.save.assert_not_called()
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_publish_labels_adds_only_missing(self, gitlab_provider):
+        mr = self._prime_mr_for_labels(gitlab_provider, ["bug"])
+
+        gitlab_provider.publish_labels(["bug", "review effort 3/5"])
+
+        # Server-side state is left to GitLab to compute; we only assert what
+        # we wrote on the wire.
+        assert mr.save.call_count == 1
+        # ``add_labels`` is deleted on the finally branch after save().
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_publish_labels_removes_stale_managed_labels(self, gitlab_provider):
+        mr = self._prime_mr_for_labels(
+            gitlab_provider, ["review effort 5/5", "Possible security concern"]
+        )
+
+        # Caller wants to switch the managed labels to a fresh set.
+        gitlab_provider.publish_labels(["review effort 2/5"])
+
+        assert mr.save.call_count == 1
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_publish_labels_preserves_user_labels_outside_diff(self, gitlab_provider):
+        # The bug this PR fixes: a user-added label outside the diff must
+        # not be touched. With spec on the mock, ``mr.labels`` should remain
+        # the exact list we primed it with (no full-array overwrite).
+        mr = self._prime_mr_for_labels(
+            gitlab_provider, ["area/backend", "review effort 3/5"]
+        )
+
+        # Caller flipped the managed label only; ``area/backend`` stays.
+        gitlab_provider.publish_labels(["area/backend", "review effort 4/5"])
+
+        # We wrote exactly one save and never reassigned ``mr.labels`` (the
+        # pre-fix bug). The server-side set-diff is what preserves the user
+        # label; here we just confirm we did not perform a full overwrite.
+        assert mr.save.call_count == 1
+        assert mr.labels == ["area/backend", "review effort 3/5"]
+        # Diff attrs cleared on the way out.
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_publish_labels_aborts_when_refresh_fails(self, gitlab_provider):
+        # Pre-fix behavior would have proceeded against the cached snapshot,
+        # potentially clobbering user labels. New strict behavior: abort the
+        # publish and leave server state untouched.
+        cached_mr = MagicMock(spec=["labels", "save"])
+        cached_mr.labels = ["stale label that no longer reflects server"]
+        gitlab_provider.mr = cached_mr
+        gitlab_provider._get_merge_request = MagicMock(side_effect=RuntimeError("boom"))
+
+        gitlab_provider.publish_labels(["review effort 3/5"])
+
+        cached_mr.save.assert_not_called()
+
+    def test_publish_labels_clears_diff_attrs_on_save_failure(self, gitlab_provider):
+        # If ``self.mr.save()`` raises, the transient diff fields must still
+        # be cleared so a later, unrelated save() (e.g. publish_description)
+        # does not resend them.
+        mr = self._prime_mr_for_labels(gitlab_provider, ["bug"])
+        mr.save.side_effect = RuntimeError("network blip")
+
+        gitlab_provider.publish_labels(["review effort 3/5"])  # adds + removes
+
+        # publish_labels swallows the outer Exception by design; what matters
+        # is that the transient attrs do not leak into the next save().
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_get_pr_labels_no_update_returns_cached(self, gitlab_provider):
+        cached_mr = MagicMock()
+        cached_mr.labels = ["cached"]
+        gitlab_provider.mr = cached_mr
+        gitlab_provider._get_merge_request = MagicMock()
+
+        result = gitlab_provider.get_pr_labels(update=False)
+
+        assert result == ["cached"]
+        gitlab_provider._get_merge_request.assert_not_called()
+
+    def test_get_pr_labels_with_update_refreshes(self, gitlab_provider):
+        cached_mr = MagicMock()
+        cached_mr.labels = ["cached-stale"]
+        fresh_mr = MagicMock()
+        fresh_mr.labels = ["fresh-from-server"]
+        gitlab_provider.mr = cached_mr
+        gitlab_provider._get_merge_request = MagicMock(return_value=fresh_mr)
+
+        result = gitlab_provider.get_pr_labels(update=True)
+
+        assert result == ["fresh-from-server"]
+        assert gitlab_provider.mr is fresh_mr
+
+    def test_get_pr_labels_with_update_propagates_refresh_failure(self, gitlab_provider):
+        # Strict policy: surface the refresh failure to the caller (which
+        # wraps the call in a broader try/except), rather than silently
+        # returning stale data that would corrupt the read-modify-write cycle.
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider._get_merge_request = MagicMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError):
+            gitlab_provider.get_pr_labels(update=True)

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -494,19 +494,23 @@ class TestGitLabProvider:
         assert captured["remove_labels"] == "Possible security concern,review effort 1/5"
         assert mr.save.call_count == 1
 
-    def test_publish_managed_labels_aborts_when_refresh_fails(self, gitlab_provider):
+    def test_publish_managed_labels_raises_when_refresh_fails(self, gitlab_provider):
         # Strict policy: a stale snapshot would produce an incorrect diff and
-        # could clobber user labels. Abort and return None instead.
+        # could clobber user labels. Raise LabelRefreshError so callers can
+        # log refresh failures distinctly from genuine no-ops, then leave
+        # server state untouched.
+        from pr_agent.git_providers.git_provider import LabelRefreshError
+
         cached_mr = MagicMock(spec=["labels", "save"])
         cached_mr.labels = ["stale"]
         gitlab_provider.mr = cached_mr
         gitlab_provider._get_merge_request = MagicMock(side_effect=RuntimeError("boom"))
 
-        result = gitlab_provider.publish_managed_labels(
-            ["review effort 3/5"], self._is_review_managed
-        )
+        with pytest.raises(LabelRefreshError):
+            gitlab_provider.publish_managed_labels(
+                ["review effort 3/5"], self._is_review_managed
+            )
 
-        assert result is None
         cached_mr.save.assert_not_called()
 
     def test_publish_managed_labels_clears_diff_attrs_on_save_failure(self, gitlab_provider):

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -265,13 +265,31 @@ class TestGitLabProvider:
         same label set, simulating a successful server refresh. spec=[...]
         keeps MagicMock from silently auto-creating add_labels /
         remove_labels attrs so tests can assert which side(s) of the diff
-        were written.
+        were written (or were cleared) after publish_labels returns.
         """
         mr = MagicMock(spec=["labels", "save"])
         mr.labels = list(server_labels)
         gitlab_provider.mr = mr
         gitlab_provider._get_merge_request = MagicMock(return_value=mr)
         return mr
+
+    def _capture_wire_payload_on_save(self, mr):
+        """Capture add_labels / remove_labels at the moment save() is called.
+
+        publish_labels deletes the transient diff attributes in a ``finally``
+        block, so asserting on them *after* the call returns is meaningless
+        (they will always be absent). This helper installs a save() side_effect
+        that records the diff payload that was actually written to the wire,
+        which is what we need to validate.
+        """
+        captured = {}
+
+        def _record_then_succeed(*_a, **_kw):
+            captured["add_labels"] = getattr(mr, "add_labels", None)
+            captured["remove_labels"] = getattr(mr, "remove_labels", None)
+
+        mr.save.side_effect = _record_then_succeed
+        return captured
 
     def test_publish_labels_noop_when_sets_equal(self, gitlab_provider):
         mr = self._prime_mr_for_labels(gitlab_provider, ["bug", "review effort 3/5"])
@@ -285,13 +303,16 @@ class TestGitLabProvider:
 
     def test_publish_labels_adds_only_missing(self, gitlab_provider):
         mr = self._prime_mr_for_labels(gitlab_provider, ["bug"])
+        captured = self._capture_wire_payload_on_save(mr)
 
         gitlab_provider.publish_labels(["bug", "review effort 3/5"])
 
-        # Server-side state is left to GitLab to compute; we only assert what
-        # we wrote on the wire.
         assert mr.save.call_count == 1
-        # ``add_labels`` is deleted on the finally branch after save().
+        # Only the missing label is in the add diff; nothing is being
+        # removed because every server label is still desired.
+        assert captured["add_labels"] == "review effort 3/5"
+        assert captured["remove_labels"] is None
+        # Diff attrs are cleared on the way out.
         assert not hasattr(mr, "add_labels")
         assert not hasattr(mr, "remove_labels")
 
@@ -299,11 +320,17 @@ class TestGitLabProvider:
         mr = self._prime_mr_for_labels(
             gitlab_provider, ["review effort 5/5", "Possible security concern"]
         )
+        captured = self._capture_wire_payload_on_save(mr)
 
         # Caller wants to switch the managed labels to a fresh set.
         gitlab_provider.publish_labels(["review effort 2/5"])
 
         assert mr.save.call_count == 1
+        # "review effort 2/5" is added; both prior managed labels are removed.
+        # sorted() determinism is part of the contract so we can assert the
+        # exact comma-separated payload sent on the wire.
+        assert captured["add_labels"] == "review effort 2/5"
+        assert captured["remove_labels"] == "Possible security concern,review effort 5/5"
         assert not hasattr(mr, "add_labels")
         assert not hasattr(mr, "remove_labels")
 
@@ -314,13 +341,16 @@ class TestGitLabProvider:
         mr = self._prime_mr_for_labels(
             gitlab_provider, ["area/backend", "review effort 3/5"]
         )
+        captured = self._capture_wire_payload_on_save(mr)
 
         # Caller flipped the managed label only; ``area/backend`` stays.
         gitlab_provider.publish_labels(["area/backend", "review effort 4/5"])
 
+        # Wire-level diff: only the managed label is updated.
+        assert captured["add_labels"] == "review effort 4/5"
+        assert captured["remove_labels"] == "review effort 3/5"
         # We wrote exactly one save and never reassigned ``mr.labels`` (the
-        # pre-fix bug). The server-side set-diff is what preserves the user
-        # label; here we just confirm we did not perform a full overwrite.
+        # pre-fix bug).
         assert mr.save.call_count == 1
         assert mr.labels == ["area/backend", "review effort 3/5"]
         # Diff attrs cleared on the way out.
@@ -387,3 +417,107 @@ class TestGitLabProvider:
 
         with pytest.raises(RuntimeError):
             gitlab_provider.get_pr_labels(update=True)
+
+    # ---- publish_managed_labels (atomic refresh+filter+diff) tests ----
+
+    @staticmethod
+    def _is_review_managed(label):
+        if label is None:
+            return False
+        lowered = label.lower()
+        return (lowered.startswith("review effort")
+                or lowered.startswith("possible security concern"))
+
+    def test_publish_managed_labels_refreshes_once(self, gitlab_provider):
+        # The whole point of this method: a single refresh feeds both the
+        # filter (managed vs user) and the diff (add/remove). Two refreshes
+        # would re-introduce the cross-snapshot race the reviewer flagged.
+        mr = self._prime_mr_for_labels(gitlab_provider, ["review effort 1/5", "area/backend"])
+        self._capture_wire_payload_on_save(mr)
+
+        gitlab_provider.publish_managed_labels(["review effort 3/5"], self._is_review_managed)
+
+        gitlab_provider._get_merge_request.assert_called_once()
+
+    def test_publish_managed_labels_preserves_user_labels(self, gitlab_provider):
+        mr = self._prime_mr_for_labels(
+            gitlab_provider, ["review effort 1/5", "area/backend", "team/security"]
+        )
+        captured = self._capture_wire_payload_on_save(mr)
+
+        result = gitlab_provider.publish_managed_labels(
+            ["review effort 3/5"], self._is_review_managed
+        )
+
+        # The returned "new labels" set is what would exist server-side after
+        # the publish: the managed set plus every user label.
+        assert sorted(result) == sorted([
+            "review effort 3/5", "area/backend", "team/security"
+        ])
+        # Wire payload: only the managed labels are diffed. The user labels
+        # are not in to_add (already present) and not in to_remove (not
+        # managed, so filter kept them).
+        assert captured["add_labels"] == "review effort 3/5"
+        assert captured["remove_labels"] == "review effort 1/5"
+        assert mr.save.call_count == 1
+
+    def test_publish_managed_labels_noop_when_nothing_changes(self, gitlab_provider):
+        # If the desired managed set already matches what's on the server,
+        # publish_managed_labels returns None without calling save().
+        mr = self._prime_mr_for_labels(
+            gitlab_provider, ["review effort 3/5", "area/backend"]
+        )
+
+        result = gitlab_provider.publish_managed_labels(
+            ["review effort 3/5"], self._is_review_managed
+        )
+
+        assert result is None
+        mr.save.assert_not_called()
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")
+
+    def test_publish_managed_labels_removes_managed_when_desired_empty(self, gitlab_provider):
+        # /review may decide no managed labels apply this run (e.g. effort
+        # disabled). The provider must remove every label classified as
+        # managed and leave user labels alone.
+        mr = self._prime_mr_for_labels(
+            gitlab_provider,
+            ["review effort 1/5", "Possible security concern", "area/backend"],
+        )
+        captured = self._capture_wire_payload_on_save(mr)
+
+        result = gitlab_provider.publish_managed_labels([], self._is_review_managed)
+
+        assert sorted(result) == ["area/backend"]
+        assert captured["add_labels"] is None
+        assert captured["remove_labels"] == "Possible security concern,review effort 1/5"
+        assert mr.save.call_count == 1
+
+    def test_publish_managed_labels_aborts_when_refresh_fails(self, gitlab_provider):
+        # Strict policy: a stale snapshot would produce an incorrect diff and
+        # could clobber user labels. Abort and return None instead.
+        cached_mr = MagicMock(spec=["labels", "save"])
+        cached_mr.labels = ["stale"]
+        gitlab_provider.mr = cached_mr
+        gitlab_provider._get_merge_request = MagicMock(side_effect=RuntimeError("boom"))
+
+        result = gitlab_provider.publish_managed_labels(
+            ["review effort 3/5"], self._is_review_managed
+        )
+
+        assert result is None
+        cached_mr.save.assert_not_called()
+
+    def test_publish_managed_labels_clears_diff_attrs_on_save_failure(self, gitlab_provider):
+        # The transient add_labels / remove_labels must never leak into a
+        # later unrelated mr.save() (e.g. publish_description).
+        mr = self._prime_mr_for_labels(gitlab_provider, ["review effort 1/5"])
+        mr.save.side_effect = RuntimeError("network blip")
+
+        gitlab_provider.publish_managed_labels(
+            ["review effort 3/5"], self._is_review_managed
+        )
+
+        assert not hasattr(mr, "add_labels")
+        assert not hasattr(mr, "remove_labels")

--- a/tests/unittest/test_pr_description_output_core.py
+++ b/tests/unittest/test_pr_description_output_core.py
@@ -484,7 +484,7 @@ class TestSafePublishLabels:
 
     /describe wraps the entire publish flow in a single try/except; if the
     label step raises, the description publish is aborted. The helper exists
-    so a transient refresh failure during ``get_pr_labels(update=True)``
+    so a transient refresh failure during ``publish_managed_labels``
     degrades to a logged warning instead of skipping the description.
     """
 
@@ -493,54 +493,73 @@ class TestSafePublishLabels:
         obj.git_provider = provider
         return obj
 
-    def test_skips_publish_when_refresh_raises(self):
+    def test_swallows_expected_provider_errors(self):
         provider = MagicMock()
-        provider.get_pr_labels.side_effect = RuntimeError("transient gitlab error")
+        # Each of these is a failure mode we expect from the provider/network
+        # path and explicitly catch in _safe_publish_labels.
+        for err in (
+            ConnectionError("network down"),
+            TimeoutError("read timeout"),
+            OSError("socket closed"),
+            ValueError("bad payload"),
+            KeyError("missing key on MR"),
+            AttributeError("stale attr"),
+        ):
+            provider.reset_mock()
+            provider.publish_managed_labels.side_effect = err
+
+            obj = self._obj_with_provider(provider)
+            # Must not raise.
+            obj._safe_publish_labels(["Bug fix"])
+
+            provider.publish_managed_labels.assert_called_once()
+
+    def test_does_not_swallow_unexpected_errors(self):
+        # Programmer errors (e.g. a typo causing TypeError) must surface,
+        # not be silently logged. _safe_publish_labels catches only the
+        # narrow set above; anything else propagates so /describe's outer
+        # handler logs it with a traceback.
+        provider = MagicMock()
+        provider.publish_managed_labels.side_effect = TypeError("unexpected kwarg")
 
         obj = self._obj_with_provider(provider)
 
-        # Must not raise.
-        obj._safe_publish_labels(["Bug fix"])
+        try:
+            obj._safe_publish_labels(["Bug fix"])
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("TypeError should not be swallowed by _safe_publish_labels")
 
-        provider.publish_labels.assert_not_called()
-
-    def test_skips_publish_when_publish_raises(self):
+    def test_passes_managed_labels_and_predicate(self):
         provider = MagicMock()
-        provider.get_pr_labels.return_value = ["area/backend"]
-        provider.publish_labels.side_effect = RuntimeError("transient gitlab error")
+        provider.publish_managed_labels.return_value = ["Bug fix", "area/backend"]
 
         obj = self._obj_with_provider(provider)
-
-        # Must not raise even though publish_labels itself failed.
         obj._safe_publish_labels(["Bug fix"])
 
-        provider.publish_labels.assert_called_once()
+        provider.publish_managed_labels.assert_called_once()
+        managed_arg, predicate_arg = provider.publish_managed_labels.call_args[0]
+        assert managed_arg == ["Bug fix"]
+        # Predicate must mirror get_user_labels' exclusion set so the standard
+        # /describe-managed names are classified as managed (and therefore
+        # eligible for removal) while user labels are preserved.
+        assert predicate_arg("Bug fix") is True
+        assert predicate_arg("BUG FIX") is True
+        assert predicate_arg("tests") is True
+        assert predicate_arg("Enhancement") is True
+        assert predicate_arg("Documentation") is True
+        assert predicate_arg("Other") is True
+        assert predicate_arg("area/backend") is False
+        assert predicate_arg(None) is False
 
-    def test_publishes_when_labels_differ(self):
+    def test_skips_log_when_no_change(self):
+        # publish_managed_labels returns None when nothing changed; the helper
+        # must treat that as a no-op rather than an error.
         provider = MagicMock()
-        provider.get_pr_labels.return_value = ["area/backend"]
+        provider.publish_managed_labels.return_value = None
 
-        with patch(
-            "pr_agent.tools.pr_description.get_user_labels",
-            return_value=["area/backend"],
-        ):
-            obj = self._obj_with_provider(provider)
-            obj._safe_publish_labels(["Bug fix"])
+        obj = self._obj_with_provider(provider)
+        obj._safe_publish_labels(["Bug fix"])
 
-        provider.publish_labels.assert_called_once()
-        published = provider.publish_labels.call_args[0][0]
-        assert "Bug fix" in published
-        assert "area/backend" in published
-
-    def test_no_publish_when_labels_unchanged(self):
-        provider = MagicMock()
-        provider.get_pr_labels.return_value = ["Bug fix", "area/backend"]
-
-        with patch(
-            "pr_agent.tools.pr_description.get_user_labels",
-            return_value=["area/backend"],
-        ):
-            obj = self._obj_with_provider(provider)
-            obj._safe_publish_labels(["Bug fix"])
-
-        provider.publish_labels.assert_not_called()
+        provider.publish_managed_labels.assert_called_once()

--- a/tests/unittest/test_pr_description_output_core.py
+++ b/tests/unittest/test_pr_description_output_core.py
@@ -477,3 +477,70 @@ class TestPrepareFileLabelsEdgeCases:
 # Ensure SimpleNamespace import is used (kept for potential future fixtures);
 # referenced here to avoid an unused-import warning without changing semantics.
 _ = SimpleNamespace
+
+
+class TestSafePublishLabels:
+    """``PRDescription._safe_publish_labels`` must isolate label failures.
+
+    /describe wraps the entire publish flow in a single try/except; if the
+    label step raises, the description publish is aborted. The helper exists
+    so a transient refresh failure during ``get_pr_labels(update=True)``
+    degrades to a logged warning instead of skipping the description.
+    """
+
+    def _obj_with_provider(self, provider):
+        obj = _make_instance()
+        obj.git_provider = provider
+        return obj
+
+    def test_skips_publish_when_refresh_raises(self):
+        provider = MagicMock()
+        provider.get_pr_labels.side_effect = RuntimeError("transient gitlab error")
+
+        obj = self._obj_with_provider(provider)
+
+        # Must not raise.
+        obj._safe_publish_labels(["Bug fix"])
+
+        provider.publish_labels.assert_not_called()
+
+    def test_skips_publish_when_publish_raises(self):
+        provider = MagicMock()
+        provider.get_pr_labels.return_value = ["area/backend"]
+        provider.publish_labels.side_effect = RuntimeError("transient gitlab error")
+
+        obj = self._obj_with_provider(provider)
+
+        # Must not raise even though publish_labels itself failed.
+        obj._safe_publish_labels(["Bug fix"])
+
+        provider.publish_labels.assert_called_once()
+
+    def test_publishes_when_labels_differ(self):
+        provider = MagicMock()
+        provider.get_pr_labels.return_value = ["area/backend"]
+
+        with patch(
+            "pr_agent.tools.pr_description.get_user_labels",
+            return_value=["area/backend"],
+        ):
+            obj = self._obj_with_provider(provider)
+            obj._safe_publish_labels(["Bug fix"])
+
+        provider.publish_labels.assert_called_once()
+        published = provider.publish_labels.call_args[0][0]
+        assert "Bug fix" in published
+        assert "area/backend" in published
+
+    def test_no_publish_when_labels_unchanged(self):
+        provider = MagicMock()
+        provider.get_pr_labels.return_value = ["Bug fix", "area/backend"]
+
+        with patch(
+            "pr_agent.tools.pr_description.get_user_labels",
+            return_value=["area/backend"],
+        ):
+            obj = self._obj_with_provider(provider)
+            obj._safe_publish_labels(["Bug fix"])
+
+        provider.publish_labels.assert_not_called()

--- a/tests/unittest/test_pr_description_output_core.py
+++ b/tests/unittest/test_pr_description_output_core.py
@@ -541,9 +541,9 @@ class TestSafePublishLabels:
         provider.publish_managed_labels.assert_called_once()
         managed_arg, predicate_arg = provider.publish_managed_labels.call_args[0]
         assert managed_arg == ["Bug fix"]
-        # Predicate must mirror get_user_labels' exclusion set so the standard
-        # /describe-managed names are classified as managed (and therefore
-        # eligible for removal) while user labels are preserved.
+        # Predicate is the shared ``is_describe_managed_label`` so the
+        # classification stays in one place alongside ``get_user_labels``.
+        # The base set is always managed; user labels stay user.
         assert predicate_arg("Bug fix") is True
         assert predicate_arg("BUG FIX") is True
         assert predicate_arg("tests") is True
@@ -552,6 +552,57 @@ class TestSafePublishLabels:
         assert predicate_arg("Other") is True
         assert predicate_arg("area/backend") is False
         assert predicate_arg(None) is False
+
+    def test_predicate_includes_bug_fix_with_tests_when_custom_labels_default(self):
+        # Reproduces Qodo #3: when enable_custom_labels=True and no
+        # custom_labels are configured, set_custom_labels injects defaults
+        # that include "Bug fix with tests". The managed predicate must
+        # classify that label as managed so it can be removed later;
+        # otherwise it gets stuck on the MR forever.
+        from pr_agent.config_loader import get_settings
+        settings = get_settings()
+        original_enable = settings.config.get("enable_custom_labels", False)
+        original_custom = settings.get("custom_labels", None)
+        try:
+            settings.config.enable_custom_labels = True
+            # Clear any pre-existing custom_labels; we want the
+            # default-injection branch of set_custom_labels.
+            settings.set("custom_labels", [])
+
+            provider = MagicMock()
+            provider.publish_managed_labels.return_value = ["Bug fix"]
+            obj = self._obj_with_provider(provider)
+            obj._safe_publish_labels(["Bug fix"])
+
+            _, predicate_arg = provider.publish_managed_labels.call_args[0]
+            assert predicate_arg("Bug fix with tests") is True
+            assert predicate_arg("bug fix with tests") is True
+            # Base set still managed.
+            assert predicate_arg("Tests") is True
+            # User labels still user.
+            assert predicate_arg("area/backend") is False
+        finally:
+            settings.config.enable_custom_labels = original_enable
+            if original_custom is not None:
+                settings.set("custom_labels", original_custom)
+
+    def test_logs_distinctly_on_refresh_failure(self):
+        # Qodo #4: a refresh failure must not be misreported as
+        # "labels unchanged". The provider signals refresh failure via
+        # LabelRefreshError; _safe_publish_labels catches it specifically
+        # and logs a warning rather than treating None as success.
+        from pr_agent.git_providers.git_provider import LabelRefreshError
+
+        provider = MagicMock()
+        provider.publish_managed_labels.side_effect = LabelRefreshError(
+            "refresh failed: gitlab 5xx"
+        )
+
+        obj = self._obj_with_provider(provider)
+        # Must not raise (failure is isolated to the label step).
+        obj._safe_publish_labels(["Bug fix"])
+
+        provider.publish_managed_labels.assert_called_once()
 
     def test_skips_log_when_no_change(self):
         # publish_managed_labels returns None when nothing changed; the helper
@@ -563,3 +614,83 @@ class TestSafePublishLabels:
         obj._safe_publish_labels(["Bug fix"])
 
         provider.publish_managed_labels.assert_called_once()
+
+
+class TestDescribeManagedLabelNamespace:
+    """Lock the ``/describe``-managed label classification in one place.
+
+    ``is_describe_managed_label`` and ``get_user_labels`` must agree: a label
+    classified as managed is **never** a user label, and vice versa. The
+    classification has to match ``set_custom_labels``' default-injection
+    behavior so labels like ``Bug fix with tests`` (Qodo #3) can be removed
+    by ``/describe`` once they are no longer recommended.
+    """
+
+    def _with_settings(self, enable_custom_labels, custom_labels):
+        from pr_agent.config_loader import get_settings
+        settings = get_settings()
+        snap = (
+            settings.config.get("enable_custom_labels", False),
+            settings.get("custom_labels", None),
+        )
+        settings.config.enable_custom_labels = enable_custom_labels
+        if custom_labels is not None:
+            settings.set("custom_labels", custom_labels)
+        return settings, snap
+
+    def _restore(self, settings, snap):
+        original_enable, original_custom = snap
+        settings.config.enable_custom_labels = original_enable
+        if original_custom is not None:
+            settings.set("custom_labels", original_custom)
+
+    def test_default_set_classified_as_managed(self):
+        from pr_agent.algo.utils import is_describe_managed_label
+        settings, snap = self._with_settings(False, None)
+        try:
+            for label in ("Bug fix", "Tests", "Enhancement", "Documentation", "Other",
+                          "bug fix", "TESTS", "enhancement"):
+                assert is_describe_managed_label(label) is True
+            assert is_describe_managed_label("area/backend") is False
+            assert is_describe_managed_label("") is False
+            assert is_describe_managed_label(None) is False
+        finally:
+            self._restore(settings, snap)
+
+    def test_custom_labels_default_includes_bug_fix_with_tests(self):
+        # Reproduces Qodo #3: when enable_custom_labels=True and
+        # custom_labels is empty, set_custom_labels injects defaults that
+        # include "Bug fix with tests". That label must be classified as
+        # managed so /describe can remove it once it is no longer
+        # recommended.
+        from pr_agent.algo.utils import is_describe_managed_label
+        settings, snap = self._with_settings(True, [])
+        try:
+            assert is_describe_managed_label("Bug fix with tests") is True
+            assert is_describe_managed_label("bug fix with tests") is True
+            # Base set still managed.
+            assert is_describe_managed_label("Tests") is True
+            # User labels still user.
+            assert is_describe_managed_label("area/backend") is False
+        finally:
+            self._restore(settings, snap)
+
+    def test_get_user_labels_and_is_managed_are_disjoint(self):
+        # Any label classified as managed must be filtered out of
+        # get_user_labels' output, and vice versa. This is what keeps the
+        # /describe-managed namespace in one place.
+        from pr_agent.algo.utils import get_user_labels, is_describe_managed_label
+        settings, snap = self._with_settings(True, [])
+        try:
+            current = [
+                "Bug fix", "Bug fix with tests", "Tests",
+                "area/backend", "team/security",
+            ]
+            user = get_user_labels(current)
+            for label in current:
+                if is_describe_managed_label(label):
+                    assert label not in user, f"{label} leaked into user labels"
+                else:
+                    assert label in user, f"{label} dropped from user labels"
+        finally:
+            self._restore(settings, snap)

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -51,7 +51,14 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
     settings.pr_reviewer.enable_review_labels_effort = True
     settings.pr_reviewer.enable_review_labels_security = True
     git_provider = MagicMock()
-    git_provider.get_pr_labels.return_value = ["Review effort 1/5", "Possible security concern", "keep-me"]
+    # Simulate publish_managed_labels' atomic refresh+filter+diff: it sees
+    # the stale "Review effort 1/5" + user label "keep-me", filters out the
+    # managed labels, and publishes the new managed set plus the user label.
+    git_provider.publish_managed_labels.return_value = [
+        "Review effort 3/5",
+        "Possible security concern",
+        "keep-me",
+    ]
     reviewer = _make_reviewer(git_provider)
     data = {
         "review": {
@@ -63,11 +70,20 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
     try:
         reviewer.set_review_labels(data)
 
-        git_provider.publish_labels.assert_called_once_with([
-            "Review effort 3/5",
-            "Possible security concern",
-            "keep-me",
-        ])
+        # The new contract delegates filter+diff to the provider via
+        # publish_managed_labels(managed_labels, predicate). The caller no
+        # longer pre-reads labels or computes the merge itself.
+        git_provider.get_pr_labels.assert_not_called()
+        git_provider.publish_labels.assert_not_called()
+        assert git_provider.publish_managed_labels.call_count == 1
+        managed_arg, predicate_arg = git_provider.publish_managed_labels.call_args[0]
+        assert managed_arg == ["Review effort 3/5", "Possible security concern"]
+        # Predicate must classify review-managed labels as managed and leave
+        # user labels alone.
+        assert predicate_arg("Review effort 1/5") is True
+        assert predicate_arg("Possible security concern") is True
+        assert predicate_arg("keep-me") is False
+        assert predicate_arg(None) is False
     finally:
         settings.config.publish_output = original["publish_output"]
         settings.pr_reviewer.require_estimate_effort_to_review = original["require_estimate_effort_to_review"]

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -92,6 +92,49 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
         settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
 
 
+def test_set_review_labels_logs_distinctly_on_refresh_failure():
+    # Qodo #4 on PR 2483: when publish_managed_labels raises
+    # LabelRefreshError, set_review_labels must NOT mis-log it as
+    # "Review labels are already set". The error is isolated by the
+    # surrounding except (label update is skipped, /review continues).
+    from pr_agent.git_providers.git_provider import LabelRefreshError
+
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "require_estimate_effort_to_review": settings.pr_reviewer.require_estimate_effort_to_review,
+        "require_security_review": settings.pr_reviewer.require_security_review,
+        "enable_review_labels_effort": settings.pr_reviewer.enable_review_labels_effort,
+        "enable_review_labels_security": settings.pr_reviewer.enable_review_labels_security,
+    }
+    settings.config.publish_output = True
+    settings.pr_reviewer.require_estimate_effort_to_review = True
+    settings.pr_reviewer.require_security_review = True
+    settings.pr_reviewer.enable_review_labels_effort = True
+    settings.pr_reviewer.enable_review_labels_security = True
+
+    git_provider = MagicMock()
+    git_provider.publish_managed_labels.side_effect = LabelRefreshError("refresh failed: gitlab 5xx")
+    reviewer = _make_reviewer(git_provider)
+    data = {
+        "review": {
+            "estimated_effort_to_review_[1-5]": "3, moderate",
+            "security_concerns": "yes",
+        }
+    }
+
+    try:
+        # Must not raise; refresh failure is logged at warning level only.
+        reviewer.set_review_labels(data)
+        assert git_provider.publish_managed_labels.call_count == 1
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.pr_reviewer.require_estimate_effort_to_review = original["require_estimate_effort_to_review"]
+        settings.pr_reviewer.require_security_review = original["require_security_review"]
+        settings.pr_reviewer.enable_review_labels_effort = original["enable_review_labels_effort"]
+        settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
+
+
 def test_get_user_answers_collects_question_and_answer_from_issue_comments():
     git_provider = MagicMock()
     git_provider.get_issue_comments.return_value = SimpleNamespace(reversed=[


### PR DESCRIPTION
# fix(gitlab): preserve user-added labels in `publish_labels` and `get_pr_labels`

## Summary

The GitLab provider drops user-added labels every time PR-Agent publishes a label set (most visibly during `/review`). Two compounding bugs in `GitLabProvider` cause a read-modify-write race that wipes any label a user added after the webhook fired.

This PR fixes both bugs on the GitLab provider. The hot path (no refresh requested, no label changes needed) is unchanged.

## What users see

> "Every time `/review` runs, the agent removes the labels I just added to the MR."

It only happens on GitLab. GitHub and other providers are unaffected because the bug is provider-local.

## Reproduction

1. Configure PR-Agent against a GitLab project with `auto_review` enabled (or trigger `/review` manually).
2. Open a merge request; let the agent post its first review (which applies `Review effort N/5` and possibly `Possible security concern` labels).
3. As a user, add any label of your own (e.g., `area/backend`).
4. Trigger `/review` again, or push a new commit so `auto_review` fires.
5. **Observed:** the agent's `Review effort` label is updated, but your `area/backend` label is gone.
6. **Expected:** your label is preserved; only the agent-managed labels are updated.

## Root cause

`PRReviewer.set_review_labels` does a read-modify-write cycle specifically to preserve user-added labels:

```python
current_labels = self.git_provider.get_pr_labels(update=True)
current_labels_filtered = [
    label for label in current_labels
    if not label.lower().startswith("review effort")
    and not label.lower().startswith("possible security concern")
]
new_labels = review_labels + current_labels_filtered
self.git_provider.publish_labels(new_labels)
```

Both halves of that cycle are broken on the GitLab provider.

### Bug 1 — `get_pr_labels(update=True)` ignores the flag

```python
def get_pr_labels(self, update=False):
    return self.mr.labels
```

The `update` argument is unused; the method always returns `self.mr.labels` from the snapshot cached at provider construction. A label the user added after the webhook fired is missing from `current_labels`, so the filter step drops it out of `new_labels`.

### Bug 2 — `publish_labels` does a full PUT against the same stale snapshot

```python
def publish_labels(self, pr_types):
    try:
        self.mr.labels = list(set(pr_types))
        self.mr.save()
    ...
```

Setting `self.mr.labels` and calling `save()` translates to a full PUT on the labels array — the server overwrites whatever it has with `pr_types`. Any label added during the read-modify-write window (or any label missed because of Bug 1) is wiped.

## Fix

Both halves of the cycle now refresh, and the write becomes an incremental set-diff rather than a full overwrite.

### `get_pr_labels(update=True)` now actually refreshes

```python
def get_pr_labels(self, update=False):
    if update:
        try:
            self.mr = self._get_merge_request()
        except Exception as e:
            get_logger().warning(f"get_pr_labels: refresh failed, using cached snapshot. error: {e}")
    return self.mr.labels
```

`update=False` keeps the existing cached read, so callers that don't ask for a refresh see no behavior change.

### `publish_labels` refreshes and writes a diff

```python
def publish_labels(self, pr_types):
    try:
        desired = set(pr_types)
        try:
            self.mr = self._get_merge_request()
        except Exception as refresh_err:
            get_logger().warning(
                f"publish_labels: failed to refresh MR before save, "
                f"using cached snapshot. error: {refresh_err}"
            )
        current = set(self.mr.labels or [])
        to_add = sorted(desired - current)
        to_remove = sorted(current - desired)
        if not to_add and not to_remove:
            return
        if to_add:
            self.mr.add_labels = ",".join(to_add)
        if to_remove:
            self.mr.remove_labels = ",".join(to_remove)
        self.mr.save()
    except Exception as e:
        get_logger().warning(f"Failed to publish labels, error: {e}")
```

Why `add_labels` / `remove_labels` instead of `labels`:

- They map to GitLab's `add_labels` and `remove_labels` query parameters on `PUT /projects/:id/merge_requests/:merge_request_iid` (see the [GitLab MR API](https://docs.gitlab.com/ee/api/merge_requests.html#update-mr)).
- The server then applies a **set-diff** rather than replacing the whole array.
- Any label a user adds outside the diff during the (now much smaller) race window is preserved by the server, not clobbered.

### Failure modes

- If the refresh call fails (network blip, permissions, etc.), both paths fall back to the cached snapshot rather than failing the whole publish. The behavior degrades to pre-PR semantics for that one operation instead of breaking label publishing entirely.

### Hot path

- `to_add` and `to_remove` are both empty → the method returns without calling `save()`. No-op publishes are now actually no-ops.

## What is NOT changed

- Other providers (`GithubProvider`, `BitbucketProvider`, `BitbucketServerProvider`, `AzureDevopsProvider`, `GiteaProvider`, `GerritProvider`, `CodeCommitProvider`, `LocalGitProvider`).
- The public signatures of `publish_labels` and `get_pr_labels`.
- The behavior of `get_pr_labels(update=False)` (still returns the cached snapshot).
- Any caller of `set_review_labels`, `PRDescription`, `PRGenerateLabels`, etc. — they continue to call the same provider methods with the same arguments.

## Testing

Manual testing against a self-managed GitLab instance:

1. Open an MR; let `/review` run.
2. As a user, add a label `area/backend`.
3. Trigger `/review` again.
4. Before this PR: `area/backend` is gone after the second review.
5. After this PR: `area/backend` is preserved; only the agent's `Review effort` label is updated.

Edge cases verified manually:

- `pr_types` equals the current label set → method returns early, no `save()` call.
- Refresh fails (simulated by killing the GitLab token mid-flight) → warning logged, fallback to cached snapshot, publish still attempts.
- `self.mr.labels` is `None` → handled by `current = set(self.mr.labels or [])`.
- User adds a label *during* `/review` execution (between refresh and `save()`) → preserved by the server because we only push the diff, not the whole array.

I did not add automated tests in this PR — the existing `tests/unittest/test_gitlab_provider.py` does not exercise `publish_labels` and adding a meaningful test would require either a `python-gitlab` mock with attribute-side-effect tracking or a live test environment. Happy to add tests in a follow-up if maintainers want them.

## Related

- The bug exists in every released version of pr-agent I checked (`v0.34.x`–`v0.37.0`).
- This affects every GitLab user who has both `auto_review` (or repeated manual `/review`) and any user-curated label workflow.
