### PR TITLE
fix: resolve google-cloud-storage dependency conflict on Python 3.13+ (#2480)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,10 @@ dynaconf==3.2.4
 fastapi==0.118.0
 GitPython==3.1.41
 google-cloud-aiplatform==1.154.0
-google-cloud-storage>=2.10.0,<4.0.0
+# google-cloud-aiplatform==1.154.0 requires storage <4,>=1.32.0 on py<3.13 and <4,>=3.10.0 on py>=3.13.
+# Pin per-Python (exact, like the rest of this file) so existing installs are unchanged and py3.13 resolves. See #2480.
+google-cloud-storage==2.10.0; python_version < "3.13"
+google-cloud-storage==3.12.0; python_version >= "3.13"
 protobuf==6.33.6  # grpcio-status 1.80.0 forces >=6.31.1,<7; pinned to lock the resolved transitive version
 Jinja2==3.1.6
 litellm==1.84.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ dynaconf==3.2.4
 fastapi==0.118.0
 GitPython==3.1.41
 google-cloud-aiplatform==1.154.0
-google-cloud-storage==2.10.0
+google-cloud-storage>=2.10.0,<4.0.0
 protobuf==6.33.6  # grpcio-status 1.80.0 forces >=6.31.1,<7; pinned to lock the resolved transitive version
 Jinja2==3.1.6
 litellm==1.84.0


### PR DESCRIPTION
## Summary

Fixes #2480.

This PR relaxes the `google-cloud-storage` version constraint to resolve a dependency conflict with `google-cloud-aiplatform` on Python 3.13+.

### Changes

* Updated the dependency constraint:

  ```diff
  - google-cloud-storage==2.10.0
  + google-cloud-storage>=2.10.0,<4.0.0
  ```
* Allows pip to resolve a compatible `google-cloud-storage` version required by both `pr-agent` and `google-cloud-aiplatform` on Python 3.13+.
* Maintains backward compatibility by permitting existing 2.x releases while also supporting 3.x releases.

### Root Cause

`google-cloud-aiplatform==1.154.0` requires:

```text
google-cloud-storage>=3.10.0,<4.0.0
```

on Python 3.13+, while `pr-agent` pinned:

```text
google-cloud-storage==2.10.0
```

These constraints cannot be satisfied simultaneously, causing `pip install -r requirements.txt` to fail.

### Testing

* Verified that the dependency resolution progresses past the original `google-cloud-storage` conflict after relaxing the version constraint.
* Additional installation/testing was blocked by an unrelated dependency issue (`litellm`) on my local Python 3.14 environment, which is outside the scope of this fix. The original issue targets Python 3.13, and this PR is limited to resolving the reported dependency conflict.
