### PR TITLE
docs: add pull_request_target guide for fork contribution support

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -54,6 +54,46 @@ When you open your next PR, you should see a comment from `github-actions` bot w
 
 See detailed usage instructions in the [USAGE GUIDE](../usage-guide/automations_and_usage.md#github-action)
 
+#### Using with pull_request_target (fork/contribution support)
+
+By default, the `pull_request` event does not have access to repository secrets when the PR originates from a forked repository, which means PR-Agent won't be able to access your `OPENAI_KEY` and `GITHUB_TOKEN` secrets.
+
+To support PRs from external contributors (forks), use the `pull_request_target` event instead. This event runs in the context of the base repository and has access to secrets, while the PR code is checked out manually with `actions/checkout`.
+
+```yaml
+name: PR Agent
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  issue_comment:
+jobs:
+  pr_agent_job:
+    if: ${{ github.event.sender.type != 'Bot' && (github.event_name == 'pull_request_target' || github.event.issue.pull_request) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+      - name: PR Agent action step
+        uses: the-pr-agent/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_action_config.pr_actions: '["opened", "reopened", "synchronize", "ready_for_review", "review_requested"]'
+```
+
+!!! warning "Security considerations"
+    Using `pull_request_target` requires extra care. The `actions/checkout` step with `allow-unsafe-pr-checkout: true` checks out the PR's code, which could contain modified workflows. To mitigate risks, consider:
+    - Using `pull_request_target` only when you need fork support
+    - Reviewing the [GitHub security guide on pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
+    - Avoiding running additional build steps from the checked-out PR code
+
 ### Configuration Examples
 
 This section provides detailed, step-by-step examples for configuring PR-Agent with different models and advanced options in GitHub Actions.

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -75,11 +75,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - name: Checkout PR code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
       - name: PR Agent action step
         uses: the-pr-agent/pr-agent@main
         env:
@@ -88,11 +83,11 @@ jobs:
           github_action_config.pr_actions: '["opened", "reopened", "synchronize", "ready_for_review", "review_requested"]'
 ```
 
+!!! tip "No local checkout needed"
+    PR-Agent uses the GitHub API to fetch PR data directly from the event payload — it does not require a local checkout of the PR code. This means you can safely omit the `actions/checkout` step entirely, avoiding common pitfalls with `pull_request_target` like the `issue_comment` event lacking a `pull_request.head.sha` ref.
+
 !!! warning "Security considerations"
-    Using `pull_request_target` requires extra care. The `actions/checkout` step with `allow-unsafe-pr-checkout: true` checks out the PR's code, which could contain modified workflows. To mitigate risks, consider:
-    - Using `pull_request_target` only when you need fork support
-    - Reviewing the [GitHub security guide on pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
-    - Avoiding running additional build steps from the checked-out PR code
+    Using `pull_request_target` gives the workflow access to repository secrets. Unlike the `pull_request` event, the PR code is not automatically checked out, which is a security feature. Avoid adding an `actions/checkout` step unless you have a specific need for the local files — if you do add one, review the [GitHub security guide on pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
 
 ### Configuration Examples
 

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -171,6 +171,9 @@ This means that when new code is pushed to the PR, PR-Agent will run the `descri
 
 `GitHub Action` is a different way to trigger PR-Agent tools, and uses a different configuration mechanism than `GitHub App`.<br>
 You can configure settings for `GitHub Action` by adding environment variables under the env section in `.github/workflows/pr_agent.yml` file.
+
+!!! tip "Fork/contribution support"
+    To support PRs from forked repositories, use the `pull_request_target` event instead of `pull_request`. See the [fork contribution guide](../installation/github.md#using-with-pull_request_target-forkcontribution-support) for a complete example and security considerations.
 Specifically, start by setting the following environment variables:
 
 ```yaml


### PR DESCRIPTION
## Description

Adds documentation explaining how to use the `pull_request_target` event to enable PR-Agent on PRs from forked repositories (external contributions).

The GitHub Action runner already supports this event type (`pr_agent/servers/github_action_runner.py:110`), but no documentation existed showing users how to configure it.

### Changes

- **docs/docs/installation/github.md**: Added new subsection `#### Using with pull_request_target (fork/contribution support)` with a complete YAML example, explanation of why `pull_request` doesn't work for forks, and a security warning box.
- **docs/docs/usage-guide/automations_and_usage.md**: Added a tip admonition in the GitHub Action section pointing to the new fork contribution guide.

Closes #2500