### PR TITLE
feat(gitea): native formal review submission (APPROVED/COMMENT) + provider parity

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -383,8 +383,13 @@ class GiteaProvider(GitProvider):
             comments=comments
         )
 
-        if not response:
-            self.logger.error("Failed to publish inline comment")
+        # ``create_inline_comment`` runs with ``_preload_content=False``, so a
+        # successful call returns the ``(data, status, headers)`` tuple rather
+        # than a truthy body; a non-2xx status raises ``ApiException`` before we
+        # get here. Inspect the status code instead of the (always-falsy) body.
+        status = response[1] if isinstance(response, tuple) and len(response) > 1 else None
+        if status is not None and not (200 <= status < 300):
+            self.logger.error(f"Failed to publish inline comment (status {status})")
             return
 
         self.logger.info("Inline comment published")
@@ -397,6 +402,12 @@ class GiteaProvider(GitProvider):
         APPROVED / REQUEST_CHANGES / COMMENT / PENDING. Gitea (like GitHub)
         rejects a review whose reviewer is the PR author, so the configured
         token must belong to a dedicated bot account distinct from PR authors.
+
+        ``commit_id`` is deliberately omitted so Gitea anchors the review to the
+        PR head: ``self.last_commit`` comes from ``repo_get_all_commits`` (the
+        repository/default-branch commit list, not the PR's commits), so its sha
+        is unrelated to the PR head and could mis-attach or be rejected under
+        stricter branch protection.
 
         Returns True on success; failures are logged and swallowed so a failed
         formal review never breaks the underlying ``/review`` comment.
@@ -411,7 +422,6 @@ class GiteaProvider(GitProvider):
                 pr_number=self.pr_number,
                 event=event,
                 body=body,
-                commit_id=self.last_commit.sha if self.last_commit else "",
             )
             self.logger.info(
                 f"Submitted Gitea review event={event} on {self.owner}/{self.repo}#{self.pr_number}"
@@ -942,17 +952,14 @@ class RepoApi(giteapy.RepositoryApi):
         self.logger = get_logger()
         super().__init__(client)
 
-    def create_inline_comment(self, owner: str, repo: str, pr_number: int, body : str ,commit_id : str, comments: List[Dict[str, Any]], event: Optional[str] = None):
+    def create_inline_comment(self, owner: str, repo: str, pr_number: int, body : str ,commit_id : str, comments: List[Dict[str, Any]]):
         body = {
             "body": body,
             "comments": comments,
             "commit_id": commit_id,
         }
-        # Without an ``event`` the review is created as an unsubmitted PENDING
-        # draft. Pass one of APPROVED / REQUEST_CHANGES / COMMENT / PENDING to
-        # submit a formal review in a single call.
-        if event:
-            body["event"] = event
+        # No ``event`` is sent, so the review is created as an unsubmitted
+        # PENDING draft (the pre-existing ``/review`` inline-comment behavior).
         return self.api_client.call_api(
             '/repos/{owner}/{repo}/pulls/{pr_number}/reviews',
             'POST',
@@ -987,28 +994,6 @@ class RepoApi(giteapy.RepositoryApi):
             '/repos/{owner}/{repo}/pulls/{pr_number}/reviews',
             'POST',
             path_params={'owner': owner, 'repo': repo, 'pr_number': pr_number},
-            body=review_body,
-            response_type=None,
-            _return_http_data_only=False,
-            _preload_content=False,
-            auth_settings=['AuthorizationHeaderToken']
-        )
-
-    def submit_pending_review(self, owner: str, repo: str, pr_number: int, review_id: int,
-                             event: str, body: str = ""):
-        """Submit a previously-created PENDING review.
-
-        Maps to ``POST /repos/{owner}/{repo}/pulls/{index}/reviews/{id}`` with a
-        ``SubmitPullReviewOptions`` ``{event, body}`` payload.
-        """
-        review_body = {
-            "event": event,
-            "body": body,
-        }
-        return self.api_client.call_api(
-            '/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}',
-            'POST',
-            path_params={'owner': owner, 'repo': repo, 'pr_number': pr_number, 'review_id': review_id},
             body=review_body,
             response_type=None,
             _return_http_data_only=False,

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -326,6 +326,49 @@ class GiteaProvider(GitProvider):
 
         self.logger.info("Inline comment published")
 
+    def submit_review(self, event: str, body: str = "") -> bool:
+        """Submit a formal Gitea review on the PR.
+
+        Unlike ``publish_comment`` (an issue comment) this occupies a reviewer
+        slot and can gate merges via branch protection. ``event`` is one of
+        APPROVED / REQUEST_CHANGES / COMMENT / PENDING. Gitea (like GitHub)
+        rejects a review whose reviewer is the PR author, so the configured
+        token must belong to a dedicated bot account distinct from PR authors.
+
+        Returns True on success; failures are logged and swallowed so a failed
+        formal review never breaks the underlying ``/review`` comment.
+        """
+        if not self.enabled_pr:
+            self.logger.error("Cannot submit a review: not a pull request")
+            return False
+        try:
+            self.repo_api.create_review(
+                owner=self.owner,
+                repo=self.repo,
+                pr_number=self.pr_number,
+                event=event,
+                body=body,
+                commit_id=self.last_commit.sha if self.last_commit else "",
+            )
+            self.logger.info(
+                f"Submitted Gitea review event={event} on {self.owner}/{self.repo}#{self.pr_number}"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(
+                f"Failed to submit Gitea review event={event} on "
+                f"{self.owner}/{self.repo}#{self.pr_number}: {e}"
+            )
+            return False
+
+    def auto_approve(self) -> bool:
+        """Approve the PR by submitting a formal APPROVED review.
+
+        Mirrors GithubProvider.auto_approve so that ``/review auto_approve``
+        works on Gitea (the base class is a no-op that returns False).
+        """
+        return self.submit_review("APPROVED")
+
     def publish_code_suggestions(self, suggestions: List[Dict[str, Any]]):
         """Publish code suggestions"""
         for suggestion in suggestions:
@@ -752,18 +795,77 @@ class RepoApi(giteapy.RepositoryApi):
         self.logger = get_logger()
         super().__init__(client)
 
-    def create_inline_comment(self, owner: str, repo: str, pr_number: int, body : str ,commit_id : str, comments: List[Dict[str, Any]]):
+    def create_inline_comment(self, owner: str, repo: str, pr_number: int, body : str ,commit_id : str, comments: List[Dict[str, Any]], event: Optional[str] = None):
         body = {
             "body": body,
             "comments": comments,
             "commit_id": commit_id,
         }
+        # Without an ``event`` the review is created as an unsubmitted PENDING
+        # draft. Pass one of APPROVED / REQUEST_CHANGES / COMMENT / PENDING to
+        # submit a formal review in a single call.
+        if event:
+            body["event"] = event
         return self.api_client.call_api(
             '/repos/{owner}/{repo}/pulls/{pr_number}/reviews',
             'POST',
             path_params={'owner': owner, 'repo': repo, 'pr_number': pr_number},
             body=body,
-            response_type='Repository',
+            response_type=None,
+            _return_http_data_only=False,
+            _preload_content=False,
+            auth_settings=['AuthorizationHeaderToken']
+        )
+
+    def create_review(self, owner: str, repo: str, pr_number: int, event: Optional[str] = None,
+                      body: str = "", commit_id: Optional[str] = None,
+                      comments: Optional[List[Dict[str, Any]]] = None):
+        """Create (and optionally submit) a formal pull request review.
+
+        Maps to ``POST /repos/{owner}/{repo}/pulls/{index}/reviews`` with a
+        ``CreatePullReviewOptions`` payload. ``event`` is one of APPROVED /
+        REQUEST_CHANGES / COMMENT / PENDING; omitting it leaves the review as an
+        unsubmitted PENDING draft. Each entry in ``comments`` is an inline
+        comment ``{body, path, new_position, old_position}``.
+        """
+        review_body = {
+            "body": body,
+            "comments": comments if comments is not None else [],
+        }
+        if event:
+            review_body["event"] = event
+        if commit_id:
+            review_body["commit_id"] = commit_id
+        return self.api_client.call_api(
+            '/repos/{owner}/{repo}/pulls/{pr_number}/reviews',
+            'POST',
+            path_params={'owner': owner, 'repo': repo, 'pr_number': pr_number},
+            body=review_body,
+            response_type=None,
+            _return_http_data_only=False,
+            _preload_content=False,
+            auth_settings=['AuthorizationHeaderToken']
+        )
+
+    def submit_pending_review(self, owner: str, repo: str, pr_number: int, review_id: int,
+                             event: str, body: str = ""):
+        """Submit a previously-created PENDING review.
+
+        Maps to ``POST /repos/{owner}/{repo}/pulls/{index}/reviews/{id}`` with a
+        ``SubmitPullReviewOptions`` ``{event, body}`` payload.
+        """
+        review_body = {
+            "event": event,
+            "body": body,
+        }
+        return self.api_client.call_api(
+            '/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}',
+            'POST',
+            path_params={'owner': owner, 'repo': repo, 'pr_number': pr_number, 'review_id': review_id},
+            body=review_body,
+            response_type=None,
+            _return_http_data_only=False,
+            _preload_content=False,
             auth_settings=['AuthorizationHeaderToken']
         )
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -476,6 +476,68 @@ class GiteaProvider(GitProvider):
         """
         return self.submit_review("APPROVED")
 
+    # Gitea's commit-status states (StatusState): pending / success / error /
+    # failure / warning. Not 1:1 with GitHub Checks, but the closest native
+    # surface for a pass/fail signal on a commit.
+    _COMMIT_STATUS_STATES = {"pending", "success", "error", "failure", "warning"}
+
+    def publish_commit_status(self, state: str, context: str = "PR-Agent",
+                              description: str = "", target_url: str = "",
+                              commit_sha: Optional[str] = None) -> bool:
+        """Surface a pass/fail signal as a Gitea commit status.
+
+        Gitea has no GitHub Checks API, but it has a commit-status API
+        (``POST /repos/{owner}/{repo}/statuses/{sha}`` with
+        ``{state, context, description, target_url}`` — CreateStatusOption,
+        docs.gitea.com repoCreateStatus). This is an approximate, not 1:1,
+        stand-in for a check run: the reviewer can call it to mark a commit
+        success/failure/pending so branch protection or the PR's status list
+        reflects the review outcome.
+
+        ``state`` must be one of pending/success/error/failure/warning; anything
+        else is coerced to "error" (with a log) rather than sent as-is, since
+        Gitea rejects unknown states. The status is attached to the PR head
+        (``self.sha``) unless an explicit ``commit_sha`` is given. Returns True on
+        success; failures are logged and swallowed so a status update never
+        breaks the underlying review.
+        """
+        if not self.enabled_pr:
+            self.logger.error("Cannot publish commit status: not a pull request")
+            return False
+
+        sha = commit_sha or self.sha
+        if not sha:
+            self.logger.error("Cannot publish commit status: no commit sha available")
+            return False
+
+        normalized = (state or "").lower()
+        if normalized not in self._COMMIT_STATUS_STATES:
+            self.logger.warning(
+                f"Unknown commit status state '{state}', coercing to 'error'"
+            )
+            normalized = "error"
+
+        try:
+            self.repo_api.create_commit_status(
+                owner=self.owner,
+                repo=self.repo,
+                sha=sha,
+                state=normalized,
+                context=context,
+                # Keep the description short. limit_output_characters appends
+                # "..." when it truncates, so budget for that to stay <= 255.
+                description=self.limit_output_characters(description, 252),
+                target_url=target_url,
+            )
+            self.logger.info(
+                f"Published commit status state={normalized} context={context} "
+                f"on {self.owner}/{self.repo}@{sha}"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to publish commit status: {e}")
+            return False
+
     def publish_code_suggestions(self, suggestions: List[Dict[str, Any]]):
         """Publish code suggestions"""
         for suggestion in suggestions:
@@ -1687,6 +1749,33 @@ class RepoApi(giteapy.RepositoryApi):
         return self.repository.repo_get_all_commits(
             owner=owner,
             repo=repo
+        )
+
+    def create_commit_status(self, owner: str, repo: str, sha: str, state: str,
+                             context: str = "", description: str = "", target_url: str = ""):
+        """Create a commit status on a specific sha.
+
+        Maps to ``POST /repos/{owner}/{repo}/statuses/{sha}`` with a
+        ``CreateStatusOption`` body ``{state, context, description, target_url}``
+        (docs.gitea.com repoCreateStatus). ``state`` is a Gitea StatusState
+        (pending/success/error/failure/warning). This is Gitea's nearest
+        equivalent to a GitHub check run.
+        """
+        body = {
+            "state": state,
+            "context": context,
+            "description": description,
+            "target_url": target_url,
+        }
+        return self.api_client.call_api(
+            '/repos/{owner}/{repo}/statuses/{sha}',
+            'POST',
+            path_params={'owner': owner, 'repo': repo, 'sha': sha},
+            body=body,
+            response_type=None,
+            _return_http_data_only=False,
+            _preload_content=False,
+            auth_settings=['AuthorizationHeaderToken']
         )
 
     def add_reviewer(self, owner: str, repo: str, pr_number: int, reviewers: List[str]):

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -373,20 +373,45 @@ class GiteaProvider(GitProvider):
         self.publish_inline_comments([payload])
 
 
-    def publish_inline_comments(self, comments: List[Dict[str, Any]],body : str = "Inline comment") -> None:
-        response = self.repo_api.create_inline_comment(
+    def publish_inline_comments(self, comments: List[Dict[str, Any]], body: str = "Inline comment") -> None:
+        """Publish inline comments as a *submitted* COMMENT review.
+
+        Previously this called ``create_inline_comment`` with no ``event``,
+        which created an unsubmitted PENDING draft review — the inline
+        ``/review``/``/improve`` suggestions never actually posted. We submit
+        with ``event="COMMENT"`` so the comments post immediately, mirroring
+        GithubProvider (``pr.create_review(comments=...)`` submits a review).
+
+        This is deliberately kept separate from ``submit_review``: the formal
+        verdict (APPROVED / REQUEST_CHANGES via ``submit_review``/``auto_approve``)
+        is its own submitted review with an empty ``comments`` list, so inline
+        suggestions can never accidentally carry an APPROVED event, and an
+        approval can never smuggle in inline comments.
+
+        Maps to ``POST /repos/{owner}/{repo}/pulls/{index}/reviews`` with body
+        ``{body, event: "COMMENT", comments[]}`` where each comment is
+        ``{body, path, new_position, old_position}`` (Gitea CreatePullReviewOptions).
+
+        ``commit_id`` is deliberately omitted (same reasoning as
+        ``submit_review``): ``self.last_commit`` comes from
+        ``repo_get_all_commits`` — the repository/default-branch commit list, not
+        the PR's commits — so its sha is unrelated to the PR head. Pinning it
+        would anchor the inline positions to the wrong commit; omitting it lets
+        Gitea default to the PR head, which is where the positions were computed.
+        """
+        response = self.repo_api.create_review(
             owner=self.owner,
             repo=self.repo,
             pr_number=self.pr_number if self.enabled_pr else self.issue_number,
+            event="COMMENT",
             body=body,
-            commit_id=self.last_commit.sha if self.last_commit else "",
-            comments=comments
+            comments=comments,
         )
 
-        # ``create_inline_comment`` runs with ``_preload_content=False``, so a
-        # successful call returns the ``(data, status, headers)`` tuple rather
-        # than a truthy body; a non-2xx status raises ``ApiException`` before we
-        # get here. Inspect the status code instead of the (always-falsy) body.
+        # ``create_review`` runs with ``_preload_content=False``, so a successful
+        # call returns the ``(data, status, headers)`` tuple rather than a truthy
+        # body; a non-2xx status raises ``ApiException`` before we get here.
+        # Inspect the status code instead of the (always-falsy) body.
         status = response[1] if isinstance(response, tuple) and len(response) > 1 else None
         if status is not None and not (200 <= status < 300):
             self.logger.error(f"Failed to publish inline comment (status {status})")

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -11,7 +11,8 @@ from pr_agent.algo.git_patch_processing import decode_if_bytes
 from pr_agent.algo.language_handler import is_valid_file
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.algo.utils import (clip_tokens,
-                                 find_line_number_of_relevant_line_in_file)
+                                 find_line_number_of_relevant_line_in_file,
+                                 load_large_diff)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import (MAX_FILES_ALLOWED_FULL,
                                                  FilePatchInfo, GitProvider,
@@ -96,6 +97,13 @@ class GiteaProvider(GitProvider):
             self.last_commit_id = self.last_commit
             self.base_sha = self.pr.base.sha if self.pr.base.sha else ""
             self.base_ref = self.pr.base.ref if self.pr.base.ref else ""
+            # Gitea's PR object exposes the merge base directly. Prefer it for
+            # reading *base* file content: the base branch may have advanced
+            # (parallel merges) so base.sha no longer reflects the point the PR
+            # actually diverged from. Mirrors github_provider, which reads
+            # original content from compare.merge_base_commit.sha. Falls back to
+            # base_sha when the field is absent (older Gitea).
+            self.merge_base_sha = getattr(self.pr, "merge_base", None) or self.base_sha
         elif "issues" in url:
             self.issue_url = url
             self.__set_repo_and_owner_from_issue()
@@ -578,11 +586,24 @@ class GiteaProvider(GitProvider):
             self.logger.error(f"Error processing commit messages: {str(e)}")
             return ""
 
+    def _get_merge_base_ref(self) -> str:
+        """Ref to read *base* file content from.
+
+        Uses the PR's merge base (``self.merge_base_sha``, from Gitea's
+        ``PullRequest.merge_base``) rather than the raw ``base.sha``: the base
+        branch may have advanced via parallel merges, so ``base.sha`` no longer
+        points at where the PR diverged. This mirrors github_provider reading
+        original content from ``compare.merge_base_commit.sha``. Falls back to
+        ``base_sha`` when the merge base is unknown (older Gitea), so it never
+        regresses.
+        """
+        return getattr(self, "merge_base_sha", "") or self.base_sha
+
     def _get_file_content_from_base(self, filename: str) -> str:
         return self.repo_api.get_file_content(
             owner=self.owner,
             repo=self.repo,
-            commit_sha=self.base_sha,
+            commit_sha=self._get_merge_base_ref(),
             filepath=filename
         )
 
@@ -594,10 +615,79 @@ class GiteaProvider(GitProvider):
             filepath=filename
         )
 
+    def _build_compare_patches(self, base: str, head: str) -> Dict[str, str]:
+        """Return ``{filename: patch}`` from the merge-base-relative compare diff.
+
+        Uses ``GET .../compare/{base}...{head}?output=diff`` (three-dot, so it is
+        relative to the merge base, exactly like github_provider's compare).
+        Parsed with the same hunk-extraction logic as the PR ``.diff`` so the
+        patch shape is identical. Returns ``{}`` when the compare API is
+        unavailable, so the caller falls back to the PR ``.diff`` and never
+        regresses.
+        """
+        try:
+            diff_text = self.repo_api.get_compare_diff(
+                owner=self.owner, repo=self.repo, base=base, head=head
+            )
+        except Exception as e:
+            self.logger.warning(f"Compare diff unavailable ({base}...{head}): {e}; falling back to PR diff")
+            return {}
+        if not diff_text:
+            return {}
+        return self._parse_unified_diff(diff_text)
+
+    @staticmethod
+    def _parse_unified_diff(diff_text: str) -> Dict[str, str]:
+        """Parse a unified diff into ``{filename: patch}`` (hunks only).
+
+        Shared by the PR ``.diff`` path and the compare-diff path. The patch for
+        each file starts at its first ``@@`` hunk header (headers like ``index``/
+        ``---``/``+++`` are dropped), matching the shape the rest of pr-agent
+        expects. Files with no ``@@`` hunk (pure renames, mode changes, binaries)
+        produce no entry here; ``get_diff_files`` synthesizes a patch for those
+        via ``load_large_diff`` so they are never silently dropped.
+        """
+        lines = diff_text.splitlines()
+        current_file = None
+        current_patch = []
+        file_patches: Dict[str, str] = {}
+        for line in lines:
+            if line.startswith('diff --git'):
+                if current_file and current_patch:
+                    file_patches[current_file] = '\n'.join(current_patch)
+                current_patch = []
+                current_file = line.split(' b/')[-1]
+            elif line.startswith('@@') and not current_patch:
+                current_patch = [line]
+            elif current_patch:
+                current_patch.append(line)
+        if current_file and current_patch:
+            file_patches[current_file] = '\n'.join(current_patch)
+        return file_patches
+
     def get_diff_files(self) -> List[FilePatchInfo]:
-        """Get files that were modified in the PR"""
+        """Get files that were modified in the PR.
+
+        The per-file *list* (with status/additions/deletions and, for renames,
+        ``previous_filename``) comes from ``GET .../pulls/{index}/files`` — it
+        already includes renames, mode changes and binary files. Patches come
+        from the merge-base-relative compare diff when available (falling back to
+        the PR ``.diff``); any changed file still missing a patch (pure rename,
+        mode change, binary, or a diff the parser could not attribute) gets a
+        synthesized patch via ``load_large_diff`` so it is never dropped from the
+        review input.
+        """
         if self.diff_files:
             return self.diff_files
+
+        # Prefer the merge-base-relative compare diff for patches; fall back to
+        # the PR .diff already parsed into self.file_diffs. Conservative: if the
+        # compare API returns nothing, self.file_diffs is used unchanged.
+        file_diffs = self.file_diffs
+        if self.base_sha and self.sha:
+            compare_patches = self._build_compare_patches(self.base_sha, self.sha)
+            if compare_patches:
+                file_diffs = compare_patches
 
         invalid_files_names = []
         counter_valid = 0
@@ -613,7 +703,10 @@ class GiteaProvider(GitProvider):
 
             counter_valid += 1
             avoid_load = False
-            patch = self.file_diffs.get(filename,"")
+            patch = file_diffs.get(filename, "")
+            # For renames, the base content lives under the OLD path; ChangedFile
+            # exposes it as previous_filename. Fall back to the new filename.
+            previous_filename = file.get("previous_filename") or filename
             head_file = ""
             base_file = ""
 
@@ -626,20 +719,30 @@ class GiteaProvider(GitProvider):
                 head_file = ""
             else:
                 # Get file content from this pr
-                head_file = self.file_contents.get(filename,"")
+                head_file = self.file_contents.get(filename, "")
 
             if self.incremental.is_incremental and self.unreviewed_files_set:
-                base_file = self._get_file_content_from_latest_commit(filename)
-                self.unreviewed_files_set[filename] = patch
+                base_file = self._get_file_content_from_latest_commit(previous_filename)
             else:
                 if avoid_load:
                     base_file = ""
                 else:
-                    base_file = self._get_file_content_from_base(filename)
+                    base_file = self._get_file_content_from_base(previous_filename)
 
-            num_plus_lines = file.get("additions",0)
-            num_minus_lines = file.get("deletions",0)
-            status = file.get("status","")
+            # Synthesize a patch for any changed file the diff parser could not
+            # attribute (pure rename, mode change, binary, multi-hunk gap). This
+            # mirrors github_provider, which calls load_large_diff whenever
+            # file.patch is empty. Skipped when content was intentionally not
+            # loaded (avoid_load) — there is nothing to diff against.
+            if not patch and not avoid_load and (head_file or base_file):
+                patch = load_large_diff(filename, head_file, base_file, show_warning=False)
+
+            if self.incremental.is_incremental and self.unreviewed_files_set:
+                self.unreviewed_files_set[filename] = patch
+
+            num_plus_lines = file.get("additions", 0)
+            num_minus_lines = file.get("deletions", 0)
+            status = file.get("status", "")
 
             if status == 'added':
                 edit_type = EDIT_TYPE.ADDED
@@ -647,6 +750,8 @@ class GiteaProvider(GitProvider):
                 edit_type = EDIT_TYPE.DELETED
             elif status == 'renamed':
                 edit_type = EDIT_TYPE.RENAMED
+            elif status == 'copied':
+                edit_type = EDIT_TYPE.ADDED
             elif status == 'modified' or status == 'changed':
                 edit_type = EDIT_TYPE.MODIFIED
             else:
@@ -660,7 +765,8 @@ class GiteaProvider(GitProvider):
                 filename=filename,
                 num_minus_lines=num_minus_lines,
                 num_plus_lines=num_plus_lines,
-                edit_type=edit_type
+                edit_type=edit_type,
+                old_filename=None if previous_filename == filename else previous_filename,
             )
             diff_files.append(file_patch_info)
 
@@ -1129,6 +1235,95 @@ class RepoApi(giteapy.RepositoryApi):
         except Exception as e:
             self.logger.error(f"Unexpected error: {str(e)}")
             raise e
+
+    def get_compare(self, owner: str, repo: str, base: str, head: str) -> Dict[str, Any]:
+        """Compare two refs via Gitea's compare API.
+
+        Maps to ``GET /repos/{owner}/{repo}/compare/{base}...{head}`` (three-dot,
+        merge-base relative — see docs.gitea.com repoCompareDiff). The endpoint
+        is a wildcard route (``/compare/*``), so ``base...head`` is embedded in
+        the path rather than passed as a path param.
+
+        Returns Gitea's ``Compare`` object: ``{"total_commits": int, "commits":
+        [Commit, ...]}`` where each commit carries a ``files`` array of
+        ``{"filename", "status"}`` (CommitAffectedFiles). Note that Gitea's
+        compare JSON does NOT return a merge-base sha and does NOT return a
+        merged per-file patch (only per-commit affected files); the merge-base
+        relative *diff text* is fetched separately via ``get_compare_diff``.
+
+        Returns ``{}`` on failure so callers can fall back gracefully.
+        """
+        try:
+            # base...head is merge-base relative (three-dot), matching how
+            # GitHub's compare merge_base_commit is used in github_provider.
+            url = f'/repos/{owner}/{repo}/compare/{base}...{head}'
+
+            response = self.api_client.call_api(
+                url,
+                'GET',
+                path_params={},
+                response_type=None,
+                _return_http_data_only=False,
+                _preload_content=False,
+                auth_settings=['AuthorizationHeaderToken']
+            )
+
+            if hasattr(response, 'data'):
+                raw_data = response.data.read()
+                return json.loads(raw_data.decode('utf-8'))
+            elif isinstance(response, tuple):
+                raw_data = response[0].read()
+                return json.loads(raw_data.decode('utf-8'))
+
+            return {}
+
+        except ApiException as e:
+            self.logger.error(f"Error comparing {base}...{head}: {e}")
+            return {}
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+            return {}
+
+    def get_compare_diff(self, owner: str, repo: str, base: str, head: str) -> str:
+        """Get the merge-base-relative unified diff for a ref range.
+
+        Maps to ``GET /repos/{owner}/{repo}/compare/{base}...{head}?output=diff``.
+        Gitea's compare route serves the raw diff/patch when ``output=diff`` is
+        requested (``downloadCompareDiffOrPatch``), computed over ``base...head``
+        (three-dot), i.e. relative to the merge base — the same semantics as the
+        GitHub compare used by github_provider.
+
+        Returns "" on failure so callers can fall back to the PR ``.diff``.
+        """
+        try:
+            url = f'/repos/{owner}/{repo}/compare/{base}...{head}'
+
+            response = self.api_client.call_api(
+                url,
+                'GET',
+                path_params={},
+                query_params=[('output', 'diff')],
+                response_type=None,
+                _return_http_data_only=False,
+                _preload_content=False,
+                auth_settings=['AuthorizationHeaderToken']
+            )
+
+            if hasattr(response, 'data'):
+                raw_data = response.data.read()
+                return raw_data.decode('utf-8', errors='replace')
+            elif isinstance(response, tuple):
+                raw_data = response[0].read()
+                return raw_data.decode('utf-8', errors='replace')
+
+            return ""
+
+        except ApiException as e:
+            self.logger.error(f"Error getting compare diff {base}...{head}: {e}")
+            return ""
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+            return ""
 
     def get_pull_request(self, owner: str, repo: str, pr_number: int):
         """Get pull request details including description"""

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
@@ -291,6 +292,68 @@ class GiteaProvider(GitProvider):
             self.logger.error(f"Unexpected error: {e}")
             return None
 
+    def edit_comment_from_comment_id(self, comment_id: int, body: str):
+        """Edit an existing issue/PR comment addressed by its id.
+
+        Mirrors GithubProvider.edit_comment_from_comment_id; unlocks the inline
+        ``/ask`` flow, which edits its own placeholder comment in place.
+        """
+        body = self.limit_output_characters(body, self.max_comment_chars)
+        try:
+            self.repo_api.edit_comment(
+                owner=self.owner,
+                repo=self.repo,
+                comment_id=comment_id,
+                comment=body
+            )
+        except ApiException as e:
+            self.logger.error(f"Error editing comment {comment_id}: {e}")
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+
+    def get_comment_body_from_comment_id(self, comment_id: int) -> str:
+        """Return the body text of an issue/PR comment addressed by its id."""
+        try:
+            comment = self.repo_api.get_comment(
+                owner=self.owner,
+                repo=self.repo,
+                comment_id=comment_id
+            )
+            return comment.get("body", "") if isinstance(comment, dict) else ""
+        except ApiException as e:
+            self.logger.error(f"Error getting comment {comment_id}: {e}")
+            return ""
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+            return ""
+
+    def reply_to_comment_from_comment_id(self, comment_id: int, body: str):
+        """Reply to a comment.
+
+        Gitea has no reply-to-a-specific-comment endpoint (unlike GitHub's
+        review-comment replies), so the reply is posted as a new comment on
+        the PR — which is where the inline ``/ask`` answer surfaces.
+        """
+        self.publish_comment(body)
+
+    def get_review_thread_comments(self, comment_id: int) -> List[Dict[str, Any]]:
+        """Return the comments in the thread of the given comment.
+
+        Gitea does not expose a thread-by-comment lookup, so this returns the
+        single target comment (best-effort) so inline ``/ask`` still has the
+        original comment as context.
+        """
+        try:
+            comment = self.repo_api.get_comment(
+                owner=self.owner,
+                repo=self.repo,
+                comment_id=comment_id
+            )
+            return [comment] if comment else []
+        except Exception as e:
+            self.logger.error(f"Error getting review thread comments for {comment_id}: {e}")
+            return []
+
 
     def publish_inline_comment(self,body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
         """Publish an inline comment on a specific line"""
@@ -425,20 +488,31 @@ class GiteaProvider(GitProvider):
             self.logger.error(f"Unexpected error: {e}")
             return None
 
-    def remove_reaction(self, comment_id: int) -> None:
-        """Remove reaction from a comment"""
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        """Remove the eyes reaction from a comment.
+
+        Signature mirrors the base/GithubProvider contract
+        ``remove_reaction(issue_comment_id, reaction_id)`` — the base class and
+        every caller pass two arguments, so the previous single-argument
+        Gitea signature raised a ``TypeError`` at runtime. Gitea deletes a
+        reaction by its content (not by a reaction id), so ``reaction_id`` is
+        accepted for contract compatibility but the "eyes" content is what is
+        removed. Returns True on success.
+        """
         try:
-            response = self.repo_api.remove_reaction_comment(
+            self.repo_api.remove_reaction_comment(
                 owner=self.owner,
                 repo=self.repo,
-                comment_id=comment_id
+                comment_id=issue_comment_id,
+                reaction="eyes"
             )
-            if not response:
-                self.logger.error("Failed to remove reaction")
+            return True
         except ApiException as e:
             self.logger.error(f"Error removing reaction: {e}")
+            return False
         except Exception as e:
             self.logger.error(f"Unexpected error: {e}")
+            return False
 
     def get_commit_messages(self)-> str:
         """Get commit messages for the PR"""
@@ -650,17 +724,45 @@ class GiteaProvider(GitProvider):
         return [label.name for label in labels]
 
     def get_repo_settings(self) -> bytes:
-        """Get repository settings"""
+        """Get repository settings.
+
+        When a config branch is set (via ``config.config_branch`` or the
+        ``PR_AGENT_CONFIG_BRANCH`` env var, mirroring GithubProvider), the
+        settings file is read from that branch first; a missing branch/file
+        falls back to the PR head commit. ``get_file_content`` passes the ref
+        through Gitea's ``?ref=`` query param, which accepts a branch name as
+        well as a commit sha.
+        """
         if not self.repo_settings:
             self.logger.error("Repository settings not found")
             return b""
 
-        response = self.repo_api.get_file_content(
-            owner=self.owner,
-            repo=self.repo,
-            commit_sha=self.sha,
-            filepath=self.repo_settings
-        )
+        settings_branch = get_settings().get("CONFIG.CONFIG_BRANCH", None)
+        settings_branch = settings_branch.strip() if isinstance(settings_branch, str) else ""
+        env_branch = (os.environ.get("PR_AGENT_CONFIG_BRANCH") or "").strip()
+        config_branch = settings_branch or env_branch
+
+        response = ""
+        if config_branch:
+            response = self.repo_api.get_file_content(
+                owner=self.owner,
+                repo=self.repo,
+                commit_sha=config_branch,
+                filepath=self.repo_settings
+            )
+            if not response:
+                self.logger.warning(
+                    f"Failed to load {self.repo_settings} from branch '{config_branch}', "
+                    "falling back to the PR head commit"
+                )
+
+        if not response:
+            response = self.repo_api.get_file_content(
+                owner=self.owner,
+                repo=self.repo,
+                commit_sha=self.sha,
+                filepath=self.repo_settings
+            )
         if not response:
             self.logger.error("Failed to get repository settings")
             return b""
@@ -676,7 +778,14 @@ class GiteaProvider(GitProvider):
         return f"{self.pr.user.id}" if self.pr else ""
 
     def is_supported(self, capability) -> bool:
-        """Check if the provider is supported"""
+        """Report whether a capability is available.
+
+        Mirrors GithubProvider: in restricted mode the provider must not claim
+        it can push code, so callers skip operations that need elevated
+        permissions instead of failing at the API.
+        """
+        if capability == "push_code" and get_settings().config.restricted_mode:
+            return False
         return True
 
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
@@ -706,17 +815,55 @@ class GiteaProvider(GitProvider):
                 pr_number=self.pr_number
             )
 
-    def publish_labels(self, labels: List[int]) -> None:
-        """Publish labels to the PR"""
+    def get_repo_labels(self) -> List[Dict[str, Any]]:
+        """Get all labels defined in the repository.
+
+        Returns the raw label objects (each ``{id, name, color, ...}``) so
+        callers can resolve a label name to the numeric id Gitea's
+        issue-label endpoint requires. Mirrors GithubProvider.get_repo_labels.
+        """
+        labels = self.repo_api.get_repo_labels(
+            owner=self.owner,
+            repo=self.repo
+        )
+        if not labels:
+            self.logger.error("Failed to get repository labels")
+            return []
+
+        return labels
+
+    def publish_labels(self, labels: List[str]) -> None:
+        """Publish labels to the PR.
+
+        pr-agent's tools hand this method label *names* (e.g. "Bug fix"), but
+        Gitea's issue-label endpoint takes numeric label *ids*. Resolve the
+        names against the repository's labels before posting; names with no
+        matching repository label are skipped (Gitea can only attach labels
+        that already exist in the repo).
+        """
         if not labels:
             self.logger.error("No labels provided to publish")
+            return None
+
+        repo_labels = self.get_repo_labels()
+        name_to_id = {
+            (label.get("name") if isinstance(label, dict) else getattr(label, "name", None)):
+            (label.get("id") if isinstance(label, dict) else getattr(label, "id", None))
+            for label in repo_labels
+        }
+        label_ids = [name_to_id[name] for name in labels if name in name_to_id]
+        missing = [name for name in labels if name not in name_to_id]
+        if missing:
+            self.logger.warning(f"Skipping labels not defined in the repository: {missing}")
+        if not label_ids:
+            self.logger.error("None of the provided labels exist in the repository")
             return None
 
         response = self.repo_api.add_labels(
             owner=self.owner,
             repo=self.repo,
             issue_number=self.pr_number if self.enabled_pr else self.issue_number,
-            labels=labels
+            labels=label_ids
         )
 
         if response:
@@ -905,6 +1052,41 @@ class RepoApi(giteapy.RepositoryApi):
             index=index
         )
 
+    def get_comment(self, owner: str, repo: str, comment_id: int):
+        """Fetch a single issue/PR comment by its id.
+
+        Maps to ``GET /repos/{owner}/{repo}/issues/comments/{id}`` and returns
+        the raw comment dict (``{id, body, user, ...}``).
+        """
+        try:
+            url = f'/repos/{owner}/{repo}/issues/comments/{comment_id}'
+
+            response = self.api_client.call_api(
+                url,
+                'GET',
+                path_params={},
+                response_type=None,
+                _return_http_data_only=False,
+                _preload_content=False,
+                auth_settings=['AuthorizationHeaderToken']
+            )
+
+            if hasattr(response, 'data'):
+                raw_data = response.data.read()
+                return json.loads(raw_data.decode('utf-8'))
+            elif isinstance(response, tuple):
+                raw_data = response[0].read()
+                return json.loads(raw_data.decode('utf-8'))
+
+            return {}
+
+        except ApiException as e:
+            self.logger.error(f"Error getting comment {comment_id}: {e}")
+            return {}
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+            return {}
+
     def get_pull_request_diff(self, owner: str, repo: str, pr_number: int) -> str:
         """Get the diff content of a pull request using direct API call"""
         try:
@@ -1072,6 +1254,41 @@ class RepoApi(giteapy.RepositoryApi):
             index=issue_number
         )
 
+    def get_repo_labels(self, owner: str, repo: str):
+        """Get all labels defined in the repository.
+
+        Maps to ``GET /repos/{owner}/{repo}/labels``. Returns a list of label
+        dicts (``{id, name, color, ...}``).
+        """
+        try:
+            url = f'/repos/{owner}/{repo}/labels'
+
+            response = self.api_client.call_api(
+                url,
+                'GET',
+                path_params={},
+                response_type=None,
+                _return_http_data_only=False,
+                _preload_content=False,
+                auth_settings=['AuthorizationHeaderToken']
+            )
+
+            if hasattr(response, 'data'):
+                raw_data = response.data.read()
+                return json.loads(raw_data.decode('utf-8'))
+            elif isinstance(response, tuple):
+                raw_data = response[0].read()
+                return json.loads(raw_data.decode('utf-8'))
+
+            return []
+
+        except ApiException as e:
+            self.logger.error(f"Error getting repository labels: {e}")
+            return []
+        except Exception as e:
+            self.logger.error(f"Unexpected error: {e}")
+            return []
+
     def list_all_commits(self, owner: str, repo: str):
         return self.repository.repo_get_all_commits(
             owner=owner,
@@ -1104,11 +1321,15 @@ class RepoApi(giteapy.RepositoryApi):
             auth_settings=['AuthorizationHeaderToken']
         )
 
-    def remove_reaction_comment(self, owner: str, repo: str, comment_id: int):
+    def remove_reaction_comment(self, owner: str, repo: str, comment_id: int, reaction: str = "eyes"):
+        body = {
+            "content": reaction
+        }
         return self.api_client.call_api(
             '/repos/{owner}/{repo}/issues/comments/{id}/reactions',
             'DELETE',
             path_params={'owner': owner, 'repo': repo, 'id': comment_id},
+            body=body,
             response_type='Repository',
             auth_settings=['AuthorizationHeaderToken']
         )

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -1,5 +1,6 @@
 import json
 import os
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
@@ -10,7 +11,7 @@ from pr_agent.algo.file_filter import filter_ignored
 from pr_agent.algo.git_patch_processing import decode_if_bytes
 from pr_agent.algo.language_handler import is_valid_file
 from pr_agent.algo.types import EDIT_TYPE
-from pr_agent.algo.utils import (clip_tokens,
+from pr_agent.algo.utils import (PRReviewHeader, clip_tokens,
                                  find_line_number_of_relevant_line_in_file,
                                  load_large_diff)
 from pr_agent.config_loader import get_settings
@@ -599,19 +600,185 @@ class GiteaProvider(GitProvider):
         """
         return getattr(self, "merge_base_sha", "") or self.base_sha
 
+    # ------------------------------------------------------------------
+    # Incremental review (re-review only the commits pushed since the last
+    # review). Ports github_provider's get_incremental_commits / get_commit_range
+    # / get_previous_review to Gitea's REST API. Enabled via `/review -i`.
+    # ------------------------------------------------------------------
+    def get_incremental_commits(self, incremental=None):
+        """Prepare state for an incremental review.
+
+        Mirrors GithubProvider.get_incremental_commits: records the
+        ``IncrementalPR`` and, when incremental, resets the unreviewed-files set
+        and computes the new-commit range. A no-op for a full review.
+        """
+        if incremental is None:
+            incremental = IncrementalPR(False)
+        self.incremental = incremental
+        if self.incremental.is_incremental:
+            self.unreviewed_files_set = dict()
+            self._get_incremental_commits()
+
+    def _get_incremental_commits(self):
+        """Compute which commits (and files) are new since the last review.
+
+        Uses the PR's commit list (``GET .../pulls/{index}/commits``) and the
+        most recent prior review comment (``get_previous_review``). Files changed
+        across the new-commit range are collected via the compare API
+        (``GET .../compare/{last_seen}...{head}``), whose per-commit ``files``
+        arrays list every affected path. If no previous review exists, we fall
+        back to a full review (``is_incremental = False``), matching
+        github_provider.
+        """
+        if not getattr(self, "pr_commits", None):
+            self.pr_commits = self.repo_api.get_pr_commits(
+                owner=self.owner, repo=self.repo, pr_number=self.pr_number
+            )
+        # Normalize to adapters exposing .sha and .commit.author.date, so the
+        # IncrementalPR accessors used by pr_reviewer work unchanged.
+        self.pr_commits = [self._as_commit(c) for c in (self.pr_commits or [])]
+
+        self.previous_review = self.get_previous_review(full=True, incremental=True)
+        push_before = get_settings().get("gitea.incremental_push_before_sha", None)
+        if self.previous_review:
+            self.incremental.commits_range = self.get_commit_range()
+            head = self.sha
+            base = self.incremental.last_seen_commit_sha or self.base_sha
+            changed = self._get_changed_files_in_range(base, head)
+            self.unreviewed_files_set.update(changed)
+        elif push_before:
+            # No prior review comment to diff against, but a push webhook gave us
+            # the pre-push head SHA. Anchor the incremental review to that range
+            # (before...head) so a push re-review still only looks at the new
+            # commits. Set last_seen_commit so pr_reviewer's threshold checks and
+            # the diff base both use it.
+            self.logger.info(f"No previous review found; using push before-SHA {push_before} as incremental base")
+            self.incremental.last_seen_commit = self._as_commit({"sha": push_before})
+            self.incremental.commits_range = self._commits_after_sha(push_before)
+            if self.incremental.commits_range:
+                self.incremental.first_new_commit = self.incremental.commits_range[0]
+            changed = self._get_changed_files_in_range(push_before, self.sha)
+            self.unreviewed_files_set.update(changed)
+            if not self.unreviewed_files_set:
+                self.logger.info("Push range produced no changed files, will review the entire PR")
+                self.incremental.is_incremental = False
+        else:
+            self.logger.info("No previous review found, will review the entire PR")
+            self.incremental.is_incremental = False
+
+    def _commits_after_sha(self, sha: str) -> List[Any]:
+        """Return the PR commits that come strictly after ``sha`` (exclusive).
+
+        Used to size the new-commit range for a push-anchored incremental review
+        when there is no prior review comment. If ``sha`` is not found in the PR
+        commit list, returns [] (the caller then falls back to a full review).
+        """
+        shas = [c.sha for c in self.pr_commits]
+        if sha in shas:
+            idx = shas.index(sha)
+            return self.pr_commits[idx + 1:]
+        return []
+
+    def get_commit_range(self):
+        """Return the slice of ``pr_commits`` authored after the last review.
+
+        Walks the commits newest-first; commits authored after the previous
+        review's timestamp are "new", and the first commit at/older than that
+        timestamp is the ``last_seen_commit`` (the incremental diff base). Mirrors
+        github_provider.get_commit_range.
+        """
+        last_review_time = self.previous_review.created_at
+        first_new_commit_index = None
+        for index in range(len(self.pr_commits) - 1, -1, -1):
+            if self.pr_commits[index].commit.author.date > last_review_time:
+                self.incremental.first_new_commit = self.pr_commits[index]
+                first_new_commit_index = index
+            else:
+                self.incremental.last_seen_commit = self.pr_commits[index]
+                break
+        return self.pr_commits[first_new_commit_index:] if first_new_commit_index is not None else []
+
+    def get_previous_review(self, *, full: bool, incremental: bool):
+        """Return the most recent prior review comment, or None.
+
+        Matches on the review header prefixes (regular / incremental) exactly
+        like github_provider, scanning the PR's issue comments newest-first.
+        """
+        if not (full or incremental):
+            raise ValueError("At least one of full or incremental must be True")
+        if not getattr(self, "comments", None):
+            self.comments = self.repo_api.list_all_comments(
+                owner=self.owner, repo=self.repo, index=self.pr_number
+            ) or []
+        prefixes = []
+        if full:
+            prefixes.append(PRReviewHeader.REGULAR.value)
+        if incremental:
+            prefixes.append(PRReviewHeader.INCREMENTAL.value)
+        for index in range(len(self.comments) - 1, -1, -1):
+            body = self._comment_body(self.comments[index])
+            if any(body.startswith(prefix) for prefix in prefixes):
+                return self.comments[index]
+        return None
+
+    def _get_changed_files_in_range(self, base: str, head: str) -> Dict[str, Any]:
+        """Map ``{filename: filename}`` for every file touched between two refs.
+
+        Uses the compare API's per-commit ``files`` arrays. Returns an empty
+        mapping (triggering the "no new files" path in pr_reviewer) if the
+        compare is unavailable, rather than falsely reporting the whole PR.
+        """
+        changed: Dict[str, Any] = {}
+        if not base or not head:
+            return changed
+        compare = self.repo_api.get_compare(
+            owner=self.owner, repo=self.repo, base=base, head=head
+        )
+        for commit in (compare or {}).get("commits", []) or []:
+            for f in (commit.get("files") or []):
+                name = f.get("filename")
+                if name:
+                    changed[name] = name
+        return changed
+
+    @staticmethod
+    def _comment_body(comment) -> str:
+        if isinstance(comment, dict):
+            return comment.get("body", "") or ""
+        return getattr(comment, "body", "") or ""
+
+    @staticmethod
+    def _as_commit(commit):
+        """Wrap a Gitea commit (dict or object) so ``.sha`` and
+        ``.commit.author.date`` (a ``datetime``) are always available, matching
+        what the ``IncrementalPR`` accessors and pr_reviewer expect from a
+        PyGithub commit."""
+        if not isinstance(commit, dict):
+            return commit  # already an object with the needed attributes
+
+        from datetime import datetime, timezone
+
+        def _parse_date(value):
+            if not value:
+                return datetime.min.replace(tzinfo=timezone.utc)
+            try:
+                # Gitea emits RFC 3339 (e.g. 2024-01-02T03:04:05Z).
+                return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            except Exception:
+                return datetime.min.replace(tzinfo=timezone.utc)
+
+        commit_obj = commit.get("commit") or {}
+        author = commit_obj.get("author") or {}
+        date = _parse_date(author.get("date"))
+        author_ns = SimpleNamespace(date=date, name=author.get("name", ""))
+        commit_ns = SimpleNamespace(author=author_ns, message=commit_obj.get("message", ""))
+        return SimpleNamespace(sha=commit.get("sha", ""), commit=commit_ns)
+
     def _get_file_content_from_base(self, filename: str) -> str:
         return self.repo_api.get_file_content(
             owner=self.owner,
             repo=self.repo,
             commit_sha=self._get_merge_base_ref(),
-            filepath=filename
-        )
-
-    def _get_file_content_from_latest_commit(self, filename: str) -> str:
-        return self.repo_api.get_file_content(
-            owner=self.owner,
-            repo=self.repo,
-            commit_sha=self.last_commit.sha,
             filepath=filename
         )
 
@@ -680,19 +847,35 @@ class GiteaProvider(GitProvider):
         if self.diff_files:
             return self.diff_files
 
-        # Prefer the merge-base-relative compare diff for patches; fall back to
-        # the PR .diff already parsed into self.file_diffs. Conservative: if the
-        # compare API returns nothing, self.file_diffs is used unchanged.
+        incremental = bool(self.incremental.is_incremental and self.unreviewed_files_set)
+
+        # Patch source. Full review: merge-base-relative compare diff of
+        # base...head (falling back to the PR .diff already parsed into
+        # self.file_diffs). Incremental review: only the diff introduced by the
+        # new commits, i.e. last_seen_commit...head, so re-reviews on push don't
+        # re-diff the whole PR. Both fall back conservatively.
         file_diffs = self.file_diffs
-        if self.base_sha and self.sha:
+        if incremental:
+            base_ref = self.incremental.last_seen_commit_sha or self.base_sha
+            if base_ref and self.sha:
+                compare_patches = self._build_compare_patches(base_ref, self.sha)
+                if compare_patches:
+                    file_diffs = compare_patches
+        elif self.base_sha and self.sha:
             compare_patches = self._build_compare_patches(self.base_sha, self.sha)
             if compare_patches:
                 file_diffs = compare_patches
 
+        # In incremental mode review only the files touched by the new commits.
+        files_iter = self.git_files
+        if incremental:
+            files_iter = [f for f in self.git_files
+                          if f.get("filename") in self.unreviewed_files_set]
+
         invalid_files_names = []
         counter_valid = 0
         diff_files = []
-        for file in self.git_files:
+        for file in files_iter:
             filename = file.get("filename")
             if not filename:
                 continue
@@ -721,8 +904,14 @@ class GiteaProvider(GitProvider):
                 # Get file content from this pr
                 head_file = self.file_contents.get(filename, "")
 
-            if self.incremental.is_incremental and self.unreviewed_files_set:
-                base_file = self._get_file_content_from_latest_commit(previous_filename)
+            if incremental:
+                # Incremental base = the last already-reviewed commit, so the
+                # diff reflects only what the new commits changed.
+                base_ref = self.incremental.last_seen_commit_sha or self.base_sha
+                base_file = self.repo_api.get_file_content(
+                    owner=self.owner, repo=self.repo,
+                    commit_sha=base_ref, filepath=previous_filename,
+                )
             else:
                 if avoid_load:
                     base_file = ""

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import os
 import re
 from typing import Any, Dict
@@ -36,18 +37,23 @@ async def handle_gitea_webhooks(background_tasks: BackgroundTasks, request: Requ
     return {}
 
 async def get_body(request: Request):
-    """Parse and verify webhook request body"""
+    """Parse and verify webhook request body.
+
+    The raw bytes are read FIRST and the JSON is parsed from those same bytes.
+    HMAC verification must run over the exact bytes the client signed; reading
+    ``request.json()`` before ``request.body()`` risks the body stream already
+    being consumed, so ``request.body()`` could yield empty bytes and the
+    signature check would run over the wrong payload.
+    """
     try:
-        body = await request.json()
+        body_bytes = await request.body()
     except Exception as e:
-        get_logger().error("Error parsing request body", artifact={'error': e})
-        raise HTTPException(status_code=400, detail="Error parsing request body") from e
+        get_logger().error("Error reading request body", artifact={'error': e})
+        raise HTTPException(status_code=400, detail="Error reading request body") from e
 
-
-    # Verify webhook signature
+    # Verify webhook signature over the exact raw bytes that were received.
     webhook_secret = getattr(get_settings().gitea, 'webhook_secret', None)
     if webhook_secret:
-        body_bytes = await request.body()
         signature_header = request.headers.get('x-gitea-signature', None)
         if not signature_header:
             get_logger().error("Missing signature header")
@@ -59,13 +65,40 @@ async def get_body(request: Request):
             get_logger().error(f"Invalid signature: {ex}")
             raise HTTPException(status_code=401, detail="Invalid signature")
 
+    try:
+        body = json.loads(body_bytes)
+    except Exception as e:
+        get_logger().error("Error parsing request body", artifact={'error': e})
+        raise HTTPException(status_code=400, detail="Error parsing request body") from e
+
     return body
+
+def get_bot_user() -> str:
+    """The login of the account whose token the agent runs as.
+
+    Used to filter out the agent's own comments so it never triggers on
+    itself. Configurable via ``gitea.bot_user``; defaults to "pr-agent".
+    """
+    return str(get_settings().get("GITEA.BOT_USER", "pr-agent") or "pr-agent")
+
+
+def is_self_comment(body: Dict[str, Any]) -> bool:
+    """True if the comment/event was raised by the agent's own bot account."""
+    sender = str((body.get("sender") or {}).get("login", ""))
+    return bool(sender) and sender.lower() == get_bot_user().lower()
+
 
 async def handle_request(body: Dict[str, Any], event: str):
     """Process Gitea webhook events"""
     action = body.get("action")
     if not action:
         get_logger().debug("No action found in request body")
+        return {}
+
+    # Never act on an event the agent itself raised (e.g. its own review-submitted
+    # echo or its own comment), which would otherwise self-trigger an endless loop.
+    if is_self_comment(body):
+        get_logger().debug("Request ignored: event raised by the bot user itself")
         return {}
 
     agent = PRAgent()
@@ -77,6 +110,8 @@ async def handle_request(body: Dict[str, Any], event: str):
             return {}
         if action in ["opened", "reopened", "synchronized"]:
             await handle_pr_event(body, event, action, agent)
+        elif action == "review_requested":
+            await handle_review_requested_event(body, event, action, agent)
     elif event == "issue_comment":
         if action == "created":
             await handle_comment_event(body, event, action, agent)
@@ -110,6 +145,44 @@ async def handle_pr_event(body: Dict[str, Any], event: str, action: str, agent: 
         await _perform_commands_gitea("push_commands", agent, body, api_url)
         # for command in commands_on_push:
         #     await agent.handle_request(api_url, command)
+
+def review_requested_for_bot(body: Dict[str, Any]) -> bool:
+    """True when the (re-)requested reviewer is the agent's bot account."""
+    bot = get_bot_user().lower()
+    requested = body.get("requested_reviewer") or {}
+    if isinstance(requested, dict) and str(requested.get("login", "")).lower() == bot:
+        return True
+    # fall back to the PR's current requested-reviewers list
+    for user in (body.get("pull_request") or {}).get("requested_reviewers") or []:
+        if isinstance(user, dict) and str(user.get("login", "")).lower() == bot:
+            return True
+    return False
+
+
+async def handle_review_requested_event(body: Dict[str, Any], event: str, action: str, agent: PRAgent):
+    """Auto-run /review when the bot is (re-)requested as a reviewer.
+
+    Gitea fires ``pull_request`` with ``action=review_requested`` when a
+    reviewer is added (including the "re-request review" button). Upstream
+    never wired this action, so a reviewer request was a no-op. We run the
+    configured ``pr_commands`` (which include /review) so the reviewer slot is
+    filled on demand.
+    """
+    if not review_requested_for_bot(body):
+        get_logger().debug("Review requested, but not for the bot user; ignoring")
+        return
+    if not should_process_pr_logic(body):
+        get_logger().debug("Request ignored: PR logic filtering")
+        return
+
+    pr = body.get("pull_request", {})
+    api_url = pr.get("url")
+    if not api_url:
+        return
+
+    get_logger().info(f"Bot (re-)requested as reviewer, running pr_commands for {api_url=}")
+    await _perform_commands_gitea("pr_commands", agent, body, api_url)
+
 
 async def handle_comment_event(body: Dict[str, Any], event: str, action: str, agent: PRAgent):
     """Handle comment events"""

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -142,9 +142,25 @@ async def handle_pr_event(body: Dict[str, Any], event: str, action: str, agent: 
             get_logger().info("Push event, but no push commands found or push trigger is disabled")
             return
         get_logger().debug(f'A push event has been received: {api_url}')
-        await _perform_commands_gitea("push_commands", agent, body, api_url)
-        # for command in commands_on_push:
-        #     await agent.handle_request(api_url, command)
+
+        # Gitea's synchronized payload carries the head-branch SHAs before/after
+        # the push. When incremental push review is enabled we anchor the review
+        # to that range (before...after) so a re-review only looks at the newly
+        # pushed commits. Full review remains the default/fallback: incremental
+        # only kicks in when the flag is set AND both SHAs are present.
+        before_sha = body.get("before")
+        after_sha = body.get("after")
+        incremental_push = get_settings().get("gitea.incremental_review_on_push", False)
+        if incremental_push and before_sha and after_sha and before_sha != after_sha:
+            get_logger().info(
+                f"Incremental push review for {api_url}: {before_sha}...{after_sha}"
+            )
+            await _perform_commands_gitea(
+                "push_commands", agent, body, api_url,
+                incremental=True, before_sha=before_sha, after_sha=after_sha,
+            )
+        else:
+            await _perform_commands_gitea("push_commands", agent, body, api_url)
 
 def review_requested_for_bot(body: Dict[str, Any]) -> bool:
     """True when the (re-)requested reviewer is the agent's bot account."""
@@ -200,7 +216,9 @@ async def handle_comment_event(body: Dict[str, Any], event: str, action: str, ag
 
     await agent.handle_request(pr_url, comment_body)
 
-async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict, api_url: str):
+async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict, api_url: str,
+                                  incremental: bool = False, before_sha: str = None,
+                                  after_sha: str = None):
     apply_repo_settings(api_url)
     if commands_conf == "pr_commands" and get_settings().config.disable_auto_feedback:  # auto commands for PR, and auto feedback is disabled
         get_logger().info(f"Auto feedback is disabled, skipping auto commands for PR {api_url=}")
@@ -211,11 +229,21 @@ async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict
     if not commands:
         get_logger().info(f"New PR, but no auto commands configured")
         return
+    if incremental:
+        # Expose the pushed range so the provider can anchor the incremental base
+        # to the push `before` SHA when there is no prior review comment to
+        # diff against (full review stays the fallback inside the provider).
+        get_settings().set("gitea.incremental_push_before_sha", before_sha)
+        get_settings().set("gitea.incremental_push_after_sha", after_sha)
     get_settings().set("config.is_auto_command", True)
     for command in commands:
         split_command = command.split(" ")
         command = split_command[0]
         args = split_command[1:]
+        # Turn `/review` into `/review -i` on an incremental push so only the
+        # newly pushed commits are re-reviewed. Other commands are untouched.
+        if incremental and command == "/review" and "-i" not in args:
+            args = ["-i"] + args
         other_args = update_settings_from_args(args)
         new_command = ' '.join([command] + other_args)
         get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -283,6 +283,10 @@ push_commands = [
 [gitea]
 url = "https://gitea.com"
 handle_push_trigger = false
+# When true, a push (synchronized) re-review runs as an incremental /review -i,
+# diffing only the newly pushed commits (before...after). Default false = every
+# push re-reviews the whole PR (the pre-existing behavior).
+incremental_review_on_push = false
 pr_commands = [
     "/describe",
     "/review",

--- a/tests/unittest/test_gitea_app.py
+++ b/tests/unittest/test_gitea_app.py
@@ -248,3 +248,92 @@ class TestGiteaReviewRequested:
             await gitea_app.handle_request(body, event='pull_request')
 
         mock_handler.assert_awaited_once()
+
+
+class TestGiteaSynchronizedIncremental:
+    """A push (synchronized) can run an incremental /review anchored to the
+    before/after SHAs when gitea.incremental_review_on_push is enabled; full
+    review is the default/fallback (item: incremental review on push)."""
+
+    def _settings(self, incremental_on_push, push_commands=None):
+        settings = MagicMock()
+        values = {
+            'gitea.push_commands': push_commands if push_commands is not None else ['/review'],
+            'gitea.handle_push_trigger': True,
+            'gitea.incremental_review_on_push': incremental_on_push,
+        }
+        settings.get.side_effect = lambda k, d=None: values.get(k, d)
+        return settings
+
+    def _body(self, before='beforesha', after='aftersha'):
+        return {
+            'action': 'synchronized',
+            'sender': {'login': 'alice'},
+            'before': before,
+            'after': after,
+            'pull_request': {'url': 'https://gitea.example.com/api/v1/repos/o/r/pulls/1'},
+        }
+
+    @pytest.mark.asyncio
+    async def test_incremental_push_passes_before_after_sha(self):
+        agent = MagicMock()
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings(True)), \
+             patch('pr_agent.servers.gitea_app._perform_commands_gitea', new=AsyncMock()) as mock_perform:
+            await gitea_app.handle_pr_event(self._body(), 'pull_request', 'synchronized', agent)
+
+        mock_perform.assert_awaited_once()
+        _, kwargs = mock_perform.call_args
+        assert kwargs['incremental'] is True
+        assert kwargs['before_sha'] == 'beforesha'
+        assert kwargs['after_sha'] == 'aftersha'
+
+    @pytest.mark.asyncio
+    async def test_full_review_is_default_when_flag_off(self):
+        agent = MagicMock()
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings(False)), \
+             patch('pr_agent.servers.gitea_app._perform_commands_gitea', new=AsyncMock()) as mock_perform:
+            await gitea_app.handle_pr_event(self._body(), 'pull_request', 'synchronized', agent)
+
+        mock_perform.assert_awaited_once()
+        # Called without incremental kwargs -> full review.
+        _, kwargs = mock_perform.call_args
+        assert 'incremental' not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_full_review_when_before_equals_after(self):
+        agent = MagicMock()
+        body = self._body(before='samesha', after='samesha')
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings(True)), \
+             patch('pr_agent.servers.gitea_app._perform_commands_gitea', new=AsyncMock()) as mock_perform:
+            await gitea_app.handle_pr_event(body, 'pull_request', 'synchronized', agent)
+
+        _, kwargs = mock_perform.call_args
+        assert 'incremental' not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_perform_commands_appends_dash_i_to_review(self):
+        """When incremental, /review is turned into /review -i and the push
+        range is stashed into settings for the provider."""
+        agent = MagicMock()
+        agent.handle_request = AsyncMock()
+        settings = self._settings(True, push_commands=['/review', '/describe'])
+        set_calls = {}
+        settings.set.side_effect = lambda k, v: set_calls.__setitem__(k, v)
+
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings), \
+             patch('pr_agent.servers.gitea_app.apply_repo_settings'), \
+             patch('pr_agent.servers.gitea_app.should_process_pr_logic', return_value=True), \
+             patch('pr_agent.servers.gitea_app.update_settings_from_args', side_effect=lambda a: a):
+            settings.config.disable_auto_feedback = False
+            await gitea_app._perform_commands_gitea(
+                'push_commands', agent, self._body(), 'api_url',
+                incremental=True, before_sha='beforesha', after_sha='aftersha',
+            )
+
+        # /review got -i; /describe untouched.
+        called = [c.args[1] for c in agent.handle_request.call_args_list]
+        assert '/review -i' in called
+        assert '/describe' in called
+        # Push range stashed for the provider.
+        assert set_calls.get('gitea.incremental_push_before_sha') == 'beforesha'
+        assert set_calls.get('gitea.incremental_push_after_sha') == 'aftersha'

--- a/tests/unittest/test_gitea_app.py
+++ b/tests/unittest/test_gitea_app.py
@@ -1,0 +1,250 @@
+import hashlib
+import hmac
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# pr_agent.servers.gitea_app imports PRAgent, which pulls in the litellm/openai
+# AI-handler stack at import time. Those heavy deps are irrelevant to the
+# webhook-routing logic under test here. Install lightweight stand-ins ONLY if
+# the real modules are unavailable (e.g. a minimal test env), so on a full
+# install the real modules are used untouched.
+# ---------------------------------------------------------------------------
+def _ensure_import_deps():
+    try:
+        import litellm  # noqa: F401
+        import openai  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    if 'litellm' not in sys.modules:
+        litellm_stub = types.ModuleType('litellm')
+        litellm_stub.acompletion = lambda *a, **k: None
+        sys.modules['litellm'] = litellm_stub
+
+    if 'openai' not in sys.modules:
+        openai_stub = types.ModuleType('openai')
+
+        class APIError(Exception):
+            pass
+
+        class RateLimitError(Exception):
+            pass
+
+        openai_stub.APIError = APIError
+        openai_stub.RateLimitError = RateLimitError
+        sys.modules['openai'] = openai_stub
+
+
+_ensure_import_deps()
+
+from pr_agent.servers import gitea_app  # noqa: E402
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request for get_body tests."""
+
+    def __init__(self, raw: bytes, headers=None, json_raises=False):
+        self._raw = raw
+        self.headers = headers or {}
+        self._json_raises = json_raises
+
+    async def body(self):
+        return self._raw
+
+    async def json(self):
+        if self._json_raises:
+            raise ValueError("stream already consumed")
+        return json.loads(self._raw)
+
+
+class TestGiteaGetBody:
+    """get_body must read the raw bytes first, verify the signature over those
+    exact bytes, and only then parse JSON (item (f) body-read ordering fix)."""
+
+    @pytest.mark.asyncio
+    async def test_parses_body_without_secret(self):
+        payload = {"action": "opened"}
+        req = _FakeRequest(json.dumps(payload).encode())
+
+        settings = MagicMock()
+        settings.gitea = types.SimpleNamespace()  # no webhook_secret attr
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            body = await gitea_app.get_body(req)
+
+        assert body == payload
+
+    @pytest.mark.asyncio
+    async def test_verifies_signature_over_raw_bytes(self):
+        payload = {"action": "opened", "number": 3}
+        raw = json.dumps(payload).encode()
+        secret = "s3cr3t"
+        digest = hmac.new(secret.encode(), raw, hashlib.sha256).hexdigest()
+        req = _FakeRequest(raw, headers={'x-gitea-signature': digest})
+
+        settings = MagicMock()
+        settings.gitea = types.SimpleNamespace(webhook_secret=secret)
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            body = await gitea_app.get_body(req)
+
+        assert body == payload
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_signature(self):
+        from fastapi import HTTPException
+
+        raw = json.dumps({"action": "opened"}).encode()
+        req = _FakeRequest(raw, headers={'x-gitea-signature': 'deadbeef'})
+
+        settings = MagicMock()
+        settings.gitea = types.SimpleNamespace(webhook_secret='s3cr3t')
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            with pytest.raises(HTTPException) as ei:
+                await gitea_app.get_body(req)
+        assert ei.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_signature_header_rejected(self):
+        from fastapi import HTTPException
+
+        raw = json.dumps({"action": "opened"}).encode()
+        req = _FakeRequest(raw, headers={})
+
+        settings = MagicMock()
+        settings.gitea = types.SimpleNamespace(webhook_secret='s3cr3t')
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            with pytest.raises(HTTPException) as ei:
+                await gitea_app.get_body(req)
+        assert ei.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_does_not_rely_on_request_json(self):
+        """The ordering fix means we must NOT depend on request.json() (which can
+        fail once the stream is consumed). A request whose .json() raises but
+        whose raw .body() is intact must still parse."""
+        payload = {"action": "reopened"}
+        req = _FakeRequest(json.dumps(payload).encode(), json_raises=True)
+
+        settings = MagicMock()
+        settings.gitea = types.SimpleNamespace()
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            body = await gitea_app.get_body(req)
+
+        assert body == payload
+
+
+class TestGiteaBotUserFilter:
+    """The agent must never act on an event raised by its own bot account."""
+
+    def test_is_self_comment_true_for_bot_sender(self):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'GITEA.BOT_USER': 'pr-agent'}.get(k, d)
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            assert gitea_app.is_self_comment({'sender': {'login': 'PR-Agent'}}) is True
+
+    def test_is_self_comment_false_for_other_sender(self):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'GITEA.BOT_USER': 'pr-agent'}.get(k, d)
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings):
+            assert gitea_app.is_self_comment({'sender': {'login': 'alice'}}) is False
+
+    @pytest.mark.asyncio
+    async def test_handle_request_ignores_bot_self_event(self):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'GITEA.BOT_USER': 'pr-agent'}.get(k, d)
+        body = {'action': 'created', 'sender': {'login': 'pr-agent'}}
+
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=settings), \
+             patch('pr_agent.servers.gitea_app.PRAgent') as MockAgent, \
+             patch('pr_agent.servers.gitea_app.handle_comment_event', new=AsyncMock()) as mock_comment:
+            await gitea_app.handle_request(body, event='issue_comment')
+
+        # The bot's own comment must not spin up an agent or a comment handler.
+        mock_comment.assert_not_called()
+
+
+class TestGiteaReviewRequested:
+    """review_requested must trigger /review (pr_commands) when the bot is the
+    requested reviewer (item (f) review_requested branch)."""
+
+    def _settings(self):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'GITEA.BOT_USER': 'pr-agent'}.get(k, d)
+        return settings
+
+    def test_review_requested_for_bot_singular_field(self):
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()):
+            assert gitea_app.review_requested_for_bot(
+                {'requested_reviewer': {'login': 'PR-Agent'}}
+            ) is True
+
+    def test_review_requested_for_bot_reviewers_list(self):
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()):
+            assert gitea_app.review_requested_for_bot(
+                {'pull_request': {'requested_reviewers': [{'login': 'someone'}, {'login': 'pr-agent'}]}}
+            ) is True
+
+    def test_review_requested_for_other_reviewer_is_false(self):
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()):
+            assert gitea_app.review_requested_for_bot(
+                {'requested_reviewer': {'login': 'human-reviewer'}}
+            ) is False
+
+    @pytest.mark.asyncio
+    async def test_handle_review_requested_runs_pr_commands(self):
+        body = {
+            'action': 'review_requested',
+            'sender': {'login': 'alice'},
+            'requested_reviewer': {'login': 'pr-agent'},
+            'pull_request': {'url': 'https://gitea.example.com/api/v1/repos/o/r/pulls/1'},
+        }
+        agent = MagicMock()
+
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()), \
+             patch('pr_agent.servers.gitea_app.should_process_pr_logic', return_value=True), \
+             patch('pr_agent.servers.gitea_app._perform_commands_gitea', new=AsyncMock()) as mock_perform:
+            await gitea_app.handle_review_requested_event(body, 'pull_request', 'review_requested', agent)
+
+        mock_perform.assert_awaited_once()
+        args, _ = mock_perform.call_args
+        assert args[0] == 'pr_commands'
+        assert args[3] == 'https://gitea.example.com/api/v1/repos/o/r/pulls/1'
+
+    @pytest.mark.asyncio
+    async def test_handle_review_requested_skips_when_not_for_bot(self):
+        body = {
+            'action': 'review_requested',
+            'requested_reviewer': {'login': 'human-reviewer'},
+            'pull_request': {'url': 'https://gitea.example.com/api/v1/repos/o/r/pulls/1'},
+        }
+        agent = MagicMock()
+
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()), \
+             patch('pr_agent.servers.gitea_app._perform_commands_gitea', new=AsyncMock()) as mock_perform:
+            await gitea_app.handle_review_requested_event(body, 'pull_request', 'review_requested', agent)
+
+        mock_perform.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_request_routes_review_requested(self):
+        """The pull_request/review_requested action must route to the new
+        handler (upstream let it fall through as a no-op)."""
+        body = {
+            'action': 'review_requested',
+            'sender': {'login': 'alice'},
+            'requested_reviewer': {'login': 'pr-agent'},
+            'pull_request': {'url': 'https://gitea.example.com/api/v1/repos/o/r/pulls/1'},
+        }
+
+        with patch('pr_agent.servers.gitea_app.get_settings', return_value=self._settings()), \
+             patch('pr_agent.servers.gitea_app.PRAgent'), \
+             patch('pr_agent.servers.gitea_app.should_process_pr_logic', return_value=True), \
+             patch('pr_agent.servers.gitea_app.handle_review_requested_event', new=AsyncMock()) as mock_handler:
+            await gitea_app.handle_request(body, event='pull_request')
+
+        mock_handler.assert_awaited_once()

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -386,3 +386,177 @@ class TestGiteaProviderAddFileDiff:
         provider.logger.error.assert_called_once()
         # file_diffs is left untouched when the diff cannot be fetched.
         assert provider.file_diffs == {}
+
+
+class TestRepoApiFormalReview:
+    """Tests for the formal-review HTTP calls on ``RepoApi``.
+
+    These exercise the exact request the provider makes to Gitea's reviews API,
+    mocking ``call_api`` so no real server is hit.
+    """
+
+    @staticmethod
+    def _repo_api():
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        return RepoApi(client), client
+
+    def test_create_review_sends_event_and_commit_id(self):
+        """A formal review POST must carry the ``event`` field (so it is
+        submitted, not left as a PENDING draft) plus body/commit_id/comments."""
+        repo_api, client = self._repo_api()
+
+        repo_api.create_review(
+            'owner', 'repo', 123,
+            event='APPROVED',
+            body='looks good',
+            commit_id='deadbeef',
+            comments=[],
+        )
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/{owner}/{repo}/pulls/{pr_number}/reviews'
+        assert args[1] == 'POST'
+        assert kwargs['path_params'] == {'owner': 'owner', 'repo': 'repo', 'pr_number': 123}
+        body = kwargs['body']
+        assert body['event'] == 'APPROVED'
+        assert body['body'] == 'looks good'
+        assert body['commit_id'] == 'deadbeef'
+        assert body['comments'] == []
+        # Regression: the reviews endpoint returns a review, not a Repository —
+        # the response_type must not be the mistyped 'Repository'.
+        assert kwargs['response_type'] is None
+        assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+
+    def test_create_review_without_event_is_pending_draft(self):
+        """Omitting ``event`` must NOT inject one, leaving an unsubmitted draft."""
+        repo_api, client = self._repo_api()
+
+        repo_api.create_review('owner', 'repo', 123)
+
+        _, kwargs = client.call_api.call_args
+        assert 'event' not in kwargs['body']
+        # commit_id is only sent when provided
+        assert 'commit_id' not in kwargs['body']
+        assert kwargs['body']['comments'] == []
+
+    def test_create_review_forwards_inline_comments(self):
+        repo_api, client = self._repo_api()
+
+        comments = [{'body': 'nit', 'path': 'a.py', 'new_position': 3, 'old_position': 0}]
+        repo_api.create_review(
+            'owner', 'repo', 7, event='COMMENT', body='', commit_id='c0ffee', comments=comments,
+        )
+
+        _, kwargs = client.call_api.call_args
+        assert kwargs['body']['comments'] == comments
+        assert kwargs['body']['event'] == 'COMMENT'
+
+    def test_create_inline_comment_defaults_to_pending_and_fixed_response_type(self):
+        """The pre-existing inline-comment path must still work and no longer use
+        the mistyped ``response_type='Repository'``."""
+        repo_api, client = self._repo_api()
+
+        repo_api.create_inline_comment(
+            'owner', 'repo', 5, body='review', commit_id='abc123', comments=[],
+        )
+
+        _, kwargs = client.call_api.call_args
+        assert 'event' not in kwargs['body']  # draft by default (unchanged behavior)
+        assert kwargs['response_type'] is None
+        assert kwargs['body']['commit_id'] == 'abc123'
+
+    def test_create_inline_comment_accepts_event(self):
+        repo_api, client = self._repo_api()
+
+        repo_api.create_inline_comment(
+            'owner', 'repo', 5, body='review', commit_id='abc123', comments=[], event='REQUEST_CHANGES',
+        )
+
+        _, kwargs = client.call_api.call_args
+        assert kwargs['body']['event'] == 'REQUEST_CHANGES'
+
+    def test_submit_pending_review_posts_to_review_id(self):
+        repo_api, client = self._repo_api()
+
+        repo_api.submit_pending_review('owner', 'repo', 123, review_id=99, event='APPROVED', body='ok')
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}'
+        assert args[1] == 'POST'
+        assert kwargs['path_params'] == {
+            'owner': 'owner', 'repo': 'repo', 'pr_number': 123, 'review_id': 99,
+        }
+        assert kwargs['body'] == {'event': 'APPROVED', 'body': 'ok'}
+        assert kwargs['response_type'] is None
+
+
+class TestGiteaProviderSubmitReview:
+    """Tests for ``GiteaProvider.submit_review`` / ``auto_approve``.
+
+    Built via ``__new__`` to bypass __init__'s network calls; only the
+    attributes the methods touch are wired up.
+    """
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 42
+        provider.enabled_pr = True
+        provider.last_commit = MagicMock()
+        provider.last_commit.sha = 'headsha'
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_submit_review_passes_event_and_head_commit(self):
+        provider = self._provider()
+
+        assert provider.submit_review('COMMENT', body='please look') is True
+
+        provider.repo_api.create_review.assert_called_once_with(
+            owner='owner',
+            repo='repo',
+            pr_number=42,
+            event='COMMENT',
+            body='please look',
+            commit_id='headsha',
+        )
+
+    def test_submit_review_returns_false_on_api_error(self):
+        """A failed formal review must be swallowed (return False), never raised,
+        so it cannot break the underlying /review comment."""
+        provider = self._provider()
+        provider.repo_api.create_review.side_effect = Exception('boom')
+
+        assert provider.submit_review('APPROVED') is False
+        provider.logger.error.assert_called_once()
+
+    def test_submit_review_refuses_when_not_a_pr(self):
+        provider = self._provider()
+        provider.enabled_pr = False
+
+        assert provider.submit_review('APPROVED') is False
+        provider.repo_api.create_review.assert_not_called()
+
+    def test_auto_approve_submits_approved_review(self):
+        """Mirrors github_provider.auto_approve: it must actually submit an
+        APPROVED formal review (not the base-class no-op that returns False)."""
+        provider = self._provider()
+
+        assert provider.auto_approve() is True
+
+        _, kwargs = provider.repo_api.create_review.call_args
+        assert kwargs['event'] == 'APPROVED'
+        assert kwargs['pr_number'] == 42
+
+    def test_auto_approve_returns_false_on_error(self):
+        provider = self._provider()
+        provider.repo_api.create_review.side_effect = Exception('nope')
+
+        assert provider.auto_approve() is False

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -984,3 +984,312 @@ class TestGiteaProviderConfigBranch:
         provider.repo_api.get_file_content.assert_called_once()
         _, kwargs = provider.repo_api.get_file_content.call_args
         assert kwargs['commit_sha'] == 'headsha'
+
+
+class TestGiteaProviderGetDiffFiles:
+    """Tests for the hardened ``get_diff_files`` — the core review input.
+
+    The previous implementation pulled the patch straight from the hand-parsed
+    PR ``.diff`` and dropped the patch for files with no ``@@`` hunk (pure
+    renames, mode changes, binaries), and read base content from the raw
+    ``base.sha`` instead of the merge base. The hardened version:
+      * reads base content from the PR merge base (``merge_base_sha``),
+      * prefers the merge-base-relative compare diff for patches, falling back
+        to the PR ``.diff`` when the compare API is unavailable,
+      * synthesizes a patch via ``load_large_diff`` for any changed file the
+        parser could not attribute, so renames/binaries are never dropped.
+
+    Built via ``__new__`` to bypass __init__'s network calls; only the
+    attributes ``get_diff_files`` touches are wired up.
+    """
+
+    @staticmethod
+    def _provider(git_files, file_diffs=None, file_contents=None,
+                  base_sha='basesha', head_sha='headsha', merge_base_sha='mbsha',
+                  compare_diff=None):
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 1
+        provider.enabled_pr = True
+        provider.git_files = git_files
+        provider.file_diffs = file_diffs or {}
+        provider.file_contents = file_contents or {}
+        provider.sha = head_sha
+        provider.base_sha = base_sha
+        provider.merge_base_sha = merge_base_sha
+        provider.diff_files = []
+        provider.incremental = __import__(
+            'pr_agent.git_providers.git_provider', fromlist=['IncrementalPR']
+        ).IncrementalPR(False)
+        provider.unreviewed_files_set = {}
+        provider.repo_api = MagicMock()
+        # base content read: return "" unless overridden by the test
+        provider.repo_api.get_file_content.return_value = ""
+        # compare diff: default to none so the PR .diff (file_diffs) is used
+        provider.repo_api.get_compare_diff.return_value = compare_diff or ""
+        return provider
+
+    def _patch_valid_file(self):
+        # is_valid_file consults settings; patch it to accept every .py/.txt path
+        return patch('pr_agent.git_providers.gitea_provider.is_valid_file', return_value=True)
+
+    def test_multi_hunk_patch_is_carried_through(self):
+        from pr_agent.algo.types import EDIT_TYPE
+        git_files = [{'filename': 'a.py', 'status': 'modified', 'additions': 2, 'deletions': 0}]
+        multi_hunk = (
+            '@@ -1,2 +1,3 @@\n a\n+b\n c\n'
+            '@@ -20,2 +21,3 @@\n d\n+e\n f'
+        )
+        provider = self._provider(git_files, file_diffs={'a.py': multi_hunk})
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        assert len(diff_files) == 1
+        f = diff_files[0]
+        assert f.filename == 'a.py'
+        assert f.patch.count('@@ -') == 2  # both hunks preserved
+        assert f.edit_type == EDIT_TYPE.MODIFIED
+
+    def test_rename_without_hunk_gets_synthesized_patch_and_reads_old_path(self):
+        """A pure rename has no ``@@`` hunk, so the parser produces no patch. The
+        file must NOT be dropped: base content is read from previous_filename and
+        a patch is synthesized via load_large_diff."""
+        from pr_agent.algo.types import EDIT_TYPE
+        git_files = [{
+            'filename': 'new_name.py', 'previous_filename': 'old_name.py',
+            'status': 'renamed', 'additions': 1, 'deletions': 1,
+        }]
+        provider = self._provider(
+            git_files,
+            file_diffs={},  # no patch for the rename
+            file_contents={'new_name.py': 'line1\nline2 changed\n'},
+        )
+        provider.repo_api.get_file_content.return_value = 'line1\nline2\n'  # base (old path)
+
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        assert len(diff_files) == 1
+        f = diff_files[0]
+        assert f.filename == 'new_name.py'
+        assert f.old_filename == 'old_name.py'
+        assert f.edit_type == EDIT_TYPE.RENAMED
+        # base content must have been read from the OLD path (rename source).
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['filepath'] == 'old_name.py'
+        # a patch was synthesized (not left empty) since content changed.
+        assert f.patch != ''
+        assert '@@' in f.patch
+
+    def test_binary_file_is_not_dropped(self):
+        """A binary file appears in the files list but has no textual patch; it
+        must still be represented (never silently dropped)."""
+        from pr_agent.algo.types import EDIT_TYPE
+        git_files = [{'filename': 'logo.png', 'status': 'modified', 'additions': 0, 'deletions': 0}]
+        provider = self._provider(
+            git_files,
+            file_diffs={},  # binary -> no hunk
+            file_contents={'logo.png': ''},  # binary content decoded to ""
+        )
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        # The binary file is still present in the diff-files list.
+        assert [f.filename for f in diff_files] == ['logo.png']
+        assert diff_files[0].edit_type == EDIT_TYPE.MODIFIED
+
+    def test_added_and_deleted_files_get_correct_edit_types(self):
+        from pr_agent.algo.types import EDIT_TYPE
+        git_files = [
+            {'filename': 'new.py', 'status': 'added', 'additions': 3, 'deletions': 0},
+            {'filename': 'gone.py', 'status': 'deleted', 'additions': 0, 'deletions': 3},
+        ]
+        provider = self._provider(
+            git_files,
+            file_diffs={
+                'new.py': '@@ -0,0 +1,3 @@\n+a\n+b\n+c',
+                'gone.py': '@@ -1,3 +0,0 @@\n-a\n-b\n-c',
+            },
+            file_contents={'new.py': 'a\nb\nc\n'},
+        )
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        by_name = {f.filename: f for f in diff_files}
+        assert by_name['new.py'].edit_type == EDIT_TYPE.ADDED
+        assert by_name['gone.py'].edit_type == EDIT_TYPE.DELETED
+
+    def test_base_content_read_from_merge_base(self):
+        """Base content must be read from the merge base, not the raw base.sha."""
+        git_files = [{'filename': 'a.py', 'status': 'modified', 'additions': 1, 'deletions': 0}]
+        provider = self._provider(
+            git_files,
+            file_diffs={'a.py': '@@ -1,1 +1,2 @@\n a\n+b'},
+            file_contents={'a.py': 'a\nb\n'},
+            base_sha='basesha', merge_base_sha='mergebasesha',
+        )
+        with self._patch_valid_file():
+            provider.get_diff_files()
+
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['commit_sha'] == 'mergebasesha'
+
+    def test_prefers_compare_diff_over_pr_diff(self):
+        """When the compare API returns a diff, it is used as the patch source
+        (merge-base relative) in preference to the PR .diff."""
+        git_files = [{'filename': 'a.py', 'status': 'modified', 'additions': 1, 'deletions': 0}]
+        compare_diff = (
+            'diff --git a/a.py b/a.py\n'
+            'index 111..222 100644\n'
+            '--- a/a.py\n'
+            '+++ b/a.py\n'
+            '@@ -1,1 +1,2 @@\n a\n+from_compare'
+        )
+        provider = self._provider(
+            git_files,
+            file_diffs={'a.py': '@@ -1,1 +1,2 @@\n a\n+from_pr_diff'},
+            file_contents={'a.py': 'a\nfrom_compare\n'},
+            compare_diff=compare_diff,
+        )
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        assert 'from_compare' in diff_files[0].patch
+        assert 'from_pr_diff' not in diff_files[0].patch
+        provider.repo_api.get_compare_diff.assert_called_once()
+
+    def test_falls_back_to_pr_diff_when_compare_unavailable(self):
+        """If the compare API returns nothing, the PR .diff patch is used —
+        never regressing the pre-existing behavior."""
+        git_files = [{'filename': 'a.py', 'status': 'modified', 'additions': 1, 'deletions': 0}]
+        provider = self._provider(
+            git_files,
+            file_diffs={'a.py': '@@ -1,1 +1,2 @@\n a\n+from_pr_diff'},
+            file_contents={'a.py': 'a\nfrom_pr_diff\n'},
+            compare_diff='',  # compare unavailable
+        )
+        with self._patch_valid_file():
+            diff_files = provider.get_diff_files()
+
+        assert 'from_pr_diff' in diff_files[0].patch
+
+    def test_invalid_files_are_filtered(self):
+        git_files = [
+            {'filename': 'a.py', 'status': 'modified', 'additions': 1, 'deletions': 0},
+            {'filename': 'skip.bin', 'status': 'modified', 'additions': 1, 'deletions': 0},
+        ]
+        provider = self._provider(git_files, file_diffs={'a.py': '@@ -1 +1,2 @@\n a\n+b'})
+
+        def only_py(name):
+            return name.endswith('.py')
+
+        with patch('pr_agent.git_providers.gitea_provider.is_valid_file', side_effect=only_py):
+            diff_files = provider.get_diff_files()
+
+        assert [f.filename for f in diff_files] == ['a.py']
+
+
+class TestRepoApiCompare:
+    """Tests for the compare HTTP calls used to build merge-base-relative diffs.
+
+    ``GET /repos/{owner}/{repo}/compare/{base}...{head}`` (docs.gitea.com
+    repoCompareDiff). JSON form returns ``{total_commits, commits[]}``; the
+    ``?output=diff`` form returns the raw unified diff.
+    """
+
+    @staticmethod
+    def _repo_api():
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        return RepoApi(client), client
+
+    def test_get_compare_hits_compare_endpoint_three_dot(self):
+        repo_api, client = self._repo_api()
+        mock_resp = MagicMock()
+        mock_resp.data = BytesIO(b'{"total_commits": 2, "commits": []}')
+        client.call_api.return_value = mock_resp
+
+        result = repo_api.get_compare('owner', 'repo', 'base_sha', 'head_sha')
+
+        args, kwargs = client.call_api.call_args
+        # three-dot (merge-base relative), base...head embedded in the wildcard path
+        assert args[0] == '/repos/owner/repo/compare/base_sha...head_sha'
+        assert args[1] == 'GET'
+        assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+        assert result == {'total_commits': 2, 'commits': []}
+
+    def test_get_compare_returns_empty_dict_on_error(self):
+        from giteapy.rest import ApiException
+        repo_api, client = self._repo_api()
+        client.call_api.side_effect = ApiException(status=404)
+
+        assert repo_api.get_compare('owner', 'repo', 'b', 'h') == {}
+
+    def test_get_compare_diff_requests_output_diff(self):
+        repo_api, client = self._repo_api()
+        mock_resp = MagicMock()
+        mock_resp.data = BytesIO(b'diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b')
+        client.call_api.return_value = mock_resp
+
+        diff = repo_api.get_compare_diff('owner', 'repo', 'base_sha', 'head_sha')
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/owner/repo/compare/base_sha...head_sha'
+        assert ('output', 'diff') in kwargs.get('query_params', [])
+        assert diff.startswith('diff --git')
+
+    def test_get_compare_diff_returns_empty_on_error(self):
+        from giteapy.rest import ApiException
+        repo_api, client = self._repo_api()
+        client.call_api.side_effect = ApiException(status=500)
+
+        assert repo_api.get_compare_diff('owner', 'repo', 'b', 'h') == ''
+
+
+class TestGiteaParseUnifiedDiff:
+    """The shared unified-diff parser used by both the PR .diff and compare-diff
+    paths. Multi-hunk and multi-file behavior must match the original parser."""
+
+    @staticmethod
+    def _parse(text):
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+        return GiteaProvider._parse_unified_diff(text)
+
+    def test_multi_hunk_kept(self):
+        diff = (
+            'diff --git a/f.py b/f.py\n'
+            'index 1..2 100644\n--- a/f.py\n+++ b/f.py\n'
+            '@@ -1,2 +1,3 @@\n a\n+b\n c\n'
+            '@@ -20,2 +21,3 @@\n d\n+e\n f'
+        )
+        parsed = self._parse(diff)
+        assert set(parsed) == {'f.py'}
+        assert parsed['f.py'].count('@@ -') == 2
+        assert parsed['f.py'].startswith('@@ -1,2 +1,3 @@')
+
+    def test_multiple_files(self):
+        diff = (
+            'diff --git a/f1.py b/f1.py\n@@ -1 +1,2 @@\n a\n+b\n'
+            'diff --git a/f2.py b/f2.py\n@@ -5 +5,2 @@\n c\n+d'
+        )
+        parsed = self._parse(diff)
+        assert set(parsed) == {'f1.py', 'f2.py'}
+
+    def test_rename_with_no_hunk_produces_no_entry(self):
+        """A pure rename has no @@ hunk -> no entry (get_diff_files synthesizes
+        the patch for it separately, so it is not lost)."""
+        diff = (
+            'diff --git a/old.py b/new.py\n'
+            'similarity index 100%\n'
+            'rename from old.py\n'
+            'rename to new.py'
+        )
+        assert self._parse(diff) == {}
+
+    def test_empty_diff(self):
+        assert self._parse('') == {}

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -467,30 +467,6 @@ class TestRepoApiFormalReview:
         assert kwargs['response_type'] is None
         assert kwargs['body']['commit_id'] == 'abc123'
 
-    def test_create_inline_comment_accepts_event(self):
-        repo_api, client = self._repo_api()
-
-        repo_api.create_inline_comment(
-            'owner', 'repo', 5, body='review', commit_id='abc123', comments=[], event='REQUEST_CHANGES',
-        )
-
-        _, kwargs = client.call_api.call_args
-        assert kwargs['body']['event'] == 'REQUEST_CHANGES'
-
-    def test_submit_pending_review_posts_to_review_id(self):
-        repo_api, client = self._repo_api()
-
-        repo_api.submit_pending_review('owner', 'repo', 123, review_id=99, event='APPROVED', body='ok')
-
-        args, kwargs = client.call_api.call_args
-        assert args[0] == '/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}'
-        assert args[1] == 'POST'
-        assert kwargs['path_params'] == {
-            'owner': 'owner', 'repo': 'repo', 'pr_number': 123, 'review_id': 99,
-        }
-        assert kwargs['body'] == {'event': 'APPROVED', 'body': 'ok'}
-        assert kwargs['response_type'] is None
-
 
 class TestGiteaProviderSubmitReview:
     """Tests for ``GiteaProvider.submit_review`` / ``auto_approve``.
@@ -514,7 +490,11 @@ class TestGiteaProviderSubmitReview:
         provider.repo_api = MagicMock()
         return provider
 
-    def test_submit_review_passes_event_and_head_commit(self):
+    def test_submit_review_passes_event_and_omits_commit_id(self):
+        """``submit_review`` must NOT pin ``commit_id``: ``self.last_commit`` is
+        the repo/default-branch head (from ``repo_get_all_commits``), not the PR
+        head, so pinning it anchors the review to the wrong sha. Omitting it lets
+        Gitea default to the PR head."""
         provider = self._provider()
 
         assert provider.submit_review('COMMENT', body='please look') is True
@@ -525,8 +505,9 @@ class TestGiteaProviderSubmitReview:
             pr_number=42,
             event='COMMENT',
             body='please look',
-            commit_id='headsha',
         )
+        _, kwargs = provider.repo_api.create_review.call_args
+        assert 'commit_id' not in kwargs
 
     def test_submit_review_returns_false_on_api_error(self):
         """A failed formal review must be swallowed (return False), never raised,
@@ -560,6 +541,47 @@ class TestGiteaProviderSubmitReview:
         provider.repo_api.create_review.side_effect = Exception('nope')
 
         assert provider.auto_approve() is False
+
+
+class TestGiteaProviderPublishInlineComments:
+    """``publish_inline_comments`` runs ``create_inline_comment`` with
+    ``_preload_content=False``, so a successful call returns the
+    ``(data, status, headers)`` tuple, not a truthy body. The success/failure
+    log must key off the HTTP status, not the (always-falsy) body."""
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 42
+        provider.enabled_pr = True
+        provider.last_commit = MagicMock()
+        provider.last_commit.sha = 'headsha'
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_logs_success_on_2xx_tuple(self):
+        provider = self._provider()
+        # giteapy returns (data, status, headers); data is None with _preload_content=False
+        provider.repo_api.create_inline_comment.return_value = (None, 201, {})
+
+        provider.publish_inline_comments([{'body': 'x'}])
+
+        provider.logger.info.assert_called_once()
+        provider.logger.error.assert_not_called()
+
+    def test_logs_failure_on_non_2xx_tuple(self):
+        provider = self._provider()
+        provider.repo_api.create_inline_comment.return_value = (None, 422, {})
+
+        provider.publish_inline_comments([{'body': 'x'}])
+
+        provider.logger.error.assert_called_once()
+        provider.logger.info.assert_not_called()
 
 
 class TestGiteaProviderLabels:

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1293,3 +1293,159 @@ class TestGiteaParseUnifiedDiff:
 
     def test_empty_diff(self):
         assert self._parse('') == {}
+
+
+class TestGiteaProviderIncremental:
+    """Incremental review: re-review only the commits pushed since the last
+    review (ports github_provider.get_incremental_commits & friends)."""
+
+    @staticmethod
+    def _commit(sha, iso_date, message='msg'):
+        return {'sha': sha, 'commit': {'message': message, 'author': {'date': iso_date, 'name': 'a'}}}
+
+    @staticmethod
+    def _provider(pr_commits=None, comments=None):
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+        from pr_agent.git_providers.git_provider import IncrementalPR
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 1
+        provider.enabled_pr = True
+        provider.sha = 'headsha'
+        provider.base_sha = 'basesha'
+        provider.incremental = IncrementalPR(False)
+        provider.unreviewed_files_set = {}
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_pr_commits.return_value = pr_commits or []
+        provider.repo_api.list_all_comments.return_value = comments or []
+        provider.repo_api.get_compare.return_value = {'commits': []}
+        return provider
+
+    def test_get_incremental_commits_noop_for_full_review(self):
+        from pr_agent.git_providers.git_provider import IncrementalPR
+        provider = self._provider()
+        provider.get_incremental_commits(IncrementalPR(False))
+        # Full review: no commit lookup, incremental stays off.
+        assert provider.incremental.is_incremental is False
+        provider.repo_api.get_pr_commits.assert_not_called()
+
+    def test_previous_review_matched_by_header(self):
+        from pr_agent.algo.utils import PRReviewHeader
+        c1 = MagicMock(); c1.body = 'random chatter'
+        c2 = MagicMock(); c2.body = f'{PRReviewHeader.REGULAR.value} 🔍\n\nreview text'
+        provider = self._provider(comments=[c1, c2])
+        prev = provider.get_previous_review(full=True, incremental=True)
+        assert prev is c2
+
+    def test_previous_review_none_when_no_review_comment(self):
+        c1 = MagicMock(); c1.body = 'just a comment'
+        provider = self._provider(comments=[c1])
+        assert provider.get_previous_review(full=True, incremental=True) is None
+
+    def test_no_previous_review_falls_back_to_full(self):
+        import datetime
+        commits = [
+            self._commit('sha1', '2024-01-01T00:00:00Z'),
+            self._commit('sha2', '2024-01-02T00:00:00Z'),
+        ]
+        from pr_agent.git_providers.git_provider import IncrementalPR
+        provider = self._provider(pr_commits=commits, comments=[])  # no review comment
+        with patch('pr_agent.git_providers.gitea_provider.get_settings') as gs:
+            gs.return_value.get.return_value = None  # no push before-sha
+            provider.get_incremental_commits(IncrementalPR(True))
+        # Falls back to a full review.
+        assert provider.incremental.is_incremental is False
+
+    def test_incremental_commit_range_after_previous_review(self):
+        import datetime
+        from pr_agent.git_providers.git_provider import IncrementalPR
+        # Two commits: one before the review, one after.
+        commits = [
+            self._commit('old', '2024-01-01T00:00:00Z'),
+            self._commit('new', '2024-01-03T00:00:00Z'),
+        ]
+        review = MagicMock()
+        from pr_agent.algo.utils import PRReviewHeader
+        review.body = f'{PRReviewHeader.REGULAR.value} 🔍'
+        review.created_at = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+        provider = self._provider(pr_commits=commits, comments=[review])
+        provider.repo_api.get_compare.return_value = {
+            'commits': [{'files': [{'filename': 'changed.py', 'status': 'modified'}]}]
+        }
+        with patch('pr_agent.git_providers.gitea_provider.get_settings') as gs:
+            gs.return_value.get.return_value = None
+            provider.get_incremental_commits(IncrementalPR(True))
+
+        assert provider.incremental.is_incremental is True
+        # Only the commit after the review is "new".
+        assert [c.sha for c in provider.incremental.commits_range] == ['new']
+        assert provider.incremental.first_new_commit_sha == 'new'
+        assert provider.incremental.last_seen_commit_sha == 'old'
+        # The compare range is diffed to collect changed files.
+        assert 'changed.py' in provider.unreviewed_files_set
+        _, kwargs = provider.repo_api.get_compare.call_args
+        assert kwargs['base'] == 'old'
+        assert kwargs['head'] == 'headsha'
+
+    def test_push_before_sha_anchors_incremental_without_prior_review(self):
+        """No prior review comment, but the push webhook gave a before-SHA: the
+        review still runs incrementally, anchored to that SHA."""
+        from pr_agent.git_providers.git_provider import IncrementalPR
+        commits = [
+            self._commit('c0', '2024-01-01T00:00:00Z'),
+            self._commit('c1', '2024-01-02T00:00:00Z'),
+            self._commit('c2', '2024-01-03T00:00:00Z'),
+        ]
+        provider = self._provider(pr_commits=commits, comments=[])
+        provider.repo_api.get_compare.return_value = {
+            'commits': [{'files': [{'filename': 'f.py', 'status': 'modified'}]}]
+        }
+        with patch('pr_agent.git_providers.gitea_provider.get_settings') as gs:
+            gs.return_value.get.side_effect = lambda k, d=None: (
+                'c0' if k == 'gitea.incremental_push_before_sha' else d
+            )
+            provider.get_incremental_commits(IncrementalPR(True))
+
+        assert provider.incremental.is_incremental is True
+        assert provider.incremental.last_seen_commit_sha == 'c0'
+        # commits after c0 are the new ones.
+        assert [c.sha for c in provider.incremental.commits_range] == ['c1', 'c2']
+        assert 'f.py' in provider.unreviewed_files_set
+
+    def test_incremental_get_diff_files_restricts_to_new_files_and_uses_last_seen_base(self):
+        """In incremental mode get_diff_files reviews only the unreviewed files
+        and reads base content from the last-seen commit, not the repo head."""
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+        from pr_agent.git_providers.git_provider import IncrementalPR
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'; provider.repo = 'repo'; provider.pr_number = 1
+        provider.enabled_pr = True
+        provider.sha = 'headsha'; provider.base_sha = 'basesha'; provider.merge_base_sha = 'mbsha'
+        provider.git_files = [
+            {'filename': 'new.py', 'status': 'modified', 'additions': 1, 'deletions': 0},
+            {'filename': 'untouched.py', 'status': 'modified', 'additions': 1, 'deletions': 0},
+        ]
+        provider.file_diffs = {'new.py': '@@ -1 +1,2 @@\n a\n+b'}
+        provider.file_contents = {'new.py': 'a\nb\n'}
+        provider.diff_files = []
+        inc = IncrementalPR(True)
+        inc.last_seen_commit = __import__('types').SimpleNamespace(sha='lastseen')
+        provider.incremental = inc
+        provider.unreviewed_files_set = {'new.py': 'new.py'}  # only new.py is new
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_compare_diff.return_value = ''  # fall back to file_diffs
+        provider.repo_api.get_file_content.return_value = 'a\n'  # base content
+
+        with patch('pr_agent.git_providers.gitea_provider.is_valid_file', return_value=True):
+            diff_files = provider.get_diff_files()
+
+        # Only the unreviewed file is reviewed.
+        assert [f.filename for f in diff_files] == ['new.py']
+        # Base content was read from the last-seen commit, not the repo head.
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['commit_sha'] == 'lastseen'

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -544,10 +544,14 @@ class TestGiteaProviderSubmitReview:
 
 
 class TestGiteaProviderPublishInlineComments:
-    """``publish_inline_comments`` runs ``create_inline_comment`` with
-    ``_preload_content=False``, so a successful call returns the
-    ``(data, status, headers)`` tuple, not a truthy body. The success/failure
-    log must key off the HTTP status, not the (always-falsy) body."""
+    """``publish_inline_comments`` submits a COMMENT review (not a PENDING draft).
+
+    It runs ``create_review`` with ``_preload_content=False``, so a successful
+    call returns the ``(data, status, headers)`` tuple, not a truthy body. The
+    success/failure log must key off the HTTP status, not the (always-falsy)
+    body. The review must carry ``event="COMMENT"`` so the inline comments post
+    immediately instead of lingering as an unsubmitted draft, and must NOT pin a
+    (wrong) ``commit_id`` so Gitea anchors positions to the PR head."""
 
     @staticmethod
     def _provider():
@@ -567,7 +571,7 @@ class TestGiteaProviderPublishInlineComments:
     def test_logs_success_on_2xx_tuple(self):
         provider = self._provider()
         # giteapy returns (data, status, headers); data is None with _preload_content=False
-        provider.repo_api.create_inline_comment.return_value = (None, 201, {})
+        provider.repo_api.create_review.return_value = (None, 201, {})
 
         provider.publish_inline_comments([{'body': 'x'}])
 
@@ -576,12 +580,43 @@ class TestGiteaProviderPublishInlineComments:
 
     def test_logs_failure_on_non_2xx_tuple(self):
         provider = self._provider()
-        provider.repo_api.create_inline_comment.return_value = (None, 422, {})
+        provider.repo_api.create_review.return_value = (None, 422, {})
 
         provider.publish_inline_comments([{'body': 'x'}])
 
         provider.logger.error.assert_called_once()
         provider.logger.info.assert_not_called()
+
+    def test_submits_as_comment_event_with_the_comments(self):
+        """The inline comments must be submitted as a COMMENT review, carrying
+        the exact comment payloads, so they post immediately (not as a draft)."""
+        provider = self._provider()
+        provider.repo_api.create_review.return_value = (None, 201, {})
+
+        comments = [{'body': 'nit', 'path': 'a.py', 'new_position': 3, 'old_position': 0}]
+        provider.publish_inline_comments(comments, body='Suggestion body')
+
+        _, kwargs = provider.repo_api.create_review.call_args
+        assert kwargs['event'] == 'COMMENT'
+        assert kwargs['body'] == 'Suggestion body'
+        assert kwargs['comments'] == comments
+        assert kwargs['pr_number'] == 42
+        # commit_id must NOT be pinned (self.last_commit is the wrong sha).
+        assert 'commit_id' not in kwargs
+        # The old PENDING-draft path must no longer be used.
+        provider.repo_api.create_inline_comment.assert_not_called()
+
+    def test_inline_comments_do_not_submit_an_approval(self):
+        """Guard: inline comments must never smuggle an APPROVED/REQUEST_CHANGES
+        event — the formal verdict is a separate submit_review call."""
+        provider = self._provider()
+        provider.repo_api.create_review.return_value = (None, 201, {})
+
+        provider.publish_inline_comments([{'body': 'x'}])
+
+        _, kwargs = provider.repo_api.create_review.call_args
+        assert kwargs['event'] == 'COMMENT'
+        assert kwargs['event'] not in ('APPROVED', 'REQUEST_CHANGES')
 
 
 class TestGiteaProviderLabels:

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -560,3 +560,370 @@ class TestGiteaProviderSubmitReview:
         provider.repo_api.create_review.side_effect = Exception('nope')
 
         assert provider.auto_approve() is False
+
+
+class TestGiteaProviderLabels:
+    """Tests for get_repo_labels + name-based publish_labels.
+
+    Upstream's publish_labels forwarded whatever it was given straight to
+    Gitea's issue-label endpoint, but every pr-agent tool passes label *names*
+    while Gitea expects numeric label *ids*. The provider must resolve names to
+    ids via the repository's labels first.
+    """
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 7
+        provider.enabled_pr = True
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_get_repo_labels_returns_repo_labels(self):
+        provider = self._provider()
+        provider.repo_api.get_repo_labels.return_value = [
+            {'id': 1, 'name': 'Bug fix', 'color': 'ff0000'},
+            {'id': 2, 'name': 'Enhancement', 'color': '00ff00'},
+        ]
+
+        labels = provider.get_repo_labels()
+
+        provider.repo_api.get_repo_labels.assert_called_once_with(owner='owner', repo='repo')
+        assert [l['name'] for l in labels] == ['Bug fix', 'Enhancement']
+
+    def test_get_repo_labels_empty_on_failure(self):
+        provider = self._provider()
+        provider.repo_api.get_repo_labels.return_value = []
+        assert provider.get_repo_labels() == []
+
+    def test_publish_labels_resolves_names_to_ids(self):
+        """publish_labels receives NAMES; it must resolve them to Gitea label
+        ids before posting (the core of item (a))."""
+        provider = self._provider()
+        provider.repo_api.get_repo_labels.return_value = [
+            {'id': 10, 'name': 'Bug fix'},
+            {'id': 20, 'name': 'Enhancement'},
+            {'id': 30, 'name': 'Documentation'},
+        ]
+
+        provider.publish_labels(['Enhancement', 'Bug fix'])
+
+        _, kwargs = provider.repo_api.add_labels.call_args
+        assert kwargs['issue_number'] == 7
+        assert kwargs['labels'] == [20, 10]
+
+    def test_publish_labels_skips_unknown_names(self):
+        """A name with no matching repo label is skipped (Gitea can only attach
+        labels that already exist in the repo)."""
+        provider = self._provider()
+        provider.repo_api.get_repo_labels.return_value = [{'id': 10, 'name': 'Bug fix'}]
+
+        provider.publish_labels(['Bug fix', 'Nonexistent'])
+
+        _, kwargs = provider.repo_api.add_labels.call_args
+        assert kwargs['labels'] == [10]
+
+    def test_publish_labels_no_call_when_none_resolve(self):
+        provider = self._provider()
+        provider.repo_api.get_repo_labels.return_value = [{'id': 10, 'name': 'Bug fix'}]
+
+        provider.publish_labels(['Totally Unknown'])
+
+        provider.repo_api.add_labels.assert_not_called()
+
+    def test_publish_labels_no_call_on_empty_input(self):
+        provider = self._provider()
+        provider.publish_labels([])
+        provider.repo_api.add_labels.assert_not_called()
+
+    def test_repo_api_get_repo_labels_hits_labels_endpoint(self):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.data = BytesIO(b'[{"id": 1, "name": "Bug fix"}]')
+        client.call_api.return_value = mock_resp
+        repo_api = RepoApi(client)
+
+        labels = repo_api.get_repo_labels('owner', 'repo')
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/owner/repo/labels'
+        assert args[1] == 'GET'
+        assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+        assert labels == [{'id': 1, 'name': 'Bug fix'}]
+
+
+class TestGiteaProviderRemoveReaction:
+    """Tests for the remove_reaction signature fix.
+
+    Gitea previously defined remove_reaction(self, comment_id) while the base
+    class and callers pass (issue_comment_id, reaction_id) -> the old signature
+    raised a TypeError at runtime. The signature must match the base contract
+    and return a bool.
+    """
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_remove_reaction_accepts_two_args_and_returns_true(self):
+        provider = self._provider()
+
+        # The base/caller contract passes BOTH a comment id and a reaction id.
+        result = provider.remove_reaction(123, 456)
+
+        assert result is True
+        _, kwargs = provider.repo_api.remove_reaction_comment.call_args
+        assert kwargs['comment_id'] == 123
+
+    def test_remove_reaction_returns_false_on_error(self):
+        provider = self._provider()
+        provider.repo_api.remove_reaction_comment.side_effect = Exception('boom')
+
+        assert provider.remove_reaction(123, 456) is False
+
+    def test_remove_reaction_matches_base_signature(self):
+        """Regression guard: the arity must match the base GitProvider so a
+        caller passing (issue_comment_id, reaction_id) never hits a TypeError."""
+        import inspect
+
+        from pr_agent.git_providers.git_provider import GitProvider
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        base_params = list(inspect.signature(GitProvider.remove_reaction).parameters)
+        gitea_params = list(inspect.signature(GiteaProvider.remove_reaction).parameters)
+        assert base_params == gitea_params == ['self', 'issue_comment_id', 'reaction_id']
+
+    def test_repo_api_remove_reaction_sends_content_body(self):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        repo_api = RepoApi(client)
+
+        repo_api.remove_reaction_comment('owner', 'repo', 99)
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/{owner}/{repo}/issues/comments/{id}/reactions'
+        assert args[1] == 'DELETE'
+        assert kwargs['body'] == {'content': 'eyes'}
+        assert kwargs['path_params'] == {'owner': 'owner', 'repo': 'repo', 'id': 99}
+
+
+class TestGiteaProviderIsSupported:
+    """is_supported must reflect real capability, not unconditionally True."""
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        return provider
+
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_push_code_unsupported_in_restricted_mode(self, mock_get_settings):
+        settings = MagicMock()
+        settings.config.restricted_mode = True
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        assert provider.is_supported("push_code") is False
+
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_push_code_supported_when_not_restricted(self, mock_get_settings):
+        settings = MagicMock()
+        settings.config.restricted_mode = False
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        assert provider.is_supported("push_code") is True
+
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_other_capabilities_supported(self, mock_get_settings):
+        settings = MagicMock()
+        settings.config.restricted_mode = True
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        # A non-push capability stays supported even in restricted mode.
+        assert provider.is_supported("get_labels") is True
+
+
+class TestGiteaProviderCommentById:
+    """Tests for the comment-by-id methods that unlock inline /ask.
+
+    These were base-class no-ops on Gitea; they are implemented against Gitea's
+    issue/PR comment REST endpoints.
+    """
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 5
+        provider.enabled_pr = True
+        provider.enabled_issue = False
+        provider.max_comment_chars = 65000
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_edit_comment_from_comment_id_calls_edit(self):
+        provider = self._provider()
+
+        provider.edit_comment_from_comment_id(321, 'updated body')
+
+        _, kwargs = provider.repo_api.edit_comment.call_args
+        assert kwargs['comment_id'] == 321
+        assert kwargs['comment'] == 'updated body'
+
+    def test_get_comment_body_from_comment_id_returns_body(self):
+        provider = self._provider()
+        provider.repo_api.get_comment.return_value = {'id': 321, 'body': 'hello'}
+
+        assert provider.get_comment_body_from_comment_id(321) == 'hello'
+        _, kwargs = provider.repo_api.get_comment.call_args
+        assert kwargs['comment_id'] == 321
+
+    def test_get_comment_body_from_comment_id_empty_on_missing(self):
+        provider = self._provider()
+        provider.repo_api.get_comment.return_value = {}
+        assert provider.get_comment_body_from_comment_id(321) == ''
+
+    def test_reply_to_comment_from_comment_id_posts_comment(self):
+        provider = self._provider()
+        provider.publish_comment = MagicMock()
+
+        provider.reply_to_comment_from_comment_id(321, 'my answer')
+
+        provider.publish_comment.assert_called_once_with('my answer')
+
+    def test_get_review_thread_comments_returns_target_comment(self):
+        provider = self._provider()
+        provider.repo_api.get_comment.return_value = {'id': 321, 'body': 'original'}
+
+        thread = provider.get_review_thread_comments(321)
+
+        assert thread == [{'id': 321, 'body': 'original'}]
+
+    def test_get_review_thread_comments_empty_when_missing(self):
+        provider = self._provider()
+        provider.repo_api.get_comment.return_value = {}
+        assert provider.get_review_thread_comments(321) == []
+
+    def test_repo_api_get_comment_hits_issue_comment_endpoint(self):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.data = BytesIO(b'{"id": 321, "body": "hi"}')
+        client.call_api.return_value = mock_resp
+        repo_api = RepoApi(client)
+
+        comment = repo_api.get_comment('owner', 'repo', 321)
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/owner/repo/issues/comments/321'
+        assert args[1] == 'GET'
+        assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']
+        assert comment == {'id': 321, 'body': 'hi'}
+
+
+class TestGiteaProviderConfigBranch:
+    """get_repo_settings config-branch support (mirrors GithubProvider)."""
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.sha = 'headsha'
+        provider.repo_settings = '.pr_agent.toml'
+        provider.repo_api = MagicMock()
+        return provider
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_reads_from_config_branch_when_set(self, mock_get_settings):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'CONFIG.CONFIG_BRANCH': 'config-branch'}.get(k, d)
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        provider.repo_api.get_file_content.return_value = '[config]\nx = 1\n'
+
+        result = provider.get_repo_settings()
+
+        # The ref passed to Gitea must be the config branch, not the head sha.
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['commit_sha'] == 'config-branch'
+        assert result == b'[config]\nx = 1\n'
+
+    @patch.dict('os.environ', {'PR_AGENT_CONFIG_BRANCH': 'env-branch'}, clear=True)
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_reads_from_env_branch_when_setting_unset(self, mock_get_settings):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {}.get(k, d)
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        provider.repo_api.get_file_content.return_value = 'data'
+
+        provider.get_repo_settings()
+
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['commit_sha'] == 'env-branch'
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_falls_back_to_head_sha_when_branch_missing_file(self, mock_get_settings):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {'CONFIG.CONFIG_BRANCH': 'config-branch'}.get(k, d)
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        # First call (config branch) misses -> '', second (head sha) succeeds.
+        provider.repo_api.get_file_content.side_effect = ['', 'from-head']
+
+        result = provider.get_repo_settings()
+
+        assert result == b'from-head'
+        assert provider.repo_api.get_file_content.call_count == 2
+        second_call_kwargs = provider.repo_api.get_file_content.call_args_list[1].kwargs
+        assert second_call_kwargs['commit_sha'] == 'headsha'
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('pr_agent.git_providers.gitea_provider.get_settings')
+    def test_reads_from_head_sha_when_no_config_branch(self, mock_get_settings):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {}.get(k, d)
+        mock_get_settings.return_value = settings
+
+        provider = self._provider()
+        provider.repo_api.get_file_content.return_value = 'toml'
+
+        provider.get_repo_settings()
+
+        # No config branch -> a single read from the head sha.
+        provider.repo_api.get_file_content.assert_called_once()
+        _, kwargs = provider.repo_api.get_file_content.call_args
+        assert kwargs['commit_sha'] == 'headsha'

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1449,3 +1449,103 @@ class TestGiteaProviderIncremental:
         # Base content was read from the last-seen commit, not the repo head.
         _, kwargs = provider.repo_api.get_file_content.call_args
         assert kwargs['commit_sha'] == 'lastseen'
+
+
+class TestGiteaProviderCommitStatus:
+    """publish_commit_status surfaces pass/fail as a Gitea commit status
+    (POST .../statuses/{sha}) — Gitea's nearest equivalent to a check run."""
+
+    @staticmethod
+    def _provider():
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 5
+        provider.enabled_pr = True
+        provider.sha = 'headsha'
+        provider.max_comment_chars = 65000
+        provider.repo_api = MagicMock()
+        return provider
+
+    def test_publishes_status_on_head_sha(self):
+        provider = self._provider()
+
+        assert provider.publish_commit_status(
+            'success', context='PR-Agent/review',
+            description='Looks good', target_url='https://example.com/r/1',
+        ) is True
+
+        _, kwargs = provider.repo_api.create_commit_status.call_args
+        assert kwargs['sha'] == 'headsha'
+        assert kwargs['state'] == 'success'
+        assert kwargs['context'] == 'PR-Agent/review'
+        assert kwargs['description'] == 'Looks good'
+        assert kwargs['target_url'] == 'https://example.com/r/1'
+
+    def test_explicit_commit_sha_overrides_head(self):
+        provider = self._provider()
+        provider.publish_commit_status('pending', commit_sha='othersha')
+        _, kwargs = provider.repo_api.create_commit_status.call_args
+        assert kwargs['sha'] == 'othersha'
+
+    def test_unknown_state_coerced_to_error(self):
+        provider = self._provider()
+        provider.publish_commit_status('bogus')
+        _, kwargs = provider.repo_api.create_commit_status.call_args
+        assert kwargs['state'] == 'error'
+        provider.logger.warning.assert_called_once()
+
+    def test_valid_states_pass_through(self):
+        for state in ('pending', 'success', 'error', 'failure', 'warning'):
+            provider = self._provider()
+            provider.publish_commit_status(state)
+            _, kwargs = provider.repo_api.create_commit_status.call_args
+            assert kwargs['state'] == state
+
+    def test_returns_false_when_not_a_pr(self):
+        provider = self._provider()
+        provider.enabled_pr = False
+        assert provider.publish_commit_status('success') is False
+        provider.repo_api.create_commit_status.assert_not_called()
+
+    def test_returns_false_when_no_sha(self):
+        provider = self._provider()
+        provider.sha = ''
+        assert provider.publish_commit_status('success') is False
+        provider.repo_api.create_commit_status.assert_not_called()
+
+    def test_api_error_is_swallowed_returns_false(self):
+        provider = self._provider()
+        provider.repo_api.create_commit_status.side_effect = Exception('boom')
+        assert provider.publish_commit_status('success') is False
+        provider.logger.error.assert_called_once()
+
+    def test_description_is_truncated(self):
+        provider = self._provider()
+        provider.publish_commit_status('success', description='x' * 500)
+        _, kwargs = provider.repo_api.create_commit_status.call_args
+        assert len(kwargs['description']) <= 255
+
+    def test_repo_api_create_commit_status_hits_statuses_endpoint(self):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = MagicMock()
+        repo_api = RepoApi(client)
+
+        repo_api.create_commit_status(
+            'owner', 'repo', 'sha123', 'success',
+            context='ctx', description='desc', target_url='http://u',
+        )
+
+        args, kwargs = client.call_api.call_args
+        assert args[0] == '/repos/{owner}/{repo}/statuses/{sha}'
+        assert args[1] == 'POST'
+        assert kwargs['path_params'] == {'owner': 'owner', 'repo': 'repo', 'sha': 'sha123'}
+        assert kwargs['body'] == {
+            'state': 'success', 'context': 'ctx',
+            'description': 'desc', 'target_url': 'http://u',
+        }
+        assert kwargs.get('auth_settings') == ['AuthorizationHeaderToken']


### PR DESCRIPTION
## What

Brings the Gitea provider closer to GitHub parity. The headline gap: Gitea only ever created **unsubmitted PENDING** reviews (the reviews POST never sent an `event`), and `auto_approve` was the base no-op — so branch protection requiring a PR-Agent approval could never be satisfied on Gitea.

## Changes
- **Native formal review submission**: `GiteaProvider.submit_review(event, body)` + `auto_approve()` override that submits an APPROVED review (mirrors `github_provider`). The Gitea API already supports this (`event` enum `APPROVED|REQUEST_CHANGES|COMMENT|PENDING` on `POST .../pulls/{index}/reviews`); upstream just never sent it. Fixed a wrong-SHA `commit_id` (was using the repo's default-branch commit, not the PR head).
- **Provider parity batch**: `get_repo_labels()` + name-based `publish_labels`; `remove_reaction` signature aligned to the base contract (was a latent `TypeError`); config-branch support in `get_repo_settings`; `edit_comment_from_comment_id`/`get_comment_body_from_comment_id`/`reply_to_comment_from_comment_id`/`get_review_thread_comments` (unlocks inline `/ask`); `is_supported` reflects restricted-mode.
- **Webhook**: `review_requested` auto-trigger; bot self-comment filter; HMAC body-read ordering fix (read raw bytes before JSON).

## Tests
39 new unit tests (mock the Gitea HTTP API); `tests/unittest/test_gitea_provider.py` + `test_gitea_app.py` green. GitHub provider untouched.

Running in production against a self-hosted Gitea.