### PR TITLE
feat: allow overriding Claude extended-thinking models

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -460,3 +460,16 @@ enable_claude_extended_thinking = false # Set to true to enable extended thinkin
 extended_thinking_budget_tokens = 2048
 extended_thinking_max_output_tokens = 4096
 ```
+
+By default, PR-Agent applies the extended-thinking payload only to a built-in list of Claude models
+(see `CLAUDE_EXTENDED_THINKING_MODELS` in `pr_agent/algo/__init__.py`). If you use a newer or custom
+Claude model that is not in that list, you can override it:
+
+```toml
+[config]
+claude_extended_thinking_models_override = ["anthropic/claude-my-new-model"]
+```
+
+When `claude_extended_thinking_models_override` is non-empty, it fully replaces the built-in list, so
+include every model that should receive extended thinking. Leave it empty (the default) to use the
+built-in defaults.

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -473,3 +473,9 @@ claude_extended_thinking_models_override = ["anthropic/claude-my-new-model"]
 When `claude_extended_thinking_models_override` is non-empty, it fully replaces the built-in list, so
 include every model that should receive extended thinking. Leave it empty (the default) to use the
 built-in defaults.
+
+!!! note "Only models that accept a thinking budget are supported"
+    PR-Agent enables extended thinking through the manual
+    `thinking={"type": "enabled", "budget_tokens": ...}` request. Adaptive-only Claude models
+    (e.g. Opus 4.7/4.8, Sonnet 5, Fable 5) reject `budget_tokens` and will error if you add them to
+    the list — they are intentionally excluded from the built-in defaults.

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -364,7 +364,16 @@ SUPPORT_REASONING_EFFORT_MODELS = [
 
 CLAUDE_EXTENDED_THINKING_MODELS = [
     "anthropic/claude-3-7-sonnet-20250219",
-    "claude-3-7-sonnet-20250219"
+    "claude-3-7-sonnet-20250219",
+    "anthropic/claude-sonnet-4-6",
+    "claude-sonnet-4-6",
+    "vertex_ai/claude-sonnet-4-6",
+    "bedrock/anthropic.claude-sonnet-4-6",
+    "bedrock/us.anthropic.claude-sonnet-4-6",
+    "bedrock/au.anthropic.claude-sonnet-4-6",
+    "bedrock/eu.anthropic.claude-sonnet-4-6",
+    "bedrock/jp.anthropic.claude-sonnet-4-6",
+    "bedrock/global.anthropic.claude-sonnet-4-6",
 ]
 
 # Models that require streaming mode

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -362,6 +362,14 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     "o4-mini-2025-04-16",
 ]
 
+# Claude models that support "extended thinking" through the manual
+# thinking={"type": "enabled", "budget_tokens": ...} request built by
+# LiteLLMAIHandler._configure_claude_extended_thinking(). Only models that
+# accept budget_tokens belong here. Adaptive-only models (Claude Opus 4.7/4.8,
+# Sonnet 5, Fable 5) reject budget_tokens with an HTTP 400 and must not be added
+# without also adding an adaptive-thinking code path. This list is the built-in
+# default; it can be replaced via the `claude_extended_thinking_models_override`
+# configuration option.
 CLAUDE_EXTENDED_THINKING_MODELS = [
     "anthropic/claude-3-7-sonnet-20250219",
     "claude-3-7-sonnet-20250219",
@@ -374,6 +382,42 @@ CLAUDE_EXTENDED_THINKING_MODELS = [
     "bedrock/eu.anthropic.claude-sonnet-4-6",
     "bedrock/jp.anthropic.claude-sonnet-4-6",
     "bedrock/global.anthropic.claude-sonnet-4-6",
+    "anthropic/claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-5-20250929",
+    "vertex_ai/claude-sonnet-4-5@20250929",
+    "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic/claude-opus-4-5-20251101",
+    "claude-opus-4-5-20251101",
+    "vertex_ai/claude-opus-4-5@20251101",
+    "bedrock/anthropic.claude-opus-4-5-20251101-v1:0",
+    "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0",
+    "bedrock/au.anthropic.claude-opus-4-5-20251101-v1:0",
+    "bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0",
+    "bedrock/jp.anthropic.claude-opus-4-5-20251101-v1:0",
+    "bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0",
+    "anthropic/claude-opus-4-6",
+    "claude-opus-4-6",
+    "vertex_ai/claude-opus-4-6",
+    "bedrock/anthropic.claude-opus-4-6-v1:0",
+    "bedrock/us.anthropic.claude-opus-4-6-v1:0",
+    "bedrock/au.anthropic.claude-opus-4-6-v1:0",
+    "bedrock/eu.anthropic.claude-opus-4-6-v1:0",
+    "bedrock/jp.anthropic.claude-opus-4-6-v1:0",
+    "bedrock/global.anthropic.claude-opus-4-6-v1:0",
+    "anthropic/claude-haiku-4-5-20251001",
+    "claude-haiku-4-5-20251001",
+    "vertex_ai/claude-haiku-4-5@20251001",
+    "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0",
 ]
 
 # Models that require streaming mode

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -257,7 +257,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                 "Falling back to the built-in Claude extended-thinking model list."
             )
             override = []
-        self.claude_extended_thinking_models = list(override) if override else CLAUDE_EXTENDED_THINKING_MODELS
+        # Store stripped names so exact-match checks against the model succeed even when the config
+        # entries contain surrounding whitespace (validation above already used model.strip()).
+        self.claude_extended_thinking_models = (
+            [model.strip() for model in override] if override else CLAUDE_EXTENDED_THINKING_MODELS
+        )
 
         # Models that require streaming
         self.streaming_required_models = STREAMING_REQUIRED_MODELS

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -242,8 +242,22 @@ class LiteLLMAIHandler(BaseAiHandler):
         # Models that support reasoning effort
         self.support_reasoning_models = SUPPORT_REASONING_EFFORT_MODELS
 
-        # Models that support extended thinking
-        self.claude_extended_thinking_models = CLAUDE_EXTENDED_THINKING_MODELS
+        # Models that support extended thinking (config override replaces the built-in list when non-empty)
+        override = get_settings().config.get("claude_extended_thinking_models_override", []) or []
+        if override and not isinstance(override, list):
+            get_logger().warning(
+                "Invalid claude_extended_thinking_models_override in config; expected a list of model names. "
+                "Falling back to the built-in Claude extended-thinking model list."
+            )
+            override = []
+        elif override and not all(isinstance(model, str) and model.strip() for model in override):
+            get_logger().warning(
+                "Invalid claude_extended_thinking_models_override in config; "
+                "expected a list of model name strings. "
+                "Falling back to the built-in Claude extended-thinking model list."
+            )
+            override = []
+        self.claude_extended_thinking_models = list(override) if override else CLAUDE_EXTENDED_THINKING_MODELS
 
         # Models that require streaming
         self.streaming_required_models = STREAMING_REQUIRED_MODELS

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -68,6 +68,10 @@ reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048
 extended_thinking_max_output_tokens = 4096
+# Optional: override the built-in list of Claude models that receive the extended-thinking payload.
+# When non-empty, this list fully replaces the built-in defaults (see CLAUDE_EXTENDED_THINKING_MODELS
+# in pr_agent/algo/__init__.py). Leave empty to use the defaults.
+claude_extended_thinking_models_override = []
 # Extract issue number from PR source branch name (e.g. feature/1-auth-google -> issue #1). When true, branch-derived
 # issue URLs are merged with tickets from the PR description for compliance. Set to false to restore description-only behaviour.
 # Note: Branch-name extraction is GitHub-only for now; other providers planned for later.

--- a/tests/unittest/test_litellm_claude_extended_thinking.py
+++ b/tests/unittest/test_litellm_claude_extended_thinking.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+from pr_agent.algo import CLAUDE_EXTENDED_THINKING_MODELS
+
+
+def settings_with_claude_override(override):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            verbosity_level=0,
+            get=lambda key, default=None: (
+                override if key == "claude_extended_thinking_models_override" else default
+            ),
+        ),
+        litellm=SimpleNamespace(get=lambda key, default=None: default),
+        get=lambda key, default=None: default,
+    )
+
+
+@pytest.fixture
+def logger():
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_logger") as get_logger:
+        logger = MagicMock()
+        get_logger.return_value = logger
+        yield logger
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        "claude-3-7-sonnet-latest",
+        ["claude-3-7-sonnet-latest", 123],
+        [""],
+    ],
+)
+def test_invalid_claude_extended_thinking_override_falls_back_to_built_in_models(
+    monkeypatch,
+    logger,
+    override,
+):
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings_with_claude_override(override))
+
+    handler = litellm_handler.LiteLLMAIHandler()
+
+    assert handler.claude_extended_thinking_models == CLAUDE_EXTENDED_THINKING_MODELS
+    logger.warning.assert_called_once()
+
+
+def test_valid_claude_extended_thinking_override_replaces_built_in_models(monkeypatch, logger):
+    override = ["custom-claude-model"]
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings_with_claude_override(override))
+
+    handler = litellm_handler.LiteLLMAIHandler()
+
+    assert handler.claude_extended_thinking_models == ["custom-claude-model"]
+    assert handler.claude_extended_thinking_models is not override
+    logger.warning.assert_not_called()

--- a/tests/unittest/test_litellm_claude_extended_thinking.py
+++ b/tests/unittest/test_litellm_claude_extended_thinking.py
@@ -58,3 +58,14 @@ def test_valid_claude_extended_thinking_override_replaces_built_in_models(monkey
     assert handler.claude_extended_thinking_models == ["custom-claude-model"]
     assert handler.claude_extended_thinking_models is not override
     logger.warning.assert_not_called()
+
+
+def test_claude_extended_thinking_override_entries_are_stripped(monkeypatch, logger):
+    # Entries with surrounding whitespace must be stored stripped so exact model matches succeed.
+    override = ["  custom-claude-model  ", "another-model\n"]
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings_with_claude_override(override))
+
+    handler = litellm_handler.LiteLLMAIHandler()
+
+    assert handler.claude_extended_thinking_models == ["custom-claude-model", "another-model"]
+    logger.warning.assert_not_called()


### PR DESCRIPTION
## What & why

Split out from #2387 to keep each change reviewable on its own.

Adds a `claude_extended_thinking_models_override` config option so operators can direct the extended-thinking payload at newer or custom Claude models without waiting for the built-in `CLAUDE_EXTENDED_THINKING_MODELS` list (`pr_agent/algo/__init__.py`) to be updated.

- When the override list is **non-empty**, it **fully replaces** the built-in defaults.
- When **empty** (the default), the built-in list is used — no behavior change out of the box.
- Also expands the built-in list and documents the option in `changing_a_model.md`.

## Test
- New `tests/unittest/test_litellm_claude_extended_thinking.py` covers default vs. override behavior.
- Full unit suite passes locally; `ruff` clean.

Original work by @avidspartan1 (commit authorship preserved).
