### PR TITLE
feat: support GitHub organization-level global settings

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -652,6 +652,8 @@ cp pr_agent/settings/.secrets_template.toml pr_agent/settings/.secrets.toml
 
 > **Note:** When running PR-Agent from GitHub app, the default configuration file (configuration.toml) will be loaded.
 > However, you can override the default tool parameters by uploading a local configuration file `.pr_agent.toml`
+> To use organization-level global configuration, create `<organization>/pr-agent-settings` with a `.pr_agent.toml` file and install the GitHub App on that repository too.
+> The app needs read access to the settings repository as well as the pull request repositories. This applies to both GitHub.com and GitHub Enterprise Server.
 > For more information please check out the [USAGE GUIDE](../usage-guide/automations_and_usage.md#github-app)
 ---
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -88,6 +88,8 @@ If `.pr_agent.toml` cannot be loaded from the requested branch (e.g. the branch 
 
 If you create a repo called `pr-agent-settings` in your **organization**, its configuration file `.pr_agent.toml` will be used as a global configuration file for any other repo that belongs to the same organization.
 Parameters from a local `.pr_agent.toml` file, in a specific repo, will override the global configuration parameters.
+For GitHub Enterprise Server, use the same organization-level repository on your GHES host.
+The GitHub App installation or user token used by PR-Agent must have read access to both the pull request repository and the `<organization>/pr-agent-settings` repository; otherwise, PR-Agent will skip the global configuration and continue with repository-local settings.
 
 For example, in the GitHub organization `qodo-ai`:
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -84,12 +84,20 @@ If `.pr_agent.toml` cannot be loaded from the requested branch (e.g. the branch 
 
 ## Global configuration file
 
-`Platforms supported: GitHub`
+`Platforms supported: GitHub, GitLab (cloud), Bitbucket (cloud)`
 
-If you create a repo called `pr-agent-settings` in your **organization**, its configuration file `.pr_agent.toml` (read from that repo's default branch) will be used as a global configuration file for any other repo that belongs to the same organization.
+Create a repository named `pr-agent-settings` at the organization level; its `.pr_agent.toml` (read from that repo's default branch) is used as a global configuration for every repository under the same organization:
+
+- **GitHub:** `<organization>/pr-agent-settings`
+- **GitLab (cloud):** `<top-level-group>/pr-agent-settings` (GitLab.com only; not applied on self-hosted GitLab)
+- **Bitbucket (cloud):** `<workspace>/pr-agent-settings`
+
 Parameters from a local `.pr_agent.toml` file, in a specific repo, will override the global configuration parameters (the global file is merged *beneath* the repo-local one).
 For GitHub Enterprise Server, use the same organization-level repository on your GHES host.
-The GitHub App installation or user token used by PR-Agent must have read access to both the pull request repository and the `<organization>/pr-agent-settings` repository; otherwise, PR-Agent will skip the global configuration and continue with repository-local settings.
+The app installation or token used by PR-Agent must have read access to both the pull request repository and the `pr-agent-settings` repository; otherwise, PR-Agent will skip the global configuration and continue with repository-local settings.
+
+!!! note "Caching"
+    In long-running deployments (the GitHub App / webhook server), the fetched global settings are cached **in-process** for up to 15 minutes to avoid re-fetching on every webhook event, so a change to `pr-agent-settings` may take up to that long to take effect there. CLI and CI (GitHub Action) runs are short-lived processes, so they fetch the global settings once per invocation and always see the latest version.
 
 Loading the global settings file is controlled by the `use_global_settings_file` flag, which is **enabled by default**. To opt out and rely only on each repo's local `.pr_agent.toml`, set:
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -91,6 +91,13 @@ Parameters from a local `.pr_agent.toml` file, in a specific repo, will override
 For GitHub Enterprise Server, use the same organization-level repository on your GHES host.
 The GitHub App installation or user token used by PR-Agent must have read access to both the pull request repository and the `<organization>/pr-agent-settings` repository; otherwise, PR-Agent will skip the global configuration and continue with repository-local settings.
 
+Loading the global settings file is controlled by the `use_global_settings_file` flag, which is **enabled by default**. To opt out and rely only on each repo's local `.pr_agent.toml`, set:
+
+```toml
+[config]
+use_global_settings_file = false
+```
+
 For example, in the GitHub organization `qodo-ai`:
 
 - The file [`https://github.com/the-pr-agent/pr-agent-settings/.pr_agent.toml`](https://github.com/the-pr-agent/pr-agent-settings/blob/main/.pr_agent.toml)  serves as a global configuration file for all the repos in the GitHub organization `qodo-ai`.

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -84,10 +84,10 @@ If `.pr_agent.toml` cannot be loaded from the requested branch (e.g. the branch 
 
 ## Global configuration file
 
-`Platforms supported: GitHub, GitLab (cloud), Bitbucket (cloud)`
+`Platforms supported: GitHub`
 
-If you create a repo called `pr-agent-settings` in your **organization**, its configuration file `.pr_agent.toml` will be used as a global configuration file for any other repo that belongs to the same organization.
-Parameters from a local `.pr_agent.toml` file, in a specific repo, will override the global configuration parameters.
+If you create a repo called `pr-agent-settings` in your **organization**, its configuration file `.pr_agent.toml` (read from that repo's default branch) will be used as a global configuration file for any other repo that belongs to the same organization.
+Parameters from a local `.pr_agent.toml` file, in a specific repo, will override the global configuration parameters (the global file is merged *beneath* the repo-local one).
 For GitHub Enterprise Server, use the same organization-level repository on your GHES host.
 The GitHub App installation or user token used by PR-Agent must have read access to both the pull request repository and the `<organization>/pr-agent-settings` repository; otherwise, PR-Agent will skip the global configuration and continue with repository-local settings.
 

--- a/pr_agent/custom_merge_loader.py
+++ b/pr_agent/custom_merge_loader.py
@@ -5,6 +5,10 @@ from jinja2.exceptions import SecurityError
 
 from pr_agent.log import get_logger
 
+# Prevent out-of-memory exceptions by limiting settings files to 100 MB (sufficient for up to ~1M lines).
+MAX_TOML_SIZE_IN_BYTES = 100 * 1024 * 1024
+
+
 def load(obj, env=None, silent=True, key=None, filename=None):
     """
     Load and merge TOML configuration files into a Dynaconf settings object using a secure, in-house loader.
@@ -22,8 +26,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     Returns:
         None
     """
-
-    MAX_TOML_SIZE_IN_BYTES = 100 * 1024 * 1024 # Prevent out of mem. exceptions by limiting to 100 MBs which is sufficient for up to 1M lines
 
     # Get the list of files to load
     # TODO: hasattr(obj, 'settings_files') for some reason returns False. Need to use 'settings_file'

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -110,7 +110,7 @@ class BitbucketProvider(GitProvider):
         # errors raise (via raise_for_status) so the caller does not cache a transient failure.
         repo_url = f"https://api.bitbucket.org/2.0/repositories/{workspace}/pr-agent-settings"
         repo_resp = requests.request("GET", repo_url, headers=self.headers)
-        if repo_resp.status_code == 404:  # no global settings repo
+        if repo_resp.status_code in (403, 404):  # missing repo or no access -> expected, cacheable
             return ""
         repo_resp.raise_for_status()
         main_branch = (repo_resp.json().get('mainbranch') or {}).get('name')
@@ -118,7 +118,7 @@ class BitbucketProvider(GitProvider):
             return ""
         file_resp = requests.request(
             "GET", f"{repo_url}/src/{main_branch}/.pr_agent.toml", headers=self.headers)
-        if file_resp.status_code == 404:  # repo exists but no .pr_agent.toml
+        if file_resp.status_code in (403, 404):  # missing file or no access -> expected, cacheable
             return ""
         file_resp.raise_for_status()
         return file_resp.text.encode('utf-8')

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -106,28 +106,22 @@ class BitbucketProvider(GitProvider):
             f"bitbucket:{workspace}", lambda: self._fetch_global_repo_settings(workspace))
 
     def _fetch_global_repo_settings(self, workspace):
-        try:
-            repo_url = f"https://api.bitbucket.org/2.0/repositories/{workspace}/pr-agent-settings"
-            repo_resp = requests.request("GET", repo_url, headers=self.headers)
-            if repo_resp.status_code == 404:  # no global settings repo -> expected fallback
-                return ""
-            if repo_resp.status_code >= 400:
-                get_logger().warning(f"Failed to load global settings repo, status: {repo_resp.status_code}")
-                return ""
-            main_branch = (repo_resp.json().get('mainbranch') or {}).get('name')
-            if not main_branch:
-                return ""
-            file_resp = requests.request(
-                "GET", f"{repo_url}/src/{main_branch}/.pr_agent.toml", headers=self.headers)
-            if file_resp.status_code == 404:  # repo exists but no .pr_agent.toml
-                return ""
-            if file_resp.status_code >= 400:
-                get_logger().warning(f"Failed to load global .pr_agent.toml, status: {file_resp.status_code}")
-                return ""
-            return file_resp.text.encode('utf-8')
-        except Exception as e:
-            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
+        # A missing settings repo/file (404) is an expected fallback -> return "" (cached). Other
+        # errors raise (via raise_for_status) so the caller does not cache a transient failure.
+        repo_url = f"https://api.bitbucket.org/2.0/repositories/{workspace}/pr-agent-settings"
+        repo_resp = requests.request("GET", repo_url, headers=self.headers)
+        if repo_resp.status_code == 404:  # no global settings repo
             return ""
+        repo_resp.raise_for_status()
+        main_branch = (repo_resp.json().get('mainbranch') or {}).get('name')
+        if not main_branch:
+            return ""
+        file_resp = requests.request(
+            "GET", f"{repo_url}/src/{main_branch}/.pr_agent.toml", headers=self.headers)
+        if file_resp.status_code == 404:  # repo exists but no .pr_agent.toml
+            return ""
+        file_resp.raise_for_status()
+        return file_resp.text.encode('utf-8')
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         # Read from the PR destination (target) branch, matching the other providers,

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -15,7 +15,7 @@ from ..algo.language_handler import is_valid_file
 from ..algo.utils import find_line_number_of_relevant_line_in_file
 from ..config_loader import get_settings
 from ..log import get_logger
-from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider
+from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, get_cached_global_settings
 
 
 def _gef_filename(diff):
@@ -78,15 +78,52 @@ class BitbucketProvider(GitProvider):
         self.bitbucket_pull_request_api_url = self.pr._BitbucketBase__data["links"]['self']['href']
 
     def get_repo_settings(self):
+        settings_files = []
+        global_settings = self._get_global_repo_settings()
+        if global_settings:
+            settings_files.append(("global", global_settings))
         try:
             url = (f"https://api.bitbucket.org/2.0/repositories/{self.workspace_slug}/{self.repo_slug}/src/"
                    f"{self.pr.destination_branch}/.pr_agent.toml")
             response = requests.request("GET", url, headers=self.headers)
-            if response.status_code == 404:  # not found
+            if response.status_code != 404:  # found
+                settings_files.append(("local", response.text.encode('utf-8')))
+        except Exception as e:
+            get_logger().warning(f"Failed to load local .pr_agent.toml file, error: {e}")
+        return settings_files if settings_files else ""
+
+    def _get_global_repo_settings(self):
+        # Load a workspace-wide <workspace>/pr-agent-settings/.pr_agent.toml.
+        if not get_settings().config.use_global_settings_file:
+            return ""
+        workspace = self.get_pr_owner_id()
+        if not workspace or not getattr(self, "headers", None):
+            return ""
+        return get_cached_global_settings(
+            f"bitbucket:{workspace}", lambda: self._fetch_global_repo_settings(workspace))
+
+    def _fetch_global_repo_settings(self, workspace):
+        try:
+            repo_url = f"https://api.bitbucket.org/2.0/repositories/{workspace}/pr-agent-settings"
+            repo_resp = requests.request("GET", repo_url, headers=self.headers)
+            if repo_resp.status_code == 404:  # no global settings repo -> expected fallback
                 return ""
-            contents = response.text.encode('utf-8')
-            return contents
-        except Exception:
+            if repo_resp.status_code >= 400:
+                get_logger().warning(f"Failed to load global settings repo, status: {repo_resp.status_code}")
+                return ""
+            main_branch = (repo_resp.json().get('mainbranch') or {}).get('name')
+            if not main_branch:
+                return ""
+            file_resp = requests.request(
+                "GET", f"{repo_url}/src/{main_branch}/.pr_agent.toml", headers=self.headers)
+            if file_resp.status_code == 404:  # repo exists but no .pr_agent.toml
+                return ""
+            if file_resp.status_code >= 400:
+                get_logger().warning(f"Failed to load global .pr_agent.toml, status: {file_resp.status_code}")
+                return ""
+            return file_resp.text.encode('utf-8')
+        except Exception as e:
+            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
             return ""
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -86,8 +86,11 @@ class BitbucketProvider(GitProvider):
             url = (f"https://api.bitbucket.org/2.0/repositories/{self.workspace_slug}/{self.repo_slug}/src/"
                    f"{self.pr.destination_branch}/.pr_agent.toml")
             response = requests.request("GET", url, headers=self.headers)
-            if response.status_code != 404:  # found
+            if response.status_code == 200:  # found
                 settings_files.append(("local", response.text.encode('utf-8')))
+            elif response.status_code != 404:
+                # Don't treat error bodies (401/403/500/...) as TOML content.
+                get_logger().warning(f"Failed to load local .pr_agent.toml file, status: {response.status_code}")
         except Exception as e:
             get_logger().warning(f"Failed to load local .pr_agent.toml file, error: {e}")
         return settings_files if settings_files else ""

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -16,6 +16,9 @@ MAX_FILES_ALLOWED_FULL = 50
 _GLOBAL_SETTINGS_CACHE: dict = {}
 _GLOBAL_SETTINGS_CACHE_TTL_SECONDS = 15 * 60
 _GLOBAL_SETTINGS_CACHE_MAX_SIZE = 256
+# Only cache reasonably-sized settings blobs; a valid .pr_agent.toml is tiny. This bounds the
+# process-wide cache memory (256 entries x this) regardless of the much larger apply-time size cap.
+_GLOBAL_SETTINGS_CACHE_MAX_VALUE_BYTES = 1024 * 1024
 
 
 def get_cached_global_settings(cache_key, fetch_fn):
@@ -23,7 +26,8 @@ def get_cached_global_settings(cache_key, fetch_fn):
 
     Global settings change rarely, so caching avoids a provider API lookup (and repeated
     403/404 fallbacks) on every webhook event. Empty/"not found" results are cached too, to
-    prevent repeated failed lookups. Pass a falsy cache_key to bypass the cache.
+    prevent repeated failed lookups. Oversized values are returned but not cached (to bound
+    memory). Pass a falsy cache_key to bypass the cache.
     """
     if not cache_key:
         return fetch_fn()
@@ -32,10 +36,12 @@ def get_cached_global_settings(cache_key, fetch_fn):
     if entry is not None and entry[1] > now:
         return entry[0]
     value = fetch_fn()
-    _GLOBAL_SETTINGS_CACHE[cache_key] = (value, now + _GLOBAL_SETTINGS_CACHE_TTL_SECONDS)
-    while len(_GLOBAL_SETTINGS_CACHE) > _GLOBAL_SETTINGS_CACHE_MAX_SIZE:
-        oldest_key = min(_GLOBAL_SETTINGS_CACHE, key=lambda k: _GLOBAL_SETTINGS_CACHE[k][1])
-        _GLOBAL_SETTINGS_CACHE.pop(oldest_key, None)
+    value_size = len(value) if isinstance(value, (bytes, str)) else 0
+    if value_size <= _GLOBAL_SETTINGS_CACHE_MAX_VALUE_BYTES:
+        _GLOBAL_SETTINGS_CACHE[cache_key] = (value, now + _GLOBAL_SETTINGS_CACHE_TTL_SECONDS)
+        while len(_GLOBAL_SETTINGS_CACHE) > _GLOBAL_SETTINGS_CACHE_MAX_SIZE:
+            oldest_key = min(_GLOBAL_SETTINGS_CACHE, key=lambda k: _GLOBAL_SETTINGS_CACHE[k][1])
+            _GLOBAL_SETTINGS_CACHE.pop(oldest_key, None)
     return value
 
 def get_git_ssl_env() -> dict[str, str]:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import os
 import shutil
 import subprocess
+import time
 from typing import Optional, Tuple
 
 from pr_agent.algo.types import FilePatchInfo
@@ -11,6 +12,31 @@ from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
 
 MAX_FILES_ALLOWED_FULL = 50
+
+_GLOBAL_SETTINGS_CACHE: dict = {}
+_GLOBAL_SETTINGS_CACHE_TTL_SECONDS = 15 * 60
+_GLOBAL_SETTINGS_CACHE_MAX_SIZE = 256
+
+
+def get_cached_global_settings(cache_key, fetch_fn):
+    """Return the org/group/workspace global .pr_agent.toml via a bounded TTL cache.
+
+    Global settings change rarely, so caching avoids a provider API lookup (and repeated
+    403/404 fallbacks) on every webhook event. Empty/"not found" results are cached too, to
+    prevent repeated failed lookups. Pass a falsy cache_key to bypass the cache.
+    """
+    if not cache_key:
+        return fetch_fn()
+    now = time.monotonic()
+    entry = _GLOBAL_SETTINGS_CACHE.get(cache_key)
+    if entry is not None and entry[1] > now:
+        return entry[0]
+    value = fetch_fn()
+    _GLOBAL_SETTINGS_CACHE[cache_key] = (value, now + _GLOBAL_SETTINGS_CACHE_TTL_SECONDS)
+    while len(_GLOBAL_SETTINGS_CACHE) > _GLOBAL_SETTINGS_CACHE_MAX_SIZE:
+        oldest_key = min(_GLOBAL_SETTINGS_CACHE, key=lambda k: _GLOBAL_SETTINGS_CACHE[k][1])
+        _GLOBAL_SETTINGS_CACHE.pop(oldest_key, None)
+    return value
 
 def get_git_ssl_env() -> dict[str, str]:
     """

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -29,13 +29,24 @@ def get_cached_global_settings(cache_key, fetch_fn):
     prevent repeated failed lookups. Oversized values are returned but not cached (to bound
     memory). Pass a falsy cache_key to bypass the cache.
     """
+    def _fetch_safely():
+        # A transient/unexpected fetch failure must NOT be cached, so it is retried instead of
+        # disabling global settings for the whole TTL. fetch_fn returns "" for expected "not found".
+        try:
+            return fetch_fn(), True
+        except Exception as e:
+            get_logger().warning(f"Failed to load global settings, error: {e}")
+            return "", False
+
     if not cache_key:
-        return fetch_fn()
+        return _fetch_safely()[0]
     now = time.monotonic()
     entry = _GLOBAL_SETTINGS_CACHE.get(cache_key)
     if entry is not None and entry[1] > now:
         return entry[0]
-    value = fetch_fn()
+    value, cacheable = _fetch_safely()
+    if not cacheable:
+        return value
     value_size = len(value) if isinstance(value, (bytes, str)) else 0
     if value_size <= _GLOBAL_SETTINGS_CACHE_MAX_VALUE_BYTES:
         _GLOBAL_SETTINGS_CACHE[cache_key] = (value, now + _GLOBAL_SETTINGS_CACHE_TTL_SECONDS)

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -852,10 +852,13 @@ class GithubProvider(GitProvider):
                     return settings_files
                 return contents
             except GithubException as e:
-                get_logger().warning(
-                    f"Failed to load .pr_agent.toml from branch '{config_branch}', falling back to default branch",
-                    artifact={"status": e.status, "error": str(e)},
-                )
+                # Only a missing branch/file (404) is an expected reason to fall back to the default
+                # branch. Other errors (e.g. 403/5xx) are surfaced rather than silently masked by a
+                # fallback that could apply unintended settings.
+                if e.status != 404:
+                    raise
+                get_logger().debug(
+                    f"No .pr_agent.toml on branch '{config_branch}', falling back to default branch")
         try:
             # more logical to take 'pr_agent.toml' from the default branch
             contents = self.repo_obj.get_contents(".pr_agent.toml").decoded_content
@@ -896,18 +899,15 @@ class GithubProvider(GitProvider):
             global_settings_repo = self.github_client.get_repo(f"{repo_owner}/pr-agent-settings")
             return global_settings_repo.get_contents(".pr_agent.toml").decoded_content
         except GithubException as e:
-            # A missing pr-agent-settings repo/file (404) or lack of access (403) is an expected
-            # fallback (skip global settings, continue with local), so log it quietly to avoid noise.
+            # A missing pr-agent-settings repo/file (404) or lack of access (403) is an expected,
+            # stable fallback (skip global settings, continue with local) — return "" so it's cached.
             if e.status in (403, 404):
                 get_logger().debug(
                     "No accessible organization global .pr_agent.toml; using local settings only",
                     artifact={"status": e.status})
                 return ""
-            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
-            return ""
-        except Exception as e:
-            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
-            return ""
+            # Transient/unexpected errors propagate so the caller does not cache the failure.
+            raise
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -877,6 +877,16 @@ class GithubProvider(GitProvider):
                 return ""
             global_settings_repo = self.github_client.get_repo(f"{repo_owner}/pr-agent-settings")
             return global_settings_repo.get_contents(".pr_agent.toml").decoded_content
+        except GithubException as e:
+            # A missing pr-agent-settings repo/file (404) or lack of access (403) is an expected
+            # fallback (skip global settings, continue with local), so log it quietly to avoid noise.
+            if e.status in (403, 404):
+                get_logger().debug(
+                    "No accessible organization global .pr_agent.toml; using local settings only",
+                    artifact={"status": e.status})
+                return ""
+            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
+            return ""
         except Exception as e:
             get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
             return ""

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -862,6 +862,13 @@ class GithubProvider(GitProvider):
             if config_branch and not settings_files:
                 return contents
             settings_files.append(("local", contents))
+        except GithubException as e:
+            # A missing local .pr_agent.toml (404) is expected for most repos; log it quietly to
+            # avoid warning noise, and surface only unexpected errors as warnings.
+            if e.status == 404:
+                get_logger().debug("No local .pr_agent.toml found; using existing settings")
+            else:
+                get_logger().warning(f"Failed to load .pr_agent.toml file, error: {e}")
         except Exception as e:
             get_logger().warning(f"Failed to load .pr_agent.toml file, error: {e}")
 
@@ -869,6 +876,11 @@ class GithubProvider(GitProvider):
 
     def _get_global_repo_settings(self):
         if not get_settings().config.use_global_settings_file:
+            return ""
+
+        # Be robust to providers built without full __init__ (e.g. __new__ in tests/helpers):
+        # without a repo/client there is no org to resolve, so skip global settings quietly.
+        if not getattr(self, "repo", None) or getattr(self, "github_client", None) is None:
             return ""
 
         try:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -830,6 +830,11 @@ class GithubProvider(GitProvider):
         return self.pr.get_issue_comments()
 
     def get_repo_settings(self):
+        settings_files = []
+        global_settings = self._get_global_repo_settings()
+        if global_settings:
+            settings_files.append(("global", global_settings))
+
         # Normalize each candidate before applying precedence so a whitespace-only
         # settings value doesn't short-circuit the PR_AGENT_CONFIG_BRANCH fallback.
         settings_branch = get_settings().get("CONFIG.CONFIG_BRANCH", None)
@@ -841,16 +846,39 @@ class GithubProvider(GitProvider):
             # reason to fall back to the default branch. Unexpected errors are
             # left to propagate so they aren't masked by a silent fallback.
             try:
-                return self.repo_obj.get_contents(".pr_agent.toml", ref=config_branch).decoded_content
+                contents = self.repo_obj.get_contents(".pr_agent.toml", ref=config_branch).decoded_content
+                if settings_files:
+                    settings_files.append(("local", contents))
+                    return settings_files
+                return contents
             except GithubException as e:
                 get_logger().warning(
                     f"Failed to load .pr_agent.toml from branch '{config_branch}', falling back to default branch",
                     artifact={"status": e.status, "error": str(e)},
                 )
         try:
+            # more logical to take 'pr_agent.toml' from the default branch
             contents = self.repo_obj.get_contents(".pr_agent.toml").decoded_content
-            return contents
-        except Exception:
+            if config_branch and not settings_files:
+                return contents
+            settings_files.append(("local", contents))
+        except Exception as e:
+            get_logger().warning(f"Failed to load .pr_agent.toml file, error: {e}")
+
+        return settings_files if settings_files else ""
+
+    def _get_global_repo_settings(self):
+        if not get_settings().config.use_global_settings_file:
+            return ""
+
+        try:
+            repo_owner = self.get_pr_owner_id()
+            if not repo_owner:
+                return ""
+            global_settings_repo = self.github_client.get_repo(f"{repo_owner}/pr-agent-settings")
+            return global_settings_repo.get_contents(".pr_agent.toml").decoded_content
+        except Exception as e:
+            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
             return ""
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -27,7 +27,7 @@ from ..config_loader import get_settings
 from ..log import get_logger
 from ..servers.utils import RateLimitExceeded
 from .git_provider import (MAX_FILES_ALLOWED_FULL, FilePatchInfo, GitProvider,
-                           IncrementalPR)
+                           IncrementalPR, get_cached_global_settings)
 
 
 def _next_page_url(headers: dict) -> str:
@@ -883,10 +883,16 @@ class GithubProvider(GitProvider):
         if not getattr(self, "repo", None) or getattr(self, "github_client", None) is None:
             return ""
 
+        repo_owner = self.get_pr_owner_id()
+        if not repo_owner:
+            return ""
+        # Cache per org: global settings change rarely, so avoid a lookup (and repeated 403/404
+        # fallbacks) on every webhook event.
+        return get_cached_global_settings(
+            f"github:{repo_owner}", lambda: self._fetch_global_repo_settings(repo_owner))
+
+    def _fetch_global_repo_settings(self, repo_owner):
         try:
-            repo_owner = self.get_pr_owner_id()
-            if not repo_owner:
-                return ""
             global_settings_repo = self.github_client.get_repo(f"{repo_owner}/pr-agent-settings")
             return global_settings_repo.get_contents(".pr_agent.toml").decoded_content
         except GithubException as e:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -817,10 +817,12 @@ class GitLabProvider(GitProvider):
             return ""
         if not getattr(self, "gl", None) or not getattr(self, "id_project", None):
             return ""
-        # get_pr_owner_id returns the top-level group on gitlab.com, or the host on self-hosted;
-        # global settings are group-scoped, so only apply on gitlab.com.
+        # Group-level global settings are GitLab.com only. Match the host exactly so a self-hosted
+        # instance whose hostname merely contains "gitlab.com" (e.g. "mygitlab.com") is not treated
+        # as GitLab.com. get_pr_owner_id returns the top-level group on gitlab.com.
+        host = (urlparse(self.gitlab_url).hostname or "").lower() if self.gitlab_url else ""
         group = self.get_pr_owner_id()
-        if not group or not self.gitlab_url or 'gitlab.com' not in self.gitlab_url:
+        if not group or host != "gitlab.com":
             return ""
         return get_cached_global_settings(
             f"gitlab:{group}", lambda: self._fetch_global_repo_settings(group))

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -20,7 +20,8 @@ from ..algo.utils import (clip_tokens,
                           load_large_diff)
 from ..config_loader import get_settings
 from ..log import get_logger
-from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider
+from .git_provider import (MAX_FILES_ALLOWED_FULL, GitProvider,
+                           get_cached_global_settings)
 
 
 class DiffNotFoundError(Exception):
@@ -795,11 +796,44 @@ class GitLabProvider(GitProvider):
         return self.mr.notes.list(get_all=True)[::-1]
 
     def get_repo_settings(self):
+        settings_files = []
+        global_settings = self._get_global_repo_settings()
+        if global_settings:
+            settings_files.append(("global", global_settings))
         try:
             main_branch = self.gl.projects.get(self.id_project).default_branch
             contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=main_branch).decode()
-            return contents
-        except Exception:
+            if contents:
+                settings_files.append(("local", contents))
+        except GitlabGetError:
+            pass  # a missing local .pr_agent.toml is expected
+        except Exception as e:
+            get_logger().warning(f"Failed to load local .pr_agent.toml file, error: {e}")
+        return settings_files if settings_files else ""
+
+    def _get_global_repo_settings(self):
+        # Load an org-wide <group>/pr-agent-settings/.pr_agent.toml (GitLab.com groups only).
+        if not get_settings().config.use_global_settings_file:
+            return ""
+        if not getattr(self, "gl", None) or not getattr(self, "id_project", None):
+            return ""
+        # get_pr_owner_id returns the top-level group on gitlab.com, or the host on self-hosted;
+        # global settings are group-scoped, so only apply on gitlab.com.
+        group = self.get_pr_owner_id()
+        if not group or not self.gitlab_url or 'gitlab.com' not in self.gitlab_url:
+            return ""
+        return get_cached_global_settings(
+            f"gitlab:{group}", lambda: self._fetch_global_repo_settings(group))
+
+    def _fetch_global_repo_settings(self, group):
+        try:
+            project = self.gl.projects.get(f"{group}/pr-agent-settings")
+            return project.files.get(file_path='.pr_agent.toml', ref=project.default_branch).decode()
+        except GitlabGetError:
+            # missing pr-agent-settings project/file is an expected fallback
+            return ""
+        except Exception as e:
+            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
             return ""
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -832,11 +832,9 @@ class GitLabProvider(GitProvider):
             project = self.gl.projects.get(f"{group}/pr-agent-settings")
             return project.files.get(file_path='.pr_agent.toml', ref=project.default_branch).decode()
         except GitlabGetError:
-            # missing pr-agent-settings project/file is an expected fallback
+            # A missing pr-agent-settings project/file is an expected fallback -> return "" (cached).
             return ""
-        except Exception as e:
-            get_logger().warning(f"Failed to load global .pr_agent.toml file, error: {e}")
-            return ""
+        # Transient/unexpected errors propagate so the caller does not cache the failure.
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -419,11 +419,14 @@ def handle_configurations_errors(config_errors, git_provider):
                 get_logger().warning("Sending a 'configuration error' comment to the PR", artifact={'body': body})
                 # git_provider.publish_comment(body)
                 if hasattr(git_provider, 'publish_persistent_comment'):
+                    # Use a per-scope name so multiple settings errors (e.g. global + local) don't
+                    # collide: in GitHub check-run mode the name keys the check run, so a shared name
+                    # would make later errors overwrite earlier ones and hide failures.
                     git_provider.publish_persistent_comment(body,
                                                             initial_header=header,
                                                             update_header=False,
                                                             final_update_message=False,
-                                                            name="config-errors")
+                                                            name=f"config-errors-{config_type}")
                 else:
                     git_provider.publish_comment(body)
     except Exception as e:

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -345,32 +345,12 @@ def _apply_repo_settings_file(repo_settings_file):
     # internal filesystem path into the PR configuration-error comment.
     validate_file_security(parsed_toml, ".pr_agent.toml")
 
-    try:
-        dynconf_kwargs = {'core_loaders': [],
-             # Disable default loaders, otherwise TOML files load more than once.
-             'loaders': ['pr_agent.custom_merge_loader'],
-             # Merge sections and overwrite overlapping values without involving environment variables.
-             'merge_enabled': True
-         }
-        new_settings = Dynaconf(settings_files=[repo_settings_file],
-                                # Disable all dynamic loading features
-                                load_dotenv=False,  # Don't load .env files
-                                envvar_prefix=False,  # Drop DYNACONF for env. variables
-                                **dynconf_kwargs
-                                )
-    except TypeError as e:
-        # Fallback for older Dynaconf versions that don't support these parameters
-        get_logger().warning(
-            "Your Dynaconf version does not support disabled 'load_dotenv'/'merge_enabled' parameters. "
-            "Loading repo settings without these security features. "
-            "Please upgrade Dynaconf for better security.",
-            artifact={"error": e, "traceback": traceback.format_exc()})
-        new_settings = Dynaconf(settings_files=[repo_settings_file])
-
-    for section, contents in new_settings.as_dict().items():
-        if not contents:
-            # Skip excluded items, such as forbidden to load env.
-            get_logger().debug(f"Skipping a section: {section} which is not allowed")
+    # Apply the already-parsed data directly instead of re-reading the file through Dynaconf, which
+    # would parse the same TOML a second time. Section names are matched case-insensitively (Dynaconf
+    # stores them upper-cased); list/dict values replace rather than merge, matching the loader.
+    for section, contents in parsed_toml.items():
+        if not isinstance(contents, dict) or not contents:
+            get_logger().debug(f"Skipping non-table or empty section: {section}")
             continue
         allowed_keys = _REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
         if allowed_keys is not None:
@@ -383,7 +363,7 @@ def _apply_repo_settings_file(repo_settings_file):
             contents = {k: v for k, v in contents.items() if k.lower() in allowed_keys}
             if not contents:
                 continue
-        section_dict = copy.deepcopy(get_settings().as_dict().get(section, {}))
+        section_dict = copy.deepcopy(get_settings().as_dict().get(section.upper(), {}))
         for key, value in contents.items():
             section_dict[key] = value
         get_settings().unset(section)
@@ -395,7 +375,7 @@ def _apply_repo_settings_file(repo_settings_file):
     # (e.g. openai.key, gitlab.personal_access_token) that would otherwise leak into
     # CI logs. Section names are safe and sufficient for debugging.
     get_logger().info(
-        f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
+        f"Applying repo settings (sections: {sorted(parsed_toml.keys())})"
     )
 
 
@@ -422,7 +402,9 @@ def handle_configurations_errors(config_errors, git_provider):
                 body += f"___\n\n**Error message:**\n`{err_message}`\n\n"
                 if config_type == "global":
                     # Global content is redacted, so we never render it — skip decoding it entirely.
-                    body += "\n\nThe invalid configuration came from the organization's global settings file."
+                    # Global settings live in a `pr-agent-settings` repo scoped per platform
+                    # (GitHub organization, GitLab group, or Bitbucket workspace).
+                    body += "\n\nThe invalid configuration came from the global `pr-agent-settings` settings repository."
                 else:
                     settings_content = err['settings']
                     configuration_file_content = (

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -410,11 +410,6 @@ def handle_configurations_errors(config_errors, git_provider):
 
         for err in config_errors:
             if err:
-                settings_content = err['settings']
-                configuration_file_content = (
-                    settings_content.decode("utf-8", errors="replace")
-                    if isinstance(settings_content, bytes) else settings_content
-                )
                 err_message = err['error']
                 config_type = err['category']
                 header = f"❌ **PR-Agent failed to apply '{config_type}' repo settings**"
@@ -424,14 +419,21 @@ def handle_configurations_errors(config_errors, git_provider):
                 )
                 body += f"___\n\n**Error message:**\n`{err_message}`\n\n"
                 if config_type == "global":
+                    # Global content is redacted, so we never render it — skip decoding it entirely.
                     body += "\n\nThe invalid configuration came from the organization's global settings file."
-                elif git_provider.is_supported("gfm_markdown"):
-                    body += (
-                        "\n\n<details><summary>Configuration content:</summary>\n\n"
-                        f"```toml\n{configuration_file_content}\n```\n\n</details>"
-                    )
                 else:
-                    body += f"\n\n**Configuration content:**\n\n```toml\n{configuration_file_content}\n```\n\n"
+                    settings_content = err['settings']
+                    configuration_file_content = (
+                        settings_content.decode("utf-8", errors="replace")
+                        if isinstance(settings_content, bytes) else settings_content
+                    )
+                    if git_provider.is_supported("gfm_markdown"):
+                        body += (
+                            "\n\n<details><summary>Configuration content:</summary>\n\n"
+                            f"```toml\n{configuration_file_content}\n```\n\n</details>"
+                        )
+                    else:
+                        body += f"\n\n**Configuration content:**\n\n```toml\n{configuration_file_content}\n```\n\n"
                 get_logger().warning("Sending a 'configuration error' comment to the PR", artifact={'body': body})
                 # git_provider.publish_comment(body)
                 if hasattr(git_provider, 'publish_persistent_comment'):

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -12,7 +12,8 @@ from dynaconf.loaders import env_loader
 from starlette_context import context
 
 from pr_agent.config_loader import get_settings
-from pr_agent.custom_merge_loader import validate_file_security
+from pr_agent.custom_merge_loader import (MAX_TOML_SIZE_IN_BYTES,
+                                          validate_file_security)
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
 
@@ -328,6 +329,13 @@ def _apply_repo_settings_file(repo_settings_file):
     secrets). Raises on load/parse failure so the caller can attribute the error to the correct
     settings scope (e.g. 'global' vs 'local').
     """
+    # Enforce the same size cap as the loader BEFORE parsing, so an oversized file can't be fully
+    # read/parsed in-process (OOM/CPU) by the explicit validation below.
+    if os.path.getsize(repo_settings_file) > MAX_TOML_SIZE_IN_BYTES:
+        get_logger().warning(
+            f"Settings file too large (> {MAX_TOML_SIZE_IN_BYTES} bytes); skipping repo settings file")
+        return
+
     # Validate the file explicitly first: the shared custom_merge_loader runs with silent=True and
     # would otherwise swallow TOML/security errors, skipping the file without surfacing a scoped
     # configuration error. Parsing here makes malformed/forbidden config raise so it gets reported.

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -404,7 +404,8 @@ def handle_configurations_errors(config_errors, git_provider):
             if err:
                 settings_content = err['settings']
                 configuration_file_content = (
-                    settings_content.decode() if isinstance(settings_content, bytes) else settings_content
+                    settings_content.decode("utf-8", errors="replace")
+                    if isinstance(settings_content, bytes) else settings_content
                 )
                 err_message = err['error']
                 config_type = err['category']

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -341,7 +341,9 @@ def _apply_repo_settings_file(repo_settings_file):
     # configuration error. Parsing here makes malformed/forbidden config raise so it gets reported.
     with open(repo_settings_file, "rb") as f:
         parsed_toml = tomllib.load(f)
-    validate_file_security(parsed_toml, repo_settings_file)
+    # Use a generic name (not the temp path) so a SecurityError message can't leak the server's
+    # internal filesystem path into the PR configuration-error comment.
+    validate_file_security(parsed_toml, ".pr_agent.toml")
 
     try:
         dynconf_kwargs = {'core_loaders': [],

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -294,12 +294,12 @@ def apply_repo_settings(pr_url):
                 for category, settings_content in _normalize_repo_settings(repo_settings):
                     fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
                     repo_settings_files.append(repo_settings_file)
-                    try:
-                        if isinstance(settings_content, str):
-                            settings_content = settings_content.encode("utf-8")
-                        os.write(fd, settings_content)
-                    finally:
-                        os.close(fd)
+                    if isinstance(settings_content, str):
+                        settings_content = settings_content.encode("utf-8")
+                    # os.fdopen takes ownership of fd (closes it) and write() writes all bytes,
+                    # avoiding a silently-truncated file from a partial os.write.
+                    with os.fdopen(fd, "wb") as settings_file_handle:
+                        settings_file_handle.write(settings_content)
                     try:
                         _apply_repo_settings_file(repo_settings_file)
                     except Exception as e:

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -315,7 +315,7 @@ def apply_repo_settings(pr_url):
                 try:
                     os.remove(repo_settings_file)
                 except Exception as e:
-                    get_logger().error(f"Failed to remove temporary settings file {repo_settings_file}", e)
+                    get_logger().error(f"Failed to remove temporary settings file {repo_settings_file}: {e}")
 
     # enable switching models with a short definition
     if get_settings().config.model.lower() == 'claude-3-5-sonnet':

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -270,7 +270,7 @@ def apply_repo_settings(pr_url):
     git_provider = get_git_provider_with_context(pr_url)
 
     if get_settings().config.use_repo_settings_file:
-        repo_settings_file = None
+        repo_settings_files = []
         try:
             try:
                 repo_settings = context.get("repo_settings", None)
@@ -286,23 +286,29 @@ def apply_repo_settings(pr_url):
 
             error_local = None
             if repo_settings:
-                repo_settings_file = None
-                category = 'local'
+                repo_settings_files = []
+                normalized_repo_settings = []
                 try:
-                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
-                    try:
-                        os.write(fd, repo_settings)
-                    finally:
-                        os.close(fd)
+                    normalized_repo_settings = _normalize_repo_settings(repo_settings)
+                    for _category, settings_content in normalized_repo_settings:
+                        fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
+                        repo_settings_files.append(repo_settings_file)
+                        try:
+                            if isinstance(settings_content, str):
+                                settings_content = settings_content.encode("utf-8")
+                            os.write(fd, settings_content)
+                        finally:
+                            os.close(fd)
 
                     try:
-                        dynconf_kwargs = {'core_loaders': [],  # DISABLE default loaders, otherwise will load toml files more than once.
+                        dynconf_kwargs = {'core_loaders': [],
+                             # Disable default loaders, otherwise TOML files load more than once.
                              'loaders': ['pr_agent.custom_merge_loader'],
-                             # Use a custom loader to merge sections, but overwrite their overlapping values. Don't involve ENV variables.
-                             'merge_enabled': True  # Merge multiple files; ensures [XYZ] sections only overwrite overlapping keys, not whole sections.
+                             # Merge sections and overwrite overlapping values without involving environment variables.
+                             'merge_enabled': True
                          }
 
-                        new_settings = Dynaconf(settings_files=[repo_settings_file],
+                        new_settings = Dynaconf(settings_files=repo_settings_files,
                                                 # Disable all dynamic loading features
                                                 load_dotenv=False,  # Don't load .env files
                                                 envvar_prefix=False,  # Drop DYNACONF for env. variables
@@ -315,7 +321,7 @@ def apply_repo_settings(pr_url):
                             "Loading repo settings without these security features. "
                             "Please upgrade Dynaconf for better security.",
                             artifact={"error": e, "traceback": traceback.format_exc()})
-                        new_settings = Dynaconf(settings_files=[repo_settings_file])
+                        new_settings = Dynaconf(settings_files=repo_settings_files)
 
                     for section, contents in new_settings.as_dict().items():
                         if not contents:
@@ -349,15 +355,17 @@ def apply_repo_settings(pr_url):
                         f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
                     )
                 except Exception as e:
+                    category = normalized_repo_settings[-1][0] if normalized_repo_settings else "local"
+                    settings_content = normalized_repo_settings[-1][1] if normalized_repo_settings else repo_settings
                     get_logger().warning(f"Failed to apply repo {category} settings, error: {str(e)}")
-                    error_local = {'error': str(e), 'settings': repo_settings, 'category': category}
+                    error_local = {'error': str(e), 'settings': settings_content, 'category': category}
 
                 if error_local:
                     handle_configurations_errors([error_local], git_provider)
         except Exception as e:
             get_logger().exception("Failed to apply repo settings", e)
         finally:
-            if repo_settings_file:
+            for repo_settings_file in repo_settings_files:
                 try:
                     os.remove(repo_settings_file)
                 except Exception as e:
@@ -368,6 +376,12 @@ def apply_repo_settings(pr_url):
         set_claude_model()
 
 
+def _normalize_repo_settings(repo_settings):
+    if isinstance(repo_settings, (bytes, str)):
+        return [("local", repo_settings)]
+    return repo_settings
+
+
 def handle_configurations_errors(config_errors, git_provider):
     try:
         if not any(config_errors):
@@ -375,17 +389,28 @@ def handle_configurations_errors(config_errors, git_provider):
 
         for err in config_errors:
             if err:
-                configuration_file_content = err['settings'].decode()
+                settings_content = err['settings']
+                configuration_file_content = (
+                    settings_content.decode() if isinstance(settings_content, bytes) else settings_content
+                )
                 err_message = err['error']
                 config_type = err['category']
                 header = f"❌ **PR-Agent failed to apply '{config_type}' repo settings**"
-                body = f"{header}\n\nThe configuration file needs to be a valid [TOML](https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/), please fix it.\n\n"
+                body = (
+                    f"{header}\n\nThe configuration file needs to be a valid "
+                    "[TOML](https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/), please fix it.\n\n"
+                )
                 body += f"___\n\n**Error message:**\n`{err_message}`\n\n"
-                if git_provider.is_supported("gfm_markdown"):
-                    body += f"\n\n<details><summary>Configuration content:</summary>\n\n```toml\n{configuration_file_content}\n```\n\n</details>"
+                if config_type == "global":
+                    body += "\n\nThe invalid configuration came from the organization's global settings file."
+                elif git_provider.is_supported("gfm_markdown"):
+                    body += (
+                        "\n\n<details><summary>Configuration content:</summary>\n\n"
+                        f"```toml\n{configuration_file_content}\n```\n\n</details>"
+                    )
                 else:
                     body += f"\n\n**Configuration content:**\n\n```toml\n{configuration_file_content}\n```\n\n"
-                get_logger().warning(f"Sending a 'configuration error' comment to the PR", artifact={'body': body})
+                get_logger().warning("Sending a 'configuration error' comment to the PR", artifact={'body': body})
                 # git_provider.publish_comment(body)
                 if hasattr(git_provider, 'publish_persistent_comment'):
                     git_provider.publish_persistent_comment(body,
@@ -396,7 +421,7 @@ def handle_configurations_errors(config_errors, git_provider):
                 else:
                     git_provider.publish_comment(body)
     except Exception as e:
-        get_logger().exception(f"Failed to handle configurations errors", e)
+        get_logger().exception("Failed to handle configurations errors", e)
 
 
 def set_claude_model():

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -284,84 +284,29 @@ def apply_repo_settings(pr_url):
                 except Exception:
                     pass
 
-            error_local = None
+            config_errors = []
             if repo_settings:
-                repo_settings_files = []
-                normalized_repo_settings = []
-                try:
-                    normalized_repo_settings = _normalize_repo_settings(repo_settings)
-                    for _category, settings_content in normalized_repo_settings:
-                        fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
-                        repo_settings_files.append(repo_settings_file)
-                        try:
-                            if isinstance(settings_content, str):
-                                settings_content = settings_content.encode("utf-8")
-                            os.write(fd, settings_content)
-                        finally:
-                            os.close(fd)
-
+                # Apply each settings source (e.g. global then local) independently and in order.
+                # Loading them in a single Dynaconf call would fail all sources on one bad file and
+                # misattribute the error to the last source; applying per-scope keeps error reporting
+                # (and redaction) accurate and lets valid sources still take effect.
+                for category, settings_content in _normalize_repo_settings(repo_settings):
+                    fd, repo_settings_file = tempfile.mkstemp(suffix='.toml')
+                    repo_settings_files.append(repo_settings_file)
                     try:
-                        dynconf_kwargs = {'core_loaders': [],
-                             # Disable default loaders, otherwise TOML files load more than once.
-                             'loaders': ['pr_agent.custom_merge_loader'],
-                             # Merge sections and overwrite overlapping values without involving environment variables.
-                             'merge_enabled': True
-                         }
+                        if isinstance(settings_content, str):
+                            settings_content = settings_content.encode("utf-8")
+                        os.write(fd, settings_content)
+                    finally:
+                        os.close(fd)
+                    try:
+                        _apply_repo_settings_file(repo_settings_file)
+                    except Exception as e:
+                        get_logger().warning(f"Failed to apply repo {category} settings, error: {str(e)}")
+                        config_errors.append({'error': str(e), 'settings': settings_content, 'category': category})
 
-                        new_settings = Dynaconf(settings_files=repo_settings_files,
-                                                # Disable all dynamic loading features
-                                                load_dotenv=False,  # Don't load .env files
-                                                envvar_prefix=False,  # Drop DYNACONF for env. variables
-                                                **dynconf_kwargs
-                                                )
-                    except TypeError as e:
-                        # Fallback for older Dynaconf versions that don't support these parameters
-                        get_logger().warning(
-                            "Your Dynaconf version does not support disabled 'load_dotenv'/'merge_enabled' parameters. "
-                            "Loading repo settings without these security features. "
-                            "Please upgrade Dynaconf for better security.",
-                            artifact={"error": e, "traceback": traceback.format_exc()})
-                        new_settings = Dynaconf(settings_files=repo_settings_files)
-
-                    for section, contents in new_settings.as_dict().items():
-                        if not contents:
-                            # Skip excluded items, such as forbidden to load env.
-                            get_logger().debug(f"Skipping a section: {section} which is not allowed")
-                            continue
-                        allowed_keys = _REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
-                        if allowed_keys is not None:
-                            rejected = [k for k in contents if k.lower() not in allowed_keys]
-                            if rejected:
-                                get_logger().warning(
-                                    f"Ignoring host-only key(s) {rejected} in section [{section}] from repo "
-                                    f"settings; only {sorted(allowed_keys)} may be set per-repo for this section"
-                                )
-                            contents = {k: v for k, v in contents.items() if k.lower() in allowed_keys}
-                            if not contents:
-                                continue
-                        section_dict = copy.deepcopy(get_settings().as_dict().get(section, {}))
-                        for key, value in contents.items():
-                            section_dict[key] = value
-                        get_settings().unset(section)
-                        get_settings().set(section, section_dict, merge=False)
-                    # Same precedence-restoration rationale as the extra-config
-                    # path: env-sourced values must remain the highest layer.
-                    _reapply_env_overrides()
-                    # Do NOT log the merged dict: repo/global .pr_agent.toml may contain secrets
-                    # (e.g. openai.key, gitlab.personal_access_token) that would otherwise leak into
-                    # CI logs. Section names are safe and sufficient for debugging (same rationale as
-                    # the extra-config path above).
-                    get_logger().info(
-                        f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
-                    )
-                except Exception as e:
-                    category = normalized_repo_settings[-1][0] if normalized_repo_settings else "local"
-                    settings_content = normalized_repo_settings[-1][1] if normalized_repo_settings else repo_settings
-                    get_logger().warning(f"Failed to apply repo {category} settings, error: {str(e)}")
-                    error_local = {'error': str(e), 'settings': settings_content, 'category': category}
-
-                if error_local:
-                    handle_configurations_errors([error_local], git_provider)
+                if config_errors:
+                    handle_configurations_errors(config_errors, git_provider)
         except Exception as e:
             get_logger().exception("Failed to apply repo settings", e)
         finally:
@@ -374,6 +319,67 @@ def apply_repo_settings(pr_url):
     # enable switching models with a short definition
     if get_settings().config.model.lower() == 'claude-3-5-sonnet':
         set_claude_model()
+
+
+def _apply_repo_settings_file(repo_settings_file):
+    """Load a single repo settings file and merge its allowed keys into the global settings.
+
+    Enforces the per-repo host-key restrictions and logs only section names (values may contain
+    secrets). Raises on load/parse failure so the caller can attribute the error to the correct
+    settings scope (e.g. 'global' vs 'local').
+    """
+    try:
+        dynconf_kwargs = {'core_loaders': [],
+             # Disable default loaders, otherwise TOML files load more than once.
+             'loaders': ['pr_agent.custom_merge_loader'],
+             # Merge sections and overwrite overlapping values without involving environment variables.
+             'merge_enabled': True
+         }
+        new_settings = Dynaconf(settings_files=[repo_settings_file],
+                                # Disable all dynamic loading features
+                                load_dotenv=False,  # Don't load .env files
+                                envvar_prefix=False,  # Drop DYNACONF for env. variables
+                                **dynconf_kwargs
+                                )
+    except TypeError as e:
+        # Fallback for older Dynaconf versions that don't support these parameters
+        get_logger().warning(
+            "Your Dynaconf version does not support disabled 'load_dotenv'/'merge_enabled' parameters. "
+            "Loading repo settings without these security features. "
+            "Please upgrade Dynaconf for better security.",
+            artifact={"error": e, "traceback": traceback.format_exc()})
+        new_settings = Dynaconf(settings_files=[repo_settings_file])
+
+    for section, contents in new_settings.as_dict().items():
+        if not contents:
+            # Skip excluded items, such as forbidden to load env.
+            get_logger().debug(f"Skipping a section: {section} which is not allowed")
+            continue
+        allowed_keys = _REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
+        if allowed_keys is not None:
+            rejected = [k for k in contents if k.lower() not in allowed_keys]
+            if rejected:
+                get_logger().warning(
+                    f"Ignoring host-only key(s) {rejected} in section [{section}] from repo "
+                    f"settings; only {sorted(allowed_keys)} may be set per-repo for this section"
+                )
+            contents = {k: v for k, v in contents.items() if k.lower() in allowed_keys}
+            if not contents:
+                continue
+        section_dict = copy.deepcopy(get_settings().as_dict().get(section, {}))
+        for key, value in contents.items():
+            section_dict[key] = value
+        get_settings().unset(section)
+        get_settings().set(section, section_dict, merge=False)
+    # Same precedence-restoration rationale as the extra-config path: env-sourced values
+    # must remain the highest layer.
+    _reapply_env_overrides()
+    # Do NOT log the merged dict: repo/global .pr_agent.toml may contain secrets
+    # (e.g. openai.key, gitlab.personal_access_token) that would otherwise leak into
+    # CI logs. Section names are safe and sufficient for debugging.
+    get_logger().info(
+        f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
+    )
 
 
 def _normalize_repo_settings(repo_settings):

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -328,6 +328,13 @@ def _apply_repo_settings_file(repo_settings_file):
     secrets). Raises on load/parse failure so the caller can attribute the error to the correct
     settings scope (e.g. 'global' vs 'local').
     """
+    # Validate the file explicitly first: the shared custom_merge_loader runs with silent=True and
+    # would otherwise swallow TOML/security errors, skipping the file without surfacing a scoped
+    # configuration error. Parsing here makes malformed/forbidden config raise so it gets reported.
+    with open(repo_settings_file, "rb") as f:
+        parsed_toml = tomllib.load(f)
+    validate_file_security(parsed_toml, repo_settings_file)
+
     try:
         dynconf_kwargs = {'core_loaders': [],
              # Disable default loaders, otherwise TOML files load more than once.

--- a/tests/unittest/test_apply_repo_settings_security.py
+++ b/tests/unittest/test_apply_repo_settings_security.py
@@ -235,6 +235,11 @@ def test_forbidden_directive_publishes_one_local_error(monkeypatch, settings_sna
     assert len(captured["errors"]) == 1
     assert captured["errors"][0]["category"] == "local"
     assert captured["errors"][0]["settings"] == forbidden_toml
+    # The error message must not leak the server's internal temp path to PR users.
+    import tempfile
+    error_text = captured["errors"][0]["error"]
+    assert tempfile.gettempdir() not in error_text
+    assert ".pr_agent.toml" in error_text
 
 
 def test_temp_file_is_removed_after_successful_apply(monkeypatch, tmp_path, settings_snapshot):

--- a/tests/unittest/test_apply_repo_settings_security.py
+++ b/tests/unittest/test_apply_repo_settings_security.py
@@ -183,15 +183,6 @@ def test_invalid_toml_does_not_pollute_settings(monkeypatch, settings_snapshot):
     assert after.get("num_max_findings") != 7
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Behavior gap: pr_agent.custom_merge_loader is invoked with silent=True, "
-        "so TOMLDecodeError is logged and swallowed instead of being surfaced to "
-        "handle_configurations_errors. apply_repo_settings therefore never publishes "
-        "a 'local' configuration-error comment for malformed TOML."
-    ),
-    strict=True,
-)
 def test_invalid_toml_publishes_one_local_error(monkeypatch, settings_snapshot):
     malformed = b"[pr_reviewer\nnum_max_findings = 7\n"
     provider = FakeGitProvider(repo_settings_bytes=malformed)
@@ -232,15 +223,6 @@ def test_forbidden_directive_does_not_pollute_settings(monkeypatch, settings_sna
     assert "dynaconf_include" not in {k.lower() for k in settings.as_dict().keys()}
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Behavior gap: forbidden-directive SecurityError raised by "
-        "validate_file_security is swallowed by the silent-loader path, so "
-        "apply_repo_settings does not publish a 'local' configuration-error "
-        "comment for forbidden TOML directives."
-    ),
-    strict=True,
-)
 def test_forbidden_directive_publishes_one_local_error(monkeypatch, settings_snapshot):
     forbidden_toml = b"dynaconf_include = ['evil.toml']\n[pr_reviewer]\nnum_max_findings = 42\n"
     provider = FakeGitProvider(repo_settings_bytes=forbidden_toml)

--- a/tests/unittest/test_apply_repo_settings_security.py
+++ b/tests/unittest/test_apply_repo_settings_security.py
@@ -285,10 +285,11 @@ def test_temp_file_is_removed_after_failed_apply(monkeypatch, tmp_path, settings
 
     monkeypatch.setattr(tempfile, "mkstemp", fake_mkstemp)
 
-    def exploding_dynaconf(*args, **kwargs):
+    def exploding_validate(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(git_utils, "Dynaconf", exploding_dynaconf)
+    # Force a failure during apply (validate_file_security runs after mkstemp/parse).
+    monkeypatch.setattr(git_utils, "validate_file_security", exploding_validate)
 
     apply_repo_settings("https://example.com/owner/repo/pull/1")
 

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -433,6 +433,17 @@ class TestBitbucketGlobalSettings:
         assert "myws/pr-agent-settings" in rq.call_args_list[0].args[1]
         assert "src/main/.pr_agent.toml" in rq.call_args_list[1].args[1]
 
+    def test_no_access_403_returns_empty_and_caches(self):
+        # A 403 (no access) is a stable/expected condition like 404: return "" AND cache it.
+        provider = self._provider()
+        repo_resp = MagicMock(status_code=403)
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=repo_resp) as rq, \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            assert provider._get_global_repo_settings() == ""
+            assert provider._get_global_repo_settings() == ""  # served from cache
+        assert rq.call_count == 1
+
     def test_missing_settings_repo_returns_empty(self):
         provider = self._provider()
         repo_resp = MagicMock(status_code=404)

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from atlassian.bitbucket import Bitbucket
 from requests.exceptions import HTTPError
 
@@ -399,3 +400,67 @@ class TestBitbucketServerProvider:
         actual = provider.get_diff_files()
 
         assert actual == expected
+
+
+@pytest.fixture(autouse=True)
+def _clear_global_settings_cache():
+    from pr_agent.git_providers import git_provider as _gp
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
+    yield
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
+
+
+class TestBitbucketGlobalSettings:
+    def _provider(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.workspace_slug = "myws"
+        provider.headers = {"Authorization": "Bearer x"}
+        return provider
+
+    def test_loads_workspace_pr_agent_settings(self):
+        provider = self._provider()
+        repo_resp = MagicMock(status_code=200)
+        repo_resp.json.return_value = {"mainbranch": {"name": "main"}}
+        file_resp = MagicMock(status_code=200)
+        file_resp.text = "[pr_reviewer]\nnum_max_findings = 5\n"
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request",
+                   side_effect=[repo_resp, file_resp]) as rq, \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            result = provider._get_global_repo_settings()
+        assert result == b"[pr_reviewer]\nnum_max_findings = 5\n"
+        assert rq.call_count == 2  # repo info + file
+        assert "myws/pr-agent-settings" in rq.call_args_list[0].args[1]
+        assert "src/main/.pr_agent.toml" in rq.call_args_list[1].args[1]
+
+    def test_missing_settings_repo_returns_empty(self):
+        provider = self._provider()
+        repo_resp = MagicMock(status_code=404)
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request",
+                   return_value=repo_resp), \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            assert provider._get_global_repo_settings() == ""
+
+    def test_disabled_returns_empty(self):
+        provider = self._provider()
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request") as rq, \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = False
+            assert provider._get_global_repo_settings() == ""
+        rq.assert_not_called()
+
+    def test_result_is_cached(self):
+        provider = self._provider()
+        repo_resp = MagicMock(status_code=200)
+        repo_resp.json.return_value = {"mainbranch": {"name": "main"}}
+        file_resp = MagicMock(status_code=200)
+        file_resp.text = "[pr_reviewer]\nx = 1\n"
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request",
+                   side_effect=[repo_resp, file_resp]) as rq, \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            provider._get_global_repo_settings()
+            provider._get_global_repo_settings()
+        # Two HTTP calls total (first fetch), none on the cached second call.
+        assert rq.call_count == 2

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -464,3 +464,20 @@ class TestBitbucketGlobalSettings:
             provider._get_global_repo_settings()
         # Two HTTP calls total (first fetch), none on the cached second call.
         assert rq.call_count == 2
+
+
+class TestBitbucketLocalSettingsRobustness:
+    def test_get_repo_settings_ignores_error_response_for_local(self):
+        # A non-200/404 response (e.g. 500 error page) must NOT be treated as local TOML content.
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.workspace_slug = "myws"
+        provider.repo_slug = "myrepo"
+        provider.headers = {"Authorization": "Bearer x"}
+        provider.pr = MagicMock(destination_branch="main")
+        resp = MagicMock(status_code=500)
+        resp.text = "<html>internal error</html>"
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=resp), \
+             patch("pr_agent.git_providers.bitbucket_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = False
+            result = provider.get_repo_settings()
+        assert result == ""

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -181,6 +181,22 @@ def test_handle_configurations_errors_publishes_each_error():
     assert "num_max_findings" not in provider.comments[1]
 
 
+def test_apply_repo_settings_file_skips_oversized_file(monkeypatch, tmp_path):
+    # An oversized settings file must be skipped by size BEFORE it is parsed, so it can't be
+    # fully read/parsed in-process (the explicit validation would otherwise bypass the loader cap).
+    from unittest.mock import MagicMock
+
+    f = tmp_path / "big.toml"
+    f.write_bytes(b"[pr_reviewer]\nnum_max_findings = 3\n")
+    monkeypatch.setattr(utils, "MAX_TOML_SIZE_IN_BYTES", 5)  # smaller than the file
+    load_spy = MagicMock(side_effect=AssertionError("oversized file must not be parsed"))
+    monkeypatch.setattr(utils.tomllib, "load", load_spy)
+
+    # Returns quietly (skips) without parsing or raising.
+    utils._apply_repo_settings_file(str(f))
+    load_spy.assert_not_called()
+
+
 def test_handle_configurations_errors_tolerates_non_utf8_settings():
     # Non-UTF-8 settings bytes must not raise (UnicodeDecodeError) and abort posting the error.
     provider = FakePlainProvider()

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -246,3 +246,39 @@ def test_handle_configurations_errors_skips_empty_sentinel_entries_in_mixed_list
 
     assert len(provider.comments) == 1
     assert "Only error" in provider.comments[0]
+
+
+def test_get_cached_global_settings_skips_oversized_values(monkeypatch):
+    from pr_agent.git_providers import git_provider as gp
+    gp._GLOBAL_SETTINGS_CACHE.clear()
+    monkeypatch.setattr(gp, "_GLOBAL_SETTINGS_CACHE_MAX_VALUE_BYTES", 4)
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return b"way too big for the cap"
+
+    try:
+        gp.get_cached_global_settings("k", fetch)
+        gp.get_cached_global_settings("k", fetch)  # oversized -> not cached, fetched again
+        assert calls["n"] == 2
+        assert "k" not in gp._GLOBAL_SETTINGS_CACHE
+    finally:
+        gp._GLOBAL_SETTINGS_CACHE.clear()
+
+
+def test_get_cached_global_settings_caches_small_values():
+    from pr_agent.git_providers import git_provider as gp
+    gp._GLOBAL_SETTINGS_CACHE.clear()
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return b"tiny"
+
+    try:
+        gp.get_cached_global_settings("k2", fetch)
+        gp.get_cached_global_settings("k2", fetch)  # cached -> not fetched again
+        assert calls["n"] == 1
+    finally:
+        gp._GLOBAL_SETTINGS_CACHE.clear()

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -90,7 +90,7 @@ def test_apply_repo_settings_attributes_global_error_and_still_applies_local(mon
         assert settings.pr_reviewer.extra_instructions == "local-applied"
         # One error comment, attributed to global, with the global content redacted (not echoed).
         assert len(provider.comments) == 1
-        assert "organization's global settings file" in provider.comments[0]
+        assert "global `pr-agent-settings` settings repository" in provider.comments[0]
         assert "unclosed_section" not in provider.comments[0]
     finally:
         settings.pr_reviewer.extra_instructions = original_extra_instructions
@@ -176,7 +176,7 @@ def test_handle_configurations_errors_publishes_each_error():
     assert "First error" in provider.comments[0]
     assert "[config]\nmodel =" in provider.comments[0]
     assert "Second error" in provider.comments[1]
-    assert "organization's global settings file" in provider.comments[1]
+    assert "global `pr-agent-settings` settings repository" in provider.comments[1]
     assert "dummy-value" not in provider.comments[1]
     assert "num_max_findings" not in provider.comments[1]
 

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -61,6 +61,54 @@ def test_apply_repo_settings_merges_global_before_local_settings(monkeypatch):
         settings.pr_reviewer.enable_intro_text = original_enable_intro_text
 
 
+class FakeErrorReportingProvider(FakePlainProvider):
+    def __init__(self, settings_list):
+        super().__init__()
+        self._settings_list = settings_list
+
+    def get_repo_settings(self):
+        return self._settings_list
+
+
+def test_apply_repo_settings_attributes_global_error_and_still_applies_local(monkeypatch):
+    # When applying the global settings file fails, the error must be reported against the
+    # *global* scope (redacted, no content leaked) while a valid local file still takes effect.
+    # Sources are applied independently, so one failing source neither blocks the others nor
+    # misattributes its error to another scope.
+    settings = get_settings()
+    original_extra_instructions = settings.pr_reviewer.extra_instructions
+    provider = FakeErrorReportingProvider([
+        ("global", b"[pr_reviewer]\nnum_max_findings = 3\n"),
+        ("local", b"[pr_reviewer]\nextra_instructions = \"local-applied\"\n"),
+    ])
+    monkeypatch.setattr(utils, "get_git_provider_with_context", lambda pr_url: provider)
+    monkeypatch.delenv("AUTO_CAST_FOR_DYNACONF", raising=False)
+
+    # Fail applying the first source (global), apply the rest (local) for real.
+    real_apply = utils._apply_repo_settings_file
+    state = {"n": 0}
+
+    def flaky_apply(path):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise ValueError("bad global settings")
+        return real_apply(path)
+
+    monkeypatch.setattr(utils, "_apply_repo_settings_file", flaky_apply)
+
+    try:
+        apply_repo_settings("https://github.example.com/org/service/pull/1")
+
+        # Local settings still applied despite the global failure.
+        assert settings.pr_reviewer.extra_instructions == "local-applied"
+        # One error comment, attributed to global, with the global content redacted (not echoed).
+        assert len(provider.comments) == 1
+        assert "organization's global settings file" in provider.comments[0]
+        assert "num_max_findings" not in provider.comments[0]
+    finally:
+        settings.pr_reviewer.extra_instructions = original_extra_instructions
+
+
 def test_handle_configurations_errors_uses_persistent_comment_when_supported():
     provider = FakeMarkdownProvider()
 

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -282,3 +282,21 @@ def test_get_cached_global_settings_caches_small_values():
         assert calls["n"] == 1
     finally:
         gp._GLOBAL_SETTINGS_CACHE.clear()
+
+
+def test_get_cached_global_settings_does_not_cache_fetch_errors():
+    from pr_agent.git_providers import git_provider as gp
+    gp._GLOBAL_SETTINGS_CACHE.clear()
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        raise RuntimeError("transient 500")
+
+    try:
+        assert gp.get_cached_global_settings("k3", fetch) == ""  # error -> "" (not cached)
+        assert gp.get_cached_global_settings("k3", fetch) == ""  # retried, not served from cache
+        assert calls["n"] == 2
+        assert "k3" not in gp._GLOBAL_SETTINGS_CACHE
+    finally:
+        gp._GLOBAL_SETTINGS_CACHE.clear()

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -1,4 +1,6 @@
-from pr_agent.git_providers.utils import handle_configurations_errors
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import utils
+from pr_agent.git_providers.utils import apply_repo_settings, handle_configurations_errors
 
 
 class FakeMarkdownProvider:
@@ -32,6 +34,31 @@ class FakePlainProvider:
 class FakeMarkdownCommentProvider(FakePlainProvider):
     def is_supported(self, capability):
         return capability == "gfm_markdown"
+
+
+class FakeSettingsProvider:
+    def get_repo_settings(self):
+        return [
+            ("global", b"[pr_reviewer]\nextra_instructions = \"global\"\nenable_intro_text = false\n"),
+            ("local", b"[pr_reviewer]\nextra_instructions = \"local\"\n"),
+        ]
+
+
+def test_apply_repo_settings_merges_global_before_local_settings(monkeypatch):
+    settings = get_settings()
+    original_extra_instructions = settings.pr_reviewer.extra_instructions
+    original_enable_intro_text = settings.pr_reviewer.enable_intro_text
+    monkeypatch.setattr(utils, "get_git_provider_with_context", lambda pr_url: FakeSettingsProvider())
+    monkeypatch.delenv("AUTO_CAST_FOR_DYNACONF", raising=False)
+
+    try:
+        apply_repo_settings("https://github.example.com/org/service/pull/1")
+
+        assert settings.pr_reviewer.extra_instructions == "local"
+        assert settings.pr_reviewer.enable_intro_text is False
+    finally:
+        settings.pr_reviewer.extra_instructions = original_extra_instructions
+        settings.pr_reviewer.enable_intro_text = original_enable_intro_text
 
 
 def test_handle_configurations_errors_uses_persistent_comment_when_supported():
@@ -104,7 +131,7 @@ def test_handle_configurations_errors_publishes_each_error():
             "category": "local",
         },
         {
-            "settings": b"[pr_reviewer]\nnum_max_findings =",
+            "settings": b"[github]\nuser_token = \"dummy-value\"\n[pr_reviewer]\nnum_max_findings =",
             "error": "Second error",
             "category": "global",
         },
@@ -114,7 +141,9 @@ def test_handle_configurations_errors_publishes_each_error():
     assert "First error" in provider.comments[0]
     assert "[config]\nmodel =" in provider.comments[0]
     assert "Second error" in provider.comments[1]
-    assert "[pr_reviewer]\nnum_max_findings =" in provider.comments[1]
+    assert "organization's global settings file" in provider.comments[1]
+    assert "dummy-value" not in provider.comments[1]
+    assert "num_max_findings" not in provider.comments[1]
 
 
 def test_handle_configurations_errors_ignores_empty_sentinel_entry():

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -71,40 +71,27 @@ class FakeErrorReportingProvider(FakePlainProvider):
 
 
 def test_apply_repo_settings_attributes_global_error_and_still_applies_local(monkeypatch):
-    # When applying the global settings file fails, the error must be reported against the
-    # *global* scope (redacted, no content leaked) while a valid local file still takes effect.
-    # Sources are applied independently, so one failing source neither blocks the others nor
-    # misattributes its error to another scope.
+    # A malformed global settings file must (a) actually surface an error rather than being silently
+    # swallowed by the loader, (b) be reported against the *global* scope with content redacted, and
+    # (c) not prevent a valid local file from taking effect — sources are applied independently.
     settings = get_settings()
     original_extra_instructions = settings.pr_reviewer.extra_instructions
     provider = FakeErrorReportingProvider([
-        ("global", b"[pr_reviewer]\nnum_max_findings = 3\n"),
+        ("global", b"[unclosed_section\n"),  # malformed TOML
         ("local", b"[pr_reviewer]\nextra_instructions = \"local-applied\"\n"),
     ])
     monkeypatch.setattr(utils, "get_git_provider_with_context", lambda pr_url: provider)
     monkeypatch.delenv("AUTO_CAST_FOR_DYNACONF", raising=False)
 
-    # Fail applying the first source (global), apply the rest (local) for real.
-    real_apply = utils._apply_repo_settings_file
-    state = {"n": 0}
-
-    def flaky_apply(path):
-        state["n"] += 1
-        if state["n"] == 1:
-            raise ValueError("bad global settings")
-        return real_apply(path)
-
-    monkeypatch.setattr(utils, "_apply_repo_settings_file", flaky_apply)
-
     try:
         apply_repo_settings("https://github.example.com/org/service/pull/1")
 
-        # Local settings still applied despite the global failure.
+        # Local settings still applied despite the global parse error.
         assert settings.pr_reviewer.extra_instructions == "local-applied"
         # One error comment, attributed to global, with the global content redacted (not echoed).
         assert len(provider.comments) == 1
         assert "organization's global settings file" in provider.comments[0]
-        assert "num_max_findings" not in provider.comments[0]
+        assert "unclosed_section" not in provider.comments[0]
     finally:
         settings.pr_reviewer.extra_instructions = original_extra_instructions
 

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -194,6 +194,21 @@ def test_handle_configurations_errors_publishes_each_error():
     assert "num_max_findings" not in provider.comments[1]
 
 
+def test_handle_configurations_errors_uses_unique_name_per_scope():
+    # In GitHub check-run mode the persistent-comment `name` keys the check run, so multiple
+    # settings errors (global + local) must use distinct names or later ones overwrite earlier ones.
+    provider = FakeMarkdownProvider()
+
+    handle_configurations_errors([
+        {"settings": b"[config]\nmodel =", "error": "global error", "category": "global"},
+        {"settings": b"[config]\nmodel =", "error": "local error", "category": "local"},
+    ], provider)
+
+    names = [c["name"] for c in provider.persistent_comments]
+    assert names == ["config-errors-global", "config-errors-local"]
+    assert len(set(names)) == 2
+
+
 def test_handle_configurations_errors_ignores_empty_sentinel_entry():
     provider = FakePlainProvider()
 

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -181,6 +181,18 @@ def test_handle_configurations_errors_publishes_each_error():
     assert "num_max_findings" not in provider.comments[1]
 
 
+def test_handle_configurations_errors_tolerates_non_utf8_settings():
+    # Non-UTF-8 settings bytes must not raise (UnicodeDecodeError) and abort posting the error.
+    provider = FakePlainProvider()
+
+    handle_configurations_errors([
+        {"settings": b"\xff\xfe[config]\nmodel =", "error": "bad config", "category": "local"},
+    ], provider)
+
+    assert len(provider.comments) == 1
+    assert "bad config" in provider.comments[0]
+
+
 def test_handle_configurations_errors_uses_unique_name_per_scope():
     # In GitHub check-run mode the persistent-comment `name` keys the check run, so multiple
     # settings errors (global + local) must use distinct names or later ones overwrite earlier ones.

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -1,0 +1,92 @@
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.github_provider import GithubProvider
+
+
+class FakeContent:
+    def __init__(self, decoded_content):
+        self.decoded_content = decoded_content
+
+
+class FakeRepo:
+    def __init__(self, files=None):
+        self.files = files or {}
+
+    def get_contents(self, path):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return FakeContent(self.files[path])
+
+
+class FakeGithubClient:
+    def __init__(self, repos=None):
+        self.repos = repos or {}
+
+    def get_repo(self, repo_name):
+        if repo_name not in self.repos:
+            raise FileNotFoundError(repo_name)
+        return self.repos[repo_name]
+
+
+def _provider(local_settings=None, global_settings=None):
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.repo = "org/service"
+    provider.repo_obj = FakeRepo({".pr_agent.toml": local_settings} if local_settings is not None else {})
+    provider.github_client = FakeGithubClient(
+        {"org/pr-agent-settings": FakeRepo({".pr_agent.toml": global_settings})}
+        if global_settings is not None
+        else {}
+    )
+    return provider
+
+
+def test_get_repo_settings_returns_global_settings_when_local_settings_missing():
+    provider = _provider(global_settings=b"[pr_reviewer]\nextra_instructions = \"global\"\n")
+
+    settings = provider.get_repo_settings()
+
+    assert settings == [("global", b"[pr_reviewer]\nextra_instructions = \"global\"\n")]
+
+
+def test_get_repo_settings_merges_global_before_local_settings():
+    provider = _provider(
+        global_settings=b"[pr_reviewer]\nextra_instructions = \"global\"\n",
+        local_settings=b"[pr_description]\npublish_labels = false\n",
+    )
+
+    settings = provider.get_repo_settings()
+
+    assert settings == [
+        ("global", b"[pr_reviewer]\nextra_instructions = \"global\"\n"),
+        ("local", b"[pr_description]\npublish_labels = false\n"),
+    ]
+
+
+def test_get_repo_settings_keeps_global_and_local_same_section_separate():
+    provider = _provider(
+        global_settings=b"[pr_reviewer]\nextra_instructions = \"global\"\nnum_code_suggestions = 3\n",
+        local_settings=b"[pr_reviewer]\nextra_instructions = \"local\"\n",
+    )
+
+    settings = provider.get_repo_settings()
+
+    assert settings == [
+        ("global", b"[pr_reviewer]\nextra_instructions = \"global\"\nnum_code_suggestions = 3\n"),
+        ("local", b"[pr_reviewer]\nextra_instructions = \"local\"\n"),
+    ]
+
+
+def test_get_repo_settings_skips_global_settings_when_disabled():
+    settings = get_settings()
+    original = settings.config.use_global_settings_file
+    settings.config.use_global_settings_file = False
+    try:
+        provider = _provider(
+            global_settings=b"[pr_reviewer]\nextra_instructions = \"global\"\n",
+            local_settings=b"[pr_reviewer]\nextra_instructions = \"local\"\n",
+        )
+
+        repo_settings = provider.get_repo_settings()
+
+        assert repo_settings == [("local", b"[pr_reviewer]\nextra_instructions = \"local\"\n")]
+    finally:
+        settings.config.use_global_settings_file = original

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -1,7 +1,17 @@
+import pytest
 from github import GithubException
 
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import git_provider as _gp
 from pr_agent.git_providers.github_provider import GithubProvider
+
+
+@pytest.fixture(autouse=True)
+def _clear_global_settings_cache():
+    # The org global-settings cache is process-level; clear it between tests to avoid pollution.
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
+    yield
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
 
 
 def _not_found(name):

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -1,5 +1,13 @@
+from github import GithubException
+
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.github_provider import GithubProvider
+
+
+def _not_found(name):
+    # Match PyGithub: a missing repo/file raises GithubException(404), which the provider
+    # handles, rather than FileNotFoundError.
+    return GithubException(404, {"message": f"Not Found: {name}"}, {})
 
 
 class FakeContent:
@@ -11,9 +19,9 @@ class FakeRepo:
     def __init__(self, files=None):
         self.files = files or {}
 
-    def get_contents(self, path):
+    def get_contents(self, path, ref=None):
         if path not in self.files:
-            raise FileNotFoundError(path)
+            raise _not_found(path)
         return FakeContent(self.files[path])
 
 
@@ -23,7 +31,7 @@ class FakeGithubClient:
 
     def get_repo(self, repo_name):
         if repo_name not in self.repos:
-            raise FileNotFoundError(repo_name)
+            raise _not_found(repo_name)
         return self.repos[repo_name]
 
 
@@ -37,6 +45,27 @@ def _provider(local_settings=None, global_settings=None):
         else {}
     )
     return provider
+
+
+def test_get_global_repo_settings_missing_repo_logged_quietly():
+    # A missing/inaccessible <owner>/pr-agent-settings repo is an expected fallback, so it must be
+    # logged quietly (debug), not as a warning that would flood logs on every webhook event.
+    from unittest.mock import patch
+
+    provider = _provider()  # no global settings repo -> get_repo raises GithubException(404)
+    settings = get_settings()
+    original = settings.config.use_global_settings_file
+    settings.config.use_global_settings_file = True
+    try:
+        with patch("pr_agent.git_providers.github_provider.get_logger") as mock_get_logger:
+            logger = mock_get_logger.return_value
+            result = provider._get_global_repo_settings()
+
+        assert result == ""
+        logger.warning.assert_not_called()
+        logger.debug.assert_called_once()
+    finally:
+        settings.config.use_global_settings_file = original
 
 
 def test_get_repo_settings_returns_global_settings_when_local_settings_missing():

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -67,6 +67,7 @@ def test_get_repo_settings_missing_local_file_logged_quietly(monkeypatch):
     provider = _provider()  # no local .pr_agent.toml -> get_contents raises GithubException(404)
     settings = get_settings()
     original = settings.config.use_global_settings_file
+    original_branch = settings.get("CONFIG.CONFIG_BRANCH", None)
     settings.config.use_global_settings_file = False  # isolate the local-load path
     monkeypatch.delenv("PR_AGENT_CONFIG_BRANCH", raising=False)
     settings.set("CONFIG.CONFIG_BRANCH", "")  # ensure the default-branch load path runs
@@ -79,6 +80,7 @@ def test_get_repo_settings_missing_local_file_logged_quietly(monkeypatch):
         logger.warning.assert_not_called()
     finally:
         settings.config.use_global_settings_file = original
+        settings.set("CONFIG.CONFIG_BRANCH", original_branch)
 
 
 def test_get_global_repo_settings_missing_repo_logged_quietly():

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from github import GithubException
 
@@ -163,5 +165,22 @@ def test_get_repo_settings_skips_global_settings_when_disabled():
         repo_settings = provider.get_repo_settings()
 
         assert repo_settings == [("local", b"[pr_reviewer]\nextra_instructions = \"local\"\n")]
+    finally:
+        settings.config.use_global_settings_file = original
+
+
+def test_get_repo_settings_config_branch_non_404_error_propagates(monkeypatch):
+    # A non-404 error loading the config branch must NOT be masked by a silent default-branch fallback.
+    provider = _provider()  # no global settings repo -> _get_global returns "" quietly
+    provider.repo_obj = MagicMock()
+    provider.repo_obj.get_contents.side_effect = GithubException(403, {"message": "Forbidden"}, {})
+    monkeypatch.setenv("PR_AGENT_CONFIG_BRANCH", "release")
+    settings = get_settings()
+    original = settings.config.use_global_settings_file
+    settings.config.use_global_settings_file = False
+    try:
+        import pytest as _pytest
+        with _pytest.raises(GithubException):
+            provider.get_repo_settings()
     finally:
         settings.config.use_global_settings_file = original

--- a/tests/unittest/test_github_provider_settings.py
+++ b/tests/unittest/test_github_provider_settings.py
@@ -47,6 +47,40 @@ def _provider(local_settings=None, global_settings=None):
     return provider
 
 
+def test_get_global_repo_settings_repo_less_provider_does_not_crash():
+    # A provider built via __new__ (no repo/github_client) must not raise from _get_global_repo_settings.
+    provider = GithubProvider.__new__(GithubProvider)
+    settings = get_settings()
+    original = settings.config.use_global_settings_file
+    settings.config.use_global_settings_file = True
+    try:
+        assert provider._get_global_repo_settings() == ""
+    finally:
+        settings.config.use_global_settings_file = original
+
+
+def test_get_repo_settings_missing_local_file_logged_quietly(monkeypatch):
+    # A missing local .pr_agent.toml (404) is expected for most repos; it must be logged at debug,
+    # not warning.
+    from unittest.mock import patch
+
+    provider = _provider()  # no local .pr_agent.toml -> get_contents raises GithubException(404)
+    settings = get_settings()
+    original = settings.config.use_global_settings_file
+    settings.config.use_global_settings_file = False  # isolate the local-load path
+    monkeypatch.delenv("PR_AGENT_CONFIG_BRANCH", raising=False)
+    settings.set("CONFIG.CONFIG_BRANCH", "")  # ensure the default-branch load path runs
+    try:
+        with patch("pr_agent.git_providers.github_provider.get_logger") as mock_get_logger:
+            logger = mock_get_logger.return_value
+            result = provider.get_repo_settings()
+
+        assert result == ""
+        logger.warning.assert_not_called()
+    finally:
+        settings.config.use_global_settings_file = original
+
+
 def test_get_global_repo_settings_missing_repo_logged_quietly():
     # A missing/inaccessible <owner>/pr-agent-settings repo is an expected fallback, so it must be
     # logged quietly (debug), not as a warning that would flood logs on every webhook event.

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -335,7 +335,8 @@ class TestGitLabGlobalSettings:
         proj.files.get.assert_called_once_with(file_path=".pr_agent.toml", ref="main")
 
     def test_skips_on_self_hosted(self):
-        provider = self._provider(gitlab_url="https://gitlab.mycompany.com")
+        # "mygitlab.com" contains the substring "gitlab.com" but is NOT GitLab.com — must be skipped.
+        provider = self._provider(gitlab_url="https://mygitlab.com")
         with patch("pr_agent.git_providers.gitlab_provider.get_settings") as ms:
             ms.return_value.config.use_global_settings_file = True
             assert provider._get_global_repo_settings() == ""

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -302,3 +302,61 @@ class TestGitLabProvider:
         assert gitlab_provider.mr.title == "AI title"
         assert gitlab_provider.mr.description == "Updated description"
         gitlab_provider.mr.save.assert_called_once()
+
+
+@pytest.fixture(autouse=True)
+def _clear_global_settings_cache():
+    # The group global-settings cache is process-level; clear it between tests.
+    from pr_agent.git_providers import git_provider as _gp
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
+    yield
+    _gp._GLOBAL_SETTINGS_CACHE.clear()
+
+
+class TestGitLabGlobalSettings:
+    def _provider(self, gitlab_url="https://gitlab.com"):
+        provider = GitLabProvider.__new__(GitLabProvider)
+        provider.gl = MagicMock()
+        provider.id_project = "mygroup/myrepo"
+        provider.gitlab_url = gitlab_url
+        return provider
+
+    def test_loads_group_pr_agent_settings(self):
+        provider = self._provider()
+        proj = MagicMock()
+        proj.default_branch = "main"
+        proj.files.get.return_value.decode.return_value = b"[pr_reviewer]\nnum_max_findings = 5\n"
+        provider.gl.projects.get.return_value = proj
+        with patch("pr_agent.git_providers.gitlab_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            result = provider._get_global_repo_settings()
+        assert result == b"[pr_reviewer]\nnum_max_findings = 5\n"
+        provider.gl.projects.get.assert_called_with("mygroup/pr-agent-settings")
+        proj.files.get.assert_called_once_with(file_path=".pr_agent.toml", ref="main")
+
+    def test_skips_on_self_hosted(self):
+        provider = self._provider(gitlab_url="https://gitlab.mycompany.com")
+        with patch("pr_agent.git_providers.gitlab_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            assert provider._get_global_repo_settings() == ""
+        provider.gl.projects.get.assert_not_called()
+
+    def test_disabled_returns_empty(self):
+        provider = self._provider()
+        with patch("pr_agent.git_providers.gitlab_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = False
+            assert provider._get_global_repo_settings() == ""
+        provider.gl.projects.get.assert_not_called()
+
+    def test_result_is_cached(self):
+        provider = self._provider()
+        proj = MagicMock()
+        proj.default_branch = "main"
+        proj.files.get.return_value.decode.return_value = b"[pr_reviewer]\nx = 1\n"
+        provider.gl.projects.get.return_value = proj
+        with patch("pr_agent.git_providers.gitlab_provider.get_settings") as ms:
+            ms.return_value.config.use_global_settings_file = True
+            provider._get_global_repo_settings()
+            provider._get_global_repo_settings()
+        # Only one lookup for the settings project despite two calls (cached).
+        assert provider.gl.projects.get.call_count == 1


### PR DESCRIPTION
## What & why

Split out from #2387 to keep each change reviewable on its own.

Lets an organization centralize PR-Agent defaults in a shared `<org>/pr-agent-settings` repository. When enabled, its `.pr_agent.toml` is loaded and merged **beneath** each repo's local `.pr_agent.toml` (local overrides global).

- `GithubProvider.get_repo_settings()` now returns an ordered `(scope, content)` list; `apply_repo_settings()` merges `global -> local`.
- Gated behind the existing `use_global_settings_file` config flag.
- Configuration errors originating from the global file report the source **without echoing the file's contents** into the PR comment (avoids leaking org-wide config/secrets across repos).

## ⚠️ Note for reviewers
`use_global_settings_file` already defaults to `true` in `configuration.toml`. With this change merged, GitHub flows will make a best-effort extra API call to fetch `<org>/pr-agent-settings` (silently returns empty if the repo doesn't exist). Please confirm whether that default is desired, or whether this should ship defaulting to `false`.

## Test
- New `tests/unittest/test_github_provider_settings.py` and additions to `test_git_provider_utils.py` cover global/local merge precedence and the redaction-on-error behavior.
- Full unit suite passes locally; `ruff` clean.

Original work by @avidspartan1 (commit authorship preserved).
