### PR TITLE
fix(security): do not log merged repo settings dict (may contain secrets)

### DIFF
--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -341,7 +341,13 @@ def apply_repo_settings(pr_url):
                     # Same precedence-restoration rationale as the extra-config
                     # path: env-sourced values must remain the highest layer.
                     _reapply_env_overrides()
-                    get_logger().info(f"Applying repo settings:\n{new_settings.as_dict()}")
+                    # Do NOT log the merged dict: repo/global .pr_agent.toml may contain secrets
+                    # (e.g. openai.key, gitlab.personal_access_token) that would otherwise leak into
+                    # CI logs. Section names are safe and sufficient for debugging (same rationale as
+                    # the extra-config path above).
+                    get_logger().info(
+                        f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
+                    )
                 except Exception as e:
                     get_logger().warning(f"Failed to apply repo {category} settings, error: {str(e)}")
                     error_local = {'error': str(e), 'settings': repo_settings, 'category': category}


### PR DESCRIPTION
## Problem

`apply_repo_settings()` logs the full merged Dynaconf settings dict at `INFO`:

```python
get_logger().info(f"Applying repo settings:\n{new_settings.as_dict()}")
```

`new_settings` is loaded from a repository's (and, with `use_global_settings_file`, an organization's) `.pr_agent.toml`. If such a file contains sensitive values, they are written to CI/server logs verbatim.

This is a pre-existing issue on `main`. The **same file already guards against it** in the sibling extra-config path, which logs only section names with this exact rationale:

```python
# Do NOT log the merged dict: external/repo .pr_agent.toml may contain
# secrets (e.g. openai.key, gitlab.personal_access_token) that would
# otherwise leak into CI logs. Section names are safe and sufficient...
```

## Fix

Make the main path match the sibling path — log the merged **section names** only, never the values:

```python
get_logger().info(
    f"Applying repo settings (sections: {sorted(new_settings.as_dict().keys())})"
)
```

Zero logic change (log statement only); full unit suite passes and `ruff` is clean.
