### PR TITLE
feat(openrouter): add provider routing and reasoning controls

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -417,6 +417,23 @@ key = "..." # your openrouter api key
 
 (you can obtain an Openrouter API key from [here](https://openrouter.ai/settings/keys))
 
+#### Openrouter provider routing, reasoning and output cap
+
+For `openrouter/...` models you can optionally restrict which upstream providers Openrouter uses, control reasoning, and cap the completion length. All keys live in the `[openrouter]` section of `configuration.toml` and default to unset (no change to Openrouter's default behavior):
+
+```toml
+[openrouter]
+# Uncomment and adjust the keys you need; unset keys keep Openrouter's defaults.
+# provider_only = ["z-ai"]             # hard allowlist of upstream providers; empty = default routing
+# provider_order = ["z-ai", "novita"]  # preferred order instead of an allowlist; ignored when provider_only is set
+# allow_fallbacks = true               # when provider_order is set, allow routing beyond the list
+# reasoning_effort = "low"             # "none" disables reasoning; otherwise "low", "medium" or "high"
+# reasoning_max_tokens = 2048          # cap the reasoning budget in tokens
+# max_tokens = 16000                   # hard cap on completion tokens for the request
+```
+
+`provider_only` and `reasoning_effort = "none"` are useful to pin a specific provider and to bound the cost of reasoning models. See the Openrouter [provider routing](https://openrouter.ai/docs/features/provider-routing) and [reasoning tokens](https://openrouter.ai/docs/use-cases/reasoning-tokens) docs.
+
 ### Custom models
 
 If the relevant model doesn't appear [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py), you can still use it as a custom model:

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -443,7 +443,12 @@ class LiteLLMAIHandler(BaseAiHandler):
                 # a multi-provider config) would otherwise hide the 'databricks/' prefix and bypass
                 # the guards that keep Databricks on its own DATABRICKS_API_KEY/DATABRICKS_API_BASE.
                 is_databricks = model.startswith("databricks/")
-                if self.azure and not is_databricks:
+                # OpenRouter models keep their "openrouter/" prefix: __init__ already
+                # routed them to the OpenRouter api_key/api_base, and rewriting to
+                # "azure/openrouter/..." would both misroute the request and skip the
+                # OpenRouter controls block below (guarded by the same prefix).
+                is_openrouter = isinstance(model, str) and model.startswith("openrouter/")
+                if self.azure and not is_databricks and not is_openrouter:
                     model = 'azure/' + model
                 if 'claude' in model and not system:
                     system = "No system prompt provided"

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -652,7 +652,8 @@ class LiteLLMAIHandler(BaseAiHandler):
 
                     max_tokens = _as_int(openrouter_settings.get("max_tokens", 0))
                     if max_tokens > 0:
-                        kwargs["max_tokens"] = max_tokens
+                        existing = _as_int(kwargs.get("max_tokens", 0))
+                        kwargs["max_tokens"] = min(existing, max_tokens) if existing > 0 else max_tokens
 
                 get_logger().debug("Prompts", artifact={"system": system, "user": user})
 

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -590,6 +590,70 @@ class LiteLLMAIHandler(BaseAiHandler):
                     kwargs["model_id"] = model_id
                     get_logger().info(f"Using Bedrock custom inference profile: {model_id}")
 
+                # OpenRouter provider routing, reasoning control and output cap.
+                # Applied only to "openrouter/*" models. Every key defaults to unset in
+                # the [openrouter] section of configuration.toml, so this block is a
+                # no-op unless explicitly configured, and never affects other providers.
+                if isinstance(model, str) and model.startswith("openrouter/"):
+                    openrouter_settings = get_settings().get("openrouter", {})
+                    extra_body = kwargs.get("extra_body") or {}
+
+                    # Normalize operator-controlled config: Dynaconf/env overrides can
+                    # arrive as strings (AUTO_CAST_FOR_DYNACONF is disabled), so coerce
+                    # defensively instead of trusting the declared types.
+                    def _as_list(value):
+                        if isinstance(value, (list, tuple)):
+                            return [str(v).strip() for v in value if str(v).strip()]
+                        if isinstance(value, str):
+                            return [v.strip() for v in value.split(",") if v.strip()]
+                        return []
+
+                    def _as_bool(value, default=True):
+                        if isinstance(value, bool):
+                            return value
+                        if isinstance(value, str):
+                            return value.strip().lower() in ("1", "true", "yes", "on")
+                        return default
+
+                    def _as_int(value):
+                        try:
+                            return int(value)
+                        except (TypeError, ValueError):
+                            return 0
+
+                    provider_only = _as_list(openrouter_settings.get("provider_only", []))
+                    provider_order = _as_list(openrouter_settings.get("provider_order", []))
+                    if provider_only:
+                        extra_body.setdefault("provider", {})["only"] = provider_only
+                    elif provider_order:
+                        provider = extra_body.setdefault("provider", {})
+                        provider["order"] = provider_order
+                        provider["allow_fallbacks"] = _as_bool(openrouter_settings.get("allow_fallbacks", True))
+
+                    reasoning = {}
+                    reasoning_effort = str(openrouter_settings.get("reasoning_effort", "") or "").strip().lower()
+                    if reasoning_effort == "none":
+                        reasoning["enabled"] = False
+                    elif reasoning_effort in ("low", "medium", "high"):
+                        reasoning["effort"] = reasoning_effort
+                    elif reasoning_effort:
+                        get_logger().warning(
+                            f"Ignoring invalid openrouter.reasoning_effort '{reasoning_effort}'. "
+                            "Valid values: none, low, medium, high."
+                        )
+                    reasoning_max_tokens = _as_int(openrouter_settings.get("reasoning_max_tokens", 0))
+                    if reasoning_max_tokens > 0 and reasoning.get("enabled") is not False:
+                        reasoning["max_tokens"] = reasoning_max_tokens
+                    if reasoning:
+                        extra_body["reasoning"] = reasoning
+
+                    if extra_body:
+                        kwargs["extra_body"] = extra_body
+
+                    max_tokens = _as_int(openrouter_settings.get("max_tokens", 0))
+                    if max_tokens > 0:
+                        kwargs["max_tokens"] = max_tokens
+
                 get_logger().debug("Prompts", artifact={"system": system, "user": user})
 
                 if get_settings().config.verbosity_level >= 2:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -342,6 +342,19 @@ failure_callback = []
 service_callback = []
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
+[openrouter]
+# OpenRouter provider routing, reasoning control and output cap. These apply only
+# to models addressed as "openrouter/...". The API key and api_base live in
+# .secrets.toml (or the openrouter__key env var); the keys below are non-secret.
+# Refs: https://openrouter.ai/docs/features/provider-routing
+#       https://openrouter.ai/docs/use-cases/reasoning-tokens
+provider_only = [] # restrict routing to these upstream providers only, a hard allowlist (e.g. ["z-ai"]); empty = OpenRouter default routing
+provider_order = [] # preferred provider order; ignored when provider_only is set; empty = unset
+allow_fallbacks = true # when provider_order is set, allow routing beyond the listed providers
+reasoning_effort = "" # "" leaves reasoning to the model default; "none" disables it; otherwise "low", "medium" or "high"
+reasoning_max_tokens = 0 # cap the reasoning budget in tokens; 0 = unset
+max_tokens = 0 # hard cap on completion tokens for the request; 0 = unset
+
 [pr_similar_issue]
 skip_comments = false
 force_update_dataset = false

--- a/tests/unittest/test_litellm_openrouter_controls.py
+++ b/tests/unittest/test_litellm_openrouter_controls.py
@@ -1,0 +1,147 @@
+"""
+Tests for the OpenRouter provider-routing / reasoning / output-cap controls in
+LiteLLMAIHandler.chat_completion.
+
+The [openrouter] settings (provider_only, provider_order, allow_fallbacks,
+reasoning_effort, reasoning_max_tokens, max_tokens) are injected into the request
+as `extra_body.provider`, `extra_body.reasoning` and `max_tokens`, but only for
+models addressed as "openrouter/...". When nothing is configured the block is a
+no-op, and non-openrouter models are never touched.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+
+
+def _make_settings(openrouter=None):
+    """Minimal settings whose `.get("openrouter", ...)` returns the given dict."""
+    openrouter = openrouter or {}
+    return type("Settings", (), {
+        "config": type("Config", (), {
+            "reasoning_effort": None,
+            "ai_timeout": 30,
+            "custom_reasoning_model": False,
+            "max_model_tokens": 32000,
+            "verbosity_level": 0,
+            "seed": -1,
+            "get": lambda self, key, default=None: default,
+        })(),
+        "litellm": type("LiteLLM", (), {
+            "get": lambda self, key, default=None: default,
+        })(),
+        "get": lambda self, key, default=None: (openrouter if key == "openrouter" else default),
+    })()
+
+
+def _mock_response():
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: {
+        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
+    }[key]
+    return mock
+
+
+async def _run(monkeypatch, model, openrouter):
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings(openrouter))
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+               new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        await handler.chat_completion(model=model, system="sys", user="usr")
+    return mock_call.call_args[1]
+
+
+class TestOpenRouterControls:
+
+    @pytest.mark.asyncio
+    async def test_provider_only_and_reasoning_effort_and_max_tokens(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "provider_only": ["z-ai"],
+            "reasoning_effort": "low",
+            "max_tokens": 16000,
+        })
+        assert kwargs["extra_body"] == {"provider": {"only": ["z-ai"]}, "reasoning": {"effort": "low"}}
+        assert kwargs["max_tokens"] == 16000
+
+    @pytest.mark.asyncio
+    async def test_provider_order_with_allow_fallbacks(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "provider_order": ["z-ai", "novita"],
+            "allow_fallbacks": False,
+        })
+        assert kwargs["extra_body"]["provider"] == {"order": ["z-ai", "novita"], "allow_fallbacks": False}
+
+    @pytest.mark.asyncio
+    async def test_provider_only_wins_over_order(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "provider_only": ["z-ai"],
+            "provider_order": ["novita"],
+        })
+        assert kwargs["extra_body"]["provider"] == {"only": ["z-ai"]}
+
+    @pytest.mark.asyncio
+    async def test_reasoning_none_disables(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {"reasoning_effort": "none"})
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_reasoning_max_tokens(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "reasoning_effort": "high",
+            "reasoning_max_tokens": 2048,
+        })
+        assert kwargs["extra_body"]["reasoning"] == {"effort": "high", "max_tokens": 2048}
+
+    @pytest.mark.asyncio
+    async def test_no_config_is_noop(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {})
+        assert "extra_body" not in kwargs
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_non_openrouter_model_unaffected(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "gpt-4o", {
+            "provider_only": ["z-ai"],
+            "max_tokens": 16000,
+        })
+        assert "extra_body" not in kwargs
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_invalid_reasoning_effort_ignored(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {"reasoning_effort": "loww"})
+        assert "extra_body" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_reasoning_max_tokens_dropped_when_disabled(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "reasoning_effort": "none",
+            "reasoning_max_tokens": 2048,
+        })
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_string_overrides_are_coerced(self, monkeypatch):
+        # Dynaconf/env overrides can arrive as strings; they must not crash or
+        # be split into characters.
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "provider_only": "z-ai",
+            "max_tokens": "16000",
+        })
+        assert kwargs["extra_body"]["provider"] == {"only": ["z-ai"]}
+        assert kwargs["max_tokens"] == 16000
+
+    @pytest.mark.asyncio
+    async def test_allow_fallbacks_string_false(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {
+            "provider_order": ["z-ai", "novita"],
+            "allow_fallbacks": "false",
+        })
+        assert kwargs["extra_body"]["provider"]["allow_fallbacks"] is False
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_max_tokens_ignored(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {"max_tokens": "16k"})
+        assert "max_tokens" not in kwargs

--- a/tests/unittest/test_litellm_openrouter_controls.py
+++ b/tests/unittest/test_litellm_openrouter_controls.py
@@ -160,3 +160,19 @@ class TestOpenRouterControls:
     async def test_non_numeric_max_tokens_ignored(self, monkeypatch):
         kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {"max_tokens": "16k"})
         assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_azure_mode_does_not_mask_openrouter(self, monkeypatch):
+        # Azure mode must not rewrite "openrouter/..." to "azure/openrouter/...":
+        # that would misroute the request and skip the OpenRouter controls block.
+        monkeypatch.setattr(litellm_handler, "get_settings",
+                            lambda: _make_settings({"provider_only": ["z-ai"]}))
+        with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+                   new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = _mock_response()
+            handler = litellm_handler.LiteLLMAIHandler()
+            handler.azure = True
+            await handler.chat_completion(model="openrouter/z-ai/glm-5.2", system="sys", user="usr")
+        kwargs = mock_call.call_args[1]
+        assert kwargs["model"] == "openrouter/z-ai/glm-5.2"
+        assert kwargs["extra_body"]["provider"] == {"only": ["z-ai"]}

--- a/tests/unittest/test_litellm_openrouter_controls.py
+++ b/tests/unittest/test_litellm_openrouter_controls.py
@@ -10,9 +10,24 @@ no-op, and non-openrouter models are never touched.
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
+import openai
 import pytest
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+
+
+@pytest.fixture(autouse=True)
+def _restore_litellm_globals():
+    """LiteLLMAIHandler.__init__ mutates global litellm/openai state; snapshot and
+    restore it so these tests do not leak into the rest of the suite."""
+    saved = (litellm.api_key, getattr(litellm, "openai_key", None), openai.api_key)
+    try:
+        yield
+    finally:
+        litellm.api_key = saved[0]
+        litellm.openai_key = saved[1]
+        openai.api_key = saved[2]
 
 
 def _make_settings(openrouter=None):
@@ -37,9 +52,9 @@ def _make_settings(openrouter=None):
 
 def _mock_response():
     mock = MagicMock()
-    mock.__getitem__ = lambda self, key: {
-        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
-    }[key]
+    response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    mock.__getitem__.side_effect = response.__getitem__
+    mock.dict.return_value = response
     return mock
 
 

--- a/tests/unittest/test_litellm_openrouter_controls.py
+++ b/tests/unittest/test_litellm_openrouter_controls.py
@@ -8,6 +8,7 @@ as `extra_body.provider`, `extra_body.reasoning` and `max_tokens`, but only for
 models addressed as "openrouter/...". When nothing is configured the block is a
 no-op, and non-openrouter models are never touched.
 """
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
@@ -16,18 +17,38 @@ import pytest
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 
+# Environment variables that LiteLLMAIHandler.__init__ reads or mutates: the AWS
+# credential path (entered when AWS_USE_IMDS is set) writes the AWS_* variables,
+# and OPENAI_API_KEY influences the litellm.api_key fallback.
+_HANDLER_ENV_VARS = (
+    "AWS_USE_IMDS",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_REGION_NAME",
+    "OPENAI_API_KEY",
+)
+
 
 @pytest.fixture(autouse=True)
 def _restore_litellm_globals():
-    """LiteLLMAIHandler.__init__ mutates global litellm/openai state; snapshot and
-    restore it so these tests do not leak into the rest of the suite."""
+    """LiteLLMAIHandler.__init__ mutates global litellm/openai state and, when
+    AWS_USE_IMDS is set, os.environ; snapshot and restore both, and drop
+    AWS_USE_IMDS so the AWS credential path never runs in these tests."""
     saved = (litellm.api_key, getattr(litellm, "openai_key", None), openai.api_key)
+    saved_env = {name: os.environ.get(name) for name in _HANDLER_ENV_VARS}
+    os.environ.pop("AWS_USE_IMDS", None)
     try:
         yield
     finally:
         litellm.api_key = saved[0]
         litellm.openai_key = saved[1]
         openai.api_key = saved[2]
+        for name, value in saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def _make_settings(openrouter=None):


### PR DESCRIPTION
Add an [openrouter] configuration section that lets operators restrict which upstream providers OpenRouter uses, control reasoning, and cap completion length for models addressed as "openrouter/...".

The LiteLLM handler now injects, only for openrouter/* models:
- extra_body.provider.only (hard allowlist) or provider.order + allow_fallbacks
- extra_body.reasoning (effort, "none" to disable, or a max_tokens budget)
- a hard max_tokens cap on the completion

Every key defaults to unset, so the block is a no-op unless configured and never affects other providers. Includes documentation and unit tests covering provider routing, reasoning control, the output cap, and the no-op and non-openrouter cases.