### PR TITLE
fix(local): return language names from get_languages()

### DIFF
--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -156,15 +156,31 @@ class LocalGitProvider(GitProvider):
     def get_languages(self):
         """
         Calculate percentage of languages in repository. Used for hunk prioritisation.
+
+        Keys are language NAMES (e.g. "Python"), not raw extensions: the consumer
+        sort_files_by_main_languages() maps each name back to its extensions, so
+        returning extensions ("py") silently drops every file into the "Other"
+        bucket and defeats the prioritisation this method exists for. Invert the
+        settings map (name -> [extensions]) into an extension -> name lookup;
+        files with unknown extensions are left out and fall through to "Other".
         """
+        ext_to_lang = {}
+        lang_map = get_settings().get("language_extension_map_org", {}) or {}
+        for language, extensions in lang_map.items():
+            for ext in extensions:
+                ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
+
         # Get all files in repository
         filepaths = [Path(item.path) for item in self.repo.tree().traverse() if item.type == 'blob']
-        # Identify language by file extension and count
-        lang_count = Counter(ext.lstrip('.') for filepath in filepaths for ext in [filepath.suffix.lower()])
+        # Identify language by file extension (mapped to its language name) and count
+        lang_count = Counter()
+        for filepath in filepaths:
+            language = ext_to_lang.get(filepath.suffix.lower())
+            if language:
+                lang_count[language] += 1
         # Convert counts to percentages
-        total_files = len(filepaths)
-        lang_percentage = {lang: count / total_files * 100 for lang, count in lang_count.items()}
-        return lang_percentage
+        total = sum(lang_count.values()) or 1
+        return {lang: count / total * 100 for lang, count in lang_count.items()}
 
     def get_pr_branch(self):
         return self.repo.head

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -164,18 +164,35 @@ class LocalGitProvider(GitProvider):
         settings map (name -> [extensions]) into an extension -> name lookup;
         files with unknown extensions are left out and fall through to "Other".
         """
+        # Invert to a filename-token -> language lookup. Map entries are mostly
+        # ".ext", but also include multi-part extensions (".cmake.in") and full
+        # filenames ("Dockerfile", "Makefile"); normalize the glob form ("*.bsl").
         ext_to_lang = {}
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
         for language, extensions in lang_map.items():
             for ext in extensions:
                 ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
 
+        def _match_language(name: str):
+            # Full-filename rules (Dockerfile, Makefile) carry no extension.
+            language = ext_to_lang.get(name.lower())
+            if language:
+                return language
+            # Try progressively shorter dotted suffixes so multi-part extensions
+            # (".cmake.in") win over their simple tail (".in") when both exist.
+            parts = name.split(".")
+            for i in range(1, len(parts)):
+                language = ext_to_lang.get("." + ".".join(parts[i:]).lower())
+                if language:
+                    return language
+            return None
+
         # Get all files in repository
         filepaths = [Path(item.path) for item in self.repo.tree().traverse() if item.type == 'blob']
-        # Identify language by file extension (mapped to its language name) and count
+        # Identify language by filename (mapped to its language name) and count
         lang_count = Counter()
         for filepath in filepaths:
-            language = ext_to_lang.get(filepath.suffix.lower())
+            language = _match_language(filepath.name)
             if language:
                 lang_count[language] += 1
         # Convert counts to percentages

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -39,4 +39,18 @@ def test_get_languages_returns_language_names(tmp_path):
                for b in sort_files_by_main_languages(languages, files)}
     assert buckets["Python"] == {"a.py"}
     assert buckets["JavaScript"] == {"d.js"}
-    assert buckets["Other"] == {"weird.zzz"}
+    assert buckets["Other"] == {"weird.zzz"}  # unknown extension falls through
+
+
+def test_get_languages_matches_full_names_and_multipart_extensions(tmp_path):
+    # Beyond simple ".ext", the language map also has full-filename rules
+    # ("Dockerfile") and multi-part extensions (".cmake.in"); Path.suffix alone
+    # would miss both. Match on the whole filename and dotted-suffix fallbacks.
+    repo = _make_repo(tmp_path, ["Dockerfile", "build.cmake.in", "app.py"])
+    provider = object.__new__(LocalGitProvider)
+    provider.repo = repo
+
+    languages = provider.get_languages()
+    # One file each -> ~33.33% apiece, and none dropped as "unknown".
+    assert set(languages) == {"Dockerfile", "CMake", "Python"}
+    assert all(abs(v - 100 / 3) < 1e-6 for v in languages.values())

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -1,0 +1,42 @@
+import git
+
+from pr_agent.git_providers.local_git_provider import LocalGitProvider
+
+
+def _make_repo(tmp_path, filenames):
+    repo = git.Repo.init(tmp_path)
+    for name in filenames:
+        f = tmp_path / name
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("x\n")
+        repo.index.add([str(f)])
+    repo.index.commit("init")
+    return repo
+
+
+def test_get_languages_returns_language_names(tmp_path):
+    # get_languages() must key on language NAMES (e.g. "Python"), not raw
+    # extensions ("py"): sort_files_by_main_languages() maps names back to
+    # extensions, so extension keys would drop every file into "Other" and
+    # defeat the hunk prioritisation this method exists for.
+    repo = _make_repo(tmp_path, ["a.py", "b.py", "c.py", "d.js", "weird.zzz"])
+    provider = object.__new__(LocalGitProvider)  # bypass heavy __init__
+    provider.repo = repo
+
+    languages = provider.get_languages()
+    # 3 Python + 1 JavaScript known; .zzz is unknown and excluded from the total.
+    assert languages == {"Python": 75.0, "JavaScript": 25.0}
+
+    # Verify the values flow through the real consumer into proper buckets.
+    from pr_agent.algo.language_handler import sort_files_by_main_languages
+
+    class _F:
+        def __init__(self, name):
+            self.filename = name
+
+    files = [_F("a.py"), _F("d.js"), _F("weird.zzz")]
+    buckets = {b["language"]: {f.filename for f in b["files"]}
+               for b in sort_files_by_main_languages(languages, files)}
+    assert buckets["Python"] == {"a.py"}
+    assert buckets["JavaScript"] == {"d.js"}
+    assert buckets["Other"] == {"weird.zzz"}


### PR DESCRIPTION
## Summary

`LocalGitProvider.get_languages()` returns raw file **extensions** as keys (`{"py": 60.0, "js": 30.0}`), but its only consumer, `sort_files_by_main_languages()`, keys on language **names** — it maps each name back to its extensions via `language_extension_map_org`. Since `"py"` is never a language name, the lookup always misses and **every file is dropped into the `"Other"` bucket**, defeating the language-based hunk prioritisation the method's own docstring describes ("Used for hunk prioritisation").

The hosted providers (GitHub/GitLab/Gitea) all return language *names* from their platform APIs, so `LocalGitProvider` is the odd one out.

## Reproduction

```python
from pr_agent.algo.language_handler import sort_files_by_main_languages
files = [F("a.js"), F("b.js"), F("c.py"), F("d.py"), F("e.py")]

# what LocalGitProvider returns today (extension-keyed):
sort_files_by_main_languages({"py": 60, "js": 40}, files)
#  -> [{'language': 'Other', 'files': [a.js, b.js, c.py, d.py, e.py]}]   # all in Other

# name-keyed (this PR):
sort_files_by_main_languages({"Python": 60, "JavaScript": 40}, files)
#  -> [{'language': 'Python', 'files': [c.py, d.py, e.py]},
#      {'language': 'JavaScript', 'files': [a.js, b.js]}, ...]           # correctly bucketed
```

## Impact

- Small PRs (under the token limit): only the file **ordering** in the prompt changes — minor.
- Large PRs (over the limit): pruning follows arbitrary diff order instead of keeping main-language files in full and reviewing them first — the prioritisation is lost where it matters most.

## Fix

Invert `language_extension_map_org` (name → [extensions]) into an extension → name lookup and return name-keyed percentages, matching the hosted providers. Files with unknown extensions are excluded and fall through to `"Other"` downstream.

## Tests

Adds `tests/unittest/test_local_git_provider.py` covering the name-keyed output and correct bucketing through `sort_files_by_main_languages()`.
