### PR TITLE
Honor reasoning_effort for Gemini 2.5 (and provider-prefixed reasoning models)

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -364,6 +364,14 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     "o3-2025-04-16",
     "o4-mini",
     "o4-mini-2025-04-16",
+    # Gemini 2.5 exposes a thinking budget that LiteLLM maps from reasoning_effort
+    # (low/medium/high -> thinkingConfig.thinkingBudget). Without these entries a
+    # configured reasoning_effort is silently dropped for Gemini, so a runaway
+    # thinking trace can consume the whole output budget and return an empty
+    # completion. Matched provider-prefix-insensitively in litellm_ai_handler so
+    # prefixed forms (e.g. "openrouter/google/gemini-2.5-pro") are covered too.
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
 ]
 
 # Claude models that support "extended thinking" through the manual

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -537,8 +537,12 @@ class LiteLLMAIHandler(BaseAiHandler):
                     if 'temperature' in kwargs:
                         del kwargs['temperature']
 
-                # Add reasoning_effort if model supports it
-                if model in self.support_reasoning_models:
+                # Add reasoning_effort if model supports it. Match the bare model
+                # id as well as any provider-prefixed form (e.g.
+                # "openrouter/google/gemini-2.5-pro", "gemini/gemini-2.5-pro"), so a
+                # configured reasoning_effort is not silently dropped for models the
+                # user references with a provider prefix.
+                if any(model == m or model.endswith("/" + m) for m in self.support_reasoning_models):
                     config_effort = get_settings().config.reasoning_effort
                     try:
                         ReasoningEffort(config_effort)

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -830,3 +830,81 @@ class TestLiteLLMReasoningEffort:
                 assert call_kwargs["model"] == expected, (
                     f"wrong routing for {input_model}: got {call_kwargs['model']}, expected {expected}"
                 )
+
+
+class TestLiteLLMReasoningEffortGemini:
+    """Gemini 2.5 reasoning_effort handling via the SUPPORT_REASONING_EFFORT_MODELS path.
+
+    Gemini 2.5 exposes a thinking budget that LiteLLM maps from reasoning_effort. The
+    membership test in chat_completion matches the bare model id as well as any
+    provider-prefixed form (e.g. "openrouter/google/gemini-2.5-pro"), so a configured
+    reasoning_effort is not silently dropped for models referenced with a prefix.
+    """
+
+    def _isolate_env(self, monkeypatch):
+        # LiteLLMAIHandler.__init__ branches on these; clear them for a deterministic handler.
+        for _var in ("AWS_USE_IMDS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                     "AWS_SESSION_TOKEN", "AWS_REGION_NAME", "OPENAI_API_KEY"):
+            monkeypatch.delenv(_var, raising=False)
+
+    @pytest.mark.asyncio
+    async def test_gemini_prefixed_forms_get_reasoning_effort(self, monkeypatch, mock_logger):
+        """Bare and provider-prefixed Gemini 2.5 ids all receive the configured reasoning_effort."""
+        fake_settings = create_mock_settings("low")
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        self._isolate_env(monkeypatch)
+
+        gemini_models = [
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini/gemini-2.5-pro",
+            "vertex_ai/gemini-2.5-pro",
+            "openrouter/google/gemini-2.5-pro",
+            "openrouter/google/gemini-2.5-flash",
+        ]
+
+        for model in gemini_models:
+            with patch('pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion', new_callable=AsyncMock) as mock_completion:
+                mock_completion.return_value = create_mock_acompletion_response()
+
+                handler = LiteLLMAIHandler()
+                await handler.chat_completion(model=model, system="test system", user="test user")
+
+                call_kwargs = mock_completion.call_args[1]
+                assert call_kwargs["reasoning_effort"] == "low", f"failed for {model}"
+                # Gemini keeps temperature (it supports it) — unlike the GPT-5 path.
+                assert call_kwargs["model"] == model, f"model mutated for {model}: {call_kwargs['model']}"
+
+    @pytest.mark.asyncio
+    async def test_non_listed_gemini_gets_no_reasoning_effort(self, monkeypatch, mock_logger):
+        """A Gemini model not in the support list (e.g. 1.5) must not receive reasoning_effort."""
+        fake_settings = create_mock_settings("low")
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        self._isolate_env(monkeypatch)
+
+        for model in ("openrouter/google/gemini-1.5-pro", "gemini-1.5-flash"):
+            with patch('pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion', new_callable=AsyncMock) as mock_completion:
+                mock_completion.return_value = create_mock_acompletion_response()
+
+                handler = LiteLLMAIHandler()
+                await handler.chat_completion(model=model, system="test system", user="test user")
+
+                call_kwargs = mock_completion.call_args[1]
+                assert "reasoning_effort" not in call_kwargs, f"unexpected reasoning_effort for {model}"
+
+    @pytest.mark.asyncio
+    async def test_suffix_match_does_not_overmatch(self, monkeypatch, mock_logger):
+        """endswith('/' + id) must not match a model whose id is a substring without the slash boundary."""
+        fake_settings = create_mock_settings("low")
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        self._isolate_env(monkeypatch)
+
+        # "my-gemini-2.5-pro" is not equal to and does not end with "/gemini-2.5-pro".
+        with patch('pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion', new_callable=AsyncMock) as mock_completion:
+            mock_completion.return_value = create_mock_acompletion_response()
+
+            handler = LiteLLMAIHandler()
+            await handler.chat_completion(model="my-gemini-2.5-pro", system="test system", user="test user")
+
+            call_kwargs = mock_completion.call_args[1]
+            assert "reasoning_effort" not in call_kwargs


### PR DESCRIPTION
> [!NOTE]
> **This PR is agent-generated and offered purely as a quick compute-courtesy — take it or leave it, no guarantees, no obligation to review.** It came out of debugging our own PR-Agent deployment; we figured the fix might be useful upstream, so we're passing it along. If it's not a direction you want, or it's incomplete for your standards, feel free to close it — no hard feelings. It's a spare-cycles contribution, not a support request.

## Problem

`SUPPORT_REASONING_EFFORT_MODELS` contains only bare `o3`/`o4` ids, and the gate in `LiteLLMAIHandler.chat_completion` is an **exact-string** test:

```python
if model in self.support_reasoning_models:
    kwargs["reasoning_effort"] = reasoning_effort
```

So a configured `reasoning_effort` is **silently dropped** in two cases:

1. **Gemini 2.5 (pro/flash)** — these support a thinking budget that LiteLLM maps from `reasoning_effort` (`low`/`medium`/`high` → `thinkingConfig.thinkingBudget`), but they were never in the list.
2. **Any reasoning model referenced with a provider prefix** — e.g. `openrouter/o3`, `openrouter/google/gemini-2.5-pro`. The prefixed string never equals the bare id, so the gate misses even models that *are* listed.

For Gemini this bites beyond "a knob doesn't work": with reasoning left uncapped, a runaway thinking trace can consume the entire output budget and return an **empty completion** (`AI response: None`). In our deployment (Gemini 2.5 Pro via OpenRouter) that produced occasional silently-unreviewed PRs, and `reasoning_effort` in config was a no-op against it.

## Change

- Add `gemini-2.5-pro` / `gemini-2.5-flash` to `SUPPORT_REASONING_EFFORT_MODELS`.
- Match the **bare id OR any `"<provider>/<id>"` suffix form**, so provider-prefixed configs are honored — without over-matching (`my-gemini-2.5-pro` is *not* matched, since it neither equals nor ends with `/gemini-2.5-pro`):

```python
if any(model == m or model.endswith("/" + m) for m in self.support_reasoning_models):
```

The o3/o4 exact-match behavior is preserved (bare ids still match via `model == m`); this only *adds* the prefixed and Gemini cases.

## Tests

Added to `tests/unittest/test_litellm_reasoning_effort.py`, following the existing patterns:
- Prefixed + bare Gemini forms (`gemini-2.5-pro`, `gemini/…`, `vertex_ai/…`, `openrouter/google/…`) all receive the configured `reasoning_effort`.
- A non-listed Gemini (`gemini-1.5-*`) receives none.
- The suffix match doesn't over-match (`my-gemini-2.5-pro`).

`python -m pytest tests/unittest/test_litellm_reasoning_effort.py` → **32 passed** (29 existing + 3 new).

## Scope / caveats (in the take-it-or-leave-it spirit)

- Deliberately narrow: only the exact `gemini-2.5-pro`/`-flash` ids. Dated/preview variants (`gemini-2.5-pro-preview-*`) are **not** matched — didn't want to guess your naming policy.
- I did **not** add `allowed_openai_params=["reasoning_effort"]` for the Gemini path (the GPT-5 branch uses it). On the providers I exercised LiteLLM forwards `reasoning_effort` for Gemini 2.5 fine; if a provider variant rejects it, that'd be the follow-up. Flagging so it's a conscious choice on your side, not an oversight.