### PR TITLE
AI: fix(gitea): allow description updates without titles

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -883,12 +883,13 @@ class RepoApi(giteapy.RepositoryApi):
             index=pr_number
         )
 
-    def edit_pull_request(self, owner: str, repo: str, pr_number: int,title : str, body: str):
+    def edit_pull_request(self, owner: str, repo: str, pr_number: int, body: str, title: Optional[str] = None):
         """Edit pull request description"""
         body = {
-            "body": body,
-            "title" : title
+            "body": body
         }
+        if title is not None:
+            body["title"] = title
         return self.repository.repo_edit_pull_request(
             owner=owner,
             repo=repo,

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -500,3 +500,31 @@ class TestGiteaProviderAddFileDiff:
         provider.logger.error.assert_called_once()
         # file_diffs is left untouched when the diff cannot be fetched.
         assert provider.file_diffs == {}
+
+    @patch('pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi')
+    def test_edit_pull_request_without_title(self, mock_repository_api_cls):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        repo_api = RepoApi(MagicMock())
+        repo_api.edit_pull_request('owner', 'repo', 123, 'Updated description')
+
+        mock_repository_api_cls.return_value.repo_edit_pull_request.assert_called_once_with(
+            owner='owner',
+            repo='repo',
+            index=123,
+            body={'body': 'Updated description'}
+        )
+
+    @patch('pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi')
+    def test_edit_pull_request_with_title(self, mock_repository_api_cls):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        repo_api = RepoApi(MagicMock())
+        repo_api.edit_pull_request('owner', 'repo', 123, 'Updated description', 'Updated title')
+
+        mock_repository_api_cls.return_value.repo_edit_pull_request.assert_called_once_with(
+            owner='owner',
+            repo='repo',
+            index=123,
+            body={'body': 'Updated description', 'title': 'Updated title'}
+        )

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -501,30 +501,30 @@ class TestGiteaProviderAddFileDiff:
         # file_diffs is left untouched when the diff cannot be fetched.
         assert provider.file_diffs == {}
 
-    @patch('pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi')
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi")
     def test_edit_pull_request_without_title(self, mock_repository_api_cls):
         from pr_agent.git_providers.gitea_provider import RepoApi
 
         repo_api = RepoApi(MagicMock())
-        repo_api.edit_pull_request('owner', 'repo', 123, 'Updated description')
+        repo_api.edit_pull_request("owner", "repo", 123, "Updated description")
 
         mock_repository_api_cls.return_value.repo_edit_pull_request.assert_called_once_with(
-            owner='owner',
-            repo='repo',
+            owner="owner",
+            repo="repo",
             index=123,
-            body={'body': 'Updated description'}
+            body={"body": "Updated description"}
         )
 
-    @patch('pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi')
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.RepositoryApi")
     def test_edit_pull_request_with_title(self, mock_repository_api_cls):
         from pr_agent.git_providers.gitea_provider import RepoApi
 
         repo_api = RepoApi(MagicMock())
-        repo_api.edit_pull_request('owner', 'repo', 123, 'Updated description', 'Updated title')
+        repo_api.edit_pull_request("owner", "repo", 123, "Updated description", "Updated title")
 
         mock_repository_api_cls.return_value.repo_edit_pull_request.assert_called_once_with(
-            owner='owner',
-            repo='repo',
+            owner="owner",
+            repo="repo",
             index=123,
-            body={'body': 'Updated description', 'title': 'Updated title'}
+            body={"body": "Updated description", "title": "Updated title"}
         )


### PR DESCRIPTION
**Content warning:** This pull request is _mostly_ AI-generated.  While I'm following the contributing guidelines as much as possible I'm not competent enough to fully validate the content at the moment.  _Feel free to drop it if it isn't salvageable._

---

Make the Gitea pull request edit wrapper accept an omitted title and only include the title field in the request when one is supplied. This preserves manually edited titles when AI title generation is disabled.

Add coverage for description updates both with and without a title.

Fixes #2525.

Assisted-by: Codex:GPT-5.6
Tested-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>