### PR TITLE
fix(gitlab): allow overriding is_bot_user indicators 

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -64,11 +64,12 @@ def is_bot_user(data) -> bool:
     try:
         # logic to ignore bot users (unlike Github, no direct flag for bot users in gitlab)
         sender_name = data.get("user", {}).get("name", "unknown").lower()
-        # Indicators are sourced from gitlab.bot_user_indicators in configuration.toml so the
-        # default list has a single source of truth. Normalize the value defensively: a
-        # misconfigured .pr_agent.toml (string instead of list, non-string entries) should not
-        # break bot detection, and matching is documented as case-insensitive.
-        raw_indicators = get_settings().get("gitlab.bot_user_indicators", [])
+        # Indicators are sourced from config.bot_user_indicators in configuration.toml so the
+        # default list has a single source of truth and can be reused by other providers in
+        # the future. Normalize the value defensively: a misconfigured .pr_agent.toml (string
+        # instead of list, non-string entries) should not break bot detection, and matching
+        # is documented as case-insensitive.
+        raw_indicators = get_settings().get("config.bot_user_indicators", [])
         if isinstance(raw_indicators, str):
             raw_indicators = [raw_indicators]
         try:

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -64,7 +64,8 @@ def is_bot_user(data) -> bool:
     try:
         # logic to ignore bot users (unlike Github, no direct flag for bot users in gitlab)
         sender_name = data.get("user", {}).get("name", "unknown").lower()
-        bot_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot']
+        default_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot']
+        bot_indicators = get_settings().get("gitlab.bot_user_indicators", default_indicators)
         if any(indicator in sender_name for indicator in bot_indicators):
             get_logger().info(f"Skipping GitLab bot user: {sender_name}")
             return True

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -64,8 +64,21 @@ def is_bot_user(data) -> bool:
     try:
         # logic to ignore bot users (unlike Github, no direct flag for bot users in gitlab)
         sender_name = data.get("user", {}).get("name", "unknown").lower()
-        default_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot']
-        bot_indicators = get_settings().get("gitlab.bot_user_indicators", default_indicators)
+        # Indicators are sourced from gitlab.bot_user_indicators in configuration.toml so the
+        # default list has a single source of truth. Normalize the value defensively: a
+        # misconfigured .pr_agent.toml (string instead of list, non-string entries) should not
+        # break bot detection, and matching is documented as case-insensitive.
+        raw_indicators = get_settings().get("gitlab.bot_user_indicators", [])
+        if isinstance(raw_indicators, str):
+            raw_indicators = [raw_indicators]
+        try:
+            raw_indicators = list(raw_indicators)
+        except TypeError:
+            get_logger().warning(
+                f"Ignoring non-iterable gitlab.bot_user_indicators value: {raw_indicators!r}"
+            )
+            raw_indicators = []
+        bot_indicators = [s.lower() for s in raw_indicators if isinstance(s, str)]
         if any(indicator in sender_name for indicator in bot_indicators):
             get_logger().info(f"Skipping GitLab bot user: {sender_name}")
             return True

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -284,6 +284,10 @@ push_commands = [
     "/describe",
     "/review",
 ]
+# Substring indicators used to skip GitLab bot users on webhook events (case-insensitive match against
+# the sender's display name). When unset, defaults to ['codium', 'bot_', 'bot-', '_bot', '-bot'].
+# Override to extend or replace the default list (e.g. to include 'renovate', 'dependabot', etc.).
+# bot_user_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot', 'renovate']
 # Configure SSL validation for GitLab. Can be either set to the path of a custom CA or disabled entirely.
 # ssl_verify = true
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -284,10 +284,11 @@ push_commands = [
     "/describe",
     "/review",
 ]
-# Substring indicators used to skip GitLab bot users on webhook events (case-insensitive match against
-# the sender's display name). When unset, defaults to ['codium', 'bot_', 'bot-', '_bot', '-bot'].
-# Override to extend or replace the default list (e.g. to include 'renovate', 'dependabot', etc.).
-# bot_user_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot', 'renovate']
+# Substring indicators used to skip GitLab bot users on webhook events. The match is
+# case-insensitive and performed against the sender's display name. Overriding this
+# setting REPLACES the default list; include the entries below in your override if you
+# want to keep them (e.g. `["codium", "bot_", "bot-", "_bot", "-bot", "renovate"]`).
+bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]
 # Configure SSL validation for GitLab. Can be either set to the path of a custom CA or disabled entirely.
 # ssl_verify = true
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -59,6 +59,12 @@ ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
 ignore_repositories = [] # a list of regular expressions of repository full names (e.g. "org/repo") to ignore from PR agent processing
 ignore_language_framework = [] # a list of code-generation languages or frameworks (e.g. 'protobuf', 'go_gen') whose auto-generated source files will be excluded from analysis
+# Substring indicators used to skip bot users on webhook events. Currently consumed by
+# the GitLab webhook (`is_bot_user`); other providers may adopt this list in future.
+# The match is case-insensitive against the sender's display name. Overriding this
+# setting REPLACES the default list — include the entries below in your override if
+# you want to keep them (e.g. `["codium", "bot_", "bot-", "_bot", "-bot", "renovate"]`).
+bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]
 #
 restricted_mode = false # when true, skip operations that require elevated permissions (e.g. pushing code to the repository)
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
@@ -284,11 +290,6 @@ push_commands = [
     "/describe",
     "/review",
 ]
-# Substring indicators used to skip GitLab bot users on webhook events. The match is
-# case-insensitive and performed against the sender's display name. Overriding this
-# setting REPLACES the default list; include the entries below in your override if you
-# want to keep them (e.g. `["codium", "bot_", "bot-", "_bot", "-bot", "renovate"]`).
-bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]
 # Configure SSL validation for GitLab. Can be either set to the path of a custom CA or disabled entirely.
 # ssl_verify = true
 

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -215,8 +215,8 @@ def test_gitlab_is_bot_user_uses_default_indicators(
 
 def test_gitlab_is_bot_user_honors_configured_indicators(gitlab_webhook_module):
     settings = get_settings()
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
-    settings.set("GITLAB.BOT_USER_INDICATORS", ["renovate", "dependabot"])
+    original_override = settings.get("CONFIG.BOT_USER_INDICATORS")
+    settings.set("CONFIG.BOT_USER_INDICATORS", ["renovate", "dependabot"])
     try:
         assert gitlab_webhook_module.is_bot_user(
             {"user": {"name": "renovate[bot]"}}
@@ -230,15 +230,15 @@ def test_gitlab_is_bot_user_honors_configured_indicators(gitlab_webhook_module):
             {"user": {"name": "codium-agent"}}
         ) is False
     finally:
-        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+        settings.set("CONFIG.BOT_USER_INDICATORS", original_override)
 
 
 def test_gitlab_is_bot_user_matches_case_insensitively(gitlab_webhook_module):
     # Operator supplies indicators with varied casing; matching must be case-insensitive
     # against the (already lowercased) sender display name.
     settings = get_settings()
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
-    settings.set("GITLAB.BOT_USER_INDICATORS", ["Renovate", "DEPENDABOT"])
+    original_override = settings.get("CONFIG.BOT_USER_INDICATORS")
+    settings.set("CONFIG.BOT_USER_INDICATORS", ["Renovate", "DEPENDABOT"])
     try:
         assert gitlab_webhook_module.is_bot_user(
             {"user": {"name": "renovate[bot]"}}
@@ -247,15 +247,15 @@ def test_gitlab_is_bot_user_matches_case_insensitively(gitlab_webhook_module):
             {"user": {"name": "dependabot"}}
         ) is True
     finally:
-        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+        settings.set("CONFIG.BOT_USER_INDICATORS", original_override)
 
 
 def test_gitlab_is_bot_user_normalizes_string_value(gitlab_webhook_module):
     # A misconfigured .pr_agent.toml that sets a bare string instead of a list must not
     # trigger per-character iteration; the value should be treated as a single indicator.
     settings = get_settings()
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
-    settings.set("GITLAB.BOT_USER_INDICATORS", "renovate")
+    original_override = settings.get("CONFIG.BOT_USER_INDICATORS")
+    settings.set("CONFIG.BOT_USER_INDICATORS", "renovate")
     try:
         assert gitlab_webhook_module.is_bot_user(
             {"user": {"name": "renovate[bot]"}}
@@ -267,14 +267,14 @@ def test_gitlab_is_bot_user_normalizes_string_value(gitlab_webhook_module):
             {"user": {"name": "Jane Developer"}}
         ) is False
     finally:
-        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+        settings.set("CONFIG.BOT_USER_INDICATORS", original_override)
 
 
 def test_gitlab_is_bot_user_skips_non_string_entries(gitlab_webhook_module):
     # Non-string entries in the list should be silently dropped, not crash detection.
     settings = get_settings()
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
-    settings.set("GITLAB.BOT_USER_INDICATORS", ["renovate", 42, None, "bot"])
+    original_override = settings.get("CONFIG.BOT_USER_INDICATORS")
+    settings.set("CONFIG.BOT_USER_INDICATORS", ["renovate", 42, None, "bot"])
     try:
         assert gitlab_webhook_module.is_bot_user(
             {"user": {"name": "renovate[bot]"}}
@@ -283,4 +283,4 @@ def test_gitlab_is_bot_user_skips_non_string_entries(gitlab_webhook_module):
             {"user": {"name": "Jane Developer"}}
         ) is False
     finally:
-        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+        settings.set("CONFIG.BOT_USER_INDICATORS", original_override)

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -191,3 +191,56 @@ def test_gitlab_handle_ask_line_converts_new_line_diff_note_to_right_side_comman
         "/ask_line --line_start=10 --line_end=12 --side=RIGHT "
         "--file_name=src/app.py --comment_id=disc-1 why this change?"
     )
+
+
+@pytest.mark.parametrize(
+    "sender_name, expected",
+    [
+        ("Codium Bot", True),
+        ("release_bot", True),
+        ("release-bot", True),
+        ("bot-release", True),
+        ("bot_release", True),
+        ("Jane Developer", False),
+        ("renovate[bot]", False),  # 'renovate' is not in the default list
+    ],
+)
+def test_gitlab_is_bot_user_uses_default_indicators(
+    gitlab_webhook_module, sender_name, expected
+):
+    settings = get_settings()
+    # Ensure no override is set: default list must apply.
+    had_override = "GITLAB.BOT_USER_INDICATORS" in settings
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS", None)
+    if had_override:
+        settings.unset("GITLAB.BOT_USER_INDICATORS", force=True)
+    try:
+        data = {"user": {"name": sender_name}}
+        assert gitlab_webhook_module.is_bot_user(data) is expected
+    finally:
+        if had_override:
+            settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+
+
+def test_gitlab_is_bot_user_honors_configured_indicators(gitlab_webhook_module):
+    settings = get_settings()
+    had_override = "GITLAB.BOT_USER_INDICATORS" in settings
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS", None)
+    settings.set("GITLAB.BOT_USER_INDICATORS", ["renovate", "dependabot"])
+    try:
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "renovate[bot]"}}
+        ) is True
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "dependabot"}}
+        ) is True
+        # A name matching the built-in default list must NOT be flagged when the
+        # override is set: configured indicators fully replace the defaults.
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "codium-agent"}}
+        ) is False
+    finally:
+        if had_override:
+            settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+        else:
+            settings.unset("GITLAB.BOT_USER_INDICATORS", force=True)

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -208,24 +208,14 @@ def test_gitlab_handle_ask_line_converts_new_line_diff_note_to_right_side_comman
 def test_gitlab_is_bot_user_uses_default_indicators(
     gitlab_webhook_module, sender_name, expected
 ):
-    settings = get_settings()
-    # Ensure no override is set: default list must apply.
-    had_override = "GITLAB.BOT_USER_INDICATORS" in settings
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS", None)
-    if had_override:
-        settings.unset("GITLAB.BOT_USER_INDICATORS", force=True)
-    try:
-        data = {"user": {"name": sender_name}}
-        assert gitlab_webhook_module.is_bot_user(data) is expected
-    finally:
-        if had_override:
-            settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+    # No override applied: fall back to the authoritative default in configuration.toml.
+    data = {"user": {"name": sender_name}}
+    assert gitlab_webhook_module.is_bot_user(data) is expected
 
 
 def test_gitlab_is_bot_user_honors_configured_indicators(gitlab_webhook_module):
     settings = get_settings()
-    had_override = "GITLAB.BOT_USER_INDICATORS" in settings
-    original_override = settings.get("GITLAB.BOT_USER_INDICATORS", None)
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
     settings.set("GITLAB.BOT_USER_INDICATORS", ["renovate", "dependabot"])
     try:
         assert gitlab_webhook_module.is_bot_user(
@@ -240,7 +230,57 @@ def test_gitlab_is_bot_user_honors_configured_indicators(gitlab_webhook_module):
             {"user": {"name": "codium-agent"}}
         ) is False
     finally:
-        if had_override:
-            settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
-        else:
-            settings.unset("GITLAB.BOT_USER_INDICATORS", force=True)
+        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+
+
+def test_gitlab_is_bot_user_matches_case_insensitively(gitlab_webhook_module):
+    # Operator supplies indicators with varied casing; matching must be case-insensitive
+    # against the (already lowercased) sender display name.
+    settings = get_settings()
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
+    settings.set("GITLAB.BOT_USER_INDICATORS", ["Renovate", "DEPENDABOT"])
+    try:
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "renovate[bot]"}}
+        ) is True
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "dependabot"}}
+        ) is True
+    finally:
+        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+
+
+def test_gitlab_is_bot_user_normalizes_string_value(gitlab_webhook_module):
+    # A misconfigured .pr_agent.toml that sets a bare string instead of a list must not
+    # trigger per-character iteration; the value should be treated as a single indicator.
+    settings = get_settings()
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
+    settings.set("GITLAB.BOT_USER_INDICATORS", "renovate")
+    try:
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "renovate[bot]"}}
+        ) is True
+        # 'r', 'e', 'n', 'o', 'v', 'a', 't', 'e' are individual chars — none of these
+        # should have matched 'Jane Developer' if the normalization treated the string
+        # as a list of characters. Guard against that regression.
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "Jane Developer"}}
+        ) is False
+    finally:
+        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)
+
+
+def test_gitlab_is_bot_user_skips_non_string_entries(gitlab_webhook_module):
+    # Non-string entries in the list should be silently dropped, not crash detection.
+    settings = get_settings()
+    original_override = settings.get("GITLAB.BOT_USER_INDICATORS")
+    settings.set("GITLAB.BOT_USER_INDICATORS", ["renovate", 42, None, "bot"])
+    try:
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "renovate[bot]"}}
+        ) is True
+        assert gitlab_webhook_module.is_bot_user(
+            {"user": {"name": "Jane Developer"}}
+        ) is False
+    finally:
+        settings.set("GITLAB.BOT_USER_INDICATORS", original_override)


### PR DESCRIPTION
## Summary
Makes the GitLab webhook's bot-detection list configurable. Today `is_bot_user` in `pr_agent/servers/gitlab_webhook.py` hardcodes the substrings used to skip GitLab bot senders:

`bot_indicators = ['codium', 'bot_', 'bot-', '_bot', '-bot']`

This means operators running self-hosted GitLab (or GitLab.com with non-standard bot naming) have no way to skip senders like `renovate`, `dependabot`, or in-house automation without forking the code.

This PR reads the list from `gitlab.bot_user_indicators` and falls back to the existing hardcoded values when unset. Default behavior is unchanged — no new members added to the default list, so nothing breaks for existing deployments.

## Change

- `pr_agent/settings/configuration.toml`: add
  `bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]`
  under `[gitlab]` as the authoritative default. Comment documents the
  case-insensitive match and the replacement semantics.
- `pr_agent/servers/gitlab_webhook.py`: read the list from
  `gitlab.bot_user_indicators` and normalize defensively — coerce
  strings to `[string]`, filter non-string entries, log-and-empty on
  non-iterable values, and lowercase all entries before matching.
- `tests/unittest/test_webhook_logic_core.py`: 11 new tests total —
  7 parametrized covering the default list, 1 covering the
  full-replacement override, and 3 new ones covering
  case-insensitivity, bare-string normalization (with an explicit
  guard against per-character iteration), and non-string entry
  filtering.

## Verification
```bash
PYTHONPATH=. pytest tests/unittest/test_webhook_logic_core.py -v
17 passed (6 pre-existing + 11 new)

PYTHONPATH=. pytest tests/unittest/test_gitlab_webhook_port.py -q
4 passed (adjacent module smoke check)
```

### Real-world usage
We've been running this exact patch in production against a self-hosted GitLab instance for some time. It has reliably suppressed renovate MR events for us via:

```toml
[gitlab]
bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot", "renovate"]
```
No regressions observed.

### Semantics — replace, not merge
The override fully replaces the default list rather than extending it. This is intentional and matches every other list-typed setting in pr-agent (gitlab.pr_commands, CONFIG.IGNORE_PR_AUTHORS, etc.), so operators only need to learn one mental model.

The trade-off: someone who just wants to add renovate has to copy the five default entries into their .pr_agent.toml. We chose this shape because it's consistent with the rest of the codebase and it's worked well for us in practice.

#### Possible follow-up (out of scope for this PR)
If maintainers prefer an additive UX, a natural follow-up would be adding a second setting — e.g. gitlab.extra_bot_user_indicators — that is unioned with the defaults, letting bot_user_indicators remain the "full replacement" override. Happy to open a follow-up PR if there's appetite; keeping this PR small and reversible for now.

### Non-goals

- No change to the default list. Anyone relying on the current five substrings continues to work with zero config.
- No changes to GitHub or Bitbucket bot detection. Both providers have their own is_bot_user functions and use different signals (GitHub has a native bot flag; Bitbucket uses different substrings). Scope kept to GitLab.
- No new dependency, no new import.