### PR TITLE
feat(config): accept max reasoning effort

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -64,6 +64,7 @@ class PRReviewHeader(str, Enum):
 
 
 class ReasoningEffort(str, Enum):
+    MAX = "max"
     XHIGH = "xhigh"
     HIGH = "high"
     MEDIUM = "medium"

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -65,6 +65,7 @@ class PRReviewHeader(str, Enum):
 
 
 class ReasoningEffort(str, Enum):
+    MAX = "max"
     XHIGH = "xhigh"
     HIGH = "high"
     MEDIUM = "medium"

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -63,7 +63,7 @@ ignore_language_framework = [] # a list of code-generation languages or framewor
 restricted_mode = false # when true, skip operations that require elevated permissions (e.g. pushing code to the repository)
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata
-reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
+reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh", "max"
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -75,7 +75,7 @@ is_auto_command = false # will be auto-set to true if the command is triggered b
 propagate_tool_errors = false # when true, a tool re-raises instead of swallowing an internal error, so a caller can tell a failed run from an empty one
 enable_ai_metadata = false # will enable adding ai metadata
 add_user_to_requests = false # send the current command and PR URL in the OpenAI-compatible "user" request field, for provider-side attribution of requests (e.g. OpenRouter "external_user")
-reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
+reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh", "max"
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -170,6 +170,30 @@ class TestLiteLLMReasoningEffort:
             mock_logger.info.assert_any_call("Using reasoning_effort='xhigh' for GPT-5 model")
 
     @pytest.mark.asyncio
+    async def test_gpt5_valid_reasoning_effort_max(self, monkeypatch, mock_logger):
+        """Test GPT-5 with valid reasoning_effort='max' from config."""
+        fake_settings = create_mock_settings("max")
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+        with patch(
+            'pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion',
+            new_callable=AsyncMock,
+        ) as mock_completion:
+            mock_completion.return_value = create_mock_acompletion_response()
+
+            handler = LiteLLMAIHandler()
+            await handler.chat_completion(
+                model="gpt-5.6",
+                system="test system",
+                user="test user"
+            )
+
+            call_kwargs = mock_completion.call_args[1]
+            assert call_kwargs["reasoning_effort"] == "max"
+            assert "reasoning_effort" in call_kwargs["allowed_openai_params"]
+            mock_logger.info.assert_any_call("Using reasoning_effort='max' for GPT-5 model")
+
+    @pytest.mark.asyncio
     async def test_gpt5_valid_reasoning_effort_minimal(self, monkeypatch, mock_logger):
         """Test GPT-5 with valid reasoning_effort='minimal' from config."""
         fake_settings = create_mock_settings("minimal")


### PR DESCRIPTION

## Summary

- add `max` to the shared `ReasoningEffort` enum
- document `max` alongside the existing selectable reasoning-effort values
- keep the default at `medium`; this patch only makes `max` selectable

The only runtime consumers use the enum for validation and diagnostic value lists; there are no exhaustive maps or positional assumptions to update. OpenAI documents `max` reasoning effort for GPT-5.6: https://developers.openai.com/api/docs/guides/latest-model

## Testing

- focused reasoning-effort tests: `33 passed`
- full unit suite: `1340 passed, 1 skipped, 1 xfailed`
- changed-file Ruff/Flake8 results introduce no violations relative to clean upstream `main`
