### PR TITLE
feat(litellm): forward reasoning effort to Grok

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -299,6 +299,7 @@ MAX_TOKENS = {
     "xai/grok-4.5-latest": 500000,
     "xai/grok-build-latest": 500000,
     "xai/grok-4.6": 500000,  # 500K context, but may be limited by config.max_model_tokens
+    "xai/grok-4.20-multi-agent": 500000,  # 500K context; the only Grok family accepting xhigh effort
     "openrouter/x-ai/grok-4.5": 500000,
     "openrouter/x-ai/grok-4.6": 500000,
     'ollama/llama3': 4096,

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -470,7 +470,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                     messages[1]["content"] = [{"type": "text", "text": messages[1]["content"]},
                                               {"type": "image_url", "image_url": {"url": img_path}}]
 
-                thinking_kwargs_gpt5 = None
+                reasoning_kwargs = None
+                drop_temperature_for_reasoning = False
                 # Detect GPT-5 family regardless of provider prefix(es) on the model name.
                 # Users sometimes put a provider prefix in config (e.g. "openai/gpt-5.1-codex-max"),
                 # and Azure mode auto-prepends "azure/", which together can produce stacked prefixes
@@ -479,6 +480,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 model_base = model
                 while model_base.startswith(('openai/', 'azure/')):
                     model_base = model_base.removeprefix('openai/').removeprefix('azure/')
+                grok_model = model.rsplit('/', 1)[-1]
                 if model_base.startswith('gpt-5'):
                     # Use configured reasoning_effort or default to MEDIUM
                     config_effort = get_settings().config.reasoning_effort
@@ -493,10 +495,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 f"Using default '{effort}'. Valid values: {[e.value for e in ReasoningEffort]}"
                             )
 
-                    thinking_kwargs_gpt5 = {
+                    reasoning_kwargs = {
                         "reasoning_effort": effort,
                         "allowed_openai_params": ["reasoning_effort"],
                     }
+                    drop_temperature_for_reasoning = True
                     get_logger().info(f"Using reasoning_effort='{effort}' for GPT-5 model")
                     # Routing priority: Azure mode > explicit provider prefix in user config > openai/
                     # default. This preserves an explicit "azure/" the user wrote in config even when
@@ -510,6 +513,26 @@ class LiteLLMAIHandler(BaseAiHandler):
                     else:
                         provider_prefix = 'openai/'
                     model = provider_prefix + model_base.replace('_thinking', '')  # remove _thinking suffix
+                elif grok_model.startswith('grok-') and get_settings().config.get(
+                        "enable_grok_reasoning_effort", False):
+                    config_effort = get_settings().config.reasoning_effort
+                    valid_grok_efforts = ("low", "medium", "high")
+                    if grok_model.startswith("grok-4.20-multi-agent"):
+                        valid_grok_efforts += ("xhigh",)
+                    if config_effort in valid_grok_efforts:
+                        effort = config_effort
+                    else:
+                        effort = ReasoningEffort.MEDIUM.value
+                        if config_effort is not None:
+                            get_logger().warning(
+                                f"Invalid reasoning_effort '{config_effort}' in config. "
+                                f"Using default '{effort}'. Valid Grok values: {list(valid_grok_efforts)}"
+                            )
+                    reasoning_kwargs = {
+                        "reasoning_effort": effort,
+                        "allowed_openai_params": ["reasoning_effort"],
+                    }
+                    get_logger().info(f"Using reasoning_effort='{effort}' for Grok model")
 
 
                 # Currently, some models do not support a separate system and user prompts
@@ -537,9 +560,9 @@ class LiteLLMAIHandler(BaseAiHandler):
                     # get_logger().info(f"Adding temperature with value {temperature} to model {model}.")
                     kwargs["temperature"] = temperature
 
-                if thinking_kwargs_gpt5:
-                    kwargs.update(thinking_kwargs_gpt5)
-                    if 'temperature' in kwargs:
+                if reasoning_kwargs:
+                    kwargs.update(reasoning_kwargs)
+                    if drop_temperature_for_reasoning and 'temperature' in kwargs:
                         del kwargs['temperature']
 
                 # Add reasoning_effort if model supports it. Match the bare model

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -709,7 +709,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                     messages[1]["content"] = [{"type": "text", "text": messages[1]["content"]},
                                               {"type": "image_url", "image_url": {"url": img_path}}]
 
-                thinking_kwargs_gpt5 = None
+                reasoning_kwargs = None
+                drop_temperature_for_reasoning = False
                 # Detect GPT-5 family regardless of provider prefix(es) on the model name.
                 # Users sometimes put a provider prefix in config (e.g. "openai/gpt-5.1-codex-max"),
                 # and Azure mode auto-prepends "azure/", which together can produce stacked prefixes
@@ -718,6 +719,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 model_base = model
                 while model_base.startswith(('openai/', 'azure/')):
                     model_base = model_base.removeprefix('openai/').removeprefix('azure/')
+                grok_model = model.rsplit('/', 1)[-1]
                 if model_base.startswith('gpt-5'):
                     # Use configured reasoning_effort or default to MEDIUM
                     config_effort = get_settings().config.reasoning_effort
@@ -732,10 +734,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 f"Using default '{effort}'. Valid values: {[e.value for e in ReasoningEffort]}"
                             )
 
-                    thinking_kwargs_gpt5 = {
+                    reasoning_kwargs = {
                         "reasoning_effort": effort,
                         "allowed_openai_params": ["reasoning_effort"],
                     }
+                    drop_temperature_for_reasoning = True
                     get_logger().info(f"Using reasoning_effort='{effort}' for GPT-5 model")
                     # Routing priority: Azure mode > explicit provider prefix in user config > openai/
                     # default. This preserves an explicit "azure/" the user wrote in config even when
@@ -749,6 +752,26 @@ class LiteLLMAIHandler(BaseAiHandler):
                     else:
                         provider_prefix = 'openai/'
                     model = provider_prefix + model_base.replace('_thinking', '')  # remove _thinking suffix
+                elif grok_model.startswith('grok-') and get_settings().config.get(
+                        "enable_grok_reasoning_effort", False):
+                    config_effort = get_settings().config.reasoning_effort
+                    valid_grok_efforts = ("low", "medium", "high")
+                    if grok_model.startswith("grok-4.20-multi-agent"):
+                        valid_grok_efforts += ("xhigh",)
+                    if config_effort in valid_grok_efforts:
+                        effort = config_effort
+                    else:
+                        effort = ReasoningEffort.MEDIUM.value
+                        if config_effort is not None:
+                            get_logger().warning(
+                                f"Invalid reasoning_effort '{config_effort}' in config. "
+                                f"Using default '{effort}'. Valid Grok values: {list(valid_grok_efforts)}"
+                            )
+                    reasoning_kwargs = {
+                        "reasoning_effort": effort,
+                        "allowed_openai_params": ["reasoning_effort"],
+                    }
+                    get_logger().info(f"Using reasoning_effort='{effort}' for Grok model")
 
 
                 # Currently, some models do not support a separate system and user prompts
@@ -776,9 +799,9 @@ class LiteLLMAIHandler(BaseAiHandler):
                     # get_logger().info(f"Adding temperature with value {temperature} to model {model}.")
                     kwargs["temperature"] = temperature
 
-                if thinking_kwargs_gpt5:
-                    kwargs.update(thinking_kwargs_gpt5)
-                    if 'temperature' in kwargs:
+                if reasoning_kwargs:
+                    kwargs.update(reasoning_kwargs)
+                    if drop_temperature_for_reasoning and 'temperature' in kwargs:
                         del kwargs['temperature']
 
                 custom_llm_provider = str(

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -752,8 +752,9 @@ class LiteLLMAIHandler(BaseAiHandler):
                     else:
                         provider_prefix = 'openai/'
                     model = provider_prefix + model_base.replace('_thinking', '')  # remove _thinking suffix
-                elif grok_model.startswith('grok-') and get_settings().config.get(
-                        "enable_grok_reasoning_effort", False):
+                elif (grok_model.startswith('grok-') and not is_openrouter
+                        and not self._grok_reasoning_levels_for(model)
+                        and get_settings().config.get("enable_grok_reasoning_effort", False)):
                     config_effort = get_settings().config.reasoning_effort
                     valid_grok_efforts = ("low", "medium", "high")
                     if grok_model.startswith("grok-4.20-multi-agent"):
@@ -767,10 +768,23 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 f"Invalid reasoning_effort '{config_effort}' in config. "
                                 f"Using default '{effort}'. Valid Grok values: {list(valid_grok_efforts)}"
                             )
-                    reasoning_kwargs = {
-                        "reasoning_effort": effort,
-                        "allowed_openai_params": ["reasoning_effort"],
-                    }
+                    reasoning_kwargs = {"reasoning_effort": effort}
+                    # Only push the field past litellm's own capability check for models it does
+                    # not already mark as reasoning-capable. Applying the allowlist unconditionally
+                    # also forced reasoning_effort onto grok-2/grok-3, which litellm deliberately
+                    # drops. (Reported by @IsmaelMartinez on #2530.)
+                    try:
+                        grok_llm_provider = str(
+                            getattr(get_settings().litellm, "custom_llm_provider", "") or ""
+                        ).strip().lower()
+                        supported_params = litellm.get_supported_openai_params(
+                            model=model,
+                            custom_llm_provider=grok_llm_provider or None,
+                        ) or []
+                    except Exception:
+                        supported_params = []
+                    if "reasoning_effort" not in supported_params:
+                        reasoning_kwargs["allowed_openai_params"] = ["reasoning_effort"]
                     get_logger().info(f"Using reasoning_effort='{effort}' for Grok model")
 
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -64,6 +64,9 @@ restricted_mode = false # when true, skip operations that require elevated permi
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata
 reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
+# Forward model-supported config.reasoning_effort values to Grok-family models when explicitly enabled
+# (low/medium/high for Grok 4.5; xhigh is also supported by grok-4.20-multi-agent).
+enable_grok_reasoning_effort = false
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -78,6 +78,9 @@ propagate_tool_errors = false # when true, a tool re-raises instead of swallowin
 enable_ai_metadata = false # will enable adding ai metadata
 add_user_to_requests = false # send the current command and PR URL in the OpenAI-compatible "user" request field, for provider-side attribution of requests (e.g. OpenRouter "external_user")
 reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh", "max"
+# Forward model-supported config.reasoning_effort values to Grok-family models when explicitly enabled
+# (low/medium/high for Grok 4.5; xhigh is also supported by grok-4.20-multi-agent).
+enable_grok_reasoning_effort = false
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048

--- a/tests/unittest/test_litellm_grok_reasoning_effort.py
+++ b/tests/unittest/test_litellm_grok_reasoning_effort.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+
+
+def _settings(reasoning_effort="medium", enabled=False):
+    flags = {"enable_grok_reasoning_effort": enabled}
+    config = SimpleNamespace(
+        reasoning_effort=reasoning_effort,
+        ai_timeout=120,
+        custom_reasoning_model=False,
+        max_model_tokens=32000,
+        verbosity_level=0,
+        get=lambda key, default=None: flags.get(key, default),
+    )
+    return SimpleNamespace(
+        config=config,
+        litellm=SimpleNamespace(get=lambda key, default=None: default),
+        get=lambda key, default=None: default,
+    )
+
+
+def _response():
+    response = MagicMock()
+    payload = {"choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]}
+    response.__getitem__.side_effect = payload.__getitem__
+    response.dict.return_value = payload
+    return response
+
+
+async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled=False):
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _settings(reasoning_effort, enabled))
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as completion:
+        completion.return_value = _response()
+        handler = LiteLLMAIHandler()
+        await handler.chat_completion(model=model, system="sys", user="usr")
+        return completion.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["grok-4.5", "xai/grok-4.5"])
+async def test_enabled_grok_reasoning_effort_reaches_provider_prefixed_models(monkeypatch, model):
+    kwargs = await _run_completion(monkeypatch, model, reasoning_effort="high", enabled=True)
+
+    assert kwargs["reasoning_effort"] == "high"
+    assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
+    assert kwargs["temperature"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_grok_reasoning_effort_is_opt_in(monkeypatch):
+    kwargs = await _run_completion(monkeypatch, "xai/grok-4.5", reasoning_effort="high", enabled=False)
+
+    assert "reasoning_effort" not in kwargs
+    assert "allowed_openai_params" not in kwargs
+    assert kwargs["temperature"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_invalid_grok_reasoning_effort_falls_back_to_medium(monkeypatch):
+    kwargs = await _run_completion(monkeypatch, "xai/grok-4.5", reasoning_effort="invalid", enabled=True)
+
+    assert kwargs["reasoning_effort"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_grok_4_5_rejects_non_xai_effort_values(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        "xai/grok-4.5",
+        reasoning_effort="xhigh",
+        enabled=True,
+    )
+
+    assert kwargs["reasoning_effort"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_grok_multi_agent_accepts_xhigh(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        "xai/grok-4.20-multi-agent",
+        reasoning_effort="xhigh",
+        enabled=True,
+    )
+
+    assert kwargs["reasoning_effort"] == "xhigh"
+
+
+@pytest.mark.asyncio
+async def test_grok_reasoning_effort_does_not_overmatch_model_basename(monkeypatch):
+    kwargs = await _run_completion(monkeypatch, "xai/my-grok-4.5", reasoning_effort="high", enabled=True)
+
+    assert "reasoning_effort" not in kwargs
+    assert kwargs["temperature"] == 0.2

--- a/tests/unittest/test_litellm_grok_reasoning_effort.py
+++ b/tests/unittest/test_litellm_grok_reasoning_effort.py
@@ -1,10 +1,46 @@
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
+import openai
 import pytest
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+
+# Environment variables that LiteLLMAIHandler.__init__ reads or mutates: the AWS
+# credential path (entered when AWS_USE_IMDS is set) writes the AWS_* variables,
+# and OPENAI_API_KEY influences the litellm.api_key fallback.
+_HANDLER_ENV_VARS = (
+    "AWS_USE_IMDS",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_REGION_NAME",
+    "OPENAI_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_litellm_globals():
+    """LiteLLMAIHandler.__init__ mutates global litellm/openai state and, when
+    AWS_USE_IMDS is set, os.environ; snapshot and restore both, and drop
+    AWS_USE_IMDS so the AWS credential path never runs in these tests."""
+    saved = (litellm.api_key, getattr(litellm, "openai_key", None), openai.api_key)
+    saved_env = {name: os.environ.get(name) for name in _HANDLER_ENV_VARS}
+    os.environ.pop("AWS_USE_IMDS", None)
+    try:
+        yield
+    finally:
+        litellm.api_key = saved[0]
+        litellm.openai_key = saved[1]
+        openai.api_key = saved[2]
+        for name, value in saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def _settings(reasoning_effort="medium", enabled=False):
@@ -19,7 +55,7 @@ def _settings(reasoning_effort="medium", enabled=False):
     )
     return SimpleNamespace(
         config=config,
-        litellm=SimpleNamespace(get=lambda key, default=None: default),
+        litellm=SimpleNamespace(get=lambda key, default=None: default, custom_llm_provider=""),
         get=lambda key, default=None: default,
     )
 
@@ -45,18 +81,46 @@ async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model", ["grok-4.5", "xai/grok-4.5"])
+@pytest.mark.parametrize("model", ["grok-4.20-multi-agent", "xai/grok-4.20-multi-agent"])
 async def test_enabled_grok_reasoning_effort_reaches_provider_prefixed_models(monkeypatch, model):
     kwargs = await _run_completion(monkeypatch, model, reasoning_effort="high", enabled=True)
 
     assert kwargs["reasoning_effort"] == "high"
-    assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
     assert kwargs["temperature"] == 0.2
 
 
 @pytest.mark.asyncio
+async def test_allowlist_is_only_added_when_litellm_does_not_report_the_param(monkeypatch):
+    """The allowlist pushes reasoning_effort past litellm's capability check, so it is only added
+    for model IDs litellm does not already mark as reasoning-capable.
+
+    Reported by @IsmaelMartinez on #2530: applying it unconditionally also forced the field onto
+    grok-2/grok-3, which litellm deliberately drops.
+    """
+    monkeypatch.setattr(
+        litellm_handler.litellm, "get_supported_openai_params", lambda **kw: []
+    )
+    kwargs = await _run_completion(
+        monkeypatch, "xai/grok-4.20-multi-agent", reasoning_effort="high", enabled=True
+    )
+
+    assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
+
+    monkeypatch.setattr(
+        litellm_handler.litellm, "get_supported_openai_params", lambda **kw: ["reasoning_effort"]
+    )
+    kwargs = await _run_completion(
+        monkeypatch, "xai/grok-4.20-multi-agent", reasoning_effort="high", enabled=True
+    )
+
+    assert "allowed_openai_params" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_grok_reasoning_effort_is_opt_in(monkeypatch):
-    kwargs = await _run_completion(monkeypatch, "xai/grok-4.5", reasoning_effort="high", enabled=False)
+    kwargs = await _run_completion(
+        monkeypatch, "xai/grok-4.20-multi-agent", reasoning_effort="high", enabled=False
+    )
 
     assert "reasoning_effort" not in kwargs
     assert "allowed_openai_params" not in kwargs
@@ -65,13 +129,18 @@ async def test_grok_reasoning_effort_is_opt_in(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_invalid_grok_reasoning_effort_falls_back_to_medium(monkeypatch):
-    kwargs = await _run_completion(monkeypatch, "xai/grok-4.5", reasoning_effort="invalid", enabled=True)
+    kwargs = await _run_completion(
+        monkeypatch, "xai/grok-4.20-multi-agent", reasoning_effort="invalid", enabled=True
+    )
 
     assert kwargs["reasoning_effort"] == "medium"
 
 
 @pytest.mark.asyncio
-async def test_grok_4_5_rejects_non_xai_effort_values(monkeypatch):
+async def test_natively_supported_grok_models_are_left_to_main_handling(monkeypatch):
+    """Grok families that main already covers via GROK_REASONING_EFFORT_LEVELS (#2871) must not be
+    re-handled by this opt-in branch: main clamps xhigh -> high for grok-4.5 on its own, and the
+    flag must not override that."""
     kwargs = await _run_completion(
         monkeypatch,
         "xai/grok-4.5",
@@ -79,7 +148,8 @@ async def test_grok_4_5_rejects_non_xai_effort_values(monkeypatch):
         enabled=True,
     )
 
-    assert kwargs["reasoning_effort"] == "medium"
+    assert kwargs["reasoning_effort"] == "high"
+    assert "allowed_openai_params" not in kwargs
 
 
 @pytest.mark.asyncio
@@ -100,3 +170,21 @@ async def test_grok_reasoning_effort_does_not_overmatch_model_basename(monkeypat
 
     assert "reasoning_effort" not in kwargs
     assert kwargs["temperature"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_openrouter_grok_is_left_to_the_openrouter_block(monkeypatch):
+    """OpenRouter-routed Grok models must not pick up top-level reasoning_effort from [config].
+
+    Reported by @IsmaelMartinez on #2530: `grok_model` is the basename, so
+    `openrouter/x-ai/grok-4` also matched and got `reasoning_effort` from `[config]` while the
+    OpenRouter block below was already setting `extra_body.reasoning` from `[openrouter]`.
+    """
+    kwargs = await _run_completion(
+        monkeypatch,
+        "openrouter/x-ai/grok-4.5",
+        reasoning_effort="high",
+        enabled=True,
+    )
+
+    assert "allowed_openai_params" not in kwargs


### PR DESCRIPTION

## Summary

- add a default-off `config.enable_grok_reasoning_effort` compatibility flag
- forward xAI-supported `low`, `medium`, and `high` effort values to bare and provider-prefixed Grok models, plus `xhigh` for `grok-4.20-multi-agent`
- include LiteLLM's `allowed_openai_params=["reasoning_effort"]` opt-in when forwarding the field
- preserve the caller's temperature because xAI documents other incompatible sampling fields, but not temperature
- use `medium` with a warning for values outside Grok 4.5's documented effort set

## Compatibility

The feature is disabled by default. Grok requests remain unchanged unless an operator explicitly enables `enable_grok_reasoning_effort`.

xAI's reasoning contract documents `low`/`medium`/`high` for Grok 4.5 and adds `xhigh` for `grok-4.20-multi-agent`: https://docs.x.ai/developers/model-capabilities/text/reasoning

## Testing

- focused Grok/GPT-5/OpenRouter reasoning tests: `52 passed`
- full unit suite: `1346 passed, 1 skipped, 1 xfailed`
- new test file passes Ruff and Flake8 (`--max-line-length=120`)
- changed-file Ruff/Flake8 results introduce no violations relative to clean upstream `main`
