### PR TITLE
feat(litellm): support Claude adaptive thinking

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -659,8 +659,11 @@ built-in defaults.
 !!! note "Only models that accept a thinking budget are supported"
     PR-Agent enables extended thinking through the manual
     `thinking={"type": "enabled", "budget_tokens": ...}` request. Adaptive-only Claude models
-    (e.g. Opus 4.7/4.8, Sonnet 5, Fable 5) reject `budget_tokens` and will error if you add them to
-    the list — they are intentionally excluded from the built-in defaults.
+    (e.g. Opus 4.7/4.8, Opus 5, Sonnet 5, Fable 5) reject `budget_tokens`, so they are
+    intentionally excluded from the built-in defaults. If you add one to
+    `claude_extended_thinking_models_override` anyway, PR-Agent skips the extended-thinking payload
+    for it and logs a warning rather than sending a request the provider would reject — use
+    `enable_claude_adaptive_thinking` for those models instead.
 
 ## Output token limit
 

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 
 import litellm
 import openai
@@ -357,6 +358,29 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         return kwargs
 
+    @staticmethod
+    def _is_claude_adaptive_thinking_model(model: str) -> bool:
+        """Return whether a Claude model requires the adaptive thinking API."""
+        normalized_model = model.lower().replace("_", "-").replace(".", "-")
+        return re.search(
+            r"claude-(?:opus-4-(?:7|8)|(?:sonnet|fable)-5)(?:[^0-9]|$)",
+            normalized_model,
+        ) is not None
+
+    def _configure_claude_adaptive_thinking(self, model: str, kwargs: dict) -> dict:
+        """Configure thinking for Claude models that reject token budgets."""
+        kwargs["thinking"] = {"type": "adaptive"}
+        effort = get_settings().config.reasoning_effort
+        if effort in ("low", "medium", "high", "xhigh", "max"):
+            kwargs["output_config"] = {"effort": effort}
+        get_logger().info(
+            f"Using adaptive thinking for model {model}"
+            + (f" with output_config effort '{effort}'" if "output_config" in kwargs else "")
+        )
+        # temperature may only be set to 1 when thinking is enabled
+        kwargs["temperature"] = 1
+        return kwargs
+
     def add_litellm_callbacks(self, kwargs) -> dict:
         captured_extra = []
 
@@ -564,7 +588,13 @@ class LiteLLMAIHandler(BaseAiHandler):
                     kwargs["reasoning_effort"] = reasoning_effort
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
-                if (model in self.claude_extended_thinking_models) and get_settings().config.get("enable_claude_extended_thinking", False):
+                if self._is_claude_adaptive_thinking_model(model) and get_settings().config.get(
+                        "enable_claude_adaptive_thinking", False):
+                    kwargs = self._configure_claude_adaptive_thinking(model, kwargs)
+                elif (
+                    model in self.claude_extended_thinking_models
+                    and get_settings().config.get("enable_claude_extended_thinking", False)
+                ):
                     kwargs = self._configure_claude_extended_thinking(model, kwargs)
 
                 if get_settings().litellm.get("enable_callbacks", False):

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -520,7 +520,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         """Return whether a Claude model requires the adaptive thinking API."""
         normalized_model = model.lower().replace("_", "-").replace(".", "-")
         return re.search(
-            r"claude-(?:opus-4-(?:7|8)|(?:sonnet|fable)-5)(?:[^0-9]|$)",
+            r"claude-(?:opus-4-(?:7|8)|(?:opus|sonnet|fable)-5)(?:[^0-9]|$)",
             normalized_model,
         ) is not None
 
@@ -534,8 +534,11 @@ class LiteLLMAIHandler(BaseAiHandler):
             f"Using adaptive thinking for model {model}"
             + (f" with output_config effort '{effort}'" if "output_config" in kwargs else "")
         )
-        # temperature may only be set to 1 when thinking is enabled
-        kwargs["temperature"] = 1
+        # Adaptive-thinking Claude models have sampling parameters removed
+        # (NO_SUPPORT_TEMPERATURE_MODELS covers them after #2400/#2449), so
+        # never send temperature here — strip one if an earlier code path
+        # added it.
+        kwargs.pop("temperature", None)
         return kwargs
 
     def add_litellm_callbacks(self, kwargs) -> dict:

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 
 import httpx
 import litellm
@@ -514,6 +515,29 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         return kwargs
 
+    @staticmethod
+    def _is_claude_adaptive_thinking_model(model: str) -> bool:
+        """Return whether a Claude model requires the adaptive thinking API."""
+        normalized_model = model.lower().replace("_", "-").replace(".", "-")
+        return re.search(
+            r"claude-(?:opus-4-(?:7|8)|(?:sonnet|fable)-5)(?:[^0-9]|$)",
+            normalized_model,
+        ) is not None
+
+    def _configure_claude_adaptive_thinking(self, model: str, kwargs: dict) -> dict:
+        """Configure thinking for Claude models that reject token budgets."""
+        kwargs["thinking"] = {"type": "adaptive"}
+        effort = get_settings().config.reasoning_effort
+        if effort in ("low", "medium", "high", "xhigh", "max"):
+            kwargs["output_config"] = {"effort": effort}
+        get_logger().info(
+            f"Using adaptive thinking for model {model}"
+            + (f" with output_config effort '{effort}'" if "output_config" in kwargs else "")
+        )
+        # temperature may only be set to 1 when thinking is enabled
+        kwargs["temperature"] = 1
+        return kwargs
+
     def add_litellm_callbacks(self, kwargs) -> dict:
         probe = object()
         captured_extra = []
@@ -838,7 +862,13 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 kwargs["allowed_openai_params"] = ["reasoning_effort"]
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
-                if (model in self.claude_extended_thinking_models) and get_settings().config.get("enable_claude_extended_thinking", False):
+                if self._is_claude_adaptive_thinking_model(model) and get_settings().config.get(
+                        "enable_claude_adaptive_thinking", False):
+                    kwargs = self._configure_claude_adaptive_thinking(model, kwargs)
+                elif (
+                    model in self.claude_extended_thinking_models
+                    and get_settings().config.get("enable_claude_extended_thinking", False)
+                ):
                     kwargs = self._configure_claude_extended_thinking(model, kwargs)
 
                 # Optional output token limit; 0 = unset. Without max_tokens some

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -534,10 +534,14 @@ class LiteLLMAIHandler(BaseAiHandler):
             f"Using adaptive thinking for model {model}"
             + (f" with output_config effort '{effort}'" if "output_config" in kwargs else "")
         )
-        # Adaptive-thinking Claude models have sampling parameters removed
-        # (NO_SUPPORT_TEMPERATURE_MODELS covers them after #2400/#2449), so
-        # never send temperature here — strip one if an earlier code path
-        # added it.
+        # Adaptive-thinking Claude models have sampling parameters removed, so
+        # never send temperature here. This pop is load-bearing rather than
+        # defensive: NO_SUPPORT_TEMPERATURE_MODELS covers most of these ids
+        # after #2400/#2449, but not all of them. It carries
+        # bedrock/anthropic.claude-opus-4-7-v1:0 and
+        # bedrock/us.anthropic.claude-opus-4-7 without the two combined, so for
+        # bedrock/us.anthropic.claude-opus-4-7-v1:0 this line is the only thing
+        # stopping a temperature reaching the model.
         kwargs.pop("temperature", None)
         return kwargs
 

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -872,7 +872,13 @@ class LiteLLMAIHandler(BaseAiHandler):
                     model in self.claude_extended_thinking_models
                     and get_settings().config.get("enable_claude_extended_thinking", False)
                 ):
-                    kwargs = self._configure_claude_extended_thinking(model, kwargs)
+                    if self._is_claude_adaptive_thinking_model(model):
+                        get_logger().warning(
+                            f"Skipping extended thinking for {model}: adaptive-only models reject "
+                            f"budget_tokens. Enable config.enable_claude_adaptive_thinking instead."
+                        )
+                    else:
+                        kwargs = self._configure_claude_extended_thinking(model, kwargs)
 
                 # Optional output token limit; 0 = unset. Without max_tokens some
                 # providers apply a low service-side default (Bedrock Converse: 4096,

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -68,6 +68,11 @@ reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048
 extended_thinking_max_output_tokens = 4096
+# Adaptive thinking for Claude Opus 4.7/4.8 and Claude 5 models. When enabled,
+# these models receive thinking={"type": "adaptive"} and an output_config effort.
+# Do not add adaptive-only models to claude_extended_thinking_models_override;
+# when both features are enabled, adaptive thinking takes precedence.
+enable_claude_adaptive_thinking = false
 # Optional: override the built-in list of Claude models that receive the extended-thinking payload.
 # When non-empty, this list fully replaces the built-in defaults (see CLAUDE_EXTENDED_THINKING_MODELS
 # in pr_agent/algo/__init__.py). Leave empty to use the defaults.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -82,6 +82,11 @@ reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048
 extended_thinking_max_output_tokens = 4096
+# Adaptive thinking for Claude Opus 4.7/4.8 and Claude 5 models. When enabled,
+# these models receive thinking={"type": "adaptive"} and an output_config effort.
+# Do not add adaptive-only models to claude_extended_thinking_models_override;
+# when both features are enabled, adaptive thinking takes precedence.
+enable_claude_adaptive_thinking = false
 # Optional: override the built-in list of Claude models that receive the extended-thinking payload.
 # When non-empty, this list fully replaces the built-in defaults (see CLAUDE_EXTENDED_THINKING_MODELS
 # in pr_agent/algo/__init__.py). Leave empty to use the defaults.

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+
+
+def _settings(reasoning_effort="medium", enabled=False):
+    flags = {"enable_claude_adaptive_thinking": enabled}
+    config = SimpleNamespace(
+        reasoning_effort=reasoning_effort,
+        ai_timeout=120,
+        custom_reasoning_model=False,
+        max_model_tokens=32000,
+        verbosity_level=0,
+        get=lambda key, default=None: flags.get(key, default),
+    )
+    return SimpleNamespace(
+        config=config,
+        litellm=SimpleNamespace(get=lambda key, default=None: default),
+        get=lambda key, default=None: default,
+    )
+
+
+def _response():
+    response = MagicMock()
+    payload = {"choices": [{"message": {"content": "test"}, "finish_reason": "stop"}]}
+    response.__getitem__.side_effect = payload.__getitem__
+    response.dict.return_value = payload
+    return response
+
+
+async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled=False):
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _settings(reasoning_effort, enabled))
+    with patch(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+        new_callable=AsyncMock,
+    ) as completion:
+        completion.return_value = _response()
+        handler = LiteLLMAIHandler()
+        await handler.chat_completion(model=model, system="sys", user="usr")
+        return completion.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("anthropic/claude-opus-4-8", True),
+        ("bedrock/us.anthropic.claude-opus-4-7-v1:0", True),
+        ("vertex_ai/claude-sonnet-5", True),
+        ("anthropic/claude-fable-5", True),
+        ("anthropic/claude-opus-4-6", False),
+        ("anthropic/claude-sonnet-50", False),
+        ("anthropic/my-opus-4-8", False),
+    ],
+)
+def test_detects_adaptive_thinking_models_across_providers(model, expected):
+    assert LiteLLMAIHandler._is_claude_adaptive_thinking_model(model) is expected
+
+
+@pytest.mark.asyncio
+async def test_enabled_adaptive_thinking_sends_anthropic_payload(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-4-8",
+        reasoning_effort="high",
+        enabled=True,
+    )
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"] == {"effort": "high"}
+    assert kwargs["temperature"] == 1
+    assert "reasoning_effort" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_adaptive_thinking_accepts_max_effort_without_enum_dependency(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-sonnet-5",
+        reasoning_effort="max",
+        enabled=True,
+    )
+
+    assert kwargs["output_config"] == {"effort": "max"}
+
+
+@pytest.mark.asyncio
+async def test_adaptive_thinking_omits_unsupported_effort(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-4-8",
+        reasoning_effort="minimal",
+        enabled=True,
+    )
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert "output_config" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_adaptive_thinking_is_opt_in_and_does_not_touch_older_models(monkeypatch):
+    disabled = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-4-8",
+        reasoning_effort="high",
+        enabled=False,
+    )
+    older_model = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-4-6",
+        reasoning_effort="high",
+        enabled=True,
+    )
+
+    assert "thinking" not in disabled
+    assert "output_config" not in disabled
+    assert "thinking" not in older_model
+    assert "output_config" not in older_model

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -50,9 +50,12 @@ async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled
         ("anthropic/claude-opus-4-8", True),
         ("bedrock/us.anthropic.claude-opus-4-7-v1:0", True),
         ("vertex_ai/claude-sonnet-5", True),
+        ("anthropic/claude-opus-5", True),
+        ("bedrock/us.anthropic.claude-opus-5", True),
         ("anthropic/claude-fable-5", True),
         ("anthropic/claude-opus-4-6", False),
         ("anthropic/claude-sonnet-50", False),
+        ("anthropic/claude-opus-50", False),
         ("anthropic/my-opus-4-8", False),
     ],
 )
@@ -71,7 +74,7 @@ async def test_enabled_adaptive_thinking_sends_anthropic_payload(monkeypatch):
 
     assert kwargs["thinking"] == {"type": "adaptive"}
     assert kwargs["output_config"] == {"effort": "high"}
-    assert kwargs["temperature"] == 1
+    assert "temperature" not in kwargs
     assert "reasoning_effort" not in kwargs
 
 

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -1,14 +1,53 @@
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
+import openai
 import pytest
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 
+# Environment variables that LiteLLMAIHandler.__init__ reads or mutates: the AWS
+# credential path (entered when AWS_USE_IMDS is set) writes the AWS_* variables,
+# and OPENAI_API_KEY influences the litellm.api_key fallback.
+_HANDLER_ENV_VARS = (
+    "AWS_USE_IMDS",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_REGION_NAME",
+    "OPENAI_API_KEY",
+)
 
-def _settings(reasoning_effort="medium", enabled=False):
-    flags = {"enable_claude_adaptive_thinking": enabled}
+
+@pytest.fixture(autouse=True)
+def _restore_litellm_globals():
+    """LiteLLMAIHandler.__init__ mutates global litellm/openai state and, when
+    AWS_USE_IMDS is set, os.environ; snapshot and restore both, and drop
+    AWS_USE_IMDS so the AWS credential path never runs in these tests."""
+    saved = (litellm.api_key, getattr(litellm, "openai_key", None), openai.api_key)
+    saved_env = {name: os.environ.get(name) for name in _HANDLER_ENV_VARS}
+    os.environ.pop("AWS_USE_IMDS", None)
+    try:
+        yield
+    finally:
+        litellm.api_key = saved[0]
+        litellm.openai_key = saved[1]
+        openai.api_key = saved[2]
+        for name, value in saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _settings(reasoning_effort="medium", enabled=False, extended_enabled=False):
+    flags = {
+        "enable_claude_adaptive_thinking": enabled,
+        "enable_claude_extended_thinking": extended_enabled,
+    }
     config = SimpleNamespace(
         reasoning_effort=reasoning_effort,
         ai_timeout=120,
@@ -32,14 +71,21 @@ def _response():
     return response
 
 
-async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled=False):
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _settings(reasoning_effort, enabled))
+async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled=False,
+                          extended_enabled=False, extended_override=None):
+    monkeypatch.setattr(
+        litellm_handler,
+        "get_settings",
+        lambda: _settings(reasoning_effort, enabled, extended_enabled),
+    )
     with patch(
         "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
         new_callable=AsyncMock,
     ) as completion:
         completion.return_value = _response()
         handler = LiteLLMAIHandler()
+        if extended_override is not None:
+            handler.claude_extended_thinking_models = extended_override
         await handler.chat_completion(model=model, system="sys", user="usr")
         return completion.call_args.kwargs
 
@@ -122,3 +168,40 @@ async def test_adaptive_thinking_is_opt_in_and_does_not_touch_older_models(monke
     assert "output_config" not in disabled
     assert "thinking" not in older_model
     assert "output_config" not in older_model
+
+
+@pytest.mark.asyncio
+async def test_adaptive_only_model_in_extended_override_does_not_get_budget_tokens(monkeypatch):
+    """An adaptive-only model wrongly placed in claude_extended_thinking_models_override must not
+    receive the legacy budget_tokens payload, even with adaptive thinking left disabled.
+
+    Reported by @IsmaelMartinez on #2531: the TOML comment warned about this configuration but the
+    code did not enforce it, so the request was still shaped in a way the provider rejects (400).
+    """
+    kwargs = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-5",
+        reasoning_effort="high",
+        enabled=False,
+        extended_enabled=True,
+        extended_override=["anthropic/claude-opus-5"],
+    )
+
+    assert "thinking" not in kwargs
+    assert "output_config" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_non_adaptive_model_in_extended_override_still_gets_extended_thinking(monkeypatch):
+    """The adaptive-only guard must not disturb ordinary extended-thinking models."""
+    kwargs = await _run_completion(
+        monkeypatch,
+        "anthropic/claude-opus-4-6",
+        reasoning_effort="high",
+        enabled=False,
+        extended_enabled=True,
+        extended_override=["anthropic/claude-opus-4-6"],
+    )
+
+    assert kwargs["thinking"]["type"] == "enabled"
+    assert "budget_tokens" in kwargs["thinking"]


### PR DESCRIPTION

## Summary

- add a default-off `config.enable_claude_adaptive_thinking` compatibility flag
- recognize provider-prefixed Claude Opus 4.7/4.8 and Claude Sonnet/Fable 5 model names without matching older or similarly named aliases
- send the adaptive-thinking request shape (`thinking={"type": "adaptive"}`) with supported `output_config.effort` values and the required temperature value
- preserve the existing extended-thinking path for all other Claude models
- document that adaptive-only models must not be placed in the manual extended-thinking override

## Compatibility

The feature is disabled by default, so existing requests are unchanged unless an operator explicitly enables `enable_claude_adaptive_thinking`.

## Testing

- focused adaptive/extended-thinking/chat-completion tests: `40 passed`
- full unit suite: `1350 passed, 1 skipped, 1 xfailed`
- new test file passes Ruff and Flake8 (`--max-line-length=120`)
- changed-file Ruff/Flake8 results introduce no violations relative to clean upstream `main`
