### PR TITLE
feat(cli): add structured JSON output for local reviews

### DIFF
--- a/docs/docs/usage-guide/plain_diff_mode.md
+++ b/docs/docs/usage-guide/plain_diff_mode.md
@@ -27,6 +27,7 @@ python -m pr_agent.cli --diff-file changes.diff --output review.md review
 | `--stdin` | Read a unified diff from stdin |
 | `--diff-file <path>` | Read a unified diff from a file |
 | `--output <path>` | Write the result to a file in addition to stdout |
+| `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` command) |
 
 `--stdin` and `--diff-file` are mutually exclusive. At least one must be provided to
 enter plain-diff mode; omitting both falls back to the normal `--pr_url` flow.
@@ -54,7 +55,9 @@ suggestions. Commands that require live platform interaction (such as
    for that file. The review still runs; it simply has less context.
 
 4. **Output** — the result is written to stdout. If `--output <path>` is given, it is
-   also written to that file (UTF-8, overwritten on each run).
+   also written to that file (UTF-8, overwritten on each run). For `review`, if
+   `--json-output <path>` is given, the parsed review plus a `usage` object with the
+   run's accumulated token counts is also written to that file as JSON.
 
 No platform token, no PR URL, and no internet access are required for the diff processing
 step itself. An LLM API key is still needed unless you configure a local model.

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import os
+from typing import Any, cast
 
 import litellm
 import openai
@@ -47,6 +48,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         self._aws_imds_fell_back = False
         self._aws_boto3_creds = None  # original boto3 credentials object for IMDS refresh
         self._aws_bedrock_lock = asyncio.Lock()
+        self.last_usage = {}
 
         if get_settings().get("LITELLM.DISABLE_AIOHTTP", False):
             litellm.disable_aiohttp_transport = True
@@ -699,6 +701,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 get_logger().warning(f"Unknown error during LLM inference: {e}")
                 raise openai.APIError from e
 
+            usage = cast(dict[str, Any], response_obj.dict().get("usage", {}))
+            self.last_usage = dict(usage or {})
             get_logger().debug(f"\nAI response:\n{resp}")
 
             # log the full response for debugging

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import json
 import os
-from typing import Any, cast
 
 import httpx
 import litellm
@@ -50,7 +49,6 @@ class LiteLLMAIHandler(BaseAiHandler):
         self._aws_imds_fell_back = False
         self._aws_boto3_creds = None  # original boto3 credentials object for IMDS refresh
         self._aws_bedrock_lock = asyncio.Lock()
-        self.last_usage = {}
 
         if get_settings().get("LITELLM.DISABLE_AIOHTTP", False):
             litellm.disable_aiohttp_transport = True
@@ -885,8 +883,6 @@ class LiteLLMAIHandler(BaseAiHandler):
                     body=None,
                 ) from e
 
-            usage = cast(dict[str, Any], response_obj.dict().get("usage", {}))
-            self.last_usage = dict(usage or {})
             get_logger().debug(f"\nAI response:\n{resp}")
 
             # log the full response for debugging

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import os
+from typing import Any, cast
 
 import httpx
 import litellm
@@ -49,6 +50,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         self._aws_imds_fell_back = False
         self._aws_boto3_creds = None  # original boto3 credentials object for IMDS refresh
         self._aws_bedrock_lock = asyncio.Lock()
+        self.last_usage = {}
 
         if get_settings().get("LITELLM.DISABLE_AIOHTTP", False):
             litellm.disable_aiohttp_transport = True
@@ -883,6 +885,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                     body=None,
                 ) from e
 
+            usage = cast(dict[str, Any], response_obj.dict().get("usage", {}))
+            self.last_usage = dict(usage or {})
             get_logger().debug(f"\nAI response:\n{resp}")
 
             # log the full response for debugging

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -72,6 +72,8 @@ def set_parser():
                         help="Read a unified diff from stdin (plain-diff local mode)")
     parser.add_argument("--output", dest="output", type=str, default=None,
                         help="Write the result to this file (in addition to stdout)")
+    parser.add_argument("--json-output", dest="json_output", type=str, default=None,
+                        help="Write the parsed review and token usage to this JSON file")
     parser.add_argument('command', type=str, help='The', choices=commands, default='review')
     parser.add_argument('rest', nargs=argparse.REMAINDER, default=[])
     return parser
@@ -109,6 +111,7 @@ def run(inargs=None, args=None):
         get_settings().set("config.git_provider", "plain-diff")
         get_settings().set("plain_diff.content", diff_content)
         get_settings().set("plain_diff.output_path", getattr(args, "output", None))
+        get_settings().set("plain_diff.json_output_path", getattr(args, "json_output", None))
         # Plain-diff mode's whole purpose is to emit the result to stdout/--output, so
         # force publishing on even if a config/env set publish_output=false.
         get_settings().set("config.publish_output", True)

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -96,6 +96,8 @@ def run(inargs=None, args=None):
     if not args:
         args = parser.parse_args(inargs)
     diff_mode = getattr(args, "stdin", False) or getattr(args, "diff_file", None)
+    if getattr(args, "json_output", None) and not diff_mode:
+        parser.error("--json-output is only supported in plain-diff mode (--stdin or --diff-file)")
     if diff_mode:
         if args.stdin and args.diff_file:
             parser.error("--stdin and --diff-file are mutually exclusive")

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -75,6 +75,8 @@ def set_parser():
                         help="Read a unified diff from stdin (plain-diff local mode)")
     parser.add_argument("--output", dest="output", type=str, default=None,
                         help="Write the result to this file (in addition to stdout)")
+    parser.add_argument("--json-output", dest="json_output", type=str, default=None,
+                        help="Write the parsed review and token usage to this JSON file")
     parser.add_argument('command', type=str, help='The', choices=commands, default='review')
     parser.add_argument('rest', nargs=argparse.REMAINDER, default=[])
     return parser
@@ -112,6 +114,7 @@ def run(inargs=None, args=None):
         get_settings().set("config.git_provider", "plain-diff")
         get_settings().set("plain_diff.content", diff_content)
         get_settings().set("plain_diff.output_path", getattr(args, "output", None))
+        get_settings().set("plain_diff.json_output_path", getattr(args, "json_output", None))
         # Plain-diff mode's whole purpose is to emit the result to stdout/--output, so
         # force publishing on even if a config/env set publish_output=false.
         get_settings().set("config.publish_output", True)

--- a/pr_agent/git_providers/plain_diff_provider.py
+++ b/pr_agent/git_providers/plain_diff_provider.py
@@ -1,3 +1,4 @@
+import json
 import os
 from collections import Counter
 from typing import List, Optional
@@ -20,9 +21,9 @@ class PullRequestMimic:
 class PlainDiffGitProvider(GitProvider):
     """Provider that reviews a raw unified diff (stdin/file), no hosting platform.
 
-    The diff text and optional output path are read from global settings
-    (plain_diff.content, plain_diff.output_path). The pr_url arg is an ignored
-    sentinel.
+    The diff text and optional output paths are read from global settings
+    (plain_diff.content, plain_diff.output_path, plain_diff.json_output_path).
+    The pr_url arg is an ignored sentinel.
     """
 
     def __init__(self, pr_url=None, incremental=False):
@@ -31,6 +32,7 @@ class PlainDiffGitProvider(GitProvider):
             raise ValueError("No diff content provided for the 'plain-diff' git provider")
         self.diff_text = diff_text
         self.output_path = get_settings().get("plain_diff.output_path", None)
+        self.json_output_path = get_settings().get("plain_diff.json_output_path", None)
         # cli.run() already forces config.publish_output=True, but apply_repo_settings()
         # runs afterwards and can overwrite it back to False from an extra/repo config
         # (tools gate all publishing on this flag). This provider is constructed after
@@ -116,6 +118,17 @@ class PlainDiffGitProvider(GitProvider):
         if is_temporary:
             return  # don't emit "Preparing review..." placeholders to stdout
         self._write_output(pr_comment)
+
+    def publish_structured_review(self, review: dict):
+        if not self.json_output_path:
+            return
+        try:
+            with open(self.json_output_path, "w", encoding="utf-8") as fh:
+                json.dump(review, fh, indent=2)
+                fh.write("\n")
+        except (OSError, TypeError, ValueError) as e:
+            get_logger().error(f"Failed to write structured review to {self.json_output_path}: {e}")
+            raise
 
     def publish_description(self, pr_title: str, pr_body: str):
         self._write_output(f"{pr_title}\n\n{pr_body}")

--- a/pr_agent/git_providers/plain_diff_provider.py
+++ b/pr_agent/git_providers/plain_diff_provider.py
@@ -21,9 +21,9 @@ class PullRequestMimic:
 class PlainDiffGitProvider(GitProvider):
     """Provider that reviews a raw unified diff (stdin/file), no hosting platform.
 
-    The diff text and optional output paths are read from global settings
+    Read the diff text and optional output paths from global settings
     (plain_diff.content, plain_diff.output_path, plain_diff.json_output_path).
-    The pr_url arg is an ignored sentinel.
+    Treat the pr_url arg as an ignored sentinel.
     """
 
     def __init__(self, pr_url=None, incremental=False):

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -254,6 +254,12 @@ class PRReviewer:
             get_logger().exception("Failed to parse review data", artifact={"data": data})
             return ""
 
+        structured_publisher = getattr(self.git_provider, "publish_structured_review", None)
+        if callable(structured_publisher):
+            structured_data = dict(data)
+            structured_data["usage"] = dict(getattr(self.ai_handler, "last_usage", {}) or {})
+            structured_publisher(structured_data)
+
         # move data['review'] 'key_issues_to_review' key to the end of the dictionary
         if 'key_issues_to_review' in data['review']:
             key_issues_to_review = data['review'].pop('key_issues_to_review')

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -286,10 +286,10 @@ class PRReviewer:
 
         structured_publisher = getattr(self.git_provider, "publish_structured_review", None)
         if callable(structured_publisher):
-            # Deep copy: dict(data) is shallow, so structured_data["review"] would
-            # alias data["review"], which is mutated right below (key reordering).
-            # Harmless for providers that serialize immediately, but the hook is
-            # provider-neutral, so hand implementers an isolated snapshot.
+            # Deep-copy the data: dict(data) is shallow, so structured_data["review"]
+            # would alias data["review"], which is mutated right below (key reordering).
+            # Hand implementers an isolated snapshot, since the hook is provider-neutral
+            # and a provider that defers serialization would observe the mutation.
             structured_data = copy.deepcopy(data)
             details = get_run_details()
             usage = {}

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -18,7 +18,7 @@ from pr_agent.algo.inline_comment_dedup import (
 )
 from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.repo_context import build_repo_context
-from pr_agent.algo.run_details import init_run_details
+from pr_agent.algo.run_details import get_run_details, init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -286,8 +286,20 @@ class PRReviewer:
 
         structured_publisher = getattr(self.git_provider, "publish_structured_review", None)
         if callable(structured_publisher):
-            structured_data = dict(data)
-            structured_data["usage"] = dict(getattr(self.ai_handler, "last_usage", {}) or {})
+            # Deep copy: dict(data) is shallow, so structured_data["review"] would
+            # alias data["review"], which is mutated right below (key reordering).
+            # Harmless for providers that serialize immediately, but the hook is
+            # provider-neutral, so hand implementers an isolated snapshot.
+            structured_data = copy.deepcopy(data)
+            details = get_run_details()
+            usage = {}
+            if details is not None and details.has_token_usage:
+                usage = {
+                    "prompt_tokens": details.prompt_tokens,
+                    "completion_tokens": details.completion_tokens,
+                    "total_tokens": details.total_tokens,
+                }
+            structured_data["usage"] = usage
             structured_publisher(structured_data)
 
         # move data['review'] 'key_issues_to_review' key to the end of the dictionary

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -284,6 +284,12 @@ class PRReviewer:
             get_logger().exception("Failed to parse review data", artifact={"data": data})
             return ""
 
+        structured_publisher = getattr(self.git_provider, "publish_structured_review", None)
+        if callable(structured_publisher):
+            structured_data = dict(data)
+            structured_data["usage"] = dict(getattr(self.ai_handler, "last_usage", {}) or {})
+            structured_publisher(structured_data)
+
         # move data['review'] 'key_issues_to_review' key to the end of the dictionary
         if 'key_issues_to_review' in data['review']:
             key_issues_to_review = data['review'].pop('key_issues_to_review')

--- a/tests/unittest/test_cli_plain_diff_mode.py
+++ b/tests/unittest/test_cli_plain_diff_mode.py
@@ -6,7 +6,7 @@ from pr_agent.config_loader import get_settings
 # Keys run() mutates on the process-wide settings singleton, directly or via the
 # diff-mode CLI path. Snapshotted and restored around every test (autouse) so
 # state never leaks, even when run() sets keys the test never touches itself.
-_SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path",
+_SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path", "plain_diff.json_output_path",
                   "config.git_provider", "config.publish_output"]
 
 
@@ -27,9 +27,13 @@ def cfg():
 
 def test_parser_has_diff_flags():
     parser = set_parser()
-    args = parser.parse_args(["--diff-file", "x.diff", "--output", "out.md", "review"])
+    args = parser.parse_args([
+        "--diff-file", "x.diff", "--output", "out.md",
+        "--json-output", "out.json", "review",
+    ])
     assert args.diff_file == "x.diff"
     assert args.output == "out.md"
+    assert args.json_output == "out.json"
     assert args.command == "review"
 
 
@@ -76,3 +80,22 @@ def test_diff_mode_forces_publish_output(cfg, monkeypatch):
     monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
     run(inargs=["--stdin", "review"])
     assert captured["publish_output"] is True
+
+
+def test_diff_mode_sets_json_output_path(cfg, monkeypatch, tmp_path):
+    import io
+
+    captured = {}
+
+    class FakeAgent:
+        async def handle_request(self, target, request, notify=None):
+            captured["json_output_path"] = get_settings().plain_diff.json_output_path
+            return True
+
+    output = tmp_path / "review.json"
+    monkeypatch.setattr("pr_agent.cli.PRAgent", FakeAgent)
+    monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
+
+    run(inargs=["--stdin", "--json-output", str(output), "review"])
+
+    assert captured["json_output_path"] == str(output)

--- a/tests/unittest/test_cli_plain_diff_mode.py
+++ b/tests/unittest/test_cli_plain_diff_mode.py
@@ -53,6 +53,15 @@ def test_missing_diff_file_fails_fast(tmp_path, capsys):
     assert "Could not read --diff-file" in err
 
 
+def test_json_output_outside_diff_mode_fails_fast(capsys):
+    """Reject --json-output in hosted-provider mode via parser.error instead of
+    silently dropping the explicitly requested artifact."""
+    with pytest.raises(SystemExit):
+        run(inargs=["--pr_url", "https://example/pr/1", "--json-output", "out.json", "review"])
+    err = capsys.readouterr().err
+    assert "--json-output is only supported in plain-diff mode" in err
+
+
 _DIFF = (
     "diff --git a/foo.py b/foo.py\n"
     "index 1111111..2222222 100644\n"

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -33,9 +33,11 @@ class FakeSettings:
         return self._settings_values.get(key, default)
 
 
-def _mock_response():
+def _mock_response(usage=None):
     mock = MagicMock()
     response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    if usage is not None:
+        response["usage"] = usage
     mock.__getitem__.side_effect = response.__getitem__
     mock.dict.return_value = response
     return mock
@@ -52,6 +54,20 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
         await handler.chat_completion(model="gpt-4o", system="sys", user="usr", temperature=0)
 
     assert mock_call.call_args.kwargs["seed"] == 123
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_records_token_usage(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+    usage = {"prompt_tokens": 101, "completion_tokens": 23, "total_tokens": 124}
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response(usage)
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+    assert handler.last_usage == usage
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -34,9 +34,11 @@ class FakeSettings:
         return self._settings_values.get(key, default)
 
 
-def _mock_response():
+def _mock_response(usage=None):
     mock = MagicMock()
     response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    if usage is not None:
+        response["usage"] = usage
     mock.__getitem__.side_effect = response.__getitem__
     mock.dict.return_value = response
     return mock
@@ -53,6 +55,20 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
         await handler.chat_completion(model="gpt-4o", system="sys", user="usr", temperature=0)
 
     assert mock_call.call_args.kwargs["seed"] == 123
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_records_token_usage(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+    usage = {"prompt_tokens": 101, "completion_tokens": 23, "total_tokens": 124}
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response(usage)
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+    assert handler.last_usage == usage
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -39,6 +39,10 @@ def _mock_response(usage=None):
     response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
     if usage is not None:
         response["usage"] = usage
+        # run_details reads the litellm attribute, not the dict form
+        mock.usage = usage
+    else:
+        mock.usage = None
     mock.__getitem__.side_effect = response.__getitem__
     mock.dict.return_value = response
     return mock
@@ -58,7 +62,9 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_records_token_usage(monkeypatch):
+async def test_chat_completion_accumulates_usage_into_run_details(monkeypatch):
+    from pr_agent.algo.run_details import init_run_details
+
     monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
     usage = {"prompt_tokens": 101, "completion_tokens": 23, "total_tokens": 124}
 
@@ -66,9 +72,12 @@ async def test_chat_completion_records_token_usage(monkeypatch):
         mock_call.return_value = _mock_response(usage)
         handler = litellm_handler.LiteLLMAIHandler()
 
+        details = init_run_details()
         await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
 
-    assert handler.last_usage == usage
+    assert details.prompt_tokens == 101
+    assert details.completion_tokens == 23
+    assert details.total_tokens == 124
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_litellm_imds.py
+++ b/tests/unittest/test_litellm_imds.py
@@ -53,12 +53,13 @@ def _base_settings(extra_get=None):
     })()
 
 
-def _mock_acompletion_response():
+def _mock_acompletion_response(usage=None):
     mock = MagicMock()
-    mock.__getitem__ = lambda self, key: {
-        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
-    }[key]
-    mock.dict.return_value = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    if usage is not None:
+        response["usage"] = usage
+    mock.__getitem__ = lambda self, key: response[key]
+    mock.dict.return_value = response
     return mock
 
 
@@ -546,13 +547,14 @@ class TestImdsCallBehavior:
         }
 
         call_count = 0
+        usage = {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
 
         async def flaky_completion(**kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise openai.APIError("Bedrock auth failed", request=MagicMock(), body=None)
-            return _mock_acompletion_response()
+            return _mock_acompletion_response(usage)
 
         with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                    side_effect=flaky_completion):
@@ -565,6 +567,7 @@ class TestImdsCallBehavior:
         assert handler._aws_imds_fell_back is True
         assert os.environ["AWS_ACCESS_KEY_ID"] == "STATICKEY"
         assert os.environ["AWS_SECRET_ACCESS_KEY"] == "STATICSECRET"
+        assert handler.last_usage == usage
 
     @pytest.mark.asyncio
     async def test_fallback_not_triggered_without_static_creds(self, monkeypatch):

--- a/tests/unittest/test_litellm_imds.py
+++ b/tests/unittest/test_litellm_imds.py
@@ -591,7 +591,6 @@ class TestImdsCallBehavior:
         assert handler._aws_imds_fell_back is True
         assert os.environ["AWS_ACCESS_KEY_ID"] == "STATICKEY"
         assert os.environ["AWS_SECRET_ACCESS_KEY"] == "STATICSECRET"
-        assert handler.last_usage == usage
 
     @pytest.mark.asyncio
     async def test_fallback_not_triggered_without_static_creds(self, monkeypatch):

--- a/tests/unittest/test_litellm_imds.py
+++ b/tests/unittest/test_litellm_imds.py
@@ -53,12 +53,13 @@ def _base_settings(extra_get=None):
     })()
 
 
-def _mock_acompletion_response():
+def _mock_acompletion_response(usage=None):
     mock = MagicMock()
-    mock.__getitem__ = lambda self, key: {
-        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
-    }[key]
-    mock.dict.return_value = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    if usage is not None:
+        response["usage"] = usage
+    mock.__getitem__ = lambda self, key: response[key]
+    mock.dict.return_value = response
     return mock
 
 
@@ -570,13 +571,14 @@ class TestImdsCallBehavior:
         }
 
         call_count = 0
+        usage = {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
 
         async def flaky_completion(**kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise openai.APIError("Bedrock auth failed", request=MagicMock(), body=None)
-            return _mock_acompletion_response()
+            return _mock_acompletion_response(usage)
 
         with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                    side_effect=flaky_completion):
@@ -589,6 +591,7 @@ class TestImdsCallBehavior:
         assert handler._aws_imds_fell_back is True
         assert os.environ["AWS_ACCESS_KEY_ID"] == "STATICKEY"
         assert os.environ["AWS_SECRET_ACCESS_KEY"] == "STATICSECRET"
+        assert handler.last_usage == usage
 
     @pytest.mark.asyncio
     async def test_fallback_not_triggered_without_static_creds(self, monkeypatch):

--- a/tests/unittest/test_plain_diff_mode_e2e.py
+++ b/tests/unittest/test_plain_diff_mode_e2e.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
@@ -5,7 +7,7 @@ from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.plain_diff_provider import PlainDiffGitProvider
 
 # Diff-mode settings keys these tests mutate on the process-wide singleton.
-_SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path",
+_SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path", "plain_diff.json_output_path",
                   "config.git_provider", "config.publish_output"]
 
 
@@ -53,6 +55,21 @@ def test_provider_end_to_end_files_and_output(cfg, capsys):
     # output reaches stdout
     provider.publish_comment("## PR Review\n- finding one")
     assert "finding one" in capsys.readouterr().out
+
+
+def test_provider_writes_structured_review(cfg, tmp_path):
+    output = tmp_path / "review.json"
+    cfg("plain_diff.content", DIFF)
+    cfg("plain_diff.output_path", None)
+    cfg("plain_diff.json_output_path", str(output))
+    provider = PlainDiffGitProvider(None)
+
+    provider.publish_structured_review({"review": {"key_issues_to_review": []}, "usage": {}})
+
+    assert json.loads(output.read_text()) == {
+        "review": {"key_issues_to_review": []},
+        "usage": {},
+    }
 
 
 def test_base_file_reconstructed_from_working_tree(cfg, tmp_path, monkeypatch):

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -28,6 +28,34 @@ def test_should_publish_review_no_suggestions_respects_config():
         settings.pr_reviewer.publish_output_no_suggestions = original_publish_no_suggestions
 
 
+def test_prepare_review_publishes_provider_neutral_structured_data(monkeypatch):
+    git_provider = MagicMock()
+    git_provider.is_supported.return_value = False
+    git_provider.get_diff_files.return_value = []
+    reviewer = _make_reviewer(git_provider)
+    reviewer.prediction = """review:
+  key_issues_to_review: []
+  security_concerns: no
+"""
+    reviewer.ai_handler = SimpleNamespace(last_usage={"total_tokens": 42})
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.set_review_labels = MagicMock()
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+        lambda *args, **kwargs: "## Review",
+    )
+
+    reviewer._prepare_pr_review()
+
+    git_provider.publish_structured_review.assert_called_once_with({
+        "review": {
+            "key_issues_to_review": [],
+            "security_concerns": False,
+        },
+        "usage": {"total_tokens": 42},
+    })
+
+
 def test_can_run_incremental_review_skips_auto_mode_without_new_commit():
     reviewer = _make_reviewer()
     reviewer.is_auto = True

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -648,6 +648,34 @@ async def test_run_does_not_remove_comments_when_progress_was_not_published(monk
     git_provider.remove_initial_comment.assert_not_called()
 
 
+def test_prepare_review_publishes_provider_neutral_structured_data(monkeypatch):
+    git_provider = MagicMock()
+    git_provider.is_supported.return_value = False
+    git_provider.get_diff_files.return_value = []
+    reviewer = _make_reviewer(git_provider)
+    reviewer.prediction = """review:
+  key_issues_to_review: []
+  security_concerns: no
+"""
+    reviewer.ai_handler = SimpleNamespace(last_usage={"total_tokens": 42})
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.set_review_labels = MagicMock()
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+        lambda *args, **kwargs: "## Review",
+    )
+
+    reviewer._prepare_pr_review()
+
+    git_provider.publish_structured_review.assert_called_once_with({
+        "review": {
+            "key_issues_to_review": [],
+            "security_concerns": False,
+        },
+        "usage": {"total_tokens": 42},
+    })
+
+
 def test_can_run_incremental_review_skips_auto_mode_without_new_commit():
     reviewer = _make_reviewer()
     reviewer.is_auto = True

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -678,10 +678,12 @@ def test_prepare_review_publishes_provider_neutral_structured_data(monkeypatch):
         },
         "usage": {"prompt_tokens": 30, "completion_tokens": 12, "total_tokens": 42},
     })
-    # The published snapshot must be isolated from the reviewer's own dict —
-    # _prepare_pr_review mutates data["review"] right after the hook fires.
+    # Assert key order to prove the snapshot is isolated: _prepare_pr_review moves
+    # key_issues_to_review to the end of its own dict after the hook fires, so an
+    # aliased snapshot ends with it while a deep copy keeps the original order.
+    # (assert_called_once_with cannot catch this: dict equality ignores key order.)
     published = git_provider.publish_structured_review.call_args[0][0]
-    assert "key_issues_to_review" in published["review"]
+    assert list(published["review"].keys()) == ["key_issues_to_review", "security_concerns"]
 
 
 def test_can_run_incremental_review_skips_auto_mode_without_new_commit():

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -652,18 +652,22 @@ def test_prepare_review_publishes_provider_neutral_structured_data(monkeypatch):
     git_provider = MagicMock()
     git_provider.is_supported.return_value = False
     git_provider.get_diff_files.return_value = []
-    reviewer = _make_reviewer(git_provider)
+    reviewer = _make_prediction_reviewer(git_provider)
     reviewer.prediction = """review:
   key_issues_to_review: []
   security_concerns: no
 """
-    reviewer.ai_handler = SimpleNamespace(last_usage={"total_tokens": 42})
     reviewer.incremental = SimpleNamespace(is_incremental=False)
     reviewer.set_review_labels = MagicMock()
     monkeypatch.setattr(
         "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
         lambda *args, **kwargs: "## Review",
     )
+
+    from pr_agent.algo.run_details import add_token_usage, init_run_details
+
+    init_run_details()
+    add_token_usage({"prompt_tokens": 30, "completion_tokens": 12, "total_tokens": 42})
 
     reviewer._prepare_pr_review()
 
@@ -672,8 +676,12 @@ def test_prepare_review_publishes_provider_neutral_structured_data(monkeypatch):
             "key_issues_to_review": [],
             "security_concerns": False,
         },
-        "usage": {"total_tokens": 42},
+        "usage": {"prompt_tokens": 30, "completion_tokens": 12, "total_tokens": 42},
     })
+    # The published snapshot must be isolated from the reviewer's own dict —
+    # _prepare_pr_review mutates data["review"] right after the hook fires.
+    published = git_provider.publish_structured_review.call_args[0][0]
+    assert "key_issues_to_review" in published["review"]
 
 
 def test_can_run_incremental_review_skips_auto_mode_without_new_commit():


### PR DESCRIPTION

## Summary

- add `--json-output <path>` to plain-diff CLI mode
- capture the successful LiteLLM completion usage metadata, including the Bedrock static-credential fallback path
- expose an optional provider-neutral structured-review publication hook after the reviewer parses its YAML response
- implement that hook only in `PlainDiffGitProvider`, writing the parsed review plus usage as JSON
- keep Markdown/stdout output unchanged and add no new posting path to hosted Git providers

`usage` is the metadata returned by the successful completion that produced the review, not an aggregate across failed retries. Streaming models use the handler's existing `MockResponse.dict()` path and therefore emit an empty usage object. As with `--output`, failure to write an explicitly requested `--json-output` path is fatal rather than silently succeeding without the requested artifact.

## Scope

This is the general-purpose primitive needed by callers that run multiple local review passes or apply different review lenses. Pass orchestration, lens selection, scoring, severity normalization, and result merging remain caller concerns and are intentionally not included.

## Testing

- focused plain-diff/reviewer/chat-completion/IMDS tests: `71 passed`
- full unit suite: `1343 passed, 1 skipped, 1 xfailed`
- changed-file Ruff/Flake8 results introduce no violations relative to clean upstream `main`
