### PR TITLE
fix(ticket-compliance): fetch linked issues from their own repository

### DIFF
--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -1,5 +1,6 @@
 import re
 import traceback
+from urllib.parse import urlparse
 
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import GithubProvider
@@ -114,6 +115,71 @@ def extract_ticket_links_from_branch_name(branch_name, repo_path, base_url_html=
     return list(github_tickets)
 
 
+def _normalize_github_host(url):
+    """
+    Host of a GitHub URL, normalized so that forms addressing the same instance compare equal:
+    `urlparse().hostname` drops the port and any userinfo and lowercases the result, so
+    `github.com:443` and `github.com` are one host, and `api.github.com` is folded onto
+    `github.com` (on GitHub Enterprise both forms already share a host and differ only by the
+    `/api/v3` path prefix). Returns "" when no host can be determined.
+    """
+    try:
+        host = urlparse(url or "").hostname or ""
+    except (AttributeError, TypeError, ValueError):
+        return ""
+    return host[len("api."):] if host.startswith("api.") else host
+
+
+def _get_repo_obj_for_ticket(git_provider, ticket_url, repo_name, repo_obj_cache):
+    """
+    Resolve the repository handle that owns the ticket at `ticket_url`.
+
+    A ticket linked from a PR description may live in a different repository than the PR
+    itself, so it must be fetched from its own repository. The PR's `repo_obj` is reused
+    when the ticket belongs to the PR's repository, to avoid an extra API call.
+
+    `_parse_issue_url` drops the host, so `owner/repo` alone does not identify a repository
+    when a description links across GitHub instances (e.g. GitHub Enterprise and github.com).
+    A ticket hosted elsewhere is rejected rather than served from the PR's instance, since
+    `github_client` is authenticated against a single host. Hosts that cannot be determined
+    are treated as local, keeping the previous behaviour.
+    """
+    ticket_host = _normalize_github_host(ticket_url)
+    provider_host = _normalize_github_host(getattr(git_provider, "base_url_html", ""))
+    if ticket_host and provider_host and ticket_host != provider_host:
+        # The URL itself is left out of the message: it comes from PR description content and
+        # is logged by the caller, so only the parsed host and repo are reported.
+        raise ValueError(f"Ticket {repo_name} is hosted on {ticket_host}, "
+                         f"which is not the PR's GitHub instance ({provider_host})")
+
+    # GitHub owner/repo names are case-insensitive, so a link spelled `Org/Repo` addresses the
+    # same repository as `org/repo` and must hit the same fast path and cache entry.
+    cache_key = (ticket_host, repo_name.lower())
+    if cache_key in repo_obj_cache:
+        cached = repo_obj_cache[cache_key]
+        # Failures are cached too: several tickets or sub-issues of one run may point at the
+        # same unreachable repository, and retrying the lookup each time only repeats the
+        # failing API call and its log line.
+        if isinstance(cached, Exception):
+            raise cached
+        return cached
+
+    pr_repo_name = getattr(git_provider, "repo", None) or ""
+    pr_repo_obj = getattr(git_provider, "repo_obj", None)
+    is_pr_repo = repo_name.lower() == pr_repo_name.lower() and pr_repo_obj is not None
+    if is_pr_repo:
+        repo_obj = pr_repo_obj
+    else:
+        try:
+            repo_obj = git_provider.github_client.get_repo(repo_name)
+        except Exception as e:
+            repo_obj_cache[cache_key] = e
+            raise
+
+    repo_obj_cache[cache_key] = repo_obj
+    return repo_obj
+
+
 async def extract_tickets(git_provider):
     MAX_TICKET_CHARACTERS = 10000
     try:
@@ -138,6 +204,7 @@ async def extract_tickets(git_provider):
             else:
                 tickets = merged
             tickets_content = []
+            repo_obj_cache = {}
 
             if tickets:
 
@@ -145,9 +212,10 @@ async def extract_tickets(git_provider):
                     repo_name, original_issue_number = git_provider._parse_issue_url(ticket)
 
                     try:
-                        issue_main = git_provider.repo_obj.get_issue(original_issue_number)
+                        repo_obj = _get_repo_obj_for_ticket(git_provider, ticket, repo_name, repo_obj_cache)
+                        issue_main = repo_obj.get_issue(original_issue_number)
                     except Exception as e:
-                        get_logger().error(f"Error getting main issue: {e}",
+                        get_logger().error(f"Error getting main issue {repo_name}#{original_issue_number}: {e}",
                                            artifact={"traceback": traceback.format_exc()})
                         continue
 
@@ -162,7 +230,9 @@ async def extract_tickets(git_provider):
                         for sub_issue_url in sub_issues:
                             try:
                                 sub_repo, sub_issue_number = git_provider._parse_issue_url(sub_issue_url)
-                                sub_issue = git_provider.repo_obj.get_issue(sub_issue_number)
+                                sub_repo_obj = _get_repo_obj_for_ticket(git_provider, sub_issue_url, sub_repo,
+                                                                        repo_obj_cache)
+                                sub_issue = sub_repo_obj.get_issue(sub_issue_number)
 
                                 sub_body = sub_issue.body or ""
                                 if len(sub_body) > MAX_TICKET_CHARACTERS:

--- a/tests/unittest/test_ticket_extraction_async.py
+++ b/tests/unittest/test_ticket_extraction_async.py
@@ -50,6 +50,20 @@ class _FakeRepoObj:
         return self._issues[number]
 
 
+class _FakeGithubClient:
+    """Mimics PyGithub Github.get_repo lookup, counting calls."""
+
+    def __init__(self, repos_by_name=None):
+        self._repos = repos_by_name or {}
+        self.get_repo_calls = []
+
+    def get_repo(self, full_name):
+        self.get_repo_calls.append(full_name)
+        if full_name not in self._repos:
+            raise RuntimeError(f"no access to repository {full_name}")
+        return self._repos[full_name]
+
+
 def _make_github_provider(
     *,
     user_description="",
@@ -59,12 +73,14 @@ def _make_github_provider(
     repo_obj=None,
     sub_issues_map=None,
     sub_issues_raises=False,
+    github_client=None,
 ):
     """Build a GithubProvider that passes ``isinstance`` checks without __init__."""
     provider = GithubProvider.__new__(GithubProvider)
     provider.repo = repo
     provider.base_url_html = base_url_html
     provider.repo_obj = repo_obj
+    provider.github_client = github_client
     provider.get_user_description = lambda: user_description
     provider.get_pr_branch = lambda: branch
 
@@ -198,6 +214,180 @@ class TestGithubExtractionMerging:
         # The branch-derived #13 must be the one dropped: description tickets
         # come first in the merge order, so the cap drops the trailing entry.
         assert ids == [10, 11, 12]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1b: tickets are fetched from the repository that owns them
+# ---------------------------------------------------------------------------
+
+class TestCrossRepoTicketResolution:
+    def test_ticket_in_other_repo_is_fetched_from_that_repo(self, settings_snapshot):
+        # Both repositories happen to have an issue #5. The PR links the one in
+        # ``other/repo``, so the ``other/repo`` issue must be the one returned —
+        # not the same-numbered issue that exists in the PR's own repository.
+        pr_repo_obj = _FakeRepoObj({5: _FakeIssue(5, title="Unrelated issue in PR repo")})
+        other_repo_obj = _FakeRepoObj({5: _FakeIssue(5, title="Linked issue", body="linked")})
+        provider = _make_github_provider(
+            user_description="Relates to https://github.com/other/repo/issues/5",
+            repo="org/repo",
+            repo_obj=pr_repo_obj,
+            github_client=_FakeGithubClient({"other/repo": other_repo_obj}),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert result and len(result) == 1
+        assert result[0]["title"] == "Linked issue"
+        assert provider.github_client.get_repo_calls == ["other/repo"]
+
+    def test_same_repo_ticket_reuses_repo_obj_without_extra_api_call(self, settings_snapshot):
+        repo_obj = _FakeRepoObj({1: _FakeIssue(1, title="One")})
+        provider = _make_github_provider(
+            user_description="Fixes #1",
+            repo="org/repo",
+            repo_obj=repo_obj,
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert result and result[0]["title"] == "One"
+        # The PR's own repository handle is reused — no repository lookup at all.
+        assert provider.github_client.get_repo_calls == []
+
+    def test_same_repo_differing_in_case_reuses_repo_obj(self, settings_snapshot):
+        # GitHub repository names are case-insensitive, so a link spelled with
+        # different case is the PR's own repository and must take the fast path.
+        repo_obj = _FakeRepoObj({4: _FakeIssue(4, title="Four")})
+        provider = _make_github_provider(
+            user_description="See https://github.com/Org/Repo/issues/4",
+            repo="org/repo",
+            repo_obj=repo_obj,
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert [t["ticket_id"] for t in result] == [4]
+        assert provider.github_client.get_repo_calls == []
+
+    def test_unreachable_repo_is_skipped_without_failing_other_tickets(self, settings_snapshot):
+        repo_obj = _FakeRepoObj({1: _FakeIssue(1, title="One")})
+        provider = _make_github_provider(
+            user_description="Fixes #1, see https://github.com/private/repo/issues/9",
+            repo="org/repo",
+            repo_obj=repo_obj,
+            # ``private/repo`` is absent -> get_repo raises, e.g. no read access.
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert result is not None
+        assert [t["ticket_id"] for t in result] == [1]
+
+    def test_repeated_unreachable_repo_is_looked_up_once(self, settings_snapshot):
+        # A failed lookup is cached as well, so several tickets pointing at one
+        # inaccessible repository do not repeat the failing call.
+        provider = _make_github_provider(
+            user_description=(
+                "See https://github.com/private/repo/issues/1 "
+                "and https://github.com/private/repo/issues/2"
+            ),
+            repo="org/repo",
+            repo_obj=_FakeRepoObj({}),
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert result == []
+        assert provider.github_client.get_repo_calls == ["private/repo"]
+
+    def test_repeated_foreign_repo_is_looked_up_once(self, settings_snapshot):
+        other_repo_obj = _FakeRepoObj({
+            5: _FakeIssue(5, title="Five"),
+            6: _FakeIssue(6, title="Six"),
+        })
+        provider = _make_github_provider(
+            user_description=(
+                "See https://github.com/other/repo/issues/5 "
+                "and https://github.com/other/repo/issues/6"
+            ),
+            repo="org/repo",
+            repo_obj=_FakeRepoObj({}),
+            github_client=_FakeGithubClient({"other/repo": other_repo_obj}),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert sorted(t["ticket_id"] for t in result) == [5, 6]
+        assert provider.github_client.get_repo_calls == ["other/repo"]
+
+    def test_ticket_on_another_github_host_is_skipped_not_read_from_pr_repo(self, settings_snapshot):
+        # ``_parse_issue_url`` drops the host, so this ticket parses to the same
+        # "org/repo" as the PR. It lives on a different GitHub instance, which the
+        # PR's client cannot reach, so it must be skipped rather than served from
+        # the PR's own repository.
+        pr_repo_obj = _FakeRepoObj({
+            1: _FakeIssue(1, title="One"),
+            7: _FakeIssue(7, title="Unrelated issue on the PR's host"),
+        })
+        provider = _make_github_provider(
+            user_description="Fixes #1, see https://github.enterprise.local/org/repo/issues/7",
+            repo="org/repo",
+            base_url_html="https://github.com",
+            repo_obj=pr_repo_obj,
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert [t["ticket_id"] for t in result] == [1]
+        # Nor may it fall through to a lookup on the PR's (wrong) instance.
+        assert provider.github_client.get_repo_calls == []
+
+    def test_api_host_form_counts_as_the_same_instance(self, settings_snapshot):
+        # Sub-issue URLs may arrive in api.github.com form; that is the same
+        # instance as the PR's https://github.com and must not be rejected.
+        repo_obj = _FakeRepoObj({
+            1: _FakeIssue(1, title="Main"),
+            99: _FakeIssue(99, title="Sub", body="s"),
+        })
+        sub_url = "https://api.github.com/repos/org/repo/issues/99"
+        provider = _make_github_provider(
+            user_description="Fixes #1",
+            repo="org/repo",
+            base_url_html="https://github.com",
+            repo_obj=repo_obj,
+            github_client=_FakeGithubClient(),
+            sub_issues_map={"https://github.com/org/repo/issues/1": [sub_url]},
+        )
+        result = asyncio.run(extract_tickets(provider))
+        subs = result[0]["sub_issues"]
+        assert [s["title"] for s in subs] == ["Sub"]
+        assert provider.github_client.get_repo_calls == []
+
+    def test_explicit_default_port_is_the_same_instance(self, settings_snapshot):
+        # An explicit port must not make the host check reject an otherwise local
+        # ticket — hosts are compared without port or userinfo.
+        repo_obj = _FakeRepoObj({7: _FakeIssue(7, title="Seven")})
+        provider = _make_github_provider(
+            user_description="See https://github.com:443/org/repo/issues/7",
+            repo="org/repo",
+            base_url_html="https://github.com",
+            repo_obj=repo_obj,
+            github_client=_FakeGithubClient(),
+        )
+        result = asyncio.run(extract_tickets(provider))
+        assert [t["ticket_id"] for t in result] == [7]
+        assert provider.github_client.get_repo_calls == []
+
+    def test_sub_issue_in_other_repo_is_fetched_from_that_repo(self, settings_snapshot):
+        pr_repo_obj = _FakeRepoObj({
+            1: _FakeIssue(1, title="Main"),
+            99: _FakeIssue(99, title="Unrelated issue in PR repo"),
+        })
+        other_repo_obj = _FakeRepoObj({99: _FakeIssue(99, title="Linked sub-issue", body="s")})
+        sub_url = "https://github.com/other/repo/issues/99"
+        provider = _make_github_provider(
+            user_description="Fixes #1",
+            repo="org/repo",
+            repo_obj=pr_repo_obj,
+            github_client=_FakeGithubClient({"other/repo": other_repo_obj}),
+            sub_issues_map={"https://github.com/org/repo/issues/1": [sub_url]},
+        )
+        result = asyncio.run(extract_tickets(provider))
+        subs = result[0]["sub_issues"]
+        assert len(subs) == 1
+        assert subs[0]["title"] == "Linked sub-issue"
+        assert provider.github_client.get_repo_calls == ["other/repo"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`extract_tickets()` in `pr_agent/tools/ticket_pr_compliance_check.py` parses the owner/repo out of every linked ticket URL, then throws that value away:

```python
repo_name, original_issue_number = git_provider._parse_issue_url(ticket)  # repo_name unused
issue_main = git_provider.repo_obj.get_issue(original_issue_number)       # always the PR's repo
```

`repo_obj` is always the repository the PR lives in. So when a PR description links an issue in a *different* repository — a common setup where issues are tracked in a dedicated repo, or where a fix in one service references a ticket in another — the issue number is looked up in the PR's own repository instead.

If no issue with that number exists there, the ticket is silently dropped. If one *does* exist (likely, since issue numbers are small and dense), no error is raised and the ticket-compliance check analyses a completely unrelated issue. The sub-issue path a few lines below has the same defect.

## Fix

Resolve the repository from the parsed ticket URL rather than assuming the PR's repo, following the existing pattern in `GithubProvider._get_issue_handle()`. A helper, `_get_repo_obj_for_ticket()`, handles both the main-issue and sub-issue paths:

- **Same repo** — reuse `git_provider.repo_obj`, so the common case costs no extra API call (mirrors the cache check in `GithubProvider._get_repo()`). `owner/repo` is compared case-insensitively, since GitHub treats it that way.
- **Different repo** — `github_client.get_repo(repo_name)`, looked up once per run and cached. Failures are cached too, so several tickets pointing at one unreachable repository do not repeat the failing call.
- **Different GitHub instance** — `_parse_issue_url()` returns only the path-derived `owner/repo` and drops the host, so links differing only by instance parse identically. The ticket's host is compared against `base_url_html` and a foreign-instance ticket is skipped: `github_client` is authenticated against a single host, so attempting the lookup would either 404 or resolve a same-named repo on the PR's own instance — reproducing the very bug being fixed. Hosts are compared by `urlparse().hostname`, so port and userinfo do not split one instance in two, and `api.github.com` folds onto `github.com`.
- **Unreachable repo** (private, deleted, no read access) — the existing `except` skips that ticket and logs, instead of aborting extraction for the whole PR. The log names the ticket as `owner/repo#number`, taken from parsed values rather than the raw URL.

## Tests

Ten cases added to `tests/unittest/test_ticket_extraction_async.py` (`TestCrossRepoTicketResolution`), all fake-provider based — no network:

| Test | Asserts |
|---|---|
| `test_ticket_in_other_repo_is_fetched_from_that_repo` | With issue `#5` present in *both* repos, the linked repo's issue is returned |
| `test_sub_issue_in_other_repo_is_fetched_from_that_repo` | Same, for sub-issues |
| `test_same_repo_ticket_reuses_repo_obj_without_extra_api_call` | `get_repo()` is never called for same-repo tickets |
| `test_same_repo_differing_in_case_reuses_repo_obj` | `Org/Repo` hits the same fast path as `org/repo` |
| `test_repeated_foreign_repo_is_looked_up_once` | Two tickets in one foreign repo → a single `get_repo()` call |
| `test_repeated_unreachable_repo_is_looked_up_once` | A failed lookup is cached, not retried |
| `test_unreachable_repo_is_skipped_without_failing_other_tickets` | A repo that raises on lookup is skipped; other tickets still extracted |
| `test_ticket_on_another_github_host_is_skipped_not_read_from_pr_repo` | A foreign-instance ticket is skipped, with no fallback lookup |
| `test_api_host_form_counts_as_the_same_instance` / `test_explicit_default_port_is_the_same_instance` | Equivalent host forms are not rejected |

Full unit suite: `1349 passed, 1 skipped, 1 xfailed`.
