### PR TITLE
feat(config): update default model to OpenAI's GPT-5.6

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -475,7 +475,7 @@ If you encounter rate limiting:
         OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Add a fallback model for better reliability
-        config.fallback_models: '["gpt-5.4-mini"]'
+        config.fallback_models: '["gpt-5.6-terra"]'
         # Increase timeout for slower models
         config.ai_timeout: "300"
         github_action_config.auto_review: "true"

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -1,6 +1,6 @@
 To run PR-Agent locally, you first need to acquire two keys:
 
-1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.5 and gpt-5.4-mini (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
+1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.6 and gpt-5.6-terra (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
 2. A personal access token from your Git platform (GitHub, GitLab, BitBucket, Gitea) with repo scope. GitHub token, for example, can be issued from [here](https://github.com/settings/tokens){:target="_blank"}
 
 ## Using Docker image

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -238,7 +238,7 @@ For detailed step-by-step examples of configuring different models (Gemini, Clau
 
 **Common Model Configuration Patterns:**
 
-- **OpenAI**: Set `config.model: "gpt-5.4"` and `OPENAI_KEY`
+- **OpenAI**: Set `config.model: "gpt-5.6"` and `OPENAI_KEY`
 - **Gemini**: Set `config.model: "gemini/gemini-1.5-flash"` and `GOOGLE_AI_STUDIO.GEMINI_API_KEY` (no `OPENAI_KEY` needed)
 - **Claude**: Set `config.model: "anthropic/claude-3-opus-20240229"` and `ANTHROPIC.KEY` (no `OPENAI_KEY` needed)
 - **Azure OpenAI**: Set `OPENAI.API_TYPE: "azure"`, `OPENAI.API_BASE`, and `OPENAI.DEPLOYMENT_ID`

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -1,7 +1,7 @@
 ## Changing a model in PR-Agent
 
 See [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py) for a list of supported models in PR-Agent.
-The default model of PR-Agent is `GPT-5` from OpenAI.
+The default model of PR-Agent is `GPT-5.6` from OpenAI.
 To use a different model than the default, you need to edit in the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L7) the fields:
 
 ```toml
@@ -467,7 +467,7 @@ custom_model_max_tokens= ...
 reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
 ```
 
-With the OpenAI models that support reasoning effort (eg: gpt-5.4-mini), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to any supported value based on your usage. Available values depend on the model and provider.
+With the OpenAI models that support reasoning effort (eg: gpt-5.6-terra), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to any supported value based on your usage. Available values depend on the model and provider.
 
 ### Anthropic models
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -4,10 +4,10 @@
 
 [config]
 # models
-model="gpt-5.5-2026-04-23"
-fallback_models=["gpt-5.4-mini"]
-#model_reasoning="gpt-5.4-mini" # dedicated reasoning model for self-reflection
-#model_weak="gpt-5.4-nano" # optional, a weaker model to use for some easier tasks
+model="gpt-5.6"
+fallback_models=["gpt-5.6-terra"]
+#model_reasoning="gpt-5.6-terra" # dedicated reasoning model for self-reflection
+#model_weak="gpt-5.6-luna" # optional, a weaker model to use for some easier tasks
 # CLI
 git_provider="github"
 publish_output=true

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -48,7 +48,7 @@ class TestHealthRoute:
 # under the pinned litellm). Under the OLD (removed) gate, health_check() short-circuited
 # to "Unhealthy: LLM does not support 'stop' parameter" for exactly such models — so these
 # tests would have failed before Fix A. They guard against the gate being reintroduced.
-_MODEL_WITHOUT_STOP = "gpt-5.5-2026-04-23"
+_MODEL_WITHOUT_STOP = "gpt-5.6"
 
 
 @pytest.fixture


### PR DESCRIPTION
Use the GPT-5.6 Terra tier as the default fallback, reasoning example, and GitHub rate-limit example. Keep Luna as the weak-model example.

Align documentation with the GPT-5.6 default and fallback tiers while preserving older model IDs in registry and historical tests for compatibility. This extends the GPT-5.6 support introduced in PR #2517.

References:
- PR #2517
- https://openai.com/index/gpt-5-6/
- https://developers.openai.com/api/docs/models/gpt-5.6-sol
- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://developers.openai.com/api/docs/models/gpt-5.6-luna