### PR TITLE
fix(litellm): raise on empty content from non-streaming models

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import os
 
+import httpx
 import litellm
 import openai
 import requests
@@ -728,6 +729,14 @@ class LiteLLMAIHandler(BaseAiHandler):
             response = await acompletion(**kwargs)
             if response is None or len(response["choices"]) == 0:
                 raise openai.APIError
-            return (response["choices"][0]['message']['content'],
-                    response["choices"][0]["finish_reason"],
-                    response)
+            content = response["choices"][0]['message']['content']
+            finish_reason = response["choices"][0]["finish_reason"]
+            if not content:
+                get_logger().warning(
+                    f"Empty content in model response, finish_reason: {finish_reason}")
+                raise openai.APIError(
+                    f"Empty content in model response (finish_reason: {finish_reason})",
+                    request=httpx.Request("POST", model),
+                    body=None,
+                )
+            return content, finish_reason, response

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import openai
 import pytest
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
@@ -200,3 +201,40 @@ async def test_get_completion_uses_streaming_for_required_models():
     assert resp == "streamed text"
     assert finish_reason == "stop"
     assert response_obj.dict()["choices"][0]["message"]["content"] == "streamed text"
+
+
+def _empty_content_response(finish_reason="stop"):
+    mock = MagicMock()
+    response = {"choices": [{"message": {"content": ""}, "finish_reason": finish_reason}]}
+    mock.__getitem__.side_effect = response.__getitem__
+    mock.dict.return_value = response
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_get_completion_raises_on_empty_content_for_non_streaming_model():
+    # A reasoning model that puts everything into a thinking/reasoning block and leaves
+    # `content` empty is not caught by the "response is None or no choices" guard, so an
+    # empty response must be treated as a failure instead of silently returned.
+    handler = litellm_handler.LiteLLMAIHandler.__new__(litellm_handler.LiteLLMAIHandler)
+    handler.streaming_required_models = []
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _empty_content_response(finish_reason="stop")
+
+        with pytest.raises(openai.APIError):
+            await handler._get_completion(model="anthropic/custom-reasoning-model", messages=[])
+
+
+@pytest.mark.asyncio
+async def test_get_completion_returns_non_empty_content_for_non_streaming_model():
+    handler = litellm_handler.LiteLLMAIHandler.__new__(litellm_handler.LiteLLMAIHandler)
+    handler.streaming_required_models = []
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+
+        resp, finish_reason, response_obj = await handler._get_completion(model="gpt-4o", messages=[])
+
+    assert resp == "ok"
+    assert finish_reason == "stop"


### PR DESCRIPTION
## Root cause

`LiteLLMAIHandler._get_completion` has two branches. The streaming branch (for models in
`STREAMING_REQUIRED_MODELS`) already raises when the collected content is empty
(`litellm_helpers.py::_handle_streaming_response`). The non-streaming branch only checks
`response is None or len(response["choices"]) == 0` and returns whatever `content` the
provider sent, even if it is an empty string.

A reasoning model that puts its entire answer into a `thinking`/reasoning block and leaves
`message.content` empty produces a response with a valid `choices[0]` and a `finish_reason`,
so it passes that check and comes back as `resp = ""`. `_prepare_prediction` then sets
`self.prediction = ""`, and `PRReviewer.run` treats an empty `self.prediction` the same as an
empty diff: it removes the initial comment and returns `None` with no warning and no
exception. The GitHub Action step exits 0, no review is posted, and nothing in the log
distinguishes this from a normal "nothing to review" outcome.

## The fix

Apply the same empty-content check the streaming branch already has to the non-streaming
branch: raise `openai.APIError` when `content` is empty, after logging the `finish_reason`.
This is an `openai.APIError` (not a bare exception) so it is caught by both retry layers that
already exist for this case: the `tenacity` retry on `chat_completion` for the same model, and
`retry_with_fallback_models` for configured fallback models. If every model still returns
empty content, the run now surfaces `Failed to generate prediction with any model of [...]`
as a logged error instead of exiting clean with nothing posted.

## Verified

Reproduced with a mocked `acompletion` response carrying `choices[0].message.content = ""`
and a `finish_reason`: on `main`, `_get_completion` returns the empty string with no
exception. On this branch, it raises `openai.APIError`. Added
`test_get_completion_raises_on_empty_content_for_non_streaming_model` (fails on `main`,
passes here) and `test_get_completion_returns_non_empty_content_for_non_streaming_model` to
confirm normal responses are unaffected. Full suite: `pytest tests/unittest` in the repo's
own `docker build -f docker/Dockerfile --target test` image, 1352 passed (1350 on main plus
these 2), 1 skipped, 1 xfailed, no failures.

Not verified: behavior against a live reasoning model / real Anthropic-protocol endpoint,
since the repro in the issue needs a private provider config. The mocked response shape
matches the issue's own diagnosis (valid response, empty `content`, present `finish_reason`).

Fixes #2522
