### PR TITLE
docs(tools): add consolidated usage examples for all tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ ___
 
 <hr>
 
+### Usage Examples
+
+Every tool runs either as a comment on a PR or from the CLI. A few common ones:
+
+```bash
+# Comment on a PR (GitHub/GitLab/Bitbucket/…):
+/describe                        # generate title, summary, walkthrough and labels
+/review                          # findings, security, review effort and tests
+/improve                         # actionable code-improvement suggestions
+/ask "What does this PR change?" # free-text Q&A about the PR
+
+# Or locally via the CLI:
+pr-agent --pr_url <PR_URL> review
+```
+
+See the [Tools docs](https://docs.pr-agent.ai/tools/#usage-examples) for the full list of tools with example commands, and each tool's page for screenshots and options.
+
+<hr>
+
 ## How It Works
 
 The following diagram illustrates PR-Agent tools and their flow:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ ___
 
 ### Usage Examples
 
-Every tool runs either as a comment on a PR or from the CLI. A few common ones:
+PR-Agent tools run as a comment on a PR or from the CLI. A few common ones:
 
 ```bash
 # Comment on a PR (GitHub/GitLab/Bitbucket/…):

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -17,14 +17,14 @@ Here is a list of PR-Agent tools, each with a dedicated page that explains how t
 
 ## Usage examples
 
-Every tool can be triggered in two ways:
+Each tool can be triggered in two ways:
 
-- **As a comment on a PR** — write the command (e.g. `/review`) as a comment, and PR-Agent replies on the PR.
-- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`, where `<PR_URL>` is the URL of the relevant PR.
+- **As a comment** — write the command (e.g. `/review`) as a comment, and PR-Agent replies. Most tools are commented on a PR; issue-scoped tools such as `similar_issue` are commented on an issue.
+- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`. Issue-scoped tools take `--issue_url=<ISSUE_URL>` instead of `--pr_url`.
 
 Both accept the same tool arguments and [configuration overrides](../usage-guide/configuration_options.md).
 
-| Tool                                     | PR comment                       | CLI                                                             |
+| Tool                                     | Comment                          | CLI                                                             |
 |------------------------------------------|----------------------------------|----------------------------------------------------------------|
 | [Describe](./describe.md)                | `/describe`                      | `python -m pr_agent.cli --pr_url=<PR_URL> describe`             |
 | [Review](./review.md)                    | `/review`                        | `python -m pr_agent.cli --pr_url=<PR_URL> review`              |
@@ -32,8 +32,10 @@ Both accept the same tool arguments and [configuration overrides](../usage-guide
 | [Ask](./ask.md)                          | `/ask "How does X work?"`        | `python -m pr_agent.cli --pr_url=<PR_URL> ask "How does X work?"` |
 | [Add Docs](./add_docs.md)                | `/add_docs`                      | `python -m pr_agent.cli --pr_url=<PR_URL> add_docs`           |
 | [Generate Labels](./generate_labels.md)  | `/generate_labels`               | `python -m pr_agent.cli --pr_url=<PR_URL> generate_labels`     |
-| [Similar Issues](./similar_issues.md)    | `/similar_issue`                 | `python -m pr_agent.cli --pr_url=<PR_URL> similar_issue`       |
+| [Similar Issues](./similar_issues.md)    | `/similar_issue`                 | `python -m pr_agent.cli --issue_url=<ISSUE_URL> similar_issue` |
 | [Help](./help.md)                        | `/help`                          | `python -m pr_agent.cli --pr_url=<PR_URL> help`                |
 | [Update Changelog](./update_changelog.md)| `/update_changelog`              | `python -m pr_agent.cli --pr_url=<PR_URL> update_changelog`    |
+
+`/help_docs` is temporarily disabled (see [#2445](https://github.com/The-PR-Agent/pr-agent/issues/2445)) and is therefore omitted from the table above.
 
 For screenshots, arguments, and a walkthrough of a typical use case, see the **Example usage** section on each tool's page linked above.

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -14,3 +14,26 @@ Here is a list of PR-Agent tools, each with a dedicated page that explains how t
 | **[Help (`/help`)](./help.md)**                                                          | Provides a list of all the available tools                                                                                                  |
 | **[Help Docs (`/help_docs`)](./help_docs.md)**                                           | Answer a free-text question based on a git documentation folder                                                                             |
 | **[Update Changelog (`/update_changelog`)](./update_changelog.md)**                      | Automatically updating the CHANGELOG.md file with the PR changes                                                                            |
+
+## Usage examples
+
+Every tool can be triggered in two ways:
+
+- **As a comment on a PR** — write the command (e.g. `/review`) as a comment, and PR-Agent replies on the PR.
+- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`, where `<PR_URL>` is the URL of the relevant PR.
+
+Both accept the same tool arguments and [configuration overrides](../usage-guide/configuration_options.md).
+
+| Tool                                     | PR comment                       | CLI                                                             |
+|------------------------------------------|----------------------------------|----------------------------------------------------------------|
+| [Describe](./describe.md)                | `/describe`                      | `python -m pr_agent.cli --pr_url=<PR_URL> describe`             |
+| [Review](./review.md)                    | `/review`                        | `python -m pr_agent.cli --pr_url=<PR_URL> review`              |
+| [Improve](./improve.md)                  | `/improve`                       | `python -m pr_agent.cli --pr_url=<PR_URL> improve`             |
+| [Ask](./ask.md)                          | `/ask "How does X work?"`        | `python -m pr_agent.cli --pr_url=<PR_URL> ask "How does X work?"` |
+| [Add Docs](./add_docs.md)                | `/add_docs`                      | `python -m pr_agent.cli --pr_url=<PR_URL> add_docs`           |
+| [Generate Labels](./generate_labels.md)  | `/generate_labels`               | `python -m pr_agent.cli --pr_url=<PR_URL> generate_labels`     |
+| [Similar Issues](./similar_issues.md)    | `/similar_issue`                 | `python -m pr_agent.cli --pr_url=<PR_URL> similar_issue`       |
+| [Help](./help.md)                        | `/help`                          | `python -m pr_agent.cli --pr_url=<PR_URL> help`                |
+| [Update Changelog](./update_changelog.md)| `/update_changelog`              | `python -m pr_agent.cli --pr_url=<PR_URL> update_changelog`    |
+
+For screenshots, arguments, and a walkthrough of a typical use case, see the **Example usage** section on each tool's page linked above.


### PR DESCRIPTION
## Resolves #2039

Issue #2039 asked for usage examples for the core AI review tools. The README and the Tools docs listed the tools but gave no invocation examples. This adds a consolidated examples reference in the docs and a short pointer block in the README.

### Changes

- **`docs/docs/tools/index.md`** — new **Usage examples** section: explains the two ways to trigger a tool (comment on a PR vs. CLI) and a compact table giving the exact `/command` and `python -m pr_agent.cli --pr_url=<PR_URL> <tool>` line for every currently-enabled tool. Each row links to that tool's page for screenshots and options.
- **`README.md`** — a short **Usage Examples** block under "See It in Action" with the four most common commands (including `/ask`, which the screenshots omit) plus a CLI one-liner, linking to the docs section as the source of truth.

### Notes

- Command names were taken from the `command2class` map for accuracy (e.g. `similar_issue`, singular).
- `/help_docs` is intentionally omitted from the quick reference because it is temporarily disabled in `command2class` pending the clone-target validation fix (#2445) — listing it as runnable would mislead.
- The README addition is kept to a small pointer block to avoid duplicating content across two files.