### PR TITLE
fix(litellm): stop the placeholder key from shadowing provider env vars

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -54,7 +54,13 @@ class LiteLLMAIHandler(BaseAiHandler):
             openai.api_key = get_settings().openai.key
             litellm.openai_key = get_settings().openai.key
         elif 'OPENAI_API_KEY' not in os.environ:
-            litellm.api_key = DUMMY_LITELLM_API_KEY
+            # Keyless OpenAI-compatible endpoints (vLLM, LM Studio, ...) still need *some*
+            # key or the OpenAI SDK raises "The api_key client option must be set".
+            # The placeholder must live in litellm.openai_key, which LiteLLM only consults
+            # on the OpenAI-compatible path: the global litellm.api_key is checked ahead of
+            # provider env vars (OPENROUTER_API_KEY, AZURE_API_KEY, ...) in LiteLLM's
+            # resolution chain, so a placeholder there silently shadows them.
+            litellm.openai_key = DUMMY_LITELLM_API_KEY
         if os.environ.get("AWS_USE_IMDS", "").strip().lower() in ("1", "true", "yes"):
             import boto3
             import botocore.exceptions

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -55,6 +55,12 @@ class LiteLLMAIHandler(BaseAiHandler):
             openai.api_key = get_settings().openai.key
             litellm.openai_key = get_settings().openai.key
         elif 'OPENAI_API_KEY' not in os.environ:
+            # These are process-wide globals and __init__ runs per request, so drop any
+            # key a previous request's provider branch left behind — chat_completion()
+            # forwards a truthy litellm.api_key, which would authenticate this request
+            # with (and leak) the earlier one's credential. The provider branches below
+            # repopulate it for the current request.
+            litellm.api_key = None
             # Keyless OpenAI-compatible endpoints (vLLM, LM Studio, ...) still need *some*
             # key or the OpenAI SDK raises "The api_key client option must be set".
             # The placeholder must live in litellm.openai_key, which LiteLLM only consults

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -2,10 +2,12 @@
 Tests for the litellm.api_key guard in LiteLLMAIHandler.chat_completion.
 
 Verifies:
-  - Placeholder key (DUMMY_LITELLM_API_KEY) is never injected into the call.
+  - Placeholder key (DUMMY_LITELLM_API_KEY) is never injected into the call, and never
+    occupies the global litellm.api_key (issue #2544).
   - None is not injected (e.g. when OpenAI key is set via litellm.openai_key).
   - Real provider keys (Groq, SambaNova, XAI, OpenRouter, Azure AD) ARE injected.
 """
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
@@ -53,7 +55,7 @@ def _make_anthropic_settings():
     """Settings with ANTHROPIC.KEY configured, no OPENAI.KEY.
 
     This simulates the original bug scenario: ANTHROPIC.KEY is set,
-    but OPENAI.KEY is not, so litellm.api_key falls back to DUMMY_LITELLM_API_KEY.
+    but OPENAI.KEY is not, so __init__ falls back to the DUMMY_LITELLM_API_KEY placeholder.
     """
     anthropic_key = "test-anthropic-key-12345"
     return type("Settings", (), {
@@ -134,9 +136,9 @@ class TestApiKeyGuard:
     async def test_anthropic_key_not_shadowed_by_dummy_key(self, monkeypatch):
         """Original bug scenario: ANTHROPIC.KEY configured without OPENAI.KEY.
 
-        During __init__, litellm.api_key is set to DUMMY_LITELLM_API_KEY (fallback)
-        because OPENAI.KEY is not configured. But litellm.anthropic_key is also set.
-        The guard must prevent the dummy key from being passed to the call,
+        During __init__ the DUMMY_LITELLM_API_KEY placeholder is stored (as the OpenAI
+        fallback) because OPENAI.KEY is not configured. But litellm.anthropic_key is also
+        set. The guard must prevent the placeholder from being passed to the call,
         allowing litellm to use anthropic_key internally.
 
         This test replicates the exact bug from GitHub issue #2042.
@@ -145,7 +147,7 @@ class TestApiKeyGuard:
         monkeypatch.setattr(litellm_handler, "get_settings", _make_anthropic_settings)
 
         # Ensure deterministic preconditions: delete OPENAI_API_KEY env var so __init__
-        # will set litellm.api_key to DUMMY_LITELLM_API_KEY (line 42-43 of litellm_ai_handler.py)
+        # takes the placeholder branch in litellm_ai_handler.py
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         # Reset litellm.api_key to avoid cross-test state pollution
@@ -156,9 +158,11 @@ class TestApiKeyGuard:
             mock_call.return_value = _mock_response()
             handler = LiteLLMAIHandler()
 
-            # After init: litellm.api_key should be the dummy (OpenAI fallback),
-            # but litellm.anthropic_key is the real Anthropic key
-            assert litellm.api_key == DUMMY_LITELLM_API_KEY
+            # After init: the placeholder lives in litellm.openai_key (OpenAI fallback)
+            # and never in litellm.api_key, which LiteLLM checks ahead of provider env
+            # vars. litellm.anthropic_key holds the real Anthropic key.
+            assert litellm.openai_key == DUMMY_LITELLM_API_KEY
+            assert litellm.api_key != DUMMY_LITELLM_API_KEY
 
             # Call with Anthropic model
             await handler.chat_completion(
@@ -472,3 +476,106 @@ class TestApiKeyGuard:
             # (which is Ollama in this case, but the guard correctly allows real keys through)
             await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
             assert mock_call.call_args[1]["api_key"] == ollama_key
+
+
+class _StopCall(Exception):
+    """Sentinel raised from a patched LiteLLM transport once the api_key is captured."""
+
+
+class TestPlaceholderDoesNotShadowProviderEnvVars:
+    """Regression tests for issue #2544.
+
+    The placeholder must not sit in the global ``litellm.api_key``: LiteLLM resolves
+    several providers as ``api_key or litellm.api_key or <provider attr> or
+    get_secret("<PROVIDER>_API_KEY")``, so a truthy placeholder there wins over the
+    user's provider env var (OpenRouter, Azure, Mistral, ... ) and the request goes
+    out with "dummy_key". Keeping the placeholder in ``litellm.openai_key`` — which
+    LiteLLM only consults on the OpenAI/OpenAI-compatible paths — preserves the
+    keyless local-endpoint use case without shadowing anything else.
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_openai_key(self, monkeypatch):
+        monkeypatch.setattr(litellm, "openai_key", None)
+        monkeypatch.setattr(litellm, "api_key", None)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    def test_placeholder_not_stored_in_global_litellm_api_key(self):
+        """With no OpenAI key configured, litellm.api_key must stay falsy."""
+        LiteLLMAIHandler()
+
+        assert litellm.api_key != DUMMY_LITELLM_API_KEY, (
+            "The placeholder must not occupy litellm.api_key — it shadows provider "
+            "env vars such as OPENROUTER_API_KEY in LiteLLM's resolution chain."
+        )
+        assert litellm.openai_key == DUMMY_LITELLM_API_KEY, (
+            "The placeholder must still be available on the OpenAI-compatible path, "
+            "so keyless local endpoints (vLLM, LM Studio, ...) keep working."
+        )
+
+    def test_openrouter_env_key_wins_over_placeholder(self, monkeypatch):
+        """End-to-end through LiteLLM's own resolution chain.
+
+        Patches LiteLLM's internal HTTP handler to capture the api_key that would be
+        sent for an ``openrouter/*`` model when the key comes from the native
+        OPENROUTER_API_KEY env var rather than PR-Agent's [openrouter] settings.
+        """
+        from litellm import main as litellm_main
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real-key")
+        LiteLLMAIHandler()
+
+        captured = {}
+
+        class _CapturingHandler:
+            def completion(self, **kwargs):
+                captured["api_key"] = kwargs.get("api_key")
+                raise _StopCall
+
+        monkeypatch.setattr(litellm_main, "base_llm_http_handler", _CapturingHandler())
+        # LiteLLM maps whatever the transport raises onto its own exception types,
+        # so the sentinel comes back wrapped — the captured key is what matters.
+        with contextlib.suppress(Exception):
+            litellm.completion(
+                model="openrouter/deepseek/deepseek-chat",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert captured.get("api_key") == "sk-or-real-key", (
+            f"OPENROUTER_API_KEY must not be shadowed by the placeholder; "
+            f"LiteLLM resolved: {captured.get('api_key')!r}"
+        )
+
+    def test_openai_compatible_endpoint_still_gets_placeholder(self, monkeypatch):
+        """Keyless local endpoints must still receive a key.
+
+        The OpenAI SDK raises "The api_key client option must be set" when no key is
+        resolved, which is exactly why the placeholder exists. Dropping it entirely
+        (instead of moving it to litellm.openai_key) would break these setups.
+        """
+        from litellm import main as litellm_main
+
+        LiteLLMAIHandler()
+
+        captured = {}
+
+        class _CapturingOpenAI:
+            def completion(self, *args, **kwargs):
+                captured["api_key"] = kwargs.get("api_key")
+                raise _StopCall
+
+        # LiteLLM routes the OpenAI path through either handler depending on the
+        # EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER flag; capture on both.
+        monkeypatch.setattr(litellm_main, "openai_chat_completions", _CapturingOpenAI())
+        monkeypatch.setattr(litellm_main, "base_llm_http_handler", _CapturingOpenAI())
+        with contextlib.suppress(Exception):
+            litellm.completion(
+                model="openai/local-model",
+                api_base="http://localhost:8000/v1",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert captured.get("api_key") == DUMMY_LITELLM_API_KEY, (
+            f"Keyless OpenAI-compatible endpoints must still receive the placeholder; "
+            f"LiteLLM resolved: {captured.get('api_key')!r}"
+        )

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -48,7 +48,7 @@ def _mock_response():
 
 @pytest.fixture(autouse=True)
 def patch_settings(monkeypatch):
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings())
+    monkeypatch.setattr(litellm_handler, "get_settings", _make_settings)
 
 
 @pytest.fixture(autouse=True)
@@ -548,7 +548,7 @@ class TestPlaceholderDoesNotShadowProviderEnvVars:
         LiteLLMAIHandler()  # request 1: tenant A, Groq key lands in litellm.api_key
         assert litellm.api_key == "gsk-tenant-a"
 
-        monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings())
+        monkeypatch.setattr(litellm_handler, "get_settings", _make_settings)
         with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                    new_callable=AsyncMock) as mock_call:
             mock_call.return_value = _mock_response()

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -51,6 +51,21 @@ def patch_settings(monkeypatch):
     monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings())
 
 
+@pytest.fixture(autouse=True)
+def restore_litellm_globals():
+    """Undo the LiteLLM globals LiteLLMAIHandler.__init__ writes.
+
+    Constructing the handler mutates process-wide state (litellm.api_key and
+    litellm.openai_key). monkeypatch only reverts what a test set itself, so without
+    this the placeholder written during __init__ would outlive the test and make
+    later tests order-dependent.
+    """
+    saved = {name: getattr(litellm, name) for name in ("api_key", "openai_key")}
+    yield
+    for name, value in saved.items():
+        setattr(litellm, name, value)
+
+
 def _make_anthropic_settings():
     """Settings with ANTHROPIC.KEY configured, no OPENAI.KEY.
 
@@ -499,6 +514,53 @@ class TestPlaceholderDoesNotShadowProviderEnvVars:
         monkeypatch.setattr(litellm, "openai_key", None)
         monkeypatch.setattr(litellm, "api_key", None)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_keyless_init_clears_a_stale_provider_key(self, monkeypatch):
+        """A keyless request must not inherit the previous request's provider key.
+
+        __init__ mutates process-global LiteLLM state, so a provider branch from an
+        earlier request (Groq/xAI/SambaNova/OpenRouter all write litellm.api_key) can
+        still be sitting there. chat_completion() forwards any truthy non-placeholder
+        litellm.api_key, so without an explicit reset a keyless request would
+        authenticate with — and leak — the earlier request's credential.
+        """
+        groq_settings = type("Settings", (), {
+            "config": type("Config", (), {
+                "reasoning_effort": None,
+                "ai_timeout": 30,
+                "custom_reasoning_model": False,
+                "max_model_tokens": 32000,
+                "verbosity_level": 0,
+                "seed": -1,
+                "get": lambda self, key, default=None: default,
+            })(),
+            "litellm": type("LiteLLM", (), {
+                "get": lambda self, key, default=None: default,
+            })(),
+            "groq": type("Groq", (), {"key": "gsk-tenant-a"})(),
+            "get": lambda self, key, default=None: (
+                "gsk-tenant-a" if key == "GROQ.KEY" else default
+            ),
+        })()
+
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: groq_settings)
+        LiteLLMAIHandler()  # request 1: tenant A, Groq key lands in litellm.api_key
+        assert litellm.api_key == "gsk-tenant-a"
+
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings())
+        with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+                   new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = _mock_response()
+            handler = LiteLLMAIHandler()  # request 2: tenant B, no keys configured
+            await handler.chat_completion(
+                model="openai/local-model", system="sys", user="usr"
+            )
+
+        assert "api_key" not in mock_call.call_args[1], (
+            f"A keyless init must clear the previous request's provider key; "
+            f"kwargs had: {mock_call.call_args[1].get('api_key')!r}"
+        )
 
     def test_placeholder_not_stored_in_global_litellm_api_key(self):
         """With no OpenAI key configured, litellm.api_key must stay falsy."""

--- a/tests/unittest/test_litellm_api_key_guard.py
+++ b/tests/unittest/test_litellm_api_key_guard.py
@@ -513,6 +513,59 @@ class TestPlaceholderDoesNotShadowProviderEnvVars:
             "so keyless local endpoints (vLLM, LM Studio, ...) keep working."
         )
 
+    def test_placeholder_does_not_stick_across_handler_inits(self, monkeypatch):
+        """A keyless request must not poison later requests that do configure OPENAI.KEY.
+
+        LiteLLMAIHandler is constructed per request but writes to LiteLLM's process-wide
+        globals. With the placeholder on litellm.api_key a single keyless init left
+        "dummy_key" there for the lifetime of the process, and every later request
+        resolved the placeholder even with OPENAI.KEY set — because __init__ only ever
+        writes the real OpenAI key to litellm.openai_key, which sits *behind*
+        litellm.api_key in the chain. Keeping the placeholder on openai_key means the
+        real key simply replaces it.
+        """
+        from litellm import main as litellm_main
+
+        openai_settings = type("Settings", (), {
+            "config": type("Config", (), {
+                "reasoning_effort": None,
+                "ai_timeout": 30,
+                "custom_reasoning_model": False,
+                "max_model_tokens": 32000,
+                "verbosity_level": 0,
+                "seed": -1,
+                "get": lambda self, key, default=None: default,
+            })(),
+            "litellm": type("LiteLLM", (), {
+                "get": lambda self, key, default=None: default,
+            })(),
+            "openai": type("OpenAI", (), {"key": "sk-real-openai"})(),
+            "get": lambda self, key, default=None: (
+                "sk-real-openai" if key == "OPENAI.KEY" else default
+            ),
+        })()
+
+        LiteLLMAIHandler()  # request 1: no OpenAI key configured
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: openai_settings)
+        LiteLLMAIHandler()  # request 2: OPENAI.KEY configured
+
+        captured = {}
+
+        class _Capturing:
+            def completion(self, *args, **kwargs):
+                captured["api_key"] = kwargs.get("api_key")
+                raise _StopCall
+
+        monkeypatch.setattr(litellm_main, "openai_chat_completions", _Capturing())
+        monkeypatch.setattr(litellm_main, "base_llm_http_handler", _Capturing())
+        with contextlib.suppress(Exception):
+            litellm.completion(model="gpt-4o", messages=[{"role": "user", "content": "hi"}])
+
+        assert captured.get("api_key") == "sk-real-openai", (
+            f"A keyless init must not leave a placeholder that outlives it; "
+            f"LiteLLM resolved: {captured.get('api_key')!r}"
+        )
+
     def test_openrouter_env_key_wins_over_placeholder(self, monkeypatch):
         """End-to-end through LiteLLM's own resolution chain.
 


### PR DESCRIPTION
Fixes #2544.

## Problem

When no OpenAI key is configured, `LiteLLMAIHandler.__init__` stored the `dummy_key` placeholder on the **global** `litellm.api_key`. LiteLLM resolves many providers as:

```python
api_key = (
    api_key
    or litellm.api_key               # "dummy_key" — truthy, wins here
    or litellm.openrouter_key
    or get_secret_str("OPENROUTER_API_KEY")  # never reached
    or get_secret_str("OR_API_KEY")
)
```

so the placeholder shadows the user's provider env var and the request goes out authenticated as `dummy_key`. OpenRouter answers `401 Missing Authentication header`. The same ordering applies to Azure (`AZURE_API_KEY`), Databricks, Mistral, Codestral and GigaChat.

#2293 only prevented the placeholder from being forwarded via `kwargs["api_key"]`; that guard has no effect on LiteLLM's own auth chain.

This only bites users who configure the key through the provider's native env var (e.g. `OPENROUTER_API_KEY` in a GitHub Action) rather than PR-Agent's `[openrouter] key` setting — the latter overwrites `litellm.api_key` with the real key on the way through `__init__`.

## Fix

```python
elif 'OPENAI_API_KEY' not in os.environ:
    litellm.api_key = None                      # don't inherit a previous request's key
    litellm.openai_key = DUMMY_LITELLM_API_KEY  # keyless OpenAI-compatible endpoints
```

**Why `openai_key`.** Simply dropping the placeholder (the fix suggested in the issue) would regress the case it was added for in f3c8089: keyless OpenAI-compatible endpoints (vLLM, LM Studio, a custom `api_base`) then resolve to no key at all and the OpenAI SDK raises *"The api_key client option must be set"*. `litellm.openai_key` keeps the placeholder reachable on exactly that path.

Classifying every read of `litellm.openai_key` in the pinned litellm 1.93.0 by its enclosing provider branch:

| read site | path |
|---|---|
| `_complete_text_completion_openai`, `_complete_aiohttp_openai`, `_complete_custom_openai`, `provider == "openai"` ×2 | OpenAI / OpenAI-compatible chat — **the placeholder is wanted here** |
| `provider == "azure_ai"` | ahead of `AZURE_AI_API_KEY`, but `get_llm_provider()` supplies a dynamic key at position 1, so the real key still wins (verified) |
| `provider == "litellm_proxy"`, `moderation()` ×2, plus embeddings / fine-tuning / assistants | not called by PR-Agent |

The property the fix depends on: `openai_key` is **not** consulted on the OpenRouter, Anthropic, Gemini, Bedrock, Mistral, Groq, Cohere or Databricks chat paths. OpenRouter in 1.93.0 resolves `api_key or litellm.api_key or litellm.openrouter_key or OPENROUTER_API_KEY or OR_API_KEY` — no `openai_key` in the chain.

**Why the `api_key = None` reset.** `__init__` runs per request but writes process-wide globals, and the provider branches (Groq, xAI, SambaNova, OpenRouter, Azure AD) store their key in `litellm.api_key`. The old code cleared that global as a side effect of overwriting it with the placeholder; relocating the placeholder removed the reset, so a keyless request could authenticate with — and leak — the previous request's credential. The reset sits before every provider branch, so the current request's key is repopulated afterwards.

## Behaviour

Measured with a capture at `Logging.pre_call` (LiteLLM's universal hook, after key resolution and before the request) across 20 provider routes, with and without native provider env vars set:

- **Changed, all fixes:** `openrouter/*`, `azure/*` and `databricks/*` go from `dummy_key` to the user's real env-var key.
- **Unchanged:** `openai`, `openai/<local>`, `hosted_vllm`, `ollama`, `anthropic`, `gemini`, `groq`, `deepseek`, `deepinfra`, `xai`, `cohere`, `together_ai`, `sambanova`, `perplexity`, `mistral`, `azure_ai`, `bedrock`.
- Every documented PR-Agent flow (`[openrouter] key`, `[openai] key`, `[openai] api_base` with no key, `[ollama] api_base`, `[groq] key`, `[anthropic] key`, `[deepseek] key`) resolves an **identical** key with and without this change.

Two behaviour changes worth naming:

1. **A provider with no key configured anywhere** now fails client-side (`APIConnectionError`) instead of sending `dummy_key` and collecting a 401. Inherent to no longer pretending a key exists, and only reachable from an already-broken configuration. LiteLLM's exceptions subclass `openai.APIError`, so `chat_completion()`'s retry/fallback handling is unaffected. Some messages improve (Gemini: *"Missing Gemini API key. Set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable"*).
2. **Cross-request state improves in both directions.** Previously one keyless request left `litellm.api_key = "dummy_key"` for the process lifetime, and since `__init__` only ever writes the real OpenAI key to `litellm.openai_key` — behind `api_key` in the chain — every later request resolved `dummy_key` even with `OPENAI.KEY` set. And with the placeholder relocated, a keyless request no longer inherits an earlier request's provider key.

## Tests

`TestPlaceholderDoesNotShadowProviderEnvVars` in `tests/unittest/test_litellm_api_key_guard.py`:

- `test_placeholder_not_stored_in_global_litellm_api_key` — version-independent invariant: the placeholder lives on `openai_key`, never on `api_key`.
- `test_openrouter_env_key_wins_over_placeholder` — drives LiteLLM's real resolution chain and asserts `OPENROUTER_API_KEY` reaches the transport.
- `test_openai_compatible_endpoint_still_gets_placeholder` — guards the keyless local-endpoint case.
- `test_placeholder_does_not_stick_across_handler_inits` — a keyless request must not poison a later one that sets `OPENAI.KEY`.
- `test_keyless_init_clears_a_stale_provider_key` — tenant A's Groq key must not be forwarded on tenant B's keyless request.

All fail on `main`. A module-scoped autouse fixture now restores `litellm.api_key` / `litellm.openai_key` around every test in the file, since constructing the handler writes globals that `monkeypatch` does not revert.

Two of these tests patch LiteLLM internals (`base_llm_http_handler`, `openai_chat_completions`) because that is the only seam that proves the resolved key; both symbols exist in the pinned 1.93.0, and a future LiteLLM refactor would break them loudly rather than silently. The first test covers the same invariant without touching internals.

`1369 passed, 1 xfailed` for `tests/unittest` (excluding the pre-existing `test_mosaico_*` collection errors from the missing optional `a2a` module). Ruff: clean on the test file, unchanged (12 pre-existing findings) on the handler.

## Known gaps

- The `if OPENAI.KEY` branch and the `OPENAI_API_KEY`-in-env path still leave a stale `litellm.api_key` from an earlier request. Pre-existing and unchanged here; the complete fix is an unconditional reset at the top of `__init__`, which would also clobber a `litellm.api_key` set by callers embedding PR-Agent as a library, so it deserves its own PR.
- If `OPENAI_API_KEY` is reachable only through a LiteLLM secret manager rather than `os.environ`, the placeholder shadows it. The old placement shadowed it earlier in the chain, so this is strictly better. PR-Agent does not configure `litellm.secret_manager_client`.
- e2e and health suites were not run (they need provider tokens).
