### PR TITLE
test(github): fix build-and-test failure from _dedup_code_fp payload key

### DIFF
--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -296,6 +296,11 @@ def test_publish_code_suggestions_multi_line_payload_shape():
 
     assert "comments" in captured
     payload = captured["comments"][0]
+    # publish_code_suggestions attaches an internal '_dedup_code_fp' fingerprint that
+    # publish_inline_comments consumes and strips before the GitHub API call; it is not
+    # part of the API payload shape under test, so drop it before comparing.
+    assert "_dedup_code_fp" in payload
+    payload = {key: value for key, value in payload.items() if key != "_dedup_code_fp"}
     assert payload == {
         "body": "```suggestion\nnew\n```",
         "path": "src/foo.py",
@@ -325,6 +330,11 @@ def test_publish_code_suggestions_single_line_payload_shape():
 
     assert provider.publish_code_suggestions(suggestions) is True
     payload = captured["c"][0]
+    # publish_code_suggestions attaches an internal '_dedup_code_fp' fingerprint that
+    # publish_inline_comments consumes and strips before the GitHub API call; it is not
+    # part of the API payload shape under test, so drop it before comparing.
+    assert "_dedup_code_fp" in payload
+    payload = {key: value for key, value in payload.items() if key != "_dedup_code_fp"}
     assert payload == {
         "body": "fix",
         "path": "src/foo.py",


### PR DESCRIPTION
## Summary

`Build-and-test` has been red on `main` since #2424 merged. Two pre-existing unit tests fail:

- `tests/unittest/test_github_provider_comments.py::test_publish_code_suggestions_multi_line_payload_shape`
- `tests/unittest/test_github_provider_comments.py::test_publish_code_suggestions_single_line_payload_shape`

```
E   AssertionError: assert {'_dedup_code.../foo.py', ...} == {'body': 'fix...ide': 'RIGHT'}
E     Left contains 1 more item:
E     {'_dedup_code_fp': None}
====== 2 failed, 1384 passed, 1 skipped, 1 xfailed ======
```

## Root cause

#2424 (persistent inline comments) added an internal `_dedup_code_fp` fingerprint to each committable-suggestion payload built in `GithubProvider.publish_code_suggestions`. `publish_inline_comments` **consumes and strips** that key before the GitHub API call — both when persistent dedup is on (`marked.pop(...)`) and off (dict comprehension filter) — so it never reaches GitHub. The fingerprint is computed on the *pre-transform* body on purpose, so it must travel inside the comment dict; the production behavior is correct.

The two `*_payload_shape` tests (added earlier in #2397) stub `publish_inline_comments` and capture the payload **at that internal boundary**, then assert exact `==` equality against a dict without `_dedup_code_fp`. #2424 didn't touch this test file, so the added key broke the assertions. This is stale tests, not a code bug.

## Fix

Drop the internal `_dedup_code_fp` key before the shape comparison (and assert it is present), keeping the tests focused on the GitHub API payload shape they actually cover. No production code changes.

## Verification

`PYTHONPATH=. pytest tests/unittest` → **1386 passed, 1 skipped, 1 xfailed** (the two previously-failing tests now pass).