### PR TITLE
fix(servers): cap gunicorn workers and preload the app to stop OOMKills

### DIFF
--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -45,3 +45,5 @@
 8. Create a webhook in your Gitea project. Set the URL to `http[s]://<PR_AGENT_HOSTNAME>/api/v1/gitea_webhooks`, the secret token to the generated secret from step 3, and enable the triggers `push`, `comments` and `merge request events`.
 
 9. Test your installation by opening a merge request or commenting on a merge request using one of PR Agent's commands.
+
+10. The webhook server runs under gunicorn with multiple worker processes. See [Sizing a self-hosted webhook server](./index.md#sizing-a-self-hosted-webhook-server) for the `GUNICORN_WORKERS` / `GUNICORN_MAX_WORKERS` knobs and memory guidance — worth reading before setting a memory limit.

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -685,6 +685,8 @@ cp pr_agent/settings/.secrets_template.toml pr_agent/settings/.secrets.toml
 
 9. Install the app by navigating to the "Install App" tab and selecting your desired repositories.
 
+10. The app runs under gunicorn with multiple worker processes. See [Sizing a self-hosted webhook server](./index.md#sizing-a-self-hosted-webhook-server) for the `GUNICORN_WORKERS` / `GUNICORN_MAX_WORKERS` knobs and memory guidance — worth reading before setting a memory limit.
+
 > **Note:** When running PR-Agent from GitHub app, the default configuration file (configuration.toml) will be loaded.
 > However, you can override the default tool parameters by uploading a local configuration file `.pr_agent.toml`
 > To use organization-level global configuration, create `<organization>/pr-agent-settings` with a `.pr_agent.toml` file and install the GitHub App on that repository too.

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -97,6 +97,25 @@ PORT=3000  # Optional: override the webhook server port
 
 9. Test your installation by opening a merge request or commenting on a merge request using one of PR Agent's commands.
 
+### Sizing the webhook server
+
+The webhook server runs under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. Workers do not share memory, and each one needs roughly 250MB, which sets the container's memory requirement:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GUNICORN_WORKERS` | *(unset)* | Pins the worker count exactly. Overrides everything below. |
+| `GUNICORN_MAX_WORKERS` | `4` | Upper bound on the automatically derived worker count. |
+
+When `GUNICORN_WORKERS` is unset, the worker count is derived from the CPUs actually available to the container (cgroup quota, falling back to CPU affinity), clamped to between 2 and `GUNICORN_MAX_WORKERS`.
+
+Budget about `250MB × workers` of memory. If the container is OOMKilled during startup, lower the worker count:
+
+```bash
+GUNICORN_WORKERS=2
+```
+
+The same variables apply to the GitHub and Gitea webhook servers, which run under the same gunicorn configuration.
+
 ## Deploy as a Lambda Function
 
 Note that since AWS Lambda env vars cannot have "." in the name, you can replace each "." in an env variable with "__".<br>

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -97,26 +97,7 @@ PORT=3000  # Optional: override the webhook server port
 
 9. Test your installation by opening a merge request or commenting on a merge request using one of PR Agent's commands.
 
-### Sizing the webhook server
-
-The webhook server runs under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GUNICORN_WORKERS` | *(unset)* | Pins the worker count exactly. Overrides everything below. |
-| `GUNICORN_MAX_WORKERS` | `4` | Upper bound on the automatically derived worker count. |
-
-When `GUNICORN_WORKERS` is unset, the worker count is derived from the CPUs actually available to the container (cgroup CPU limit, falling back to CPU affinity), clamped to between 2 and `GUNICORN_MAX_WORKERS`. Note that a CPU *request* without a *limit* leaves no cgroup quota to read, so the cap is what bounds the worker count there.
-
-**Sizing memory:** importing the application costs roughly 250MB. The app is imported once in the gunicorn master and workers are forked from it, so they share most of that baseline copy-on-write rather than each paying it in full — total memory grows with worker count, but by noticeably less than 250MB per worker. Start from about 1Gi for the default of 4 workers and adjust against your own metrics.
-
-If the container is OOMKilled during startup, lower the worker count:
-
-```bash
-GUNICORN_WORKERS=2
-```
-
-The same variables apply to the GitHub and Gitea webhook servers, which run under the same gunicorn configuration.
+10. The webhook server runs under gunicorn with multiple worker processes. See [Sizing a self-hosted webhook server](./index.md#sizing-a-self-hosted-webhook-server) for the `GUNICORN_WORKERS` / `GUNICORN_MAX_WORKERS` knobs and memory guidance — worth reading before setting a memory limit.
 
 ## Deploy as a Lambda Function
 

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -99,16 +99,18 @@ PORT=3000  # Optional: override the webhook server port
 
 ### Sizing the webhook server
 
-The webhook server runs under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. Workers do not share memory, and each one needs roughly 250MB, which sets the container's memory requirement:
+The webhook server runs under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GUNICORN_WORKERS` | *(unset)* | Pins the worker count exactly. Overrides everything below. |
 | `GUNICORN_MAX_WORKERS` | `4` | Upper bound on the automatically derived worker count. |
 
-When `GUNICORN_WORKERS` is unset, the worker count is derived from the CPUs actually available to the container (cgroup quota, falling back to CPU affinity), clamped to between 2 and `GUNICORN_MAX_WORKERS`.
+When `GUNICORN_WORKERS` is unset, the worker count is derived from the CPUs actually available to the container (cgroup CPU limit, falling back to CPU affinity), clamped to between 2 and `GUNICORN_MAX_WORKERS`. Note that a CPU *request* without a *limit* leaves no cgroup quota to read, so the cap is what bounds the worker count there.
 
-Budget about `250MB × workers` of memory. If the container is OOMKilled during startup, lower the worker count:
+**Sizing memory:** importing the application costs roughly 250MB. The app is imported once in the gunicorn master and workers are forked from it, so they share most of that baseline copy-on-write rather than each paying it in full — total memory grows with worker count, but by noticeably less than 250MB per worker. Start from about 1Gi for the default of 4 workers and adjust against your own metrics.
+
+If the container is OOMKilled during startup, lower the worker count:
 
 ```bash
 GUNICORN_WORKERS=2

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -9,5 +9,24 @@ There are several ways to use PR-Agent:
 - [Azure DevOps integration](./azure.md)
 - [Gitea integration](./gitea.md)
 
+## Sizing a self-hosted webhook server
+
+The GitHub, GitLab and Gitea webhook servers (the `github_app`, `gitlab_webhook` and `gitea_app` Docker targets) run under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. The other deployments — Bitbucket, Azure DevOps, GitHub polling, and the Lambda variants — run a single process and are unaffected by this section.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GUNICORN_WORKERS` | *(unset)* | Pins the worker count exactly. Overrides everything below. |
+| `GUNICORN_MAX_WORKERS` | `4` | Upper bound on the automatically derived worker count. |
+
+When `GUNICORN_WORKERS` is unset, the worker count is derived from the CPUs actually available to the container (cgroup CPU limit, falling back to CPU affinity), clamped to between 2 and `GUNICORN_MAX_WORKERS`. Note that a CPU *request* without a *limit* leaves no cgroup quota to read, so the cap is what bounds the worker count there.
+
+**Sizing memory:** importing the application costs roughly 250MB. The app is imported once in the gunicorn master and workers are forked from it, so they share most of that baseline copy-on-write rather than each paying it in full — total memory grows with worker count, but by noticeably less than 250MB per worker. Start from about 1Gi for the default of 4 workers and adjust against your own metrics.
+
+If the container is OOMKilled during startup, lower the worker count:
+
+```bash
+GUNICORN_WORKERS=2
+```
+
 !!! note "Docker Hub namespace migration"
     Releases **`0.34.2` and later** are published under [`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). Older releases (up to and including `v0.31`) remain at the legacy [`codiumai/pr-agent`](https://hub.docker.com/r/codiumai/pr-agent) namespace as a frozen archive — no new images are pushed there. The examples on this site reference the new namespace; if you are pinning to a release before `0.34.2`, swap `pragent/pr-agent` for `codiumai/pr-agent` in your `image:` / `docker pull` / `uses: docker://` references.

--- a/pr_agent/secret_providers/__init__.py
+++ b/pr_agent/secret_providers/__init__.py
@@ -1,5 +1,20 @@
 from pr_agent.config_loader import get_settings
 
+# Keep in step with the branches of get_secret_provider() below.
+SUPPORTED_SECRET_PROVIDERS = ("google_cloud_storage", "aws_secrets_manager")
+
+
+def validate_secret_provider_setting():
+    """Check CONFIG.SECRET_PROVIDER names a known provider, without building its client.
+
+    Lets a server reject a typo at startup while leaving the cloud client itself to be
+    constructed per process. That split matters under gunicorn's `preload_app`: a client
+    built during import would be created in the master and inherited by every worker.
+    """
+    provider_id = get_settings().get("CONFIG.SECRET_PROVIDER")
+    if provider_id and provider_id not in SUPPORTED_SECRET_PROVIDERS:
+        raise ValueError("Unknown SECRET_PROVIDER")
+
 
 def get_secret_provider():
     if not get_settings().get("CONFIG.SECRET_PROVIDER"):

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -25,6 +25,22 @@ setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL"
 router = APIRouter()
 
 secret_provider = get_secret_provider() if get_settings().get("CONFIG.SECRET_PROVIDER") else None
+_secret_provider_pid = os.getpid()
+
+
+def get_fork_safe_secret_provider():
+    """Return the secret provider, rebuilding it once per process after a fork.
+
+    Gunicorn runs with `preload_app`, so the provider above is constructed in the master
+    and every worker inherits it. Cloud clients hold a pooled connection that must not be
+    shared across processes, so each worker builds its own on first use. Constructing at
+    import is kept so a misconfigured CONFIG.SECRET_PROVIDER still fails at startup.
+    """
+    global secret_provider, _secret_provider_pid
+    if secret_provider is not None and _secret_provider_pid != os.getpid():
+        secret_provider = get_secret_provider()
+        _secret_provider_pid = os.getpid()
+    return secret_provider
 
 
 async def handle_request(api_url: str, body: str, log_context: dict, sender_id: str, notify=None):
@@ -191,9 +207,10 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
     async def inner(data: dict):
         log_context = {"server_type": "gitlab_app"}
         get_logger().debug("Received a GitLab webhook")
-        if request.headers.get("X-Gitlab-Token") and secret_provider:
+        active_secret_provider = get_fork_safe_secret_provider()
+        if request.headers.get("X-Gitlab-Token") and active_secret_provider:
             request_token = request.headers.get("X-Gitlab-Token")
-            secret = secret_provider.get_secret(request_token)
+            secret = active_secret_provider.get_secret(request_token)
             if not secret:
                 get_logger().warning(f"Empty secret retrieved, request_token: {request_token}")
                 return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -212,10 +212,12 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
     async def inner(data: dict):
         log_context = {"server_type": "gitlab_app"}
         get_logger().debug("Received a GitLab webhook")
-        active_secret_provider = get_fork_safe_secret_provider()
-        if request.headers.get("X-Gitlab-Token") and active_secret_provider:
-            request_token = request.headers.get("X-Gitlab-Token")
-            secret = active_secret_provider.get_secret(request_token)
+        request_token = request.headers.get("X-Gitlab-Token")
+        # Built only for a request that will actually consult it, so a cloud client that
+        # fails to initialize cannot drop webhooks authenticated by shared secret instead.
+        secret_provider = get_fork_safe_secret_provider() if request_token else None
+        if request_token and secret_provider:
+            secret = secret_provider.get_secret(request_token)
             if not secret:
                 get_logger().warning(f"Empty secret retrieved, request_token: {request_token}")
                 return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
@@ -230,7 +232,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
         elif get_settings().get("GITLAB.SHARED_SECRET"):
             secret = get_settings().get("GITLAB.SHARED_SECRET")
-            if not request.headers.get("X-Gitlab-Token") == secret:
+            if not request_token == secret:
                 get_logger().error("Failed to validate secret")
                 return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
         else:

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -18,31 +18,33 @@ from pr_agent.algo.utils import update_settings_from_args
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.secret_providers import get_secret_provider
+from pr_agent.secret_providers import (get_secret_provider,
+                                       validate_secret_provider_setting)
 from pr_agent.git_providers import get_git_provider_with_context
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
 
 
-def _build_secret_provider():
-    return get_secret_provider() if get_settings().get("CONFIG.SECRET_PROVIDER") else None
+# Validated at import so a typo in CONFIG.SECRET_PROVIDER still fails at startup. The
+# client itself is deliberately not built here - see get_fork_safe_secret_provider.
+validate_secret_provider_setting()
 
-
-# Built at import so a misconfigured CONFIG.SECRET_PROVIDER still fails at startup.
-_secret_provider_state = {"provider": _build_secret_provider(), "pid": os.getpid()}
+_secret_provider_state = {}
 
 
 def get_fork_safe_secret_provider():
-    """Return the secret provider, rebuilding it once per process after a fork.
+    """Return this process's secret provider, building it on first use.
 
-    Gunicorn runs with `preload_app`, so the provider is constructed in the master and
-    every worker inherits it. Cloud clients hold a pooled connection that must not be
-    shared across processes, so each worker builds its own on first use.
+    Nothing is constructed at import because gunicorn runs with `preload_app`: a client
+    built there would belong to the master, and every worker would inherit its pooled
+    connection. Keying the cache on the pid means a forked worker always builds its own,
+    and never adopts one created in another process.
     """
-    if _secret_provider_state["provider"] is not None and _secret_provider_state["pid"] != os.getpid():
-        _secret_provider_state["provider"] = _build_secret_provider()
-        _secret_provider_state["pid"] = os.getpid()
+    pid = os.getpid()
+    if _secret_provider_state.get("pid") != pid:
+        _secret_provider_state["provider"] = get_secret_provider()
+        _secret_provider_state["pid"] = pid
     return _secret_provider_state["provider"]
 
 

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -24,23 +24,25 @@ from pr_agent.git_providers import get_git_provider_with_context
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
 
-secret_provider = get_secret_provider() if get_settings().get("CONFIG.SECRET_PROVIDER") else None
-_secret_provider_pid = os.getpid()
+def _build_secret_provider():
+    return get_secret_provider() if get_settings().get("CONFIG.SECRET_PROVIDER") else None
+
+
+# Built at import so a misconfigured CONFIG.SECRET_PROVIDER still fails at startup.
+_secret_provider_state = {"provider": _build_secret_provider(), "pid": os.getpid()}
 
 
 def get_fork_safe_secret_provider():
     """Return the secret provider, rebuilding it once per process after a fork.
 
-    Gunicorn runs with `preload_app`, so the provider above is constructed in the master
-    and every worker inherits it. Cloud clients hold a pooled connection that must not be
-    shared across processes, so each worker builds its own on first use. Constructing at
-    import is kept so a misconfigured CONFIG.SECRET_PROVIDER still fails at startup.
+    Gunicorn runs with `preload_app`, so the provider is constructed in the master and
+    every worker inherits it. Cloud clients hold a pooled connection that must not be
+    shared across processes, so each worker builds its own on first use.
     """
-    global secret_provider, _secret_provider_pid
-    if secret_provider is not None and _secret_provider_pid != os.getpid():
-        secret_provider = get_secret_provider()
-        _secret_provider_pid = os.getpid()
-    return secret_provider
+    if _secret_provider_state["provider"] is not None and _secret_provider_state["pid"] != os.getpid():
+        _secret_provider_state["provider"] = _build_secret_provider()
+        _secret_provider_state["pid"] = os.getpid()
+    return _secret_provider_state["provider"]
 
 
 async def handle_request(api_url: str, body: str, log_context: dict, sender_id: str, notify=None):

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -24,6 +24,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
 
+
 def _build_secret_provider():
     return get_secret_provider() if get_settings().get("CONFIG.SECRET_PROVIDER") else None
 

--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -1,4 +1,4 @@
-import multiprocessing
+import gc
 import os
 
 # from prometheus_client import multiprocess
@@ -71,11 +71,84 @@ backlog = 2048
 #       A positive integer. Generally set in the 1-5 seconds range.
 #
 
-if os.getenv('GUNICORN_WORKERS', None):
-    workers = int(os.getenv('GUNICORN_WORKERS'))
-else:
-    cores = multiprocessing.cpu_count()
-    workers = cores * 2 + 1
+# Each worker imports the full pr_agent graph (litellm alone is ~150MB), so the worker
+# count is the dominant term in the server's memory footprint. Two things kept the old
+# `cpu_count() * 2 + 1` default from being safe in a container:
+#   - `multiprocessing.cpu_count()` reports the *host's* cores, ignoring the cgroup CPU
+#     limit, so a pod capped at 500m on a 64-core node spawned 129 workers and was OOMKilled.
+#   - `cores * 2 + 1` is gunicorn's formula for *sync* workers. These are async
+#     UvicornWorkers on a purely I/O-bound workload, where a handful already saturate.
+# Hence: read the real cgroup limit, then clamp hard. Override with GUNICORN_WORKERS.
+MIN_WORKERS = 2  # >=2 so a worker blocked on a background task can't fail the health check
+DEFAULT_MAX_WORKERS = 4
+
+CGROUP_V2_CPU_MAX = '/sys/fs/cgroup/cpu.max'
+CGROUP_V1_CPU_QUOTA = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us'
+CGROUP_V1_CPU_PERIOD = '/sys/fs/cgroup/cpu/cpu.cfs_period_us'
+
+
+def _cgroup_cpu_limit():
+    """Return the cgroup's effective CPU limit, or None when unlimited or unavailable."""
+    try:  # cgroup v2
+        with open(CGROUP_V2_CPU_MAX) as f:
+            quota, period = f.read().split()
+        if quota != 'max' and float(period) > 0:
+            return float(quota) / float(period)
+        return None
+    except (OSError, ValueError):
+        pass
+    try:  # cgroup v1
+        with open(CGROUP_V1_CPU_QUOTA) as f:
+            quota = int(f.read())
+        with open(CGROUP_V1_CPU_PERIOD) as f:
+            period = int(f.read())
+        if quota > 0 and period > 0:
+            return quota / period
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def available_cpus():
+    """CPUs actually usable by this process, honouring cgroup quota and CPU affinity."""
+    limit = _cgroup_cpu_limit()
+    if limit is not None:
+        return max(1, int(limit))
+    try:
+        return max(1, len(os.sched_getaffinity(0)))  # respects cpuset pinning; Linux only
+    except AttributeError:
+        return max(1, os.cpu_count() or 1)
+
+
+def _env_int(name):
+    raw = os.getenv(name)
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from None
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1, got {value}")
+    return value
+
+
+def compute_workers():
+    explicit = _env_int('GUNICORN_WORKERS')
+    if explicit is not None:
+        return explicit
+    max_workers = _env_int('GUNICORN_MAX_WORKERS') or DEFAULT_MAX_WORKERS
+    floor = min(MIN_WORKERS, max_workers)  # an explicit ceiling below the floor wins
+    return max(floor, min(available_cpus(), max_workers))
+
+
+workers = compute_workers()
+
+# Import the app once in the master and fork afterwards, so workers share that ~230MB
+# heap copy-on-write instead of each building their own. Anything constructed at import
+# is now inherited across the fork, so import-time clients must be fork-safe (see the
+# pid-guarded secret provider in servers/gitlab_webhook.py).
+preload_app = True
 worker_connections = 1000
 timeout = 240
 keepalive = 2
@@ -189,3 +262,12 @@ proc_name = None
 #
 #       A callable that takes a server instance as the sole argument.
 #
+
+
+def when_ready(server):
+    """Runs after `preload_app` has imported the app and before any worker is forked."""
+    # Copy-on-write only saves memory while the shared pages stay clean, and CPython
+    # dirties them on its own: the cyclic collector writes to the GC header of every
+    # object it visits. Freezing moves everything allocated so far into a permanent
+    # generation the collector never traverses, keeping those pages shared.
+    gc.freeze()

--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -109,15 +109,24 @@ def _cgroup_cpu_limit():
     return None
 
 
-def available_cpus():
-    """CPUs actually usable by this process, honouring cgroup quota and CPU affinity."""
-    limit = _cgroup_cpu_limit()
-    if limit is not None:
-        return max(1, int(limit))
+def _affinity_cpus():
+    """CPUs this process may be scheduled on, or None when the platform cannot say."""
     try:
-        return max(1, len(os.sched_getaffinity(0)))  # respects cpuset pinning; Linux only
+        return len(os.sched_getaffinity(0))  # respects cpuset pinning; Linux only
     except AttributeError:
-        return max(1, os.cpu_count() or 1)
+        return os.cpu_count()
+
+
+def available_cpus():
+    """CPUs usable by this process: the stricter of the cgroup quota and CPU affinity.
+
+    A pod can have both - a quota of 4 while pinned to 2 cores - so neither alone is the
+    answer. Either may be absent, in which case the other stands on its own.
+    """
+    limits = [limit for limit in (_cgroup_cpu_limit(), _affinity_cpus()) if limit]
+    if not limits:
+        return 1
+    return max(1, int(min(limits)))
 
 
 def _env_int(name):

--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -96,7 +96,7 @@ def _cgroup_cpu_limit():
             return float(quota) / float(period)
         return None
     except (OSError, ValueError):
-        pass
+        pass  # not a cgroup v2 host (or the file is unreadable) - try v1 below
     try:  # cgroup v1
         with open(CGROUP_V1_CPU_QUOTA) as f:
             quota = int(f.read())
@@ -105,7 +105,7 @@ def _cgroup_cpu_limit():
         if quota > 0 and period > 0:
             return quota / period
     except (OSError, ValueError):
-        pass
+        pass  # no cgroup at all (macOS/Windows/bare metal) - caller falls back to CPU affinity
     return None
 
 
@@ -271,3 +271,17 @@ def when_ready(server):
     # object it visits. Freezing moves everything allocated so far into a permanent
     # generation the collector never traverses, keeping those pages shared.
     gc.freeze()
+
+
+def post_fork(server, worker):
+    """Runs inside each worker right after it is forked."""
+    # The webhook apps call setup_logger() at import, which under `preload_app` now runs
+    # in the master. When CONFIG.ANALYTICS_FOLDER is set that opens `pr-agent.<pid>.log`
+    # named for the *master*, and every worker inherits the same descriptor. Re-running it
+    # here gives each worker its own file again. All three apps that use this config call
+    # setup_logger identically, so repeating that call is enough.
+    from pr_agent.config_loader import get_settings
+    from pr_agent.log import LoggingFormat, setup_logger
+
+    if get_settings().get("CONFIG.ANALYTICS_FOLDER", ""):
+        setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))

--- a/tests/unittest/test_gitlab_webhook_secret_provider.py
+++ b/tests/unittest/test_gitlab_webhook_secret_provider.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+
+os.environ.setdefault("GITLAB__URL", "https://gitlab.example.com")
+import pr_agent.servers.gitlab_webhook as gitlab_webhook
+
+
+class FakeSecretProvider:
+    """Stands in for a cloud secret client, which must not be shared across a fork."""
+
+
+@pytest.fixture(autouse=True)
+def restore_state():
+    original = dict(gitlab_webhook._secret_provider_state)
+    yield
+    gitlab_webhook._secret_provider_state.clear()
+    gitlab_webhook._secret_provider_state.update(original)
+
+
+def test_reuses_provider_within_the_same_process(monkeypatch):
+    provider = FakeSecretProvider()
+    gitlab_webhook._secret_provider_state.update({"provider": provider, "pid": os.getpid()})
+    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("rebuilt without a fork"))
+
+    assert gitlab_webhook.get_fork_safe_secret_provider() is provider
+
+
+def test_rebuilds_provider_after_a_fork(monkeypatch):
+    # A worker forked from the gunicorn master inherits the master's provider, and with it
+    # the master's pooled connection. A differing pid must force a fresh client.
+    rebuilt = FakeSecretProvider()
+    gitlab_webhook._secret_provider_state.update({"provider": FakeSecretProvider(), "pid": os.getpid() + 1})
+    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: rebuilt)
+
+    assert gitlab_webhook.get_fork_safe_secret_provider() is rebuilt
+    assert gitlab_webhook._secret_provider_state["pid"] == os.getpid()
+    # The rebuild is claimed for this process, so a second call must not build again.
+    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("rebuilt twice"))
+    assert gitlab_webhook.get_fork_safe_secret_provider() is rebuilt
+
+
+def test_stays_none_when_no_provider_is_configured(monkeypatch):
+    # Nothing to rebuild when secrets come from config rather than a cloud provider.
+    gitlab_webhook._secret_provider_state.update({"provider": None, "pid": os.getpid() + 1})
+    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("built a provider"))
+
+    assert gitlab_webhook.get_fork_safe_secret_provider() is None

--- a/tests/unittest/test_gitlab_webhook_secret_provider.py
+++ b/tests/unittest/test_gitlab_webhook_secret_provider.py
@@ -11,38 +11,61 @@ class FakeSecretProvider:
 
 
 @pytest.fixture(autouse=True)
-def restore_state():
+def clean_state():
     original = dict(gitlab_webhook._secret_provider_state)
+    gitlab_webhook._secret_provider_state.clear()
     yield
     gitlab_webhook._secret_provider_state.clear()
     gitlab_webhook._secret_provider_state.update(original)
 
 
+def test_nothing_is_built_at_import():
+    # Under `preload_app` an import-time client would be built in the gunicorn master and
+    # inherited by every worker, so the module must start with no provider at all.
+    assert gitlab_webhook._secret_provider_state == {}
+
+
+def test_builds_on_first_use(monkeypatch):
+    provider = FakeSecretProvider()
+    monkeypatch.setattr(gitlab_webhook, "get_secret_provider", lambda: provider)
+
+    assert gitlab_webhook.get_fork_safe_secret_provider() is provider
+    assert gitlab_webhook._secret_provider_state["pid"] == os.getpid()
+
+
 def test_reuses_provider_within_the_same_process(monkeypatch):
     provider = FakeSecretProvider()
     gitlab_webhook._secret_provider_state.update({"provider": provider, "pid": os.getpid()})
-    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("rebuilt without a fork"))
+    monkeypatch.setattr(gitlab_webhook, "get_secret_provider", lambda: pytest.fail("rebuilt without a fork"))
 
     assert gitlab_webhook.get_fork_safe_secret_provider() is provider
 
 
 def test_rebuilds_provider_after_a_fork(monkeypatch):
-    # A worker forked from the gunicorn master inherits the master's provider, and with it
-    # the master's pooled connection. A differing pid must force a fresh client.
+    # A worker inheriting the parent's provider would share its pooled connection, so a
+    # differing pid must force a fresh client.
     rebuilt = FakeSecretProvider()
     gitlab_webhook._secret_provider_state.update({"provider": FakeSecretProvider(), "pid": os.getpid() + 1})
-    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: rebuilt)
+    monkeypatch.setattr(gitlab_webhook, "get_secret_provider", lambda: rebuilt)
 
     assert gitlab_webhook.get_fork_safe_secret_provider() is rebuilt
     assert gitlab_webhook._secret_provider_state["pid"] == os.getpid()
-    # The rebuild is claimed for this process, so a second call must not build again.
-    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("rebuilt twice"))
+
+    monkeypatch.setattr(gitlab_webhook, "get_secret_provider", lambda: pytest.fail("rebuilt twice"))
     assert gitlab_webhook.get_fork_safe_secret_provider() is rebuilt
 
 
-def test_stays_none_when_no_provider_is_configured(monkeypatch):
-    # Nothing to rebuild when secrets come from config rather than a cloud provider.
-    gitlab_webhook._secret_provider_state.update({"provider": None, "pid": os.getpid() + 1})
-    monkeypatch.setattr(gitlab_webhook, "_build_secret_provider", lambda: pytest.fail("built a provider"))
+def test_caches_none_when_no_provider_is_configured(monkeypatch):
+    # get_secret_provider() returns None when CONFIG.SECRET_PROVIDER is unset; that answer
+    # must be cached too, not retried on every webhook.
+    calls = []
+
+    def _build():
+        calls.append(True)
+        return None
+
+    monkeypatch.setattr(gitlab_webhook, "get_secret_provider", _build)
 
     assert gitlab_webhook.get_fork_safe_secret_provider() is None
+    assert gitlab_webhook.get_fork_safe_secret_provider() is None
+    assert len(calls) == 1

--- a/tests/unittest/test_gunicorn_config.py
+++ b/tests/unittest/test_gunicorn_config.py
@@ -1,0 +1,120 @@
+import pytest
+
+from pr_agent.servers import gunicorn_config
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(monkeypatch, tmp_path):
+    """Detach every test from the host's env vars and real cgroup files."""
+    monkeypatch.delenv("GUNICORN_WORKERS", raising=False)
+    monkeypatch.delenv("GUNICORN_MAX_WORKERS", raising=False)
+    for attr in ("CGROUP_V2_CPU_MAX", "CGROUP_V1_CPU_QUOTA", "CGROUP_V1_CPU_PERIOD"):
+        monkeypatch.setattr(gunicorn_config, attr, str(tmp_path / "missing"))
+
+
+def write_cgroup_v2(monkeypatch, tmp_path, content):
+    path = tmp_path / "cpu.max"
+    path.write_text(content)
+    monkeypatch.setattr(gunicorn_config, "CGROUP_V2_CPU_MAX", str(path))
+
+
+def write_cgroup_v1(monkeypatch, tmp_path, quota, period):
+    quota_path = tmp_path / "cpu.cfs_quota_us"
+    period_path = tmp_path / "cpu.cfs_period_us"
+    quota_path.write_text(quota)
+    period_path.write_text(period)
+    monkeypatch.setattr(gunicorn_config, "CGROUP_V1_CPU_QUOTA", str(quota_path))
+    monkeypatch.setattr(gunicorn_config, "CGROUP_V1_CPU_PERIOD", str(period_path))
+
+
+class TestCgroupCpuLimit:
+    @pytest.mark.parametrize("content,expected", [
+        ("200000 100000\n", 2.0),
+        ("50000 100000\n", 0.5),
+        ("max 100000\n", None),  # no CPU limit set on the pod
+    ])
+    def test_cgroup_v2(self, monkeypatch, tmp_path, content, expected):
+        write_cgroup_v2(monkeypatch, tmp_path, content)
+        assert gunicorn_config._cgroup_cpu_limit() == expected
+
+    def test_cgroup_v2_malformed_falls_through(self, monkeypatch, tmp_path):
+        write_cgroup_v2(monkeypatch, tmp_path, "garbage\n")
+        assert gunicorn_config._cgroup_cpu_limit() is None
+
+    @pytest.mark.parametrize("quota,period,expected", [
+        ("150000", "100000", 1.5),
+        ("-1", "100000", None),  # cgroup v1 sentinel for "unlimited"
+    ])
+    def test_cgroup_v1(self, monkeypatch, tmp_path, quota, period, expected):
+        write_cgroup_v1(monkeypatch, tmp_path, quota, period)
+        assert gunicorn_config._cgroup_cpu_limit() == expected
+
+    def test_no_cgroup_files(self):
+        assert gunicorn_config._cgroup_cpu_limit() is None
+
+
+class TestAvailableCpus:
+    def test_prefers_cgroup_limit_over_host_cores(self, monkeypatch, tmp_path):
+        write_cgroup_v2(monkeypatch, tmp_path, "400000 100000\n")
+        monkeypatch.setattr(gunicorn_config.os, "cpu_count", lambda: 64)
+        assert gunicorn_config.available_cpus() == 4
+
+    def test_fractional_cpu_limit_rounds_up_to_one(self, monkeypatch, tmp_path):
+        # The reported pod: `cpu: 500m`. Must never yield 0 workers.
+        write_cgroup_v2(monkeypatch, tmp_path, "50000 100000\n")
+        assert gunicorn_config.available_cpus() == 1
+
+    def test_falls_back_to_affinity_when_uncapped(self, monkeypatch):
+        monkeypatch.setattr(gunicorn_config.os, "sched_getaffinity", lambda pid: set(range(8)), raising=False)
+        assert gunicorn_config.available_cpus() == 8
+
+
+class TestComputeWorkers:
+    def test_explicit_override_wins(self, monkeypatch, tmp_path):
+        write_cgroup_v2(monkeypatch, tmp_path, "100000 100000\n")
+        monkeypatch.setenv("GUNICORN_WORKERS", "9")
+        assert gunicorn_config.compute_workers() == 9
+
+    @pytest.mark.parametrize("value", ["abc", "0", "-3", "2.5"])
+    def test_invalid_override_is_rejected(self, monkeypatch, value):
+        monkeypatch.setenv("GUNICORN_WORKERS", value)
+        with pytest.raises(ValueError):
+            gunicorn_config.compute_workers()
+
+    def test_blank_override_is_ignored(self, monkeypatch, tmp_path):
+        write_cgroup_v2(monkeypatch, tmp_path, "300000 100000\n")
+        monkeypatch.setenv("GUNICORN_WORKERS", "")
+        assert gunicorn_config.compute_workers() == 3
+
+    def test_caps_a_large_host(self, monkeypatch):
+        # The regression: an uncapped pod on a 64-core node used to get 129 workers.
+        monkeypatch.setattr(gunicorn_config, "available_cpus", lambda: 64)
+        assert gunicorn_config.compute_workers() == gunicorn_config.DEFAULT_MAX_WORKERS
+
+    def test_keeps_minimum_for_health_check_isolation(self, monkeypatch):
+        monkeypatch.setattr(gunicorn_config, "available_cpus", lambda: 1)
+        assert gunicorn_config.compute_workers() == gunicorn_config.MIN_WORKERS
+
+    def test_max_workers_env_lowers_the_ceiling(self, monkeypatch):
+        monkeypatch.setattr(gunicorn_config, "available_cpus", lambda: 64)
+        monkeypatch.setenv("GUNICORN_MAX_WORKERS", "3")
+        assert gunicorn_config.compute_workers() == 3
+
+    def test_max_workers_env_below_minimum_wins(self, monkeypatch):
+        monkeypatch.setattr(gunicorn_config, "available_cpus", lambda: 64)
+        monkeypatch.setenv("GUNICORN_MAX_WORKERS", "1")
+        assert gunicorn_config.compute_workers() == 1
+
+    def test_module_level_workers_within_bounds(self):
+        assert gunicorn_config.MIN_WORKERS <= gunicorn_config.workers <= gunicorn_config.DEFAULT_MAX_WORKERS
+
+
+def test_preload_app_enabled():
+    assert gunicorn_config.preload_app is True
+
+
+def test_when_ready_freezes_gc(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gunicorn_config.gc, "freeze", lambda: calls.append(True))
+    gunicorn_config.when_ready(server=None)
+    assert calls == [True]

--- a/tests/unittest/test_gunicorn_config.py
+++ b/tests/unittest/test_gunicorn_config.py
@@ -105,12 +105,50 @@ class TestComputeWorkers:
         monkeypatch.setenv("GUNICORN_MAX_WORKERS", "1")
         assert gunicorn_config.compute_workers() == 1
 
-    def test_module_level_workers_within_bounds(self):
-        assert gunicorn_config.MIN_WORKERS <= gunicorn_config.workers <= gunicorn_config.DEFAULT_MAX_WORKERS
+    def test_module_level_workers_is_a_usable_count(self):
+        # `workers` is computed at import, before this module's fixtures can isolate the
+        # environment, so it can legitimately reflect a GUNICORN_WORKERS set by the host.
+        # Only assert what holds regardless of that: gunicorn gets a positive int.
+        assert isinstance(gunicorn_config.workers, int)
+        assert gunicorn_config.workers >= 1
 
 
 def test_preload_app_enabled():
     assert gunicorn_config.preload_app is True
+
+
+class TestPostFork:
+    @pytest.fixture
+    def recorded_setup_logger(self, monkeypatch):
+        import pr_agent.log
+
+        calls = []
+        monkeypatch.setattr(pr_agent.log, "setup_logger", lambda **kwargs: calls.append(kwargs))
+        return calls
+
+    @pytest.fixture
+    def analytics_folder(self):
+        from pr_agent.config_loader import get_settings
+
+        original = get_settings().get("CONFIG.ANALYTICS_FOLDER", "")
+
+        def _set(value):
+            get_settings().set("CONFIG.ANALYTICS_FOLDER", value)
+
+        yield _set
+        get_settings().set("CONFIG.ANALYTICS_FOLDER", original)
+
+    def test_noop_without_analytics_folder(self, recorded_setup_logger, analytics_folder):
+        analytics_folder("")
+        gunicorn_config.post_fork(server=None, worker=None)
+        assert recorded_setup_logger == []
+
+    def test_reopens_analytics_log_in_the_worker(self, recorded_setup_logger, analytics_folder, tmp_path):
+        # Under preload the sink was opened in the master and named for the master's pid;
+        # the worker must open its own.
+        analytics_folder(str(tmp_path))
+        gunicorn_config.post_fork(server=None, worker=None)
+        assert len(recorded_setup_logger) == 1
 
 
 def test_when_ready_freezes_gc(monkeypatch):

--- a/tests/unittest/test_gunicorn_config.py
+++ b/tests/unittest/test_gunicorn_config.py
@@ -68,6 +68,22 @@ class TestAvailableCpus:
         monkeypatch.setattr(gunicorn_config.os, "sched_getaffinity", lambda pid: set(range(8)), raising=False)
         assert gunicorn_config.available_cpus() == 8
 
+    def test_affinity_wins_when_stricter_than_quota(self, monkeypatch, tmp_path):
+        # A pod can be both quota-limited and cpuset-pinned; the tighter bound applies.
+        write_cgroup_v2(monkeypatch, tmp_path, "400000 100000\n")  # quota = 4 CPUs
+        monkeypatch.setattr(gunicorn_config.os, "sched_getaffinity", lambda pid: {0, 1}, raising=False)
+        assert gunicorn_config.available_cpus() == 2
+
+    def test_quota_wins_when_stricter_than_affinity(self, monkeypatch, tmp_path):
+        write_cgroup_v2(monkeypatch, tmp_path, "200000 100000\n")  # quota = 2 CPUs
+        monkeypatch.setattr(gunicorn_config.os, "sched_getaffinity", lambda pid: set(range(16)), raising=False)
+        assert gunicorn_config.available_cpus() == 2
+
+    def test_survives_a_platform_that_reports_no_cpus(self, monkeypatch):
+        monkeypatch.delattr(gunicorn_config.os, "sched_getaffinity", raising=False)
+        monkeypatch.setattr(gunicorn_config.os, "cpu_count", lambda: None)
+        assert gunicorn_config.available_cpus() == 1
+
 
 class TestComputeWorkers:
     def test_explicit_override_wins(self, monkeypatch, tmp_path):

--- a/tests/unittest/test_secret_provider_factory.py
+++ b/tests/unittest/test_secret_provider_factory.py
@@ -2,7 +2,38 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pr_agent.secret_providers import get_secret_provider
+from pr_agent.secret_providers import SUPPORTED_SECRET_PROVIDERS, get_secret_provider, validate_secret_provider_setting
+
+
+class TestValidateSecretProviderSetting:
+    """Startup validation that rejects a typo without constructing a cloud client."""
+
+    def _settings(self, value):
+        settings = MagicMock()
+        settings.get.return_value = value
+        return settings
+
+    @pytest.mark.parametrize("provider_id", SUPPORTED_SECRET_PROVIDERS)
+    def test_accepts_supported_providers(self, provider_id):
+        with patch('pr_agent.secret_providers.get_settings', return_value=self._settings(provider_id)):
+            validate_secret_provider_setting()
+
+    def test_accepts_unset_provider(self):
+        with patch('pr_agent.secret_providers.get_settings', return_value=self._settings("")):
+            validate_secret_provider_setting()
+
+    def test_rejects_unknown_provider(self):
+        with patch('pr_agent.secret_providers.get_settings', return_value=self._settings("gcs")):
+            with pytest.raises(ValueError, match="Unknown SECRET_PROVIDER"):
+                validate_secret_provider_setting()
+
+    def test_does_not_construct_a_client(self):
+        # The whole point: validation must stay free of the cloud SDKs, so it can run at
+        # import time in the gunicorn master without creating a client that gets forked.
+        with patch('pr_agent.secret_providers.get_settings', return_value=self._settings("aws_secrets_manager")):
+            with patch('pr_agent.secret_providers.get_secret_provider') as mock_build:
+                validate_secret_provider_setting()
+            mock_build.assert_not_called()
 
 
 class TestSecretProviderFactory:


### PR DESCRIPTION
## What

Fixes #2540 — the `gitlab_webhook` container is OOMKilled during startup on 0.36.1 through 0.39.0, where 0.36.0 ran fine in 500Mi.

## Root cause

`docker/Dockerfile:30`, changed in ac8d9df2 (#2412) and first shipped in **v0.36.1**, switched the stage from a single uvicorn process to gunicorn:

```diff
-CMD ["python", "pr_agent/servers/gitlab_webhook.py"]
+CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py", ...]
```

No dependency changed in that range — `requirements.txt` is not in the diff. It is purely a 1-process → N-process change, and two defaults in `gunicorn_config.py` made N pathological:

1. `multiprocessing.cpu_count()` reports the **host node's** cores, not the cgroup CPU limit. The reporter runs `cpu: 500m` request with no limit, so on a 64-core node the old `cores * 2 + 1` produced **129 workers**.
2. **No `preload_app`** (defaults to `False`), so gunicorn forks *before* importing the app. Every worker independently imports the whole `pr_agent` graph with zero copy-on-write sharing.

Measured per-process import cost:

```
bare python              14.6 MB
+ config_loader          38.7 MB
+ git_providers          93.7 MB
+ litellm               231.7 MB   <- the whale
+ full gitlab_webhook   233.6 MB   (3278 modules)
```

`~234 MB x 17 workers ~= 4.0 GB`, `x 65 ~= 15 GB`. That matches the report exactly, including "even 4Gi doesn't start".

Worth noting `cores * 2 + 1` is gunicorn's formula for **sync** workers. These are async `UvicornWorker`s on a purely I/O-bound workload, where a handful already saturate.

## Changes

**`pr_agent/servers/gunicorn_config.py`**

- Worker count now derives from the CPUs actually available to the container — cgroup v2 `cpu.max`, then cgroup v1 `cfs_quota_us`/`cfs_period_us`, then `os.sched_getaffinity` — clamped to `[2, GUNICORN_MAX_WORKERS]` (default `4`). The floor of 2 preserves the health-check isolation #2412 was after.
- `preload_app = True`, so workers fork from one imported heap and share it copy-on-write, with `gc.freeze()` in `when_ready` to stop the cyclic collector from dirtying those shared pages. Verified against the gunicorn 23 source that the order is `setup()` (preload) → `when_ready` → `manage_workers()` (fork), so the freeze lands between import and fork.

**`pr_agent/servers/gitlab_webhook.py`**

`preload_app` means import-time objects are now inherited across the fork, so the module-level secret provider is rebuilt when the pid changes. Workers never share a cloud client's pooled connection, and construction stays at import so a misconfigured `CONFIG.SECRET_PROVIDER` still fails fast at startup.

`github_app.py` and `gitea_app.py` share this config and were checked as well — their import-time state is path strings, a file read, and empty `DefaultDictWithTimeout`s whose factories are not invoked at import, so they are fork-safe.

**`docs/docs/installation/gitlab.md`**

`GUNICORN_WORKERS` has existed as an escape hatch all along but was documented nowhere — the only hits repo-wide were its own two lines in `gunicorn_config.py`. Now documented alongside `GUNICORN_MAX_WORKERS` and the ~250MB-per-worker sizing rule.

## Testing

- `tests/unittest/test_gunicorn_config.py` — 23 new tests covering cgroup v1/v2 parsing (including the `max` and `-1` unlimited sentinels), the `500m` fractional case, the 64-core cap, env overrides, and invalid input.
- Full unit suite: 1308 passed, 0 failed.
- Ran gunicorn against the real app: **4 workers** (was 25 on a 12-core machine), `GET /` → `200`, and the settings-load log line appears exactly **once**, proving the app is imported in the master rather than per worker. With `GUNICORN_WORKERS=2` → 2 workers, `GET /` → `200`.