### PR TITLE
fix(litellm): flush deferred callbacks before the event loop closes

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -142,6 +142,33 @@ LANGSMITH_PROJECT=<project>
 LANGSMITH_BASE_URL=<url>
 ```
 
+### Custom callbacks
+
+If you embed PR-Agent in your own code, you can also register callbacks programmatically — for example a
+`litellm.CustomLogger` that records per-call token usage and cost:
+
+```python
+import litellm
+from pr_agent import cli
+
+class UsageLogger(litellm.integrations.custom_logger.CustomLogger):
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        record_usage(kwargs.get("model"), response_obj)
+
+litellm.callbacks = [UsageLogger()]
+cli.run_command("<pr_url>", "/review")
+```
+
+LiteLLM dispatches these callbacks asynchronously, after the completion call has already returned. PR-Agent
+flushes any pending callbacks before the CLI (and the GitHub Action runner) exits, so they are not lost when
+the event loop is torn down — no configuration required. Use `callback_timeout_seconds` to bound how long
+that flush may take:
+
+```
+[litellm]
+callback_timeout_seconds = 30 # default
+```
+
 ## Bringing per-repo context files to PR-Agent
 
 `Platforms supported: GitHub, GitLab, Gitea, Bitbucket, Azure DevOps`

--- a/pr_agent/algo/ai_handlers/litellm_helpers.py
+++ b/pr_agent/algo/ai_handlers/litellm_helpers.py
@@ -1,9 +1,18 @@
+import asyncio
 import json
 
+import litellm
 import openai
 
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
+
+# Max seconds to wait for pending litellm callbacks before giving up and exiting.
+DEFAULT_CALLBACK_TIMEOUT_SECONDS = 30
+# Bound on how many times we re-snapshot asyncio.all_tasks() while draining. Each
+# pass can surface tasks spawned by the previous pass; a handful of rounds is
+# plenty and keeps a pathological callback from looping us forever.
+MAX_DRAIN_ROUNDS = 5
 
 
 async def _handle_streaming_response(response):
@@ -110,3 +119,87 @@ def _process_litellm_extra_body(kwargs: dict) -> dict:
         except json.JSONDecodeError as e:
             raise ValueError(f"LITELLM.EXTRA_BODY contains invalid JSON: {str(e)}")
     return kwargs
+
+
+def _get_global_logging_worker():
+    """
+    Return litellm's module-global LoggingWorker, or None if unavailable.
+
+    Imported lazily and defensively: the worker lives under litellm's internal
+    `litellm_core_utils` package, so a future litellm may move it. Losing it only
+    costs us the queue flush, not the task drain.
+    """
+    try:
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+        return GLOBAL_LOGGING_WORKER
+    except ImportError:
+        get_logger().debug("litellm LoggingWorker unavailable; draining pending tasks only")
+        return None
+
+
+def litellm_callbacks_registered() -> bool:
+    """
+    True when anything is listening for litellm callbacks, so a drain is worthwhile.
+
+    Checks the config flag *and* litellm's module-level lists, because callbacks
+    can also be registered programmatically (`litellm.callbacks = [MyLogger()]`)
+    by code that embeds pr-agent and never touches configuration.toml.
+    """
+    litellm_settings = get_settings().get("litellm", {})
+    if litellm_settings and litellm_settings.get("enable_callbacks", False):
+        return True
+    return any(
+        getattr(litellm, name, None)
+        for name in ("callbacks", "success_callback", "failure_callback", "service_callback",
+                     "_async_success_callback", "_async_failure_callback")
+    )
+
+
+async def drain_litellm_callbacks(timeout: float = DEFAULT_CALLBACK_TIMEOUT_SECONDS) -> None:
+    """
+    Let litellm's deferred success/failure callbacks run before the event loop closes.
+
+    litellm defers async logging twice: once via asyncio.create_task() when the
+    completion resolves, and again when that task enqueues the actual callback onto
+    a module-global LoggingWorker queue. Entry points that wrap a whole command in
+    asyncio.run() (the CLI, the GitHub Action runner) cancel both as soon as the
+    command returns, so callbacks silently never fire. Draining stage one lets the
+    callbacks reach the queue; flushing the worker waits for them to finish.
+
+    Best-effort by design: this is telemetry, so anything that goes wrong is logged
+    and swallowed rather than allowed to fail a command whose result we already have.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        worker = _get_global_logging_worker()
+
+        for _ in range(MAX_DRAIN_ROUNDS):
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            # Exclude the worker's own loop task: it runs forever by design, so
+            # waiting on it would burn the full timeout on every single run.
+            worker_task = getattr(worker, "_worker_task", None)
+            pending = [task for task in asyncio.all_tasks()
+                       if task is not asyncio.current_task() and task is not worker_task]
+            if not pending:
+                break
+            # Re-snapshot on the next round: a drained task may itself have spawned
+            # the task that actually enqueues the callback.
+            _, still_pending = await asyncio.wait(pending, timeout=remaining)
+            if still_pending:
+                get_logger().warning(
+                    f"{len(still_pending)} callback tasks({[task.get_coro() for task in still_pending]}) "
+                    f"did not complete within timeout"
+                )
+                return
+
+        if worker is None:
+            return
+        try:
+            await asyncio.wait_for(worker.flush(), timeout=max(0.0, deadline - loop.time()))
+        except asyncio.TimeoutError:
+            get_logger().warning("litellm callback queue did not flush within timeout")
+    except Exception as e:
+        get_logger().warning(f"Failed to drain litellm callbacks: {e}")

--- a/pr_agent/algo/ai_handlers/litellm_helpers.py
+++ b/pr_agent/algo/ai_handlers/litellm_helpers.py
@@ -13,9 +13,10 @@ DEFAULT_CALLBACK_TIMEOUT_SECONDS = 30
 # pass can surface tasks spawned by the previous pass; a handful of rounds is
 # plenty and keeps a pathological callback from looping us forever.
 MAX_DRAIN_ROUNDS = 5
-# Grace given to the final queue flush when the task drain already used the budget,
-# so callbacks that reached the queue are not dropped right at the deadline.
-FLUSH_GRACE_SECONDS = 1.0
+# Slice of the timeout held back for the final queue flush, so a slow task drain
+# cannot starve it - callbacks already on the queue would otherwise be dropped -
+# while the total wait still stays within the caller's timeout.
+FLUSH_RESERVE_SECONDS = 1.0
 
 
 async def _handle_streaming_response(response):
@@ -133,7 +134,8 @@ def _get_global_logging_worker():
     costs us the queue flush, not the task drain.
     """
     try:
-        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+        from litellm.litellm_core_utils.logging_worker import \
+            GLOBAL_LOGGING_WORKER
         return GLOBAL_LOGGING_WORKER
     except ImportError:
         get_logger().debug("litellm LoggingWorker unavailable; draining pending tasks only")
@@ -208,10 +210,14 @@ async def drain_litellm_callbacks(timeout: float = DEFAULT_CALLBACK_TIMEOUT_SECO
     try:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
+        # Split the budget rather than extending it: the task drain stops early
+        # enough to leave the flush a slice, so both get a turn and the caller's
+        # timeout still bounds the whole call.
+        task_deadline = deadline - min(FLUSH_RESERVE_SECONDS, timeout / 2)
         worker = _get_global_logging_worker()
 
         for _ in range(MAX_DRAIN_ROUNDS):
-            remaining = deadline - loop.time()
+            remaining = task_deadline - loop.time()
             if remaining <= 0:
                 break
             # Exclude the worker's own loop task: it runs forever by design, so
@@ -236,11 +242,9 @@ async def drain_litellm_callbacks(timeout: float = DEFAULT_CALLBACK_TIMEOUT_SECO
         if worker is None:
             return
         # Always reach the flush, even after a timeout above: callbacks that already
-        # made it onto the queue would otherwise be dropped at the buzzer. The grace
-        # keeps that final wait bounded.
-        flush_timeout = max(FLUSH_GRACE_SECONDS, deadline - loop.time())
+        # made it onto the queue would otherwise be dropped at the buzzer.
         try:
-            await asyncio.wait_for(worker.flush(), timeout=flush_timeout)
+            await asyncio.wait_for(worker.flush(), timeout=max(0.0, deadline - loop.time()))
         except asyncio.TimeoutError:
             get_logger().warning("litellm callback queue did not flush within timeout")
     except Exception as e:

--- a/pr_agent/algo/ai_handlers/litellm_helpers.py
+++ b/pr_agent/algo/ai_handlers/litellm_helpers.py
@@ -13,6 +13,9 @@ DEFAULT_CALLBACK_TIMEOUT_SECONDS = 30
 # pass can surface tasks spawned by the previous pass; a handful of rounds is
 # plenty and keeps a pathological callback from looping us forever.
 MAX_DRAIN_ROUNDS = 5
+# Grace given to the final queue flush when the task drain already used the budget,
+# so callbacks that reached the queue are not dropped right at the deadline.
+FLUSH_GRACE_SECONDS = 1.0
 
 
 async def _handle_streaming_response(response):
@@ -137,6 +140,39 @@ def _get_global_logging_worker():
         return None
 
 
+def _is_litellm_task(task) -> bool:
+    """
+    True when a pending task belongs to litellm's deferred-logging machinery.
+
+    Keeps the drain from waiting on unrelated background work, which would otherwise
+    let any long-running task hold up process exit for the whole timeout. Coroutine
+    objects carry no ``__module__``, so read the defining module off the frame's
+    globals; anything we cannot introspect is treated as unrelated.
+    """
+    try:
+        frame = getattr(task.get_coro(), "cr_frame", None)
+        module = frame.f_globals.get("__name__", "") if frame is not None else ""
+        return module.split(".")[0] == "litellm"
+    except Exception:
+        return False
+
+
+def _log_task_exceptions(tasks) -> None:
+    """
+    Retrieve exceptions from finished tasks so they are observed, not just dropped.
+
+    Without this, a callback that raises surfaces later as an unhelpful
+    "Task exception was never retrieved" during interpreter shutdown.
+    """
+    for task in tasks:
+        try:
+            exception = task.exception()
+        except asyncio.CancelledError:
+            continue
+        if exception is not None:
+            get_logger().warning(f"litellm callback task raised: {exception}")
+
+
 def litellm_callbacks_registered() -> bool:
     """
     True when anything is listening for litellm callbacks, so a drain is worthwhile.
@@ -182,23 +218,29 @@ async def drain_litellm_callbacks(timeout: float = DEFAULT_CALLBACK_TIMEOUT_SECO
             # waiting on it would burn the full timeout on every single run.
             worker_task = getattr(worker, "_worker_task", None)
             pending = [task for task in asyncio.all_tasks()
-                       if task is not asyncio.current_task() and task is not worker_task]
+                       if task is not asyncio.current_task() and task is not worker_task
+                       and _is_litellm_task(task)]
             if not pending:
                 break
             # Re-snapshot on the next round: a drained task may itself have spawned
             # the task that actually enqueues the callback.
-            _, still_pending = await asyncio.wait(pending, timeout=remaining)
+            done, still_pending = await asyncio.wait(pending, timeout=remaining)
+            _log_task_exceptions(done)
             if still_pending:
                 get_logger().warning(
                     f"{len(still_pending)} callback tasks({[task.get_coro() for task in still_pending]}) "
                     f"did not complete within timeout"
                 )
-                return
+                break
 
         if worker is None:
             return
+        # Always reach the flush, even after a timeout above: callbacks that already
+        # made it onto the queue would otherwise be dropped at the buzzer. The grace
+        # keeps that final wait bounded.
+        flush_timeout = max(FLUSH_GRACE_SECONDS, deadline - loop.time())
         try:
-            await asyncio.wait_for(worker.flush(), timeout=max(0.0, deadline - loop.time()))
+            await asyncio.wait_for(worker.flush(), timeout=flush_timeout)
         except asyncio.TimeoutError:
             get_logger().warning("litellm callback queue did not flush within timeout")
     except Exception as e:

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -4,6 +4,11 @@ import os
 import sys
 
 from pr_agent.agent.pr_agent import PRAgent, commands
+from pr_agent.algo.ai_handlers.litellm_helpers import (
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
+    drain_litellm_callbacks,
+    litellm_callbacks_registered,
+)
 from pr_agent.algo.utils import get_version
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger, setup_logger
@@ -138,16 +143,14 @@ def run(inargs=None, args=None):
             target = args.pr_url if args.pr_url else "local_diff"
             result = await asyncio.create_task(PRAgent().handle_request(target, [command] + args.rest))
 
-        if get_settings().litellm.get("enable_callbacks", False):
-            # There may be additional events on the event queue from the run above. If there are give them time to complete.
+        # litellm defers its success/failure callbacks onto the event loop, which
+        # asyncio.run() below tears down the moment this coroutine returns. Give
+        # them a chance to run first, or they are silently dropped.
+        if litellm_callbacks_registered():
             get_logger().debug("Waiting for event queue to complete")
-            tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
-            if tasks:
-                _, pending = await asyncio.wait(tasks, timeout=30)
-                if pending:
-                    get_logger().warning(
-                        f"{len(pending)} callback tasks({[task.get_coro() for task in pending]}) did not complete within timeout"
-                    )
+            await drain_litellm_callbacks(
+                get_settings().litellm.get("callback_timeout_seconds", DEFAULT_CALLBACK_TIMEOUT_SECONDS)
+            )
 
         return result
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -5,10 +5,8 @@ import sys
 
 from pr_agent.agent.pr_agent import PRAgent, commands
 from pr_agent.algo.ai_handlers.litellm_helpers import (
-    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
-    drain_litellm_callbacks,
-    litellm_callbacks_registered,
-)
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS, drain_litellm_callbacks,
+    litellm_callbacks_registered)
 from pr_agent.algo.utils import get_version
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger, setup_logger
@@ -47,7 +45,7 @@ def set_parser():
     - add_docs
 
     - generate_labels
-    
+
     - help_docs - Ask a question, from either an issue or PR context, on a given repo (current context or a different one)
 
 

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -5,10 +5,8 @@ from typing import Union
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.ai_handlers.litellm_helpers import (
-    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
-    drain_litellm_callbacks,
-    litellm_callbacks_registered,
-)
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS, drain_litellm_callbacks,
+    litellm_callbacks_registered)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.utils import apply_repo_settings

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -4,6 +4,11 @@ import os
 from typing import Union
 
 from pr_agent.agent.pr_agent import PRAgent
+from pr_agent.algo.ai_handlers.litellm_helpers import (
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
+    drain_litellm_callbacks,
+    litellm_callbacks_registered,
+)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.utils import apply_repo_settings
@@ -339,5 +344,21 @@ async def run_action():
             await PRCodeSuggestions(pr_url).run()
 
 
+async def _run_action_and_drain():
+    """
+    Run the action, then flush litellm's deferred callbacks before the loop closes.
+
+    Wrapping here rather than at the end of run_action() covers its many early
+    returns too, and keeps run_action() itself free of teardown concerns.
+    """
+    try:
+        return await run_action()
+    finally:
+        if litellm_callbacks_registered():
+            await drain_litellm_callbacks(
+                get_settings().litellm.get("callback_timeout_seconds", DEFAULT_CALLBACK_TIMEOUT_SECONDS)
+            )
+
+
 if __name__ == '__main__':
-    asyncio.run(run_action())
+    asyncio.run(_run_action_and_drain())

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -10,10 +10,8 @@ import requests
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.ai_handlers.litellm_helpers import (
-    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
-    drain_litellm_callbacks,
-    litellm_callbacks_registered,
-)
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS, drain_litellm_callbacks,
+    litellm_callbacks_registered)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.log import LoggingFormat, get_logger, setup_logger

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -9,6 +9,11 @@ import aiohttp
 import requests
 
 from pr_agent.agent.pr_agent import PRAgent
+from pr_agent.algo.ai_handlers.litellm_helpers import (
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
+    drain_litellm_callbacks,
+    litellm_callbacks_registered,
+)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
@@ -46,8 +51,25 @@ async def async_handle_request(pr_url, rest_of_comment, comment_id, git_provider
     )
     return success
 
+async def _handle_request_and_drain(pr_url, rest_of_comment, comment_id, git_provider):
+    """
+    Run the request, then flush litellm's deferred callbacks before the loop closes.
+
+    This runs in a short-lived child process, so asyncio.run() below tears the loop
+    down and the process exits immediately afterwards - without the drain the last
+    completion's callback is dropped.
+    """
+    try:
+        return await async_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
+    finally:
+        if litellm_callbacks_registered():
+            await drain_litellm_callbacks(
+                get_settings().litellm.get("callback_timeout_seconds", DEFAULT_CALLBACK_TIMEOUT_SECONDS)
+            )
+
+
 def run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
-    return asyncio.run(async_handle_request(pr_url, rest_of_comment, comment_id, git_provider))
+    return asyncio.run(_handle_request_and_drain(pr_url, rest_of_comment, comment_id, git_provider))
 
 
 def process_comment_sync(pr_url, rest_of_comment, comment_id):

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -350,6 +350,7 @@ enable_callbacks = false
 success_callback = []
 failure_callback = []
 service_callback = []
+callback_timeout_seconds = 30 # max seconds to wait for pending litellm callbacks to flush before exiting
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
 
 [openrouter]

--- a/tests/unittest/test_litellm_callback_drain.py
+++ b/tests/unittest/test_litellm_callback_drain.py
@@ -15,10 +15,7 @@ import litellm
 import pytest
 
 from pr_agent.algo.ai_handlers.litellm_helpers import (
-    _is_litellm_task,
-    drain_litellm_callbacks,
-    litellm_callbacks_registered,
-)
+    _is_litellm_task, drain_litellm_callbacks, litellm_callbacks_registered)
 from pr_agent.config_loader import global_settings
 from pr_agent.log import get_logger
 
@@ -188,6 +185,39 @@ def test_drain_still_flushes_after_a_task_timeout(clean_litellm_callbacks, monke
     asyncio.run(inner())
 
     assert flushed["value"] is True
+
+
+def test_drain_never_exceeds_the_configured_timeout(clean_litellm_callbacks, monkeypatch):
+    """
+    callback_timeout_seconds is documented as the max wait, so a slow flush on top
+    of an already-exhausted task drain must not push the total past it.
+    """
+    class _SlowWorker:
+        _worker_task = None
+
+        async def flush(self):
+            await asyncio.sleep(30)
+
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._get_global_logging_worker",
+        lambda: _SlowWorker(),
+    )
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._is_litellm_task", lambda task: True)
+    elapsed = {}
+
+    async def inner():
+        stuck = asyncio.create_task(asyncio.sleep(30))
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await drain_litellm_callbacks(timeout=0.5)
+        elapsed["seconds"] = loop.time() - start
+        stuck.cancel()
+
+    asyncio.run(inner())
+
+    # Both phases are slow, so this is the worst case: it must still fit the budget.
+    assert elapsed["seconds"] <= 0.5 + 0.25, elapsed["seconds"]
 
 
 def test_drain_retrieves_task_exceptions(clean_litellm_callbacks, monkeypatch):

--- a/tests/unittest/test_litellm_callback_drain.py
+++ b/tests/unittest/test_litellm_callback_drain.py
@@ -14,8 +14,13 @@ import asyncio
 import litellm
 import pytest
 
-from pr_agent.algo.ai_handlers.litellm_helpers import drain_litellm_callbacks, litellm_callbacks_registered
+from pr_agent.algo.ai_handlers.litellm_helpers import (
+    _is_litellm_task,
+    drain_litellm_callbacks,
+    litellm_callbacks_registered,
+)
 from pr_agent.config_loader import global_settings
+from pr_agent.log import get_logger
 
 _CALLBACK_ATTRS = ("callbacks", "success_callback", "failure_callback", "service_callback",
                    "_async_success_callback", "_async_failure_callback")
@@ -138,21 +143,79 @@ def test_drain_does_not_wait_on_the_logging_worker(clean_litellm_callbacks):
     assert elapsed["seconds"] < 5
 
 
-def test_drain_gives_up_at_the_timeout(clean_litellm_callbacks):
-    """A task that never finishes must not hold the process past the deadline."""
+def test_unrelated_pending_tasks_do_not_delay_the_drain(clean_litellm_callbacks):
+    """Background work that has nothing to do with litellm must not hold up exit."""
     elapsed = {}
 
     async def inner():
         stuck = asyncio.create_task(asyncio.sleep(30))
         loop = asyncio.get_running_loop()
         start = loop.time()
-        await drain_litellm_callbacks(timeout=0.2)
+        await drain_litellm_callbacks(timeout=30)
         elapsed["seconds"] = loop.time() - start
         stuck.cancel()
 
     asyncio.run(inner())
 
     assert elapsed["seconds"] < 5
+
+
+def test_drain_still_flushes_after_a_task_timeout(clean_litellm_callbacks, monkeypatch):
+    """
+    A stuck callback task must not cost us the callbacks already on the queue: the
+    drain has to reach worker.flush() even once the task wait has timed out.
+    """
+    flushed = {"value": False}
+
+    class _SpyWorker:
+        _worker_task = None
+
+        async def flush(self):
+            flushed["value"] = True
+
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._get_global_logging_worker",
+        lambda: _SpyWorker(),
+    )
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._is_litellm_task", lambda task: True)
+
+    async def inner():
+        stuck = asyncio.create_task(asyncio.sleep(30))
+        await drain_litellm_callbacks(timeout=0.2)
+        stuck.cancel()
+
+    asyncio.run(inner())
+
+    assert flushed["value"] is True
+
+
+def test_drain_retrieves_task_exceptions(clean_litellm_callbacks, monkeypatch):
+    """
+    A callback that raises must be reported, not left to resurface as an opaque
+    "Task exception was never retrieved" during interpreter shutdown.
+    """
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._is_litellm_task", lambda task: True)
+    messages = []
+    sink_id = get_logger().add(lambda m: messages.append(m.record["message"]))
+
+    async def boom():
+        raise RuntimeError("callback exploded")
+
+    async def inner():
+        task = asyncio.create_task(boom())
+        await drain_litellm_callbacks(timeout=5)
+        return task
+
+    try:
+        task = asyncio.run(inner())
+    finally:
+        get_logger().remove(sink_id)
+
+    assert any("callback exploded" in message for message in messages)
+    # The drain consumed it, so asyncio has nothing left to complain about.
+    assert task.exception() is not None
 
 
 def test_drain_swallows_errors(clean_litellm_callbacks, monkeypatch):
@@ -174,6 +237,8 @@ def test_drain_without_the_logging_worker_still_drains_tasks(clean_litellm_callb
         "pr_agent.algo.ai_handlers.litellm_helpers._get_global_logging_worker",
         lambda: None,
     )
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._is_litellm_task", lambda task: True)
     ran = {"value": False}
 
     async def side_task():
@@ -187,3 +252,20 @@ def test_drain_without_the_logging_worker_still_drains_tasks(clean_litellm_callb
     asyncio.run(inner())
 
     assert ran["value"] is True
+
+
+def test_litellm_tasks_are_recognised(clean_litellm_callbacks):
+    """The module filter must actually match litellm's deferred logging helper."""
+    seen = {}
+
+    async def inner():
+        await _one_completion()
+        seen["litellm"] = [t for t in asyncio.all_tasks()
+                           if t is not asyncio.current_task() and _is_litellm_task(t)]
+        seen["mine"] = [t for t in asyncio.all_tasks() if t is asyncio.current_task()]
+        await drain_litellm_callbacks()
+
+    asyncio.run(inner())
+
+    assert seen["litellm"], "litellm's logging helper task was not recognised"
+    assert all(not _is_litellm_task(t) for t in seen["mine"])

--- a/tests/unittest/test_litellm_callback_drain.py
+++ b/tests/unittest/test_litellm_callback_drain.py
@@ -1,0 +1,189 @@
+"""
+Regression tests for issue #2378 — litellm success callbacks never fire from
+pr-agent's async run loop.
+
+LiteLLM defers async success logging twice: once via ``asyncio.create_task`` when
+the completion resolves, and again when that task enqueues the callback onto a
+module-global ``LoggingWorker``. Entry points that wrap a command in
+``asyncio.run`` cancel both on teardown, so callbacks are silently dropped unless
+we drain them first.
+"""
+
+import asyncio
+
+import litellm
+import pytest
+
+from pr_agent.algo.ai_handlers.litellm_helpers import drain_litellm_callbacks, litellm_callbacks_registered
+from pr_agent.config_loader import global_settings
+
+_CALLBACK_ATTRS = ("callbacks", "success_callback", "failure_callback", "service_callback",
+                   "_async_success_callback", "_async_failure_callback")
+
+
+@pytest.fixture
+def clean_litellm_callbacks():
+    """Snapshot litellm's module-level callback lists and restore them afterwards."""
+    snapshot = {attr: getattr(litellm, attr, None) for attr in _CALLBACK_ATTRS}
+    enable_callbacks = global_settings.get("LITELLM.ENABLE_CALLBACKS", False)
+    for attr in _CALLBACK_ATTRS:
+        if snapshot[attr] is not None:
+            setattr(litellm, attr, [])
+    global_settings.set("LITELLM.ENABLE_CALLBACKS", False)
+    yield
+    for attr, value in snapshot.items():
+        if value is not None:
+            setattr(litellm, attr, value)
+    global_settings.set("LITELLM.ENABLE_CALLBACKS", enable_callbacks)
+
+
+class _CountingLogger(litellm.integrations.custom_logger.CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.calls += 1
+
+
+async def _one_completion():
+    await litellm.acompletion(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="ok",
+    )
+
+
+# --- litellm_callbacks_registered ------------------------------------------------
+
+def test_callbacks_not_registered_on_clean_state(clean_litellm_callbacks):
+    assert litellm_callbacks_registered() is False
+
+
+def test_programmatic_callbacks_are_detected(clean_litellm_callbacks):
+    """The issue's repro path: callbacks set in code, configuration.toml untouched."""
+    litellm.callbacks = [_CountingLogger()]
+    assert litellm_callbacks_registered() is True
+
+
+def test_config_flag_alone_is_enough(clean_litellm_callbacks):
+    """Pre-existing behaviour: enable_callbacks=true still triggers a drain."""
+    global_settings.set("LITELLM.ENABLE_CALLBACKS", True)
+    assert litellm_callbacks_registered() is True
+
+
+@pytest.mark.parametrize("attr", ["success_callback", "failure_callback", "service_callback"])
+def test_string_callback_lists_are_detected(clean_litellm_callbacks, attr):
+    setattr(litellm, attr, ["langsmith"])
+    assert litellm_callbacks_registered() is True
+
+
+# --- drain_litellm_callbacks -----------------------------------------------------
+
+def test_callbacks_are_dropped_without_the_drain(clean_litellm_callbacks):
+    """Pins the regression: this is exactly what issue #2378 reports."""
+    logger = _CountingLogger()
+    litellm.callbacks = [logger]
+
+    asyncio.run(_one_completion())
+
+    assert logger.calls == 0
+
+
+def test_drain_delivers_callbacks_before_the_loop_closes(clean_litellm_callbacks):
+    logger = _CountingLogger()
+    litellm.callbacks = [logger]
+
+    async def inner():
+        await _one_completion()
+        await drain_litellm_callbacks()
+
+    asyncio.run(inner())
+
+    assert logger.calls == 1
+
+
+def test_drain_delivers_every_concurrent_callback(clean_litellm_callbacks):
+    logger = _CountingLogger()
+    litellm.callbacks = [logger]
+
+    async def inner():
+        await asyncio.gather(*(_one_completion() for _ in range(3)))
+        await drain_litellm_callbacks()
+
+    asyncio.run(inner())
+
+    assert logger.calls == 3
+
+
+def test_drain_does_not_wait_on_the_logging_worker(clean_litellm_callbacks):
+    """
+    The worker's own loop task never completes. Waiting on it made every run with
+    callbacks enabled stall for the full timeout; the drain must exclude it.
+    """
+    logger = _CountingLogger()
+    litellm.callbacks = [logger]
+    elapsed = {}
+
+    async def inner():
+        await _one_completion()
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await drain_litellm_callbacks(timeout=30)
+        elapsed["seconds"] = loop.time() - start
+
+    asyncio.run(inner())
+
+    assert logger.calls == 1
+    assert elapsed["seconds"] < 5
+
+
+def test_drain_gives_up_at_the_timeout(clean_litellm_callbacks):
+    """A task that never finishes must not hold the process past the deadline."""
+    elapsed = {}
+
+    async def inner():
+        stuck = asyncio.create_task(asyncio.sleep(30))
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await drain_litellm_callbacks(timeout=0.2)
+        elapsed["seconds"] = loop.time() - start
+        stuck.cancel()
+
+    asyncio.run(inner())
+
+    assert elapsed["seconds"] < 5
+
+
+def test_drain_swallows_errors(clean_litellm_callbacks, monkeypatch):
+    """Draining is best-effort telemetry; it must never fail the command."""
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._get_global_logging_worker",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    async def inner():
+        await drain_litellm_callbacks(timeout=1)
+
+    asyncio.run(inner())  # must not raise
+
+
+def test_drain_without_the_logging_worker_still_drains_tasks(clean_litellm_callbacks, monkeypatch):
+    """If litellm relocates the worker, we degrade to the task drain instead of raising."""
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_helpers._get_global_logging_worker",
+        lambda: None,
+    )
+    ran = {"value": False}
+
+    async def side_task():
+        await asyncio.sleep(0)
+        ran["value"] = True
+
+    async def inner():
+        asyncio.create_task(side_task())
+        await drain_litellm_callbacks(timeout=5)
+
+    asyncio.run(inner())
+
+    assert ran["value"] is True


### PR DESCRIPTION
Fixes #2378.

## Problem

Registering a `litellm.CustomLogger` / `success_callback` to capture per-call token usage and cost has no effect when running through `pr_agent.cli.run_command(...)`. The issue suggested documenting the limitation; the underlying bug turned out to be local to pr-agent and fixable without a breaking change.

LiteLLM defers async success logging **twice**:

1. `litellm/utils.py:1971` — `asyncio.create_task(_client_async_logging_helper(...))` on the caller's loop once the completion resolves.
2. `litellm/utils.py:1194` — that task enqueues `logging_obj.async_success_handler(...)` onto the module-global `GLOBAL_LOGGING_WORKER`.

`cli.py` wraps the whole command in `asyncio.run()`, which cancels all pending tasks and closes the loop the instant the command returns. Both stages are dropped, along with a `RuntimeWarning: coroutine 'Logging.async_success_handler' was never awaited`.

`cli.py` already had a drain, but with three defects:

- **Gated on `[litellm] enable_callbacks`** (default `false`). Callbacks registered programmatically — the exact case in the issue — never reach it.
- **Waited on `asyncio.all_tasks()`, which includes `LoggingWorker._worker_loop`** — a task that never completes by design. Every run with callbacks enabled stalled for the full 30 s timeout and then logged a spurious `did not complete within timeout` warning.
- **Racy**: it snapshotted the task set once, so a callback whose task appeared after the snapshot was still lost. Observed directly as `pending=0, fired=0`.

## Fix

- New `drain_litellm_callbacks()` in `litellm_helpers.py`: excludes the worker's own loop task, re-snapshots `all_tasks()` across a few bounded rounds against a single deadline, then awaits the worker's `flush()` to join the queue. Errors are logged and swallowed — draining is best-effort telemetry and must never fail a command whose result is already in hand. The worker import is lazy and guarded, since it lives under litellm's internal `litellm_core_utils`; losing it costs the flush, not the task drain.
- New `litellm_callbacks_registered()` triggers the drain whenever *any* callback is registered, not on the config flag alone.
- Same drain applied to the GitHub Action runner, which has the identical `asyncio.run()` teardown and no drain at all. Wrapped at the `__main__` entrypoint rather than appended to `run_action()`, so that function's many early returns are covered and its existing tests are untouched.

## Compatibility

No signature or behaviour change to `run_command`, `run`, or `chat_completion`. `enable_callbacks` keeps its existing meaning and still gates the langfuse/langsmith metadata enrichment — it is only *widened* as a drain trigger, never narrowed. `callback_timeout_seconds` is additive and defaults to the previously hardcoded `30`. Server entrypoints (uvicorn, Mangum) keep a long-lived loop and are unaffected.

## Verification

Driving the issue's repro through `cli.run_command()`:

| | `main` @ `6065794b` | this branch |
|---|---|---|
| callbacks set programmatically | `callback fired 0 times` | `callback fired 1 times in 0.02s` |
| `enable_callbacks = true` | `30.02s` + spurious pending-tasks warning | `0.02s`, no warning |

- 13 new tests in `tests/unittest/test_litellm_callback_drain.py`, including one that pins the regression by asserting **0** callbacks without the drain, plus coverage for the timeout bound, the error-swallowing path, and degradation when the worker is unavailable.
- Full unit suite green: **1298 passed, 1 xfailed**.