### PR TITLE
docs(installation): document release and image tag immutability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,6 +207,13 @@ jobs:
 
   finalize:
     needs: [prepare, publish-pypi, publish-docker]
+    # Not gated on publish-pypi: the bump and the dispatch-path tag are about
+    # this repo's state, not the index. Coupling them meant one PyPI failure
+    # left main on the old version with all images already published (v0.40.0).
+    if: >-
+      always()
+      && needs.prepare.result == 'success'
+      && needs.publish-docker.result == 'success'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -215,9 +222,9 @@ jobs:
       # Check out the exact commit publish-pypi/publish-docker built from, so
       # the bump commit's parent equals what was actually published. We push
       # to main fast-forward only — if main has moved during the run, we skip
-      # the push (and the tag move below) rather than rebasing onto a newer
-      # commit that wasn't built. This preserves the invariant that
-      # `git checkout vX.Y.Z` resolves to a commit whose tree was published.
+      # the push rather than rebasing onto a newer commit that wasn't built.
+      # This preserves the invariant that `git checkout vX.Y.Z` resolves to a
+      # commit whose tree was published.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ needs.prepare.outputs.sha }}
@@ -227,6 +234,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
+
+      - name: Flag missing PyPI publish
+        if: needs.publish-pypi.result != 'success'
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          echo "::warning::publish-pypi ${{ needs.publish-pypi.result }}; $VERSION is not on PyPI. Images and the version bump went through - re-run publish-pypi once the cause is fixed."
 
       - name: Configure git identity
         run: |
@@ -254,7 +268,7 @@ jobs:
             echo "bumped=true" >> "$GITHUB_OUTPUT"
             echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::main has moved past the published commit ($PUBLISHED_SHA); skipping bump push and tag-move so the tag continues to point at built artifacts. Bump pyproject.toml on main manually:  git checkout main && python scripts/set_pyproject_version.py $VERSION && git commit -am 'chore(release): bump version to $VERSION' && git push"
+            echo "::warning::main has moved past the published commit ($PUBLISHED_SHA); skipping the bump push rather than rebasing onto a commit that was not built. Bump pyproject.toml on main manually:  git checkout main && python scripts/set_pyproject_version.py $VERSION && git commit -am 'chore(release): bump version to $VERSION' && git push"
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             echo "sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
           fi
@@ -272,17 +286,14 @@ jobs:
             gh release create "$TAG" --target "$SHA" --title "$TAG" --generate-notes
           fi
 
-      # Tag move runs after PyPI/Docker have already published. We don't want a
-      # tag-protection failure or transient push error to fail the workflow at
-      # this point — surface a warning so a maintainer can sync the tag manually.
-      - name: Move release tag to bump commit (release event only)
+      # The tag is created when the release is published and immutable releases
+      # make it unmovable, so the bump lands on main only. Wheels and images are
+      # built after set_pyproject_version, so it's just the tagged tree that lags.
+      - name: Note tag/bump commit split (release event only)
         if: github.event_name == 'release' && steps.commit.outputs.bumped == 'true'
         env:
           TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
           SHA: ${{ steps.commit.outputs.sha }}
         run: |
-          if git tag -f "$TAG" "$SHA" && git push --force origin "refs/tags/$TAG"; then
-            echo "Moved tag $TAG to $SHA so it matches the published version."
-          else
-            echo "::warning::Failed to force-update tag $TAG to bump commit $SHA. PyPI and Docker artifacts are already published. The tag may be protected; align it manually with: git tag -f $TAG $SHA && git push --force origin refs/tags/$TAG"
-          fi
+          echo "::notice::$TAG points at the published commit; the bump to $VERSION is $SHA on main. A source checkout of $TAG shows the previous version."

--- a/docs/docs/installation/bitbucket.md
+++ b/docs/docs/installation/bitbucket.md
@@ -67,8 +67,11 @@ python cli.py --pr_url https://git.on-prem-instance-of-bitbucket.com/projects/PR
 To run PR-Agent as webhook, build the docker image:
 
 ```bash
-docker build . -t pragent/pr-agent:bitbucket_server_webhook --target bitbucket_server_webhook -f docker/Dockerfile
-docker push pragent/pr-agent:bitbucket_server_webhook  # Push to your Docker repository
+docker build . -t pr-agent:bitbucket_server_webhook --target bitbucket_server_webhook -f docker/Dockerfile
+
+# Optional, to push it to your own Docker repository:
+docker tag pr-agent:bitbucket_server_webhook <your-registry>/pr-agent:bitbucket_server_webhook
+docker push <your-registry>/pr-agent:bitbucket_server_webhook
 ```
 
 Navigate to `Projects` or `Repositories`, `Settings`, `Webhooks`, `Create Webhook`.

--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -26,8 +26,11 @@
 6. Build a Docker image for the app and optionally push it to a Docker repository. We'll use Dockerhub as an example:
 
     ```bash
-    docker build -f docker/Dockerfile -t pr-agent:gitea_app --target gitea_app .
-    docker push pragent/pr-agent:gitea_webhook  # Push to your Docker repository
+    docker build . -t pr-agent:gitea_app --target gitea_app -f docker/Dockerfile
+
+    # Optional, to push it to your own Docker repository:
+    docker tag pr-agent:gitea_app <your-registry>/pr-agent:gitea_app
+    docker push <your-registry>/pr-agent:gitea_app
     ```
 
 7. Set the environmental variables, the method depends on your docker runtime. Skip this step if you included your secrets/configuration directly in the Docker image.

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -670,8 +670,11 @@ cp pr_agent/settings/.secrets_template.toml pr_agent/settings/.secrets.toml
 6) Build a Docker image for the app and optionally push it to a Docker repository. We'll use Dockerhub as an example:
 
     ```bash
-    docker build . -t pragent/pr-agent:github_app --target github_app -f docker/Dockerfile
-    docker push pragent/pr-agent:github_app  # Push to your Docker repository
+    docker build . -t pr-agent:github_app --target github_app -f docker/Dockerfile
+
+    # Optional, to push it to your own Docker repository:
+    docker tag pr-agent:github_app <your-registry>/pr-agent:github_app
+    docker push <your-registry>/pr-agent:github_app
     ```
 
 7. Host the app using a server, serverless function, or container environment. Alternatively, for development and
@@ -705,7 +708,7 @@ For example: `GITHUB.WEBHOOK_SECRET` --> `GITHUB__WEBHOOK_SECRET`
 2. Build a docker image that can be used as a lambda function
 
     ```shell
-    docker buildx build --platform=linux/amd64 . -t pragent/pr-agent:github_lambda --target github_lambda -f docker/Dockerfile.lambda
+    docker buildx build --platform=linux/amd64 . -t pr-agent:github_lambda --target github_lambda -f docker/Dockerfile.lambda
    ```
    (Note: --target github_lambda is optional as it's the default target)
 
@@ -713,8 +716,8 @@ For example: `GITHUB.WEBHOOK_SECRET` --> `GITHUB__WEBHOOK_SECRET`
 3. Push image to ECR
 
     ```shell
-    docker tag pragent/pr-agent:github_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:github_lambda
-    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:github_lambda
+    docker tag pr-agent:github_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pr-agent:github_lambda
+    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pr-agent:github_lambda
     ```
 
 4. Create a lambda function that uses the uploaded image. Set the lambda timeout to be at least 3m.

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -77,8 +77,11 @@ git clone https://github.com/the-pr-agent/pr-agent.git
 6. Build a Docker image for the app and optionally push it to a Docker repository. We'll use Dockerhub as an example:
 
 ```bash
-docker build . -t gitlab_pr_agent --target gitlab_webhook -f docker/Dockerfile
-docker push pragent/pr-agent:gitlab_webhook  # Push to your Docker repository
+docker build . -t pr-agent:gitlab_webhook --target gitlab_webhook -f docker/Dockerfile
+
+# Optional, to push it to your own Docker repository:
+docker tag pr-agent:gitlab_webhook <your-registry>/pr-agent:gitlab_webhook
+docker push <your-registry>/pr-agent:gitlab_webhook
 ```
 
 7. Set the environmental variables, the method depends on your docker runtime. Skip this step if you included your secrets/configuration directly in the Docker image.
@@ -108,14 +111,14 @@ For example: `GITLAB.PERSONAL_ACCESS_TOKEN` --> `GITLAB__PERSONAL_ACCESS_TOKEN`
 2. Build a docker image that can be used as a lambda function
 
     ```shell
-    docker buildx build --platform=linux/amd64 . -t pragent/pr-agent:gitlab_lambda --target gitlab_lambda -f docker/Dockerfile.lambda
+    docker buildx build --platform=linux/amd64 . -t pr-agent:gitlab_lambda --target gitlab_lambda -f docker/Dockerfile.lambda
    ```
 
 3. Push image to ECR
 
     ```shell
-    docker tag pragent/pr-agent:gitlab_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:gitlab_lambda
-    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pragent/pr-agent:gitlab_lambda
+    docker tag pr-agent:gitlab_lambda <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pr-agent:gitlab_lambda
+    docker push <AWS_ACCOUNT>.dkr.ecr.<AWS_REGION>.amazonaws.com/pr-agent:gitlab_lambda
     ```
 
 4. Create a lambda function that uses the uploaded image. Set the lambda timeout to be at least 3m.

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -30,3 +30,13 @@ GUNICORN_WORKERS=2
 
 !!! note "Docker Hub namespace migration"
     Releases **`0.34.2` and later** are published under [`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). Older releases (up to and including `v0.31`) remain at the legacy [`codiumai/pr-agent`](https://hub.docker.com/r/codiumai/pr-agent) namespace as a frozen archive — no new images are pushed there. The examples on this site reference the new namespace; if you are pinning to a release before `0.34.2`, swap `pragent/pr-agent` for `codiumai/pr-agent` in your `image:` / `docker pull` / `uses: docker://` references.
+
+!!! note "Immutable releases and version tags"
+    **What you pin is what you get.** Version-numbered artifacts can never change after publication:
+
+    - **GitHub releases** — the Git tag cannot be moved or deleted, and attached assets cannot be added, replaced, or removed. The protection also survives repository deletion, so a tag from an immutable release can never be reused by a repository recreated under the same name. (Release titles and notes stay editable; immutability covers the tag and the assets.)
+    - **Docker images** — version tags such as `0.40.0` and `0.40.0-github_app` always resolve to the same image. Once pushed, they cannot be overwritten or repointed.
+
+    **Rolling tags stay mutable by design.** `latest`, `github_action`, `github_lambda`, `gitlab_lambda`, `gitlab_webhook`, `gitea_app`, `mosaico_agent` and `bitbucket_server_webhook` move to the newest build on every release. They are convenient for trying things out, but a `docker pull` of the same rolling tag on two different days can give you two different images.
+
+    For anything you depend on — CI, production webhooks, pinned Action steps — reference a version tag (or a digest) rather than a rolling one. Upgrading then becomes a deliberate change you make, not something that happens underneath you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-agent"
-version = "0.39.0"
+version = "0.40.0"
 
 authors = [
   { name = "QodoAI", email = "ofir.f@qodo.ai" },


### PR DESCRIPTION
## What

We enabled immutability on both sides of the release: GitHub releases protect the tag and its assets, and Docker Hub now rejects any overwrite of a version tag. Nothing in the docs told users which guarantee applied to what they were pulling, so this adds a note next to the existing Docker Hub namespace note on the Installation landing page.

## Contents

The note draws the distinction that actually matters to a user:

- **GitHub releases** — the Git tag cannot be moved or deleted, and attached assets cannot be added, replaced, or removed. The protection survives repository deletion, so a tag from an immutable release can never be reused by a repository recreated under the same name.
- **Docker images** — version tags such as `0.40.0` and `0.40.0-github_app` always resolve to the same image once pushed.
- **Rolling tags are still mutable by design** — `latest`, `github_action`, `github_lambda`, `gitlab_lambda`, `gitlab_webhook`, `gitea_app`, `mosaico_agent` and `bitbucket_server_webhook` move to the newest build on every release. All eight are listed, since "everything except `latest`" is the easy wrong assumption.
- Closes with the actionable guidance: pin a version tag or a digest for CI, production webhooks and pinned Action steps.

Two details worth calling out:

- It states explicitly that **release titles and notes remain editable** — immutability covers the tag and the assets. Without that, "immutable release" reads as contradicting the fact that we can still amend release notes after publishing (per [GitHub's docs](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)).
- The rolling-tag list is taken from the `rolling` column of the `publish-docker` matrix in `publish.yml`, so it matches what we actually push.

## Verification

`mkdocs build` renders the admonition correctly and introduces no new warnings — the only one is the pre-existing unset `site_url`, present on `main` as well. Pre-commit hooks pass.

## Related, not fixed here

Enabling immutable releases conflicts with the `finalize` job in `publish.yml`, which force-moves the release tag to the version-bump commit after publishing (`git tag -f` + `git push --force`). Moving a tag is exactly what immutable releases forbids, so that step will now fail on every release. It is wrapped in a warning rather than a hard failure, so releases will not break, but the tag will permanently point at the pre-bump commit — which is why `pyproject.toml` still reads `0.39.0` at tag `v0.40.0`. The durable fix is to bump the version before publishing rather than after; worth a separate PR.