### PR TITLE
Add newly released Claude Opus 5 model support

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -91,6 +91,7 @@ MAX_TOKENS = {
     'vertex_ai/claude-opus-4-6': 200000,
     'vertex_ai/claude-opus-4-7': 1000000,
     'vertex_ai/claude-opus-4-8': 1000000,
+    'vertex_ai/claude-opus-5': 1000000,
     'vertex_ai/claude-3-5-sonnet@20240620': 100000,
     'vertex_ai/claude-3-5-sonnet-v2@20241022': 100000,
     'vertex_ai/claude-3-7-sonnet@20250219': 200000,
@@ -152,6 +153,7 @@ MAX_TOKENS = {
     'anthropic/claude-opus-4-6-20260120': 200000,
     'anthropic/claude-opus-4-7': 1000000,
     'anthropic/claude-opus-4-8': 1000000,
+    'anthropic/claude-opus-5': 1000000,
     'anthropic/claude-3-5-sonnet-20240620': 100000,
     'anthropic/claude-3-5-sonnet-20241022': 100000,
     'anthropic/claude-3-7-sonnet-20250219': 200000,
@@ -165,6 +167,7 @@ MAX_TOKENS = {
     'claude-opus-4-6-20260120': 200000,
     'claude-opus-4-7': 1000000,
     'claude-opus-4-8': 1000000,
+    'claude-opus-5': 1000000,
     'claude-3-7-sonnet-20250219': 200000,
     'claude-sonnet-4-6': 200000,
     'claude-sonnet-5': 1000000,
@@ -182,6 +185,7 @@ MAX_TOKENS = {
     'bedrock/anthropic.claude-opus-4-7': 1000000,
     'bedrock/anthropic.claude-opus-4-7-v1:0': 1000000,
     'bedrock/anthropic.claude-opus-4-8': 1000000,
+    'bedrock/anthropic.claude-opus-5': 1000000,
     'bedrock/anthropic.claude-3-haiku-20240307-v1:0': 100000,
     'bedrock/anthropic.claude-3-5-haiku-20241022-v1:0': 100000,
     'bedrock/anthropic.claude-haiku-4-5-20251001-v1:0': 200000,
@@ -213,6 +217,11 @@ MAX_TOKENS = {
     "bedrock/us.anthropic.claude-opus-4-7": 1000000,
     "bedrock/global.anthropic.claude-opus-4-8": 1000000,
     "bedrock/us.anthropic.claude-opus-4-8": 1000000,
+    "bedrock/global.anthropic.claude-opus-5": 1000000,
+    "bedrock/us.anthropic.claude-opus-5": 1000000,
+    "bedrock/eu.anthropic.claude-opus-5": 1000000,
+    "bedrock/au.anthropic.claude-opus-5": 1000000,
+    "bedrock/jp.anthropic.claude-opus-5": 1000000,
     "bedrock/eu.anthropic.claude-opus-4-8": 1000000,
     "bedrock/au.anthropic.claude-opus-4-8": 1000000,
     "bedrock/jp.anthropic.claude-opus-4-8": 1000000,
@@ -343,6 +352,15 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "bedrock/eu.anthropic.claude-opus-4-8",
     "bedrock/au.anthropic.claude-opus-4-8",
     "bedrock/jp.anthropic.claude-opus-4-8",
+    "claude-opus-5",
+    "anthropic/claude-opus-5",
+    "vertex_ai/claude-opus-5",
+    "bedrock/anthropic.claude-opus-5",
+    "bedrock/global.anthropic.claude-opus-5",
+    "bedrock/us.anthropic.claude-opus-5",
+    "bedrock/eu.anthropic.claude-opus-5",
+    "bedrock/au.anthropic.claude-opus-5",
+    "bedrock/jp.anthropic.claude-opus-5",
     "claude-fable-5",
     "anthropic/claude-fable-5",
     "claude-sonnet-5",
@@ -382,7 +400,7 @@ SUPPORT_REASONING_EFFORT_MODELS = [
 # thinking={"type": "enabled", "budget_tokens": ...} request built by
 # LiteLLMAIHandler._configure_claude_extended_thinking(). Only models that
 # accept budget_tokens belong here. Adaptive-only models (Claude Opus 4.7/4.8,
-# Sonnet 5, Fable 5) reject budget_tokens with an HTTP 400 and must not be added
+# Opus 5, Sonnet 5, Fable 5) reject budget_tokens with an HTTP 400 and must not be added
 # without also adding an adaptive-thinking code path. This list is the built-in
 # default; it can be replaced via the `claude_extended_thinking_models_override`
 # configuration option.

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -213,6 +213,32 @@ class TestGetMaxTokens:
     @pytest.mark.parametrize(
         "model",
         [
+            "anthropic/claude-opus-5",
+            "claude-opus-5",
+            "vertex_ai/claude-opus-5",
+            "bedrock/anthropic.claude-opus-5",
+            "bedrock/global.anthropic.claude-opus-5",
+            "bedrock/us.anthropic.claude-opus-5",
+            "bedrock/eu.anthropic.claude-opus-5",
+            "bedrock/au.anthropic.claude-opus-5",
+            "bedrock/jp.anthropic.claude-opus-5",
+        ],
+    )
+    def test_claude_opus_5_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1000000
+
+    @pytest.mark.parametrize(
+        "model",
+        [
             "anthropic/claude-opus-4-7",
             "claude-opus-4-7",
             "vertex_ai/claude-opus-4-7",

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -105,6 +105,33 @@ async def test_chat_completion_strips_temperature_for_claude_opus_4_8(monkeypatc
 @pytest.mark.parametrize(
     "model",
     [
+        "anthropic/claude-opus-5",
+        "claude-opus-5",
+        "vertex_ai/claude-opus-5",
+        "bedrock/anthropic.claude-opus-5",
+        "bedrock/global.anthropic.claude-opus-5",
+        "bedrock/us.anthropic.claude-opus-5",
+        "bedrock/eu.anthropic.claude-opus-5",
+        "bedrock/au.anthropic.claude-opus-5",
+        "bedrock/jp.anthropic.claude-opus-5",
+    ],
+)
+async def test_chat_completion_strips_temperature_for_claude_opus_5(monkeypatch, model):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model=model, system="sys", user="usr", temperature=0.2)
+
+    assert "temperature" not in mock_call.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
         "anthropic/claude-sonnet-5",
         "claude-sonnet-5",
         "vertex_ai/claude-sonnet-5",
@@ -141,6 +168,39 @@ async def test_chat_completion_does_not_use_extended_thinking_for_claude_opus_4_
         handler = litellm_handler.LiteLLMAIHandler()
 
         await handler.chat_completion(model="claude-opus-4-8", system="sys", user="usr", temperature=0.2)
+
+    assert "thinking" not in mock_call.call_args.kwargs
+    assert "max_tokens" not in mock_call.call_args.kwargs
+    assert "temperature" not in mock_call.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-opus-5",
+        "claude-opus-5",
+        "vertex_ai/claude-opus-5",
+        "bedrock/anthropic.claude-opus-5",
+        "bedrock/global.anthropic.claude-opus-5",
+        "bedrock/us.anthropic.claude-opus-5",
+        "bedrock/eu.anthropic.claude-opus-5",
+        "bedrock/au.anthropic.claude-opus-5",
+        "bedrock/jp.anthropic.claude-opus-5",
+    ],
+)
+async def test_chat_completion_does_not_use_extended_thinking_for_claude_opus_5(monkeypatch, model):
+    monkeypatch.setattr(
+        litellm_handler,
+        "get_settings",
+        lambda: FakeSettings(config_values={"enable_claude_extended_thinking": True}),
+    )
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model=model, system="sys", user="usr", temperature=0.2)
 
     assert "thinking" not in mock_call.call_args.kwargs
     assert "max_tokens" not in mock_call.call_args.kwargs


### PR DESCRIPTION
Register the 1M-context aliases across Anthropic, Vertex AI, and supported Bedrock routes. Omit non-default sampling parameters and keep Claude Opus 5 outside manual extended thinking because the model uses adaptive thinking.

Require a LiteLLM version that recognizes Claude Opus 5 before the next PR-Agent release.

References:
- https://www.anthropic.com/claude-opus-5-system-card
- https://www.anthropic.com/news/claude-opus-5
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5