### PR TITLE
fix(gitea): use PR head commits for last_commit instead of default branch

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -89,11 +89,15 @@ class GiteaProvider(GitProvider):
             self.sha = self.pr.head.sha if self.pr.head.sha else ""
             self.__add_file_content()
             self.__add_file_diff()
+            # list commits starting at the PR head so we get the PR branch history,
+            # not the repository default branch (see get_commit_messages, which
+            # already uses the PR-scoped endpoint)
             self.pr_commits = self.repo_api.list_all_commits(
                 owner=self.owner,
-                repo=self.repo
+                repo=self.repo,
+                sha=self.sha
             )
-            self.last_commit = self.pr_commits[-1]
+            self.last_commit = self.__select_last_commit(self.pr_commits, self.sha)
             self.last_commit_id = self.last_commit
             self.base_sha = self.pr.base.sha if self.pr.base.sha else ""
             self.base_ref = self.pr.base.ref if self.pr.base.ref else ""
@@ -103,6 +107,21 @@ class GiteaProvider(GitProvider):
             self.enabled_issue = True
         else:
             self.pr_commits = None
+
+    @staticmethod
+    def __select_last_commit(commits, head_sha: str):
+        """Pick the PR head commit from a Gitea commit listing.
+
+        Gitea returns commits newest-first, so the head is the first entry;
+        prefer an exact ``head_sha`` match when it is present.
+        """
+        if not commits:
+            return None
+        if head_sha:
+            for commit in commits:
+                if getattr(commit, "sha", None) == head_sha:
+                    return commit
+        return commits[0]
 
     def __add_file_content(self):
         for file in self.git_files:
@@ -1010,10 +1029,14 @@ class RepoApi(giteapy.RepositoryApi):
             index=issue_number
         )
 
-    def list_all_commits(self, owner: str, repo: str):
+    def list_all_commits(self, owner: str, repo: str, sha: str | None = None):
+        kwargs = {}
+        if sha:
+            kwargs["sha"] = sha
         return self.repository.repo_get_all_commits(
             owner=owner,
-            repo=repo
+            repo=repo,
+            **kwargs
         )
 
     def add_reviewer(self, owner: str, repo: str, pr_number: int, reviewers: List[str]):

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -528,3 +528,44 @@ class TestGiteaProviderAddFileDiff:
             index=123,
             body={"body": "Updated description", "title": "Updated title"}
         )
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
+    @patch("pr_agent.git_providers.gitea_provider.RepoApi")
+    def test_last_commit_is_pr_head_not_default_branch(
+        self, mock_repo_api_cls, mock_api_client_cls, mock_get_settings
+    ):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {
+            'GITEA.URL': 'https://gitea.example.com',
+            'GITEA.PERSONAL_ACCESS_TOKEN': 'test-token',
+            'GITEA.REPO_SETTING': None,
+            'GITEA.SKIP_SSL_VERIFICATION': False,
+            'GITEA.SSL_CA_CERT': None
+        }.get(k, d)
+        mock_get_settings.return_value = settings
+
+        repo_api = mock_repo_api_cls.return_value
+        pr = MagicMock()
+        pr.head.sha = "pr-head-sha"
+        pr.base.sha = "base-sha"
+        pr.base.ref = "main"
+        repo_api.get_pull_request.return_value = pr
+        repo_api.get_change_file_pull_request.return_value = []
+
+        # Gitea returns commits newest-first; the default branch listing must not
+        # be used, and the last element of it is the oldest commit.
+        def list_all_commits(owner, repo, sha=None):
+            if sha == "pr-head-sha":
+                return [MagicMock(sha="pr-head-sha"), MagicMock(sha="pr-older-sha")]
+            return [MagicMock(sha="default-newest"), MagicMock(sha="default-oldest")]
+
+        repo_api.list_all_commits.side_effect = list_all_commits
+
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider("https://gitea.example.com/owner/repo/pulls/123")
+
+        assert repo_api.list_all_commits.call_args.kwargs.get("sha") == "pr-head-sha"
+        assert provider.last_commit.sha == "pr-head-sha"
+        assert provider.last_commit_id.sha == "pr-head-sha"


### PR DESCRIPTION
Closes #2206

`GiteaProvider.__init__` called `list_all_commits()` with no ref, which hits `GET /repos/{owner}/{repo}/commits` and returns the **default branch**. Gitea returns commits newest-first, so `self.pr_commits[-1]` was the *oldest* default-branch commit — `last_commit` never pointed at the PR head, which then propagated to `get_latest_commit_url()`, the `commit_id` used by `publish_inline_comments()`, `_get_file_content_from_latest_commit()`, and incremental-review change detection.

The listing is now anchored at the PR head sha and the head commit selected from it, matching `get_commit_messages()`, which already uses the PR-scoped endpoint.

Regression test in `tests/unittest/test_gitea_provider.py` fails without the fix (`last_commit.sha` is `None`/default-branch) and passes with it; the gitea suite is 20 passed.
