### PR TITLE
feat(mosaico): make docker/mosaico a self-contained deployment bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ pr_agent/settings/.secrets.toml
 pics/
 pr_agent.egg-info/
 build/
+**/.env

--- a/docker/mosaico/LICENSE
+++ b/docker/mosaico/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The PR Agent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker/mosaico/README.md
+++ b/docker/mosaico/README.md
@@ -1,73 +1,148 @@
-# PR-Agent MOSAICO Solution Agent — registration
+# PR-Agent — MOSAICO solution-agent deployment bundle
 
-This directory holds the MOSAICO registration template for running pr-agent as a
-MOSAICO A2A *solution agent* (in-process A2A server, image target `mosaico_agent`).
+Deployment assets for running **PR-Agent** as a [MOSAICO](https://mosaico-project.eu/) A2A
+*solution agent*. This directory contains no Python and no pr-agent source — it consumes
+PR-Agent as a published, version-pinned Docker image. The agent's source lives upstream in
+[`qodo-ai/pr-agent`](https://github.com/qodo-ai/pr-agent), under `pr_agent/mosaico/`; it is
+merged into `main` and ships in every release wheel and image starting at `v0.37.0`.
 
-## Build & run the image
+## Relationship to upstream
 
-```bash
-# from the pr-agent repo root
-docker build --target mosaico_agent -t pr-agent-mosaico -f docker/Dockerfile .
-docker run -d -p 9000:9000 --name pr-agent-mosaico pr-agent-mosaico
-```
+This is not a fork and it never becomes one:
 
-The server exposes (port 9000):
-- `GET /.well-known/agent-card.json` — the A2A agent card (streaming=false, observability extension, skills: review/improve/describe/ask)
-- `POST /` — A2A JSON-RPC `message/send`
-- `GET /health` — LLM-connectivity probe (200 `{"is_healthy": true, ...}` / 503)
+- The MOSAICO A2A server is upstream code, released in tags `v0.37.0`–`v0.40.0`. This bundle
+  holds zero Python — only a compose overlay, a registration template, an env template, a
+  smoke test, and this README.
+- **Staying current is one line**: bump the pinned tag in `docker-compose.pr-agent.yml`, then
+  re-run `./smoke_test.sh` to confirm the new image still boots and serves a valid card. That
+  is the entire upgrade procedure:
+  ```diff
+  -    image: pragent/pr-agent:0.40.0-mosaico_agent
+  +    image: pragent/pr-agent:0.41.0-mosaico_agent
+  ```
+- Upstream publishes `pragent/pr-agent:<version>-mosaico_agent` for every release, from the
+  same CI matrix that builds its other images — the MOSAICO target cannot silently stop being
+  built without the whole release failing.
+- Canonical source of every file in this bundle is `docker/mosaico/` in
+  `github.com/qodo-ai/pr-agent`. Edit there, copy here. Never edit here directly.
 
-MOSAICO LLM env vars (consumed by the Stage-1 env bridge at startup): `API_BASE`,
-`API_KEY`, `MODEL_NAME`, and optionally `LANGFUSE_HOST`/`LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY`.
-`HOST` (default `0.0.0.0`) / `PORT` (default `9000`) control the bind address.
+## Quick start (standalone, no demonstrator)
 
-## Register with MOSAICO (ENDPOINT mode)
-
-Registration is done by the demonstrator's `register-agent.py`. ENDPOINT mode is
-selected when `AGENT_CARD_URL` is set. Example:
-
-```bash
-REPOSITORY_API=http://mosaico-app:8080 \
-AGENT_NAME="PR-Agent Solution Agent" \
-AGENT_JSON=/app/pr-agent-solution-agent.json \
-AGENT_CARD_URL=http://pr-agent-mosaico:9000/.well-known/agent-card.json \
-python register-agent.py
-```
-
-- `pr-agent-solution-agent.json` is the template in this directory (kept in MOSAICO's
-  `docker/agent-registrations/` at deploy time).
-- `AGENT_NAME` is injected as the agent name; the card URL is set as the top-level
-  `a2aAgentCardUrl` and `deployment.mode` is forced to `ENDPOINT`.
-
-## Cloud dry-run probe (Path A)
-
-An offline-tested diagnostic (`pr_agent/mosaico/probe.py`) that, run behind the VPN, health-checks
-the cloud MOSAICO reference agent, sends a PR-review task, and reports which solution agent the
-router selected — the automated form of the manual "Path A" dry-run.
-
-Prerequisite: connected to the OpenVPN (vm2 `116.203.57.210` is IP-whitelisted).
+Boots from a bare `docker pull` in a couple of seconds — no repo clone, no build:
 
 ```bash
-# default target (http://116.203.57.210:4000)
-PYTHONPATH=. python -m pr_agent.mosaico.probe
+docker pull pragent/pr-agent:0.40.0-mosaico_agent
+docker run -d --name pr-agent-mosaico -p 9000:9000 \
+  -e API_BASE=https://your-openai-compatible-endpoint/v1 \
+  -e API_KEY=sk-... \
+  -e MODEL_NAME=openai/your-model-slug \
+  pragent/pr-agent:0.40.0-mosaico_agent
 
-# explicit reference-agent URL + task text
-PYTHONPATH=. python -m pr_agent.mosaico.probe http://116.203.57.210:4000 "Review https://github.com/org/repo/pull/1"
-
-# optional registry baseline (best-effort; repo may be internal-only)
-MOSAICO_REPOSITORY_URL=http://116.203.57.210:8080 PYTHONPATH=. python -m pr_agent.mosaico.probe
+curl -s http://localhost:9000/.well-known/agent-card.json | python3 -m json.tool
 ```
 
-If the repository is not reachable the probe reports `registry not reachable` and continues.
+Endpoints (port `9000`):
+- `GET /.well-known/agent-card.json` — the A2A agent card
+- `POST /` — A2A 1.0 JSON-RPC. Send the `SendMessage` method with an
+  `A2A-Version: 1.0` header; the header is required, as the server treats a request
+  without it as protocol 0.3 and rejects it. The reply comes back as a task artifact
+  (`result.task.artifacts[].parts[].text`), not as a status message.
+- `GET /health` — a **live LLM connectivity probe** (200 healthy / 503 unhealthy)
 
-Reading the output:
-- reference-agent health (`OK` / `UNHEALTHY`);
-- classification — whether the reference agent judged the task software-engineering (yes/no);
-- the selected solution agent (or `no agent selected`);
-- the registry baseline line — `pr-agent-solution-agent` will show **ABSENT (not yet registered)**
-  until we register it on vm2; that is the EXPECTED baseline right now, so the router will select
-  some OTHER agent or none;
-- a final-answer excerpt.
+Env-var contract (MOSAICO agent requirements are defined in the demonstrator's
+[`docs/agent-requirements.md`](https://gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-demonstrator/-/blob/main/docs/agent-requirements.md)):
+- `API_BASE`, `API_KEY`, `MODEL_NAME` — the LLM connection
+- `HOST` (default `0.0.0.0`), `PORT` (default `9000`) — bind address
+- `AGENT_CARD_HOST`, `AGENT_CARD_PORT` — see below; unset by default
+- `MODEL_MAX_TOKENS` (default `32000`) — token budget for models whose context size
+  pr-agent does not already know
+- `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` — optional observability
 
-Note: the routing signal is parsed from the reference agent's streamed `status-update` events
-(`Calling external agent: ...`), so the probe uses A2A `message/stream`; the exact SSE framing is
-the one unverified assumption (no live access yet).
+Expect a card whose top level carries `name: "PR-Agent Solution Agent"` and `version` equal to
+the image tag's version (it is derived from the running build, never hand-maintained), with
+skills `review`, `improve`, `describe`, `ask`, and the required
+`https://mosaico-project.eu/extensions/mosaico-observability` extension.
+
+### `AGENT_CARD_HOST` / `AGENT_CARD_PORT` — the one thing to get right
+
+These two variables set the URL the agent advertises in `supportedInterfaces`. Leave them
+unset and the card advertises `http://localhost:9000/`, which is reachable only from inside
+the container itself. The failure this causes is **silent and late**: registration with
+MOSAICO succeeds, the repository stores the unreachable URL, and the reference agent only
+fails to dereference it once it tries to route a task to this agent.
+
+In the demonstrator overlay below, these are already wired correctly:
+
+```yaml
+AGENT_CARD_HOST: ${PR_AGENT_HOST:-${DEFAULT_TASK_AGENT_HOST}}
+AGENT_CARD_PORT: ${PR_AGENT_PORT:-23000}
+```
+
+Standalone, set them explicitly to whatever host/port the *caller* will use to reach the
+container. Verify with:
+
+```bash
+curl -s http://<host>:<port>/.well-known/agent-card.json \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['supportedInterfaces'][0]['url'])"
+```
+
+If that prints a `localhost` URL, the deployment is wrong.
+
+## Deploy into the mosaico-demonstrator
+
+1. Copy `docker-compose.pr-agent.yml` into the demonstrator's `compose/` directory, next to
+   `base-definitions.yml` — the overlay's `extends:` references resolve relative to that
+   directory.
+2. Copy `pr-agent-solution-agent.json` into the demonstrator's
+   `docker/agent-registrations/` directory.
+3. Append the "demonstrator overlay" block from `pr-agent.env.example` to the demonstrator's
+   `env/llm.env` and fill in `PR_AGENT_MODEL` (`PR_AGENT_HOST` may stay empty to use the
+   demonstrator's auto-detected LAN IP; `PR_AGENT_PORT` defaults to `23000`).
+4. Add `-f compose/docker-compose.pr-agent.yml` to the demonstrator's `01-compose.sh`, next to
+   the other task-agent overlays.
+5. `./01-compose.sh up -d`.
+
+## Registration
+
+The demonstrator's `register-agent.py` reads `pr-agent-solution-agent.json` and injects, at
+registration time: `name` (from the overlay's `AGENT_NAME`), `a2aAgentCardUrl` (from
+`AGENT_CARD_URL`), and `deployment.mode = ENDPOINT`. That is why the template carries only
+four fields: `description`, `role`, `objective`, `version`.
+
+Two names are intentionally different, so don't "fix" the mismatch:
+- The MOSAICO repository entry's `name` is `pr-agent-solution-agent` (kebab-case, what
+  `register-agent.py` looks the agent up by).
+- The A2A card's own `name` field is `"PR-Agent Solution Agent"` (a display string, asserted
+  by `smoke_test.sh`).
+
+## Verify
+
+```bash
+./smoke_test.sh
+```
+
+Two outcomes:
+- **`SMOKE PASSED`** — no LLM creds available; the script pulled the pinned image, booted it,
+  and validated the agent card only.
+- **`FULL ROUND-TRIP PASSED`** — LLM creds were present (via a `.env` file beside the script,
+  copied from `pr-agent.env.example`); the script additionally exercised `GET /health` and an A2A
+  `SendMessage` review over an inline diff.
+
+## Troubleshooting
+
+- **Container stays `unhealthy`, registration never runs.** `/health` is a live LLM probe and
+  returns `503` on bad/missing credentials — this is intended (the healthcheck matches the
+  peer solution agents' probe verbatim, and a registered card backed by a dead LLM is worse
+  than no registration). Check `API_BASE`/`API_KEY`/`MODEL_NAME`, not the compose file.
+- **Agent registers but the reference agent never reaches it.** The advertised card URL is
+  `localhost`; see the `AGENT_CARD_HOST`/`AGENT_CARD_PORT` section above.
+- **The registration container itself can't fetch the agent card.** `01-compose.sh` falls back
+  to `get_fallback_ip`, which can resolve to `localhost` — reachable from the host, but not
+  from inside the `pr-agent-solution-agent-registration` container on the Docker network. If
+  registration fails to fetch `AGENT_CARD_URL`, set `PR_AGENT_HOST` explicitly to an address
+  reachable from inside Docker (e.g. the host's LAN IP, or `host.docker.internal`). Every peer
+  task agent shares this same exposure; it is not specific to PR-Agent.
+
+## License
+
+MIT — see the bundled [`LICENSE`](./LICENSE). Upstream `qodo-ai/pr-agent` is MIT-licensed too.

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -21,8 +21,10 @@ services:
     # registration - intended: a registered card with a dead LLM is worse.
     # PORT comes from base-definitions.yml's `agent` service; the :-9000 fallback keeps
     # the probe correct even if this overlay is composed without it.
+    # timeout=25 sits between /health's own 10s LLM timeout and Docker's 30s default
+    # healthcheck timeout, so a stalled probe fails as unhealthy rather than being killed.
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:$${PORT:-9000}/health')\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:$${PORT:-9000}/health', timeout=25)\""]
 
   pr-agent-solution-agent-registration:
     extends:

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -16,10 +16,12 @@ services:
       AGENT_CARD_HOST: ${PR_AGENT_HOST:-${DEFAULT_TASK_AGENT_HOST}}
       AGENT_CARD_PORT: ${PR_AGENT_PORT:-23000}
       MODEL_NAME: ${PR_AGENT_MODEL}
-    # Matches the peer agents' probe verbatim. /health is a live LLM check, so no LLM
-    # means no registration - intended: a registered card with a dead LLM is worse.
+    # Mirrors the peer agents' probe. /health is a live LLM check, so no LLM means no
+    # registration - intended: a registered card with a dead LLM is worse.
+    # PORT comes from base-definitions.yml's `agent` service; the :-9000 fallback keeps
+    # the probe correct even if this overlay is composed without it.
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:$${PORT}/health')\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:$${PORT:-9000}/health')\""]
 
   pr-agent-solution-agent-registration:
     extends:

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -9,27 +9,28 @@ services:
     extends:
       file: base-definitions.yml
       service: agent
-    # Build: docker build --target mosaico_agent -t pr-agent-solution-agent:local -f docker/Dockerfile .
-    image: pr-agent-solution-agent:local
+    image: pragent/pr-agent:0.40.0-mosaico_agent
     ports:
-      - ${PR_AGENT_PORT:-22000}:9000
+      - ${PR_AGENT_PORT:-23000}:9000
     environment:
       AGENT_CARD_HOST: ${PR_AGENT_HOST:-${DEFAULT_TASK_AGENT_HOST}}
-      AGENT_CARD_PORT: ${PR_AGENT_PORT:-22000}
+      AGENT_CARD_PORT: ${PR_AGENT_PORT:-23000}
       MODEL_NAME: ${PR_AGENT_MODEL}
-    # Gate registration on card/HTTP readiness, not /health (a live LLM probe).
+    # Matches the peer agents' probe verbatim. /health is a live LLM check, so no LLM
+    # means no registration - intended: a registered card with a dead LLM is worse.
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:9000/.well-known/agent-card.json')\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:$${PORT}/health')\""]
 
   pr-agent-solution-agent-registration:
     extends:
       file: base-definitions.yml
       service: agent-registration
     environment:
-      AGENT_NAME: PR-Agent Solution Agent
+      AGENT_NAME: pr-agent-solution-agent
       AGENT_JSON: /app/pr-agent-solution-agent.json
-      # Fetched container-to-container: use the service name and in-container port 9000.
-      AGENT_CARD_URL: http://pr-agent-solution-agent:9000/.well-known/agent-card.json
+      # Stored in the repository and fetched by out-of-Docker clients, so it must be
+      # host-reachable, not a compose service name.
+      AGENT_CARD_URL: http://${PR_AGENT_HOST:-${DEFAULT_TASK_AGENT_HOST}}:${PR_AGENT_PORT:-23000}/.well-known/agent-card.json
     depends_on:
       pr-agent-solution-agent:
         condition: service_healthy

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -1,4 +1,5 @@
-# PR-Agent MOSAICO solution-agent overlay (canonical source; versioned with the agent).
+# PR-Agent MOSAICO solution-agent overlay. Canonical source is docker/mosaico/ in
+# github.com/qodo-ai/pr-agent - edit it there, never in a copy.
 # Copy into the demonstrator's `compose/` dir, next to `base-definitions.yml`, so the
 # `extends:` refs resolve; see ./README.md for the full wiring steps.
 #

--- a/docker/mosaico/pr-agent-solution-agent.json
+++ b/docker/mosaico/pr-agent-solution-agent.json
@@ -1,6 +1,6 @@
 {
   "description": "PR-Agent solution agent for pull-request and unified-diff code review. Given a pull-request URL or a supplied git diff, it produces a structured code review (key issues, security concerns, effort estimate), inline code suggestions, a generated PR title and description, and answers to questions about that specific pull request or diff. Every action is anchored to a concrete pull request or git diff supplied in the request.",
-  "version": "0.35.0",
+  "version": "1.0.0",
   "role": "pull-request and git-diff code-review solver",
   "objective": "given a pull-request URL or a supplied git diff, review the changes and produce a solution (code review, code suggestions, PR description, or scoped answer) with rationale"
 }

--- a/docker/mosaico/pr-agent.env.example
+++ b/docker/mosaico/pr-agent.env.example
@@ -1,0 +1,37 @@
+# PR-Agent MOSAICO solution-agent — sanitized environment template. Placeholders
+# only; never commit real credentials here.
+#
+# Two uses for this one file:
+#   1. Demonstrator overlay: append the "demonstrator overlay" block below to the
+#      mosaico-demonstrator's env/llm.env. NOT env-templates/llm.env — 01-compose.sh
+#      passes exactly `--env-file env/langfuse.env --env-file env/llm.env`, so nothing
+#      outside those two files is ever loaded.
+#   2. Standalone: copy this file to `.env` (gitignored), fill in the copy, and run
+#      `docker run --env-file .env ...`. Never fill in this template itself — it is
+#      tracked, so real values entered here would be committed.
+
+# --- Standalone `docker run` (LLM connection for the agent itself) ---
+API_BASE=https://REPLACE_ME.example.com/v1
+API_KEY=REPLACE_ME
+MODEL_NAME=openai/REPLACE_ME-model-slug
+
+# Standalone only: the host/port the CALLER will use to reach this container.
+# Leave these unset and the card advertises http://localhost:9000/, which is
+# unreachable from anywhere but inside the container — registration succeeds and
+# routing fails later. The demonstrator overlay sets both for you.
+# AGENT_CARD_HOST=
+# AGENT_CARD_PORT=9000
+
+# Optional: token budget for models pr-agent does not know the context size of.
+# MODEL_MAX_TOKENS=32000
+
+# Optional, standalone only — the demonstrator supplies these via its own
+# env/langfuse.env instead.
+# LANGFUSE_HOST=
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+
+# --- Demonstrator overlay knobs (append this block to env/llm.env) ---
+PR_AGENT_MODEL=openai/REPLACE_ME-model-slug
+PR_AGENT_HOST=
+PR_AGENT_PORT=23000

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -4,7 +4,7 @@
 #
 #   Smoke (always):       boot the container and validate the A2A agent card.
 #   Full round-trip:      when LLM creds are present, also exercise GET /health
-#                         (live LLM probe) and an A2A message/send PR-review on
+#                         (live LLM probe) and an A2A SendMessage PR-review on
 #                         an inline diff.
 #
 # LLM creds are read from a .env file beside this script (gitignored), NOT the
@@ -70,7 +70,7 @@ print("    card OK: name, streaming=False, observability required, skills", ids)
 PY
 
 if [[ $have_creds == 0 ]]; then
-  echo "==> SMOKE PASSED (no LLM creds in $ENV_FILE -> skipped /health + message/send)."
+  echo "==> SMOKE PASSED (no LLM creds in $ENV_FILE -> skipped /health + SendMessage)."
   echo "    Add API_BASE/API_KEY/MODEL_NAME to $ENV_FILE for the full round-trip."
   exit 0
 fi

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -23,7 +23,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env}"
 BASE="http://localhost:${PORT}"
 
-cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+# 0700 by construction, so the /health body (which embeds the raw provider exception
+# when unhealthy) is neither world-readable nor writable at a predictable path.
+TMPDIR_RUN="$(mktemp -d)"
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  rm -rf "$TMPDIR_RUN"
+}
 trap cleanup EXIT
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -87,10 +93,10 @@ fi
 
 # --- FULL: /health (live LLM ping -> 200/503) ---
 echo "==> [full] GET /health (live LLM probe)"
-code=$(curl -s -o /tmp/mosaico_health.json -w '%{http_code}' "$BASE/health")
+code=$(curl -s -o "$TMPDIR_RUN/health.json" -w '%{http_code}' "$BASE/health")
 # On 503 the body is a raw provider exception (it can name the endpoint), which is
 # exactly the diagnostic you want here - just don't paste it into a public issue.
-cat /tmp/mosaico_health.json; echo
+cat "$TMPDIR_RUN/health.json"; echo
 [[ "$code" == "200" ]] || fail "/health returned $code (expected 200) — check LLM creds"
 
 # --- FULL: SendMessage review on an inline diff (no PR URL / GitHub token needed) ---
@@ -103,10 +109,10 @@ read -r -d '' BODY <<'JSON'
 JSON
 
 curl -fsS -X POST "$BASE/" -H 'Content-Type: application/json' -H 'A2A-Version: 1.0' \
-  -d "$BODY" -o /tmp/mosaico_resp.json || fail "SendMessage request failed"
-python3 - <<'PY' || fail "SendMessage response invalid"
-import json
-d = json.load(open("/tmp/mosaico_resp.json"))
+  -d "$BODY" -o "$TMPDIR_RUN/resp.json" || fail "SendMessage request failed"
+RESP="$TMPDIR_RUN/resp.json" python3 - <<'PY' || fail "SendMessage response invalid"
+import json, os
+d = json.load(open(os.environ["RESP"]))
 if "error" in d:
     raise SystemExit(f"    JSON-RPC error: {json.dumps(d['error'])[:300]}")
 # A2A 1.0 wraps the Task in result.task, and delivers the review as an artifact.

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -26,11 +26,22 @@ BASE="http://localhost:${PORT}"
 # 0700 by construction, so the /health body (which embeds the raw provider exception
 # when unhealthy) is neither world-readable nor writable at a predictable path.
 TMPDIR_RUN="$(mktemp -d)"
+# Only tear down a container this run actually started: the name is fixed, so an early
+# exit (a failed pull, or a `docker run` that lost a name race) must not reap someone
+# else's container - including the one a concurrent run is still testing against.
+started=0
 cleanup() {
-  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  if [[ $started == 1 ]]; then
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  fi
   rm -rf "$TMPDIR_RUN"
 }
 trap cleanup EXIT
+
+# Bound every request: the header documents unattended poll-loop use, where a stalled
+# container would otherwise hang the loop forever. Limits are generous because /health
+# and SendMessage both wait on a live LLM.
+CURL_CONNECT=(--connect-timeout 5)
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -57,12 +68,13 @@ fi
 mode=$([[ $have_creds == 1 ]] && echo "full round-trip" || echo "smoke only")
 echo "==> Starting container ($mode)"
 docker run "${run_args[@]}" "$IMAGE" || fail "docker run failed"
+started=1
 
 # --- SMOKE: fetch the card (with retry; needs no LLM) and validate it ---
 echo "==> [smoke] fetching + validating agent card"
 CARD=""
 for _ in $(seq 1 30); do
-  CARD=$(curl -fsSL "$BASE/.well-known/agent-card.json" 2>/dev/null)
+  CARD=$(curl -fsSL "${CURL_CONNECT[@]}" --max-time 30 "$BASE/.well-known/agent-card.json" 2>/dev/null)
   [[ -n "$CARD" ]] && break
   sleep 2
 done
@@ -93,7 +105,7 @@ fi
 
 # --- FULL: /health (live LLM ping -> 200/503) ---
 echo "==> [full] GET /health (live LLM probe)"
-code=$(curl -s -o "$TMPDIR_RUN/health.json" -w '%{http_code}' "$BASE/health")
+code=$(curl -s "${CURL_CONNECT[@]}" --max-time 120 -o "$TMPDIR_RUN/health.json" -w '%{http_code}' "$BASE/health")
 # On 503 the body is a raw provider exception (it can name the endpoint), which is
 # exactly the diagnostic you want here - just don't paste it into a public issue.
 cat "$TMPDIR_RUN/health.json"; echo
@@ -108,7 +120,8 @@ read -r -d '' BODY <<'JSON'
 {"id":"smoke-1","jsonrpc":"2.0","method":"SendMessage","params":{"message":{"messageId":"smoke-msg-1","role":"ROLE_USER","parts":[{"text":"review the following\n```diff\ndiff --git a/foo.py b/foo.py\nindex 1111111..2222222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -1,2 +1,2 @@\n-x = 1\n+x = 2\n y = 3\n```"}]}}}
 JSON
 
-curl -fsS -X POST "$BASE/" -H 'Content-Type: application/json' -H 'A2A-Version: 1.0' \
+curl -fsS "${CURL_CONNECT[@]}" --max-time 300 \
+  -X POST "$BASE/" -H 'Content-Type: application/json' -H 'A2A-Version: 1.0' \
   -d "$BODY" -o "$TMPDIR_RUN/resp.json" || fail "SendMessage request failed"
 RESP="$TMPDIR_RUN/resp.json" python3 - <<'PY' || fail "SendMessage response invalid"
 import json, os

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Pull and test-run the MOSAICO A2A solution-agent image published by the
+# upstream qodo-ai/pr-agent release workflow (Docker target `mosaico_agent`).
+#
+#   Smoke (always):       boot the container and validate the A2A agent card.
+#   Full round-trip:      when LLM creds are present, also exercise GET /health
+#                         (live LLM probe) and an A2A message/send PR-review on
+#                         an inline diff.
+#
+# LLM creds are read from a .env file beside this script (gitignored), NOT the
+# environment — they must survive across separate shell invocations
+# (e.g. an unattended poll loop). Copy pr-agent.env.example to .env and fill it in.
+# Format: plain KEY=VALUE lines, e.g.
+#   API_BASE=https://openrouter.ai/api/v1
+#   API_KEY=sk-...
+#   MODEL_NAME=openrouter/mistralai/devstral-small
+set -uo pipefail
+
+IMAGE="${IMAGE:-pragent/pr-agent:0.40.0-mosaico_agent}"
+PORT="${PORT:-9000}"
+CONTAINER="pr-agent-mosaico-test"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env}"
+BASE="http://localhost:${PORT}"
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "==> Pulling $IMAGE"
+docker pull "$IMAGE" || fail "docker pull failed"
+
+run_args=(-d --rm --name "$CONTAINER" -p "${PORT}:9000")
+have_creds=0
+if [[ -f "$ENV_FILE" ]]; then
+  run_args+=(--env-file "$ENV_FILE")
+  # Full round-trip requires all three LLM keys to be present and non-empty.
+  if grep -qE '^API_BASE=.+' "$ENV_FILE" \
+     && grep -qE '^API_KEY=.+' "$ENV_FILE" \
+     && grep -qE '^MODEL_NAME=.+' "$ENV_FILE"; then
+    have_creds=1
+  fi
+fi
+
+mode=$([[ $have_creds == 1 ]] && echo "full round-trip" || echo "smoke only")
+echo "==> Starting container ($mode)"
+docker run "${run_args[@]}" "$IMAGE" || fail "docker run failed"
+
+# --- SMOKE: fetch the card (with retry; needs no LLM) and validate it ---
+echo "==> [smoke] fetching + validating agent card"
+CARD=""
+for _ in $(seq 1 30); do
+  CARD=$(curl -fsSL "$BASE/.well-known/agent-card.json" 2>/dev/null)
+  [[ -n "$CARD" ]] && break
+  sleep 2
+done
+[[ -n "$CARD" ]] || { docker logs "$CONTAINER" 2>&1 | tail -40; fail "card endpoint never served a body"; }
+
+CARD="$CARD" python3 - <<'PY' || fail "agent card invalid"
+import json, os
+c = json.loads(os.environ["CARD"])
+assert c["name"] == "PR-Agent Solution Agent", c.get("name")
+assert c["capabilities"]["streaming"] is False, "streaming must be False"
+exts = c["capabilities"]["extensions"]
+assert any(e.get("required") and "observability" in e["uri"] for e in exts), "observability ext missing/required"
+ids = sorted(s["id"] for s in c["skills"])
+assert ids == ["ask", "describe", "improve", "review"], ids
+print("    card OK: name, streaming=False, observability required, skills", ids)
+PY
+
+if [[ $have_creds == 0 ]]; then
+  echo "==> SMOKE PASSED (no LLM creds in $ENV_FILE -> skipped /health + message/send)."
+  echo "    Add API_BASE/API_KEY/MODEL_NAME to $ENV_FILE for the full round-trip."
+  exit 0
+fi
+
+# --- FULL: /health (live LLM ping -> 200/503) ---
+echo "==> [full] GET /health (live LLM probe)"
+code=$(curl -s -o /tmp/mosaico_health.json -w '%{http_code}' "$BASE/health")
+# On 503 the body is a raw provider exception (it can name the endpoint), which is
+# exactly the diagnostic you want here - just don't paste it into a public issue.
+cat /tmp/mosaico_health.json; echo
+[[ "$code" == "200" ]] || fail "/health returned $code (expected 200) — check LLM creds"
+
+# --- FULL: SendMessage review on an inline diff (no PR URL / GitHub token needed) ---
+# A2A 1.0 wire contract: the `A2A-Version: 1.0` header is REQUIRED (the server treats a
+# missing header as 0.3 and rejects the call), the method is the gRPC-style `SendMessage`,
+# and Message/Part carry no `kind` discriminator.
+echo "==> [full] A2A SendMessage review (inline diff)"
+read -r -d '' BODY <<'JSON'
+{"id":"smoke-1","jsonrpc":"2.0","method":"SendMessage","params":{"message":{"messageId":"smoke-msg-1","role":"ROLE_USER","parts":[{"text":"review the following\n```diff\ndiff --git a/foo.py b/foo.py\nindex 1111111..2222222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -1,2 +1,2 @@\n-x = 1\n+x = 2\n y = 3\n```"}]}}}
+JSON
+
+curl -fsS -X POST "$BASE/" -H 'Content-Type: application/json' -H 'A2A-Version: 1.0' \
+  -d "$BODY" -o /tmp/mosaico_resp.json || fail "SendMessage request failed"
+python3 - <<'PY' || fail "SendMessage response invalid"
+import json
+d = json.load(open("/tmp/mosaico_resp.json"))
+if "error" in d:
+    raise SystemExit(f"    JSON-RPC error: {json.dumps(d['error'])[:300]}")
+# A2A 1.0 wraps the Task in result.task, and delivers the review as an artifact.
+# status.message is populated only on failure, so asserting on it would invert the test.
+task = d.get("result", d).get("task", {})
+state = (task.get("status") or {}).get("state", "")
+parts = [p for a in (task.get("artifacts") or []) for p in (a.get("parts") or [])]
+text = "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+assert state == "TASK_STATE_COMPLETED", f"task state {state!r}: {text[:300]}"
+assert text.strip(), "empty agent reply"
+assert "(no output produced)" not in text, "publish_output capture regression"
+print(f"    review returned {len(text)} chars; first line:")
+print("    " + (text.strip().splitlines() or [""])[0][:100])
+PY
+
+echo "==> FULL ROUND-TRIP PASSED."

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -31,7 +31,12 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 echo "==> Pulling $IMAGE"
 docker pull "$IMAGE" || fail "docker pull failed"
 
-run_args=(-d --rm --name "$CONTAINER" -p "${PORT}:9000")
+# AGENT_CARD_* must match the published host port, otherwise the card advertises
+# http://localhost:9000/ regardless of -p and the URL assertion below would be
+# meaningless. This is the misconfiguration the README calls out as the easiest to get
+# wrong, so the smoke test exercises it rather than sidestepping it.
+run_args=(-d --rm --name "$CONTAINER" -p "${PORT}:9000"
+          -e AGENT_CARD_HOST=localhost -e "AGENT_CARD_PORT=${PORT}")
 have_creds=0
 if [[ -f "$ENV_FILE" ]]; then
   run_args+=(--env-file "$ENV_FILE")
@@ -57,7 +62,7 @@ for _ in $(seq 1 30); do
 done
 [[ -n "$CARD" ]] || { docker logs "$CONTAINER" 2>&1 | tail -40; fail "card endpoint never served a body"; }
 
-CARD="$CARD" python3 - <<'PY' || fail "agent card invalid"
+CARD="$CARD" EXPECT_URL="$BASE/" python3 - <<'PY' || fail "agent card invalid"
 import json, os
 c = json.loads(os.environ["CARD"])
 assert c["name"] == "PR-Agent Solution Agent", c.get("name")
@@ -66,7 +71,12 @@ exts = c["capabilities"]["extensions"]
 assert any(e.get("required") and "observability" in e["uri"] for e in exts), "observability ext missing/required"
 ids = sorted(s["id"] for s in c["skills"])
 assert ids == ["ask", "describe", "improve", "review"], ids
+# The advertised URL is what MOSAICO stores and what clients dereference; if it does
+# not match the address we actually reached, the deployment is wrong.
+url = c["supportedInterfaces"][0]["url"]
+assert url == os.environ["EXPECT_URL"], f'advertised {url!r}, expected {os.environ["EXPECT_URL"]!r}'
 print("    card OK: name, streaming=False, observability required, skills", ids)
+print("    advertised URL OK:", url)
 PY
 
 if [[ $have_creds == 0 ]]; then


### PR DESCRIPTION
## Why

The MOSAICO consortium asked how a "forked pr-agent" on GitLab would be maintained. It is not a fork: the MOSAICO A2A agent is merged upstream in `pr_agent/mosaico/`, ships in the release wheel, and is published as `pragent/pr-agent:<version>-mosaico_agent`.

This makes `docker/mosaico/` a self-contained deployment bundle that consumes that published image, so the GitLab side can hold deployment assets only and no Python. Upgrading becomes a one-line tag bump.

## What changed

- **Compose overlay** now references `pragent/pr-agent:0.40.0-mosaico_agent` instead of building `:local`, so it works with no checkout.
- **Three defects fixed that would have broken registration on the demonstrator**, unrelated to the image pin:
  - host port `22000` collided with `DOCSTRING_AGENT_PORT`; now `23000`
  - `AGENT_NAME` was a display string; `register-agent.py` looks up the kebab-case slug
  - `AGENT_CARD_URL` used a compose service name, but it is stored in the repository and fetched by clients outside Docker, so it must be host-reachable
- **Smoke test** tracked, and its A2A call corrected. It still spoke pre-1.0 and could not have passed: 1.0 requires the `A2A-Version` header (a missing header is treated as `0.3` and rejected), renames the method to `SendMessage`, drops the `kind` discriminator, and returns the reply as a task artifact. The old assertion read `status.message`, which is only populated on failure, so it failed on success and would have passed on a failed task. The README documented the same stale protocol.
- **README** rewritten for an integrator who has never cloned pr-agent, plus a sanitized env template and a bundled MIT `LICENSE`.
- **Registration template** version `0.35.0` to `1.0.0`, matching all four peer registration JSONs; it describes the contract, not the running build, so it no longer needs a bump per release.
- **`.dockerignore`**: `docker/Dockerfile` ADDs `docker/mosaico` into the `test` stage, so a local `docker build --target test` baked any local `.env` into an image layer. That stage is not in the publish matrix, so nothing was ever pushed.

The cloud dry-run probe section is dropped from the README: `probe.py` is untracked and confirmed absent from the published image, so those instructions cannot work outside a checkout.

## Verification

- `pytest tests/unittest`: 1518 passed, 1 skipped, 1 xfailed
- `docker compose config` against a copy of the mosaico-demonstrator resolves cleanly; the healthcheck matches `ip-solution-agent` and `docstring-agent` byte for byte
- `./smoke_test.sh` against the pinned image: `FULL ROUND-TRIP PASSED` (card validated, `/health` 200, live review returned)

No pr-agent source is removed or modified; `pr_agent/mosaico/` stays upstream.
