### PR TITLE
fix(mosaico): fail fast when mktemp cannot create the scratch dir

### DIFF
--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -25,7 +25,7 @@ BASE="http://localhost:${PORT}"
 
 # 0700 by construction, so the /health body (which embeds the raw provider exception
 # when unhealthy) is neither world-readable nor writable at a predictable path.
-TMPDIR_RUN="$(mktemp -d)"
+TMPDIR_RUN="$(mktemp -d)" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 # Only tear down a container this run actually started: the name is fixed, so an early
 # exit (a failed pull, or a `docker run` that lost a name race) must not reap someone
 # else's container - including the one a concurrent run is still testing against.


### PR DESCRIPTION
Follow-up to #2556, from a Qodo finding that landed after it merged.

`docker/mosaico/smoke_test.sh` runs under `set -uo pipefail` without `-e`, so a failed `mktemp -d` left `TMPDIR_RUN` empty and execution continued. Every subsequent write then targeted the filesystem root:

```
$ TMPDIR_RUN="$(mktemp -d /nonexistent/tmp.XXXX 2>/dev/null)"
$ echo "$TMPDIR_RUN/health.json"
/health.json
```

Guard the assignment so the script exits instead.

Verified: guard fires and exits 1 when `mktemp` fails; `./smoke_test.sh` against the pinned image still reports `FULL ROUND-TRIP PASSED`.
