### PR TITLE
ci(mosaico): detect drift between docker/mosaico and the GitLab mirror

### DIFF
--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -117,14 +117,24 @@ emit_raw() {
 
 list_files() {
   local dir="$1" n_entries n_lines
-  n_entries="$(emit_raw "$dir" | tr -cd '\0' | wc -c | tr -d ' ')"
+  # pipefail carries an emit_raw failure out to each pipeline below; turn it into exit 2.
+  # A listing that failed partway - an unreadable subdirectory under the `find` fallback,
+  # say - still prints the entries it did reach, and every name missing from that short list
+  # then reads as a one-sided file, i.e. drift. Unchecked, an operational error reports as
+  # exit 1, the code reserved for a genuine divergence.
+  n_entries="$(emit_raw "$dir" | tr -cd '\0' | wc -c | tr -d ' ')" \
+    || die "could not list files in '$dir'"
+  # `grep -c ''` exits 1 on empty input. That is an empty listing, not a failure: a real
+  # emit_raw error already became exit 2 on the line above, and an empty bundle is caught by
+  # the "compared 0 files" guard at the end, which words it far better. Keep the `|| true`.
   n_lines="$(emit_raw "$dir" | tr '\0' '\n' | grep -c '' || true)"
   # Everything downstream (comm, the read loops) is line-based, so a filename containing a
   # literal newline cannot be compared correctly. Refuse rather than emit a confident wrong
   # verdict; the bundle has no such name, so this is a guard, not a workflow.
   [[ "$n_lines" == "$n_entries" ]] \
     || die "a filename in '$dir' contains a newline; this comparison is line-based and cannot represent it safely"
-  emit_raw "$dir" | tr '\0' '\n' | sed 's#^\./##' | LC_ALL=C sort
+  emit_raw "$dir" | tr '\0' '\n' | sed 's#^\./##' | LC_ALL=C sort \
+    || die "could not list files in '$dir'"
 }
 
 drop_allowlisted() {

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -1,33 +1,7 @@
 #!/usr/bin/env bash
-# Fail if docker/mosaico/ has drifted from the MOSAICO deployment bundle published at
+# Fail if docker/mosaico/ has drifted, either way, from the bundle mirrored at
 # gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent.
-#
-# That GitLab repo is a *mirror*, not a fork: it holds the same deployment assets at its
-# root, with zero Python. Upstream here is canonical and edits flow GitHub -> GitLab, but
-# drift is detected in BOTH directions on purpose — a consortium member editing the mirror
-# directly is exactly the case that silently strands a fix outside this repo.
-#
-#   GitHub  docker/mosaico/<f>   <->   GitLab  <f>   (bundle lives at the mirror's root)
-#
-# Usage:
-#   mosaico_bundle_parity.sh                      # fetch the mirror, compare against HEAD
-#   mosaico_bundle_parity.sh --gitlab-dir DIR     # compare against an already-fetched copy
-#   mosaico_bundle_parity.sh --github-dir DIR     # override the local side
-#   mosaico_bundle_parity.sh --ref BRANCH         # mirror ref to compare (default: main)
-#
-# Auth: none. The mirror is a public project, so the clone is anonymous and every run really
-# compares — including fork PRs, which used to be exempted from this check for the sole
-# reason that forks receive no secrets. Set GITLAB_TOKEN to a token with read_repository
-# only if the mirror is ever made private; unset or empty takes the anonymous path.
-#
-# A token that IS supplied must work. It is sent on every request and a rejected one fails
-# the run — there is no fallback to anonymous, which on a public mirror would "succeed" and
-# leave a stale or misconfigured secret looking healthy indefinitely.
-#
-# There is deliberately no way to exit 0 without having compared the two trees. A clone that
-# fails is exit 2, never a skip: "could not verify" must not be able to read as "in parity".
-#
-# Exit: 0 parity, 1 drift, 2 usage/fetch error.
+# Usage: [--github-dir DIR] [--gitlab-dir DIR] [--ref BRANCH]. Exit: 0 ok, 1 drift, 2 error.
 set -uo pipefail
 
 GITHUB_DIR="docker/mosaico"
@@ -35,23 +9,11 @@ GITLAB_DIR=""
 REF="main"
 MIRROR_URL="https://gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent.git"
 
-# Tracked on the mirror but deliberately absent from docker/mosaico/. The mirror is a
-# standalone repo, so it carries its own .gitignore (it ignores the .env a deployer creates
-# from pr-agent.env.example); upstream's root .gitignore already covers that path here.
-# Anything NOT listed here must exist on both sides — that is what catches a new file added
-# to one side only. Filtered from BOTH lists: an allowlisted name is "not part of the
-# comparison", so its presence on either side is equally uninteresting. Filtering only the
-# mirror would make an upstream copy of .gitignore report as GH-ONLY on identical trees.
+# Mirror-only by design. Filtered from BOTH lists, else a copy here reads as GH-ONLY.
 MIRROR_ONLY=(".gitignore")
 
 die() { echo "error: $*" >&2; exit 2; }
 
-# Options take a value, so a missing one is a usage error (exit 2). Relying on bash's
-# ${2:?} here would abort with exit 1, which this script defines as "drift found" — a
-# mistyped flag would be indistinguishable from a real divergence.
-# A following token that is itself an option means the value was forgotten: `--github-dir
-# --ref main` would otherwise consume "--ref" as the directory and then trip over "main",
-# reporting "unknown argument: main" for what is really a missing value on --github-dir.
 needval() {
   [[ $# -ge 2 && -n "${2:-}" && "$2" != -* ]] || die "option $1 requires a value"
 }
@@ -61,8 +23,7 @@ while [[ $# -gt 0 ]]; do
     --github-dir) needval "$@"; GITHUB_DIR="$2"; shift 2 ;;
     --gitlab-dir) needval "$@"; GITLAB_DIR="$2"; shift 2 ;;
     --ref)        needval "$@"; REF="$2";        shift 2 ;;
-    # Header comment block only; the line after it is `set -uo pipefail`, not documentation.
-    -h|--help)    sed -n '2,30p' "$0"; exit 0 ;;
+    -h|--help)    sed -n '2,4p' "$0"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
@@ -73,7 +34,6 @@ SCRATCH=""
 cleanup() { [[ -n "$SCRATCH" ]] && rm -rf "$SCRATCH"; }
 trap cleanup EXIT
 
-# --- obtain the mirror side -------------------------------------------------------------
 if [[ -z "$GITLAB_DIR" ]]; then
   SCRATCH="$(mktemp -d)" || die "mktemp -d failed"
   GITLAB_DIR="$SCRATCH/mirror"
@@ -81,29 +41,9 @@ if [[ -z "$GITLAB_DIR" ]]; then
     git clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" \
       2>"$SCRATCH/clone.err"
   }
-  # The mirror is a public project, so the default path carries no credentials at all and
-  # needs no secret configured anywhere. An empty GITLAB_TOKEN counts as absent rather than
-  # being passed through — an empty password would fail the very clone that succeeds
-  # anonymously.
-  #
-  # A token that IS supplied has to be exercised, not merely offered. Git only consults a
-  # credential helper after a 401, and a public project never returns one, so a wrong or
-  # expired token would go unused and unnoticed: the clone would succeed anonymously and the
-  # operator would keep believing authentication works. That is the silent-green failure
-  # this check exists to avoid, wearing a different hat. Sending the header on every request
-  # forces the server to judge it — GitLab answers 401 to bad credentials even on a public
-  # project (verified) — so a broken token fails the run instead of degrading quietly.
-  # There is deliberately no fallback to anonymous here: whoever supplied a credential is
-  # entitled to be told it is broken.
-  #
-  # The header travels in GIT_CONFIG_* rather than `git -c`, keeping the secret out of argv
-  # where any local process could read it off the process list. `printf` is a bash builtin,
-  # so the token never becomes a process argument there either.
+  # Sent on every request so a bad token fails the run; git would never consult a
+  # credential helper against a public repo, leaving a stale secret looking healthy.
   if [[ -n "${GITLAB_TOKEN:-}" ]]; then
-    # Encode first and check it worked. Inlined in the export, a failing base64 would yield
-    # "Authorization: Basic " with nothing after it, and the run would come back reporting
-    # authentication failure - blaming the operator's token for what is a broken tool on the
-    # runner. Kept unexported here: a plain shell variable is not visible to child processes.
     auth_basic="$(printf 'oauth2:%s' "$GITLAB_TOKEN" | base64 | tr -d '\n')" \
       || die "could not encode the credential for the Authorization header"
     [[ -n "$auth_basic" ]] \
@@ -119,34 +59,15 @@ if [[ -z "$GITLAB_DIR" ]]; then
   clone_status=$?
   if (( clone_status != 0 )); then
     echo "--- clone stderr ---" >&2
-    # Defensive: no credential should ever appear here, but strip anything credential-shaped
-    # anyway rather than trust that and echo a secret into a public log. The Authorization
-    # rule matters most — that header carries the base64 of the token, which is reversible.
     sed -E 's#://[^@]*@#://***@#g; s#glpat-[A-Za-z0-9._-]+#***#g; s#([Aa]uthorization:).*#\1 ***#g' \
       "$SCRATCH/clone.err" >&2
-    # Not a skip. Failing to reach the mirror means parity is unknown, and unknown is an
-    # error here - the whole point of dropping the old SKIP branch.
     die "could not clone the mirror at ref '$REF'"
   fi
 fi
 
 [[ -d "$GITLAB_DIR" ]] || die "gitlab dir not found: $GITLAB_DIR"
 
-# --- build both file sets ---------------------------------------------------------------
-# Ask git what is tracked (authoritative, and `git -C <dir> ls-files` already emits paths
-# relative to <dir>, so no prefix stripping is needed — and no path-spelling like
-# "./docker/mosaico" or a trailing slash can desynchronise the two lists). Fall back to a
-# plain listing so the script also works against an exported, non-git directory.
-# Symlinks are included in the fallback: the bundle has none today, but a symlink appearing
-# on one side only is drift, and -type f alone would silently ignore it.
-#
-# Both backends are read NUL-delimited. Plain `git ls-files` renders a non-ASCII or
-# quote-bearing name as a C-style quoted literal ("caf\303\251.md"), which is not a path
-# that exists on disk — the existence check below would then miss it and report false drift
-# on identical trees. `-z` emits raw bytes and sidesteps the quoting entirely. Note that
-# core.quotePath=off is NOT sufficient: it unquotes non-ASCII but still escapes " and \.
-# Emits raw NUL-delimited names. Must stay a pipeline source: a bash variable cannot hold
-# NUL, so capturing this with $(...) would silently discard every delimiter.
+# Must stay a pipeline source: a bash variable cannot hold NUL.
 emit_raw() {
   local dir="$1"
   if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
@@ -158,23 +79,10 @@ emit_raw() {
 
 list_files() {
   local dir="$1" n_entries n_lines status
-  # pipefail carries an emit_raw failure out to each pipeline below; turn it into exit 2.
-  # A listing that failed partway - an unreadable subdirectory under the `find` fallback,
-  # say - still prints the entries it did reach, and every name missing from that short list
-  # then reads as a one-sided file, i.e. drift. Unchecked, an operational error reports as
-  # exit 1, the code reserved for a genuine divergence.
   n_entries="$(emit_raw "$dir" | tr -cd '\0' | wc -c | tr -d ' ')" \
     || die "could not list files in '$dir'"
-  # `grep -c ''` exits 1 on empty input. That is an empty listing, not a failure: a real
-  # emit_raw error already became exit 2 on the line above, and an empty bundle is caught by
-  # the "compared 0 files" guard at the end, which words it far better. Above 1 is grep
-  # itself failing, which must not pass for a count of zero - hence the range test rather
-  # than a blanket `|| true`.
   n_lines="$(emit_raw "$dir" | tr '\0' '\n' | grep -c '')"; status=$?
   (( status <= 1 )) || die "could not count entries in '$dir'"
-  # Everything downstream (comm, the read loops) is line-based, so a filename containing a
-  # literal newline cannot be compared correctly. Refuse rather than emit a confident wrong
-  # verdict; the bundle has no such name, so this is a guard, not a workflow.
   [[ "$n_lines" == "$n_entries" ]] \
     || die "a filename in '$dir' contains a newline; this comparison is line-based and cannot represent it safely"
   emit_raw "$dir" | tr '\0' '\n' | sed 's#^\./##' | LC_ALL=C sort \
@@ -184,19 +92,13 @@ list_files() {
 drop_allowlisted() {
   local list="$1" f status
   for f in "${MIRROR_ONLY[@]}"; do
-    # grep exits 1 when it selects nothing, which here means the allowlisted name was the
-    # only entry left - a legitimate empty list. Above 1 is grep failing, and swallowing
-    # that would hand back a truncated list whose missing names then read as one-sided.
     list="$(printf '%s\n' "$list" | grep -vxF "$f")"; status=$?
     (( status <= 1 )) || die "could not filter '$f' out of the file list"
   done
   printf '%s\n' "$list"
 }
 
-# Both helpers run in a command substitution, so a die() inside one only kills that
-# subshell. Without propagating the status here the script would carry on with an empty file
-# list and report the resulting phantom differences as drift (exit 1) instead of the real
-# error. Every call below needs the `|| exit $?`, not just the list_files pair.
+# die() inside a command substitution kills only the subshell, so propagate every status.
 gh_raw="$(list_files "$GITHUB_DIR")" || exit $?
 gl_raw="$(list_files "$GITLAB_DIR")" || exit $?
 gh_files="$(drop_allowlisted "$gh_raw")" || exit $?
@@ -208,10 +110,6 @@ report() { printf '  %-8s %s\n' "$1" "$2"; }
 echo "Comparing  $GITHUB_DIR  <->  mirror ref '$REF'"
 echo
 
-# comm exits 0 whether or not it finds anything, so unlike grep any non-zero status here is
-# a genuine failure. Left unchecked it would hand back an empty set, and an empty set of
-# one-sided files reads as "no drift" — a silent false parity, the one wrong answer this
-# check must never give.
 only_gh="$(LC_ALL=C comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
   || die "could not compare the two file lists (GitHub-only set)"
 only_gl="$(LC_ALL=C comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
@@ -226,7 +124,6 @@ if [[ -n "$only_gl" ]]; then
   while IFS= read -r f; do [[ -n "$f" ]] && report "GL-ONLY" "$f"; done <<<"$only_gl"
 fi
 
-# --- byte-compare everything present on both sides ---------------------------------------
 shared="$(LC_ALL=C comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
   || die "could not compare the two file lists (shared set)"
 n_total=0
@@ -235,76 +132,37 @@ while IFS= read -r f; do
   [[ -z "$f" ]] && continue
   n_total=$((n_total + 1))
   gh_p="$GITHUB_DIR/$f"; gl_p="$GITLAB_DIR/$f"
-  # A file git still tracks but that is gone from the working tree (an uncommitted delete)
-  # is neither "same" nor a content difference; diff would just emit a bare "No such file"
-  # to stderr in the middle of the report. Name the real condition instead.
-  # -e follows the link, so a dangling symlink would read as absent; -L catches the entry
-  # itself, which is what is actually being compared.
   if [[ ! -e "$gh_p" && ! -L "$gh_p" ]]; then
     drift=1; report "MISSING" "$f (tracked on GitHub side, absent from the working tree)"; continue
   fi
   if [[ ! -e "$gl_p" && ! -L "$gl_p" ]]; then
     drift=1; report "MISSING" "$f (tracked on the mirror, absent from its working tree)"; continue
   fi
-  # Symlinks are compared by target, not by the bytes they resolve to. `diff` dereferences,
-  # so a link repointed on the mirror would read as identical whenever both targets happen
-  # to hold the same content - drift the mirror is supposed to surface, silently passing.
+  # Compare targets, not content: diff dereferences and would pass a repointed link.
   if [[ -L "$gh_p" || -L "$gl_p" ]]; then
     if [[ ! -L "$gh_p" || ! -L "$gl_p" ]]; then
       drift=1
       report "DIFFER" "$f (symlink on one side, regular file on the other)"
-    # `$(readlink ...; printf x)` takes printf's status, not readlink's, so a readlink that
-    # fails is invisible to the comparison below: both sides would collapse to the bare
-    # sentinel, compare equal, and a pair the script could not actually read would be
-    # reported "same". That is a false parity, the one answer this check must never give, so
-    # establish that both links are readable before trusting the comparison.
     elif ! readlink "$gh_p" >/dev/null; then
       die "could not read the symlink '$f' on the GitHub side"
     elif ! readlink "$gl_p" >/dev/null; then
       die "could not read the symlink '$f' on the mirror"
-    # The trailing `printf x` keeps a target string that ends in a newline distinguishable:
-    # command substitution strips trailing newlines, so 'a' and 'a\n' would otherwise be
-    # reported as the same link. Verified on Linux, the CI platform, where dropping the
-    # `printf x` does make the two compare equal. It is untestable on macOS, whose readlink
-    # collapses the trailing newline before the shell ever sees it - so do not "simplify"
-    # this away on the strength of a local run there.
+    # printf x keeps a target ending in a newline distinct. Linux-verified; on macOS
+    # readlink collapses it, so a local run cannot show why this is here.
     elif [[ "$(readlink "$gh_p"; printf x)" == "$(readlink "$gl_p"; printf x)" ]]; then
       report "same" "$f"
       n_same=$((n_same + 1))
     else
       drift=1
-      # Same sentinel trick as the comparison, then %q, so the message can actually show
-      # what the comparison reacted to. Bare $(readlink) would strip a trailing newline and
-      # print control characters raw, i.e. render two targets the script just called
-      # different as an identical-looking pair, leaving nothing to act on.
-      #
-      # Two strips, in order: the sentinel, then the single newline readlink itself prints
-      # as a terminator. Only that one - a target that genuinely ends in a newline keeps it
-      # and shows up as $'a\n', which is the whole point of not using bare $(readlink).
       gh_t="$(readlink "$gh_p"; printf x)"; gh_t="${gh_t%x}"; gh_t="${gh_t%$'\n'}"
       gl_t="$(readlink "$gl_p"; printf x)"; gl_t="${gl_t%x}"; gl_t="${gl_t%$'\n'}"
       report "DIFFER" "$f (symlink target: $(printf '%q' "$gh_t") vs $(printf '%q' "$gl_t"))"
     fi
     continue
   fi
-  # diff distinguishes "identical" (0) from "differs" (1) from "diff itself failed" (2+, an
-  # unreadable file or an I/O error). Folding 2 in with 1 would book an operational fault as
-  # drift and print an empty diff under it, so split the three cases on one status.
-  #
-  # One invocation, not a `diff -q` probe followed by a `diff -u` to render: two calls means
-  # two chances to fail and a second status to drop on the floor. Capturing stderr with the
-  # output puts it in the error message instead of discarding it down /dev/null, which is
-  # what made this failure mode invisible to begin with. The bundle is a handful of small
-  # config files, so holding one diff in a variable costs nothing.
   diff_out="$(diff -u "$gh_p" "$gl_p" --label "github/$GITHUB_DIR/$f" --label "gitlab/$f" 2>&1)"
   d_status=$?
   if (( d_status == 0 )); then
-    # Identical bytes are not the whole story: the consortium deploys from the mirror and
-    # runs smoke_test.sh out of it, so an executable bit lost in the copy leaves the bundle
-    # broken while every byte still matches. git tracks that bit (100644 vs 100755), which
-    # makes it drift by the same definition as any other tracked difference. -x is the
-    # portable way to ask - `stat` formats differ between GNU and BSD - and it is the only
-    # mode bit git records, so it is exactly the right question.
     if [[ -x "$gh_p" && ! -x "$gl_p" ]]; then
       drift=1
       report "DIFFER" "$f (executable here, not on the mirror)"

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -14,12 +14,14 @@
 #   mosaico_bundle_parity.sh --gitlab-dir DIR     # compare against an already-fetched copy
 #   mosaico_bundle_parity.sh --github-dir DIR     # override the local side
 #   mosaico_bundle_parity.sh --ref BRANCH         # mirror ref to compare (default: main)
-#   mosaico_bundle_parity.sh --require-token      # treat a missing token as an error
 #
-# Auth: set GITLAB_TOKEN to a token with read_repository. Without it the script cannot see
-# the mirror, so it reports SKIP and exits 0 — correct only where secrets are legitimately
-# unavailable (fork PRs). Everywhere else pass --require-token, otherwise an expired or
-# unset secret degrades into a permanently green check that verifies nothing.
+# Auth: none. The mirror is a public project, so the clone is anonymous and every run really
+# compares — including fork PRs, which used to be exempted from this check for the sole
+# reason that forks receive no secrets. Set GITLAB_TOKEN to a token with read_repository
+# only if the mirror is ever made private; unset or empty takes the anonymous path.
+#
+# There is deliberately no way to exit 0 without having compared the two trees. A clone that
+# fails is exit 2, never a skip: "could not verify" must not be able to read as "in parity".
 #
 # Exit: 0 parity, 1 drift, 2 usage/fetch error.
 set -uo pipefail
@@ -27,7 +29,6 @@ set -uo pipefail
 GITHUB_DIR="docker/mosaico"
 GITLAB_DIR=""
 REF="main"
-REQUIRE_TOKEN=0
 MIRROR_URL="https://gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent.git"
 
 # Tracked on the mirror but deliberately absent from docker/mosaico/. The mirror is a
@@ -51,9 +52,8 @@ while [[ $# -gt 0 ]]; do
     --github-dir) needval "$@"; GITHUB_DIR="$2"; shift 2 ;;
     --gitlab-dir) needval "$@"; GITLAB_DIR="$2"; shift 2 ;;
     --ref)        needval "$@"; REF="$2";        shift 2 ;;
-    --require-token) REQUIRE_TOKEN=1;            shift ;;
-    # Header comment block only; line 25 is `set -uo pipefail`, not documentation.
-    -h|--help)    sed -n '2,24p' "$0"; exit 0 ;;
+    # Header comment block only; the line after it is `set -uo pipefail`, not documentation.
+    -h|--help)    sed -n '2,26p' "$0"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
@@ -66,25 +66,35 @@ trap cleanup EXIT
 
 # --- obtain the mirror side -------------------------------------------------------------
 if [[ -z "$GITLAB_DIR" ]]; then
-  if [[ -z "${GITLAB_TOKEN:-}" ]]; then
-    if [[ $REQUIRE_TOKEN == 1 ]]; then
-      die "GITLAB_TOKEN is unset or empty and --require-token was given"
-    fi
-    echo "SKIP: GITLAB_TOKEN unset — cannot reach the mirror, so parity is unverified."
-    echo "      Legitimate only on fork PRs, where secrets are withheld. A maintainer push"
-    echo "      or the scheduled run covers it; both pass --require-token."
-    exit 0
-  fi
   SCRATCH="$(mktemp -d)" || die "mktemp -d failed"
   GITLAB_DIR="$SCRATCH/mirror"
-  # Token goes through a credential helper rather than the URL, so it never lands in the
-  # remote URL, the reflog, or a CI log line on failure.
-  if ! git -c credential.helper='!f(){ echo username=oauth2; echo "password=${GITLAB_TOKEN}"; };f' \
-         clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" 2>"$SCRATCH/clone.err"; then
+  # Wrapped so the credential helper can be passed as an argument without either repeating
+  # the clone line or expanding a possibly-empty array — the latter is an unbound-variable
+  # error under `set -u` on bash 3.2, still the system bash on macOS. "$@" has no such flaw.
+  clone_mirror() {
+    git "$@" clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" \
+      2>"$SCRATCH/clone.err"
+  }
+  # The mirror is a public project, so the default path carries no credentials at all and
+  # needs no secret to be configured anywhere. A token is still honoured when one is set: it
+  # costs nothing and keeps this working unchanged should the project ever be made private.
+  # An empty value counts as absent rather than being passed through — an empty password
+  # would fail the very clone that succeeds anonymously.
+  if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+    # Token goes through a credential helper rather than the URL, so it never lands in the
+    # remote URL, the reflog, or a CI log line on failure.
+    clone_mirror -c 'credential.helper=!f(){ echo username=oauth2; echo "password=${GITLAB_TOKEN}"; };f'
+  else
+    clone_mirror
+  fi
+  clone_status=$?
+  if (( clone_status != 0 )); then
     echo "--- clone stderr ---" >&2
     # Defensive: the token should never appear here, but strip anything token-shaped anyway
     # rather than trust that and echo a secret into a public log.
     sed -E 's#://[^@]*@#://***@#g; s#glpat-[A-Za-z0-9._-]+#***#g' "$SCRATCH/clone.err" >&2
+    # Not a skip. Failing to reach the mirror means parity is unknown, and unknown is an
+    # error here - the whole point of dropping the old SKIP branch.
     die "could not clone the mirror at ref '$REF'"
   fi
 fi

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -187,7 +187,13 @@ while IFS= read -r f; do
     if [[ ! -L "$gh_p" || ! -L "$gl_p" ]]; then
       drift=1
       report "DIFFER" "$f (symlink on one side, regular file on the other)"
-    elif [[ "$(readlink "$gh_p")" == "$(readlink "$gl_p")" ]]; then
+    # The trailing `printf x` keeps a target string that ends in a newline distinguishable:
+    # command substitution strips trailing newlines, so 'a' and 'a\n' would otherwise be
+    # reported as the same link. Verified on Linux, the CI platform, where dropping the
+    # `printf x` does make the two compare equal. It is untestable on macOS, whose readlink
+    # collapses the trailing newline before the shell ever sees it - so do not "simplify"
+    # this away on the strength of a local run there.
+    elif [[ "$(readlink "$gh_p"; printf x)" == "$(readlink "$gl_p"; printf x)" ]]; then
       report "same" "$f"
       n_same=$((n_same + 1))
     else

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -20,6 +20,10 @@
 # reason that forks receive no secrets. Set GITLAB_TOKEN to a token with read_repository
 # only if the mirror is ever made private; unset or empty takes the anonymous path.
 #
+# A token that IS supplied must work. It is sent on every request and a rejected one fails
+# the run — there is no fallback to anonymous, which on a public mirror would "succeed" and
+# leave a stale or misconfigured secret looking healthy indefinitely.
+#
 # There is deliberately no way to exit 0 without having compared the two trees. A clone that
 # fails is exit 2, never a skip: "could not verify" must not be able to read as "in parity".
 #
@@ -53,7 +57,7 @@ while [[ $# -gt 0 ]]; do
     --gitlab-dir) needval "$@"; GITLAB_DIR="$2"; shift 2 ;;
     --ref)        needval "$@"; REF="$2";        shift 2 ;;
     # Header comment block only; the line after it is `set -uo pipefail`, not documentation.
-    -h|--help)    sed -n '2,26p' "$0"; exit 0 ;;
+    -h|--help)    sed -n '2,30p' "$0"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
@@ -68,31 +72,45 @@ trap cleanup EXIT
 if [[ -z "$GITLAB_DIR" ]]; then
   SCRATCH="$(mktemp -d)" || die "mktemp -d failed"
   GITLAB_DIR="$SCRATCH/mirror"
-  # Wrapped so the credential helper can be passed as an argument without either repeating
-  # the clone line or expanding a possibly-empty array — the latter is an unbound-variable
-  # error under `set -u` on bash 3.2, still the system bash on macOS. "$@" has no such flaw.
   clone_mirror() {
-    git "$@" clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" \
+    git clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" \
       2>"$SCRATCH/clone.err"
   }
   # The mirror is a public project, so the default path carries no credentials at all and
-  # needs no secret to be configured anywhere. A token is still honoured when one is set: it
-  # costs nothing and keeps this working unchanged should the project ever be made private.
-  # An empty value counts as absent rather than being passed through — an empty password
-  # would fail the very clone that succeeds anonymously.
+  # needs no secret configured anywhere. An empty GITLAB_TOKEN counts as absent rather than
+  # being passed through — an empty password would fail the very clone that succeeds
+  # anonymously.
+  #
+  # A token that IS supplied has to be exercised, not merely offered. Git only consults a
+  # credential helper after a 401, and a public project never returns one, so a wrong or
+  # expired token would go unused and unnoticed: the clone would succeed anonymously and the
+  # operator would keep believing authentication works. That is the silent-green failure
+  # this check exists to avoid, wearing a different hat. Sending the header on every request
+  # forces the server to judge it — GitLab answers 401 to bad credentials even on a public
+  # project (verified) — so a broken token fails the run instead of degrading quietly.
+  # There is deliberately no fallback to anonymous here: whoever supplied a credential is
+  # entitled to be told it is broken.
+  #
+  # The header travels in GIT_CONFIG_* rather than `git -c`, keeping the secret out of argv
+  # where any local process could read it off the process list. `printf` is a bash builtin,
+  # so the token never becomes a process argument there either.
   if [[ -n "${GITLAB_TOKEN:-}" ]]; then
-    # Token goes through a credential helper rather than the URL, so it never lands in the
-    # remote URL, the reflog, or a CI log line on failure.
-    clone_mirror -c 'credential.helper=!f(){ echo username=oauth2; echo "password=${GITLAB_TOKEN}"; };f'
+    (
+      export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.extraHeader
+      export GIT_CONFIG_VALUE_0="Authorization: Basic $(printf 'oauth2:%s' "$GITLAB_TOKEN" | base64 | tr -d '\n')"
+      clone_mirror
+    )
   else
     clone_mirror
   fi
   clone_status=$?
   if (( clone_status != 0 )); then
     echo "--- clone stderr ---" >&2
-    # Defensive: the token should never appear here, but strip anything token-shaped anyway
-    # rather than trust that and echo a secret into a public log.
-    sed -E 's#://[^@]*@#://***@#g; s#glpat-[A-Za-z0-9._-]+#***#g' "$SCRATCH/clone.err" >&2
+    # Defensive: no credential should ever appear here, but strip anything credential-shaped
+    # anyway rather than trust that and echo a secret into a public log. The Authorization
+    # rule matters most — that header carries the base64 of the token, which is reversible.
+    sed -E 's#://[^@]*@#://***@#g; s#glpat-[A-Za-z0-9._-]+#***#g; s#([Aa]uthorization:).*#\1 ***#g' \
+      "$SCRATCH/clone.err" >&2
     # Not a skip. Failing to reach the mirror means parity is unknown, and unknown is an
     # error here - the whole point of dropping the old SKIP branch.
     die "could not clone the mirror at ref '$REF'"

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -273,7 +273,17 @@ while IFS= read -r f; do
       n_same=$((n_same + 1))
     else
       drift=1
-      report "DIFFER" "$f (symlink target: '$(readlink "$gh_p")' vs '$(readlink "$gl_p")')"
+      # Same sentinel trick as the comparison, then %q, so the message can actually show
+      # what the comparison reacted to. Bare $(readlink) would strip a trailing newline and
+      # print control characters raw, i.e. render two targets the script just called
+      # different as an identical-looking pair, leaving nothing to act on.
+      #
+      # Two strips, in order: the sentinel, then the single newline readlink itself prints
+      # as a terminator. Only that one - a target that genuinely ends in a newline keeps it
+      # and shows up as $'a\n', which is the whole point of not using bare $(readlink).
+      gh_t="$(readlink "$gh_p"; printf x)"; gh_t="${gh_t%x}"; gh_t="${gh_t%$'\n'}"
+      gl_t="$(readlink "$gl_p"; printf x)"; gl_t="${gl_t%x}"; gl_t="${gl_t%$'\n'}"
+      report "DIFFER" "$f (symlink target: $(printf '%q' "$gh_t") vs $(printf '%q' "$gl_t"))"
     fi
     continue
   fi
@@ -289,8 +299,22 @@ while IFS= read -r f; do
   diff_out="$(diff -u "$gh_p" "$gl_p" --label "github/$GITHUB_DIR/$f" --label "gitlab/$f" 2>&1)"
   d_status=$?
   if (( d_status == 0 )); then
-    report "same" "$f"
-    n_same=$((n_same + 1))
+    # Identical bytes are not the whole story: the consortium deploys from the mirror and
+    # runs smoke_test.sh out of it, so an executable bit lost in the copy leaves the bundle
+    # broken while every byte still matches. git tracks that bit (100644 vs 100755), which
+    # makes it drift by the same definition as any other tracked difference. -x is the
+    # portable way to ask - `stat` formats differ between GNU and BSD - and it is the only
+    # mode bit git records, so it is exactly the right question.
+    if [[ -x "$gh_p" && ! -x "$gl_p" ]]; then
+      drift=1
+      report "DIFFER" "$f (executable here, not on the mirror)"
+    elif [[ ! -x "$gh_p" && -x "$gl_p" ]]; then
+      drift=1
+      report "DIFFER" "$f (executable on the mirror, not here)"
+    else
+      report "same" "$f"
+      n_same=$((n_same + 1))
+    fi
   elif (( d_status > 1 )); then
     die "diff failed on '$f' (exit $d_status); cannot tell whether it differs: $diff_out"
   else

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -168,16 +168,35 @@ n_same=0
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
   n_total=$((n_total + 1))
+  gh_p="$GITHUB_DIR/$f"; gl_p="$GITLAB_DIR/$f"
   # A file git still tracks but that is gone from the working tree (an uncommitted delete)
   # is neither "same" nor a content difference; diff would just emit a bare "No such file"
   # to stderr in the middle of the report. Name the real condition instead.
-  if [[ ! -e "$GITHUB_DIR/$f" ]]; then
+  # -e follows the link, so a dangling symlink would read as absent; -L catches the entry
+  # itself, which is what is actually being compared.
+  if [[ ! -e "$gh_p" && ! -L "$gh_p" ]]; then
     drift=1; report "MISSING" "$f (tracked on GitHub side, absent from the working tree)"; continue
   fi
-  if [[ ! -e "$GITLAB_DIR/$f" ]]; then
+  if [[ ! -e "$gl_p" && ! -L "$gl_p" ]]; then
     drift=1; report "MISSING" "$f (tracked on the mirror, absent from its working tree)"; continue
   fi
-  if diff -q "$GITHUB_DIR/$f" "$GITLAB_DIR/$f" >/dev/null 2>&1; then
+  # Symlinks are compared by target, not by the bytes they resolve to. `diff` dereferences,
+  # so a link repointed on the mirror would read as identical whenever both targets happen
+  # to hold the same content - drift the mirror is supposed to surface, silently passing.
+  if [[ -L "$gh_p" || -L "$gl_p" ]]; then
+    if [[ ! -L "$gh_p" || ! -L "$gl_p" ]]; then
+      drift=1
+      report "DIFFER" "$f (symlink on one side, regular file on the other)"
+    elif [[ "$(readlink "$gh_p")" == "$(readlink "$gl_p")" ]]; then
+      report "same" "$f"
+      n_same=$((n_same + 1))
+    else
+      drift=1
+      report "DIFFER" "$f (symlink target: '$(readlink "$gh_p")' vs '$(readlink "$gl_p")')"
+    fi
+    continue
+  fi
+  if diff -q "$gh_p" "$gl_p" >/dev/null 2>&1; then
     report "same" "$f"
     n_same=$((n_same + 1))
   else

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -149,8 +149,8 @@ report() { printf '  %-8s %s\n' "$1" "$2"; }
 echo "Comparing  $GITHUB_DIR  <->  mirror ref '$REF'"
 echo
 
-only_gh="$(comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
-only_gl="$(comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+only_gh="$(LC_ALL=C comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+only_gl="$(LC_ALL=C comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
 
 if [[ -n "$only_gh" ]]; then
   drift=1
@@ -162,7 +162,7 @@ if [[ -n "$only_gl" ]]; then
 fi
 
 # --- byte-compare everything present on both sides ---------------------------------------
-shared="$(comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+shared="$(LC_ALL=C comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
 n_total=0
 n_same=0
 while IFS= read -r f; do

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -221,19 +221,25 @@ while IFS= read -r f; do
     continue
   fi
   # diff distinguishes "identical" (0) from "differs" (1) from "diff itself failed" (2+, an
-  # unreadable file or an I/O error). Folding 2 into the else branch would book an
-  # operational fault as drift and print an empty diff under it, so split the cases.
-  diff -q "$gh_p" "$gl_p" >/dev/null 2>&1; d_status=$?
+  # unreadable file or an I/O error). Folding 2 in with 1 would book an operational fault as
+  # drift and print an empty diff under it, so split the three cases on one status.
+  #
+  # One invocation, not a `diff -q` probe followed by a `diff -u` to render: two calls means
+  # two chances to fail and a second status to drop on the floor. Capturing stderr with the
+  # output puts it in the error message instead of discarding it down /dev/null, which is
+  # what made this failure mode invisible to begin with. The bundle is a handful of small
+  # config files, so holding one diff in a variable costs nothing.
+  diff_out="$(diff -u "$gh_p" "$gl_p" --label "github/$GITHUB_DIR/$f" --label "gitlab/$f" 2>&1)"
+  d_status=$?
   if (( d_status == 0 )); then
     report "same" "$f"
     n_same=$((n_same + 1))
   elif (( d_status > 1 )); then
-    die "diff failed on '$f' (exit $d_status); cannot tell whether it differs"
+    die "diff failed on '$f' (exit $d_status); cannot tell whether it differs: $diff_out"
   else
     drift=1
     report "DIFFER" "$f"
-    diff -u "$GITHUB_DIR/$f" "$GITLAB_DIR/$f" \
-      --label "github/$GITHUB_DIR/$f" --label "gitlab/$f" 2>/dev/null | sed 's/^/    /'
+    printf '%s\n' "$diff_out" | sed 's/^/    /'
   fi
 done <<<"$shared"
 

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -49,7 +49,12 @@ die() { echo "error: $*" >&2; exit 2; }
 # Options take a value, so a missing one is a usage error (exit 2). Relying on bash's
 # ${2:?} here would abort with exit 1, which this script defines as "drift found" — a
 # mistyped flag would be indistinguishable from a real divergence.
-needval() { [[ $# -ge 2 && -n "${2:-}" ]] || die "option $1 requires a value"; }
+# A following token that is itself an option means the value was forgotten: `--github-dir
+# --ref main` would otherwise consume "--ref" as the directory and then trip over "main",
+# reporting "unknown argument: main" for what is really a missing value on --github-dir.
+needval() {
+  [[ $# -ge 2 && -n "${2:-}" && "$2" != -* ]] || die "option $1 requires a value"
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -195,8 +200,14 @@ report() { printf '  %-8s %s\n' "$1" "$2"; }
 echo "Comparing  $GITHUB_DIR  <->  mirror ref '$REF'"
 echo
 
-only_gh="$(LC_ALL=C comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
-only_gl="$(LC_ALL=C comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+# comm exits 0 whether or not it finds anything, so unlike grep any non-zero status here is
+# a genuine failure. Left unchecked it would hand back an empty set, and an empty set of
+# one-sided files reads as "no drift" — a silent false parity, the one wrong answer this
+# check must never give.
+only_gh="$(LC_ALL=C comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
+  || die "could not compare the two file lists (GitHub-only set)"
+only_gl="$(LC_ALL=C comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
+  || die "could not compare the two file lists (mirror-only set)"
 
 if [[ -n "$only_gh" ]]; then
   drift=1
@@ -208,7 +219,8 @@ if [[ -n "$only_gl" ]]; then
 fi
 
 # --- byte-compare everything present on both sides ---------------------------------------
-shared="$(LC_ALL=C comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+shared="$(LC_ALL=C comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))" \
+  || die "could not compare the two file lists (shared set)"
 n_total=0
 n_same=0
 while IFS= read -r f; do
@@ -233,6 +245,15 @@ while IFS= read -r f; do
     if [[ ! -L "$gh_p" || ! -L "$gl_p" ]]; then
       drift=1
       report "DIFFER" "$f (symlink on one side, regular file on the other)"
+    # `$(readlink ...; printf x)` takes printf's status, not readlink's, so a readlink that
+    # fails is invisible to the comparison below: both sides would collapse to the bare
+    # sentinel, compare equal, and a pair the script could not actually read would be
+    # reported "same". That is a false parity, the one answer this check must never give, so
+    # establish that both links are readable before trusting the comparison.
+    elif ! readlink "$gh_p" >/dev/null; then
+      die "could not read the symlink '$f' on the GitHub side"
+    elif ! readlink "$gl_p" >/dev/null; then
+      die "could not read the symlink '$f' on the mirror"
     # The trailing `printf x` keeps a target string that ends in a newline distinguishable:
     # command substitution strips trailing newlines, so 'a' and 'a\n' would otherwise be
     # reported as the same link. Verified on Linux, the CI platform, where dropping the

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -100,9 +100,17 @@ if [[ -z "$GITLAB_DIR" ]]; then
   # where any local process could read it off the process list. `printf` is a bash builtin,
   # so the token never becomes a process argument there either.
   if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+    # Encode first and check it worked. Inlined in the export, a failing base64 would yield
+    # "Authorization: Basic " with nothing after it, and the run would come back reporting
+    # authentication failure - blaming the operator's token for what is a broken tool on the
+    # runner. Kept unexported here: a plain shell variable is not visible to child processes.
+    auth_basic="$(printf 'oauth2:%s' "$GITLAB_TOKEN" | base64 | tr -d '\n')" \
+      || die "could not encode the credential for the Authorization header"
+    [[ -n "$auth_basic" ]] \
+      || die "credential encoded to an empty string; refusing to send a malformed Authorization header"
     (
       export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.extraHeader
-      export GIT_CONFIG_VALUE_0="Authorization: Basic $(printf 'oauth2:%s' "$GITLAB_TOKEN" | base64 | tr -d '\n')"
+      export GIT_CONFIG_VALUE_0="Authorization: Basic $auth_basic"
       clone_mirror
     )
   else

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Fail if docker/mosaico/ has drifted from the MOSAICO deployment bundle published at
+# gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent.
+#
+# That GitLab repo is a *mirror*, not a fork: it holds the same deployment assets at its
+# root, with zero Python. Upstream here is canonical and edits flow GitHub -> GitLab, but
+# drift is detected in BOTH directions on purpose — a consortium member editing the mirror
+# directly is exactly the case that silently strands a fix outside this repo.
+#
+#   GitHub  docker/mosaico/<f>   <->   GitLab  <f>   (bundle lives at the mirror's root)
+#
+# Usage:
+#   mosaico_bundle_parity.sh                      # fetch the mirror, compare against HEAD
+#   mosaico_bundle_parity.sh --gitlab-dir DIR     # compare against an already-fetched copy
+#   mosaico_bundle_parity.sh --github-dir DIR     # override the local side
+#   mosaico_bundle_parity.sh --ref BRANCH         # mirror ref to compare (default: main)
+#   mosaico_bundle_parity.sh --require-token      # treat a missing token as an error
+#
+# Auth: set GITLAB_TOKEN to a token with read_repository. Without it the script cannot see
+# the mirror, so it reports SKIP and exits 0 — correct only where secrets are legitimately
+# unavailable (fork PRs). Everywhere else pass --require-token, otherwise an expired or
+# unset secret degrades into a permanently green check that verifies nothing.
+#
+# Exit: 0 parity, 1 drift, 2 usage/fetch error.
+set -uo pipefail
+
+GITHUB_DIR="docker/mosaico"
+GITLAB_DIR=""
+REF="main"
+REQUIRE_TOKEN=0
+MIRROR_URL="https://gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent.git"
+
+# Tracked on the mirror but deliberately absent from docker/mosaico/. The mirror is a
+# standalone repo, so it carries its own .gitignore (it ignores the .env a deployer creates
+# from pr-agent.env.example); upstream's root .gitignore already covers that path here.
+# Anything NOT listed here must exist on both sides — that is what catches a new file added
+# to one side only. Filtered from BOTH lists: an allowlisted name is "not part of the
+# comparison", so its presence on either side is equally uninteresting. Filtering only the
+# mirror would make an upstream copy of .gitignore report as GH-ONLY on identical trees.
+MIRROR_ONLY=(".gitignore")
+
+die() { echo "error: $*" >&2; exit 2; }
+
+# Options take a value, so a missing one is a usage error (exit 2). Relying on bash's
+# ${2:?} here would abort with exit 1, which this script defines as "drift found" — a
+# mistyped flag would be indistinguishable from a real divergence.
+needval() { [[ $# -ge 2 && -n "${2:-}" ]] || die "option $1 requires a value"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --github-dir) needval "$@"; GITHUB_DIR="$2"; shift 2 ;;
+    --gitlab-dir) needval "$@"; GITLAB_DIR="$2"; shift 2 ;;
+    --ref)        needval "$@"; REF="$2";        shift 2 ;;
+    --require-token) REQUIRE_TOKEN=1;            shift ;;
+    # Header comment block only; line 25 is `set -uo pipefail`, not documentation.
+    -h|--help)    sed -n '2,24p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -d "$GITHUB_DIR" ]] || die "github dir not found: $GITHUB_DIR"
+
+SCRATCH=""
+cleanup() { [[ -n "$SCRATCH" ]] && rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+
+# --- obtain the mirror side -------------------------------------------------------------
+if [[ -z "$GITLAB_DIR" ]]; then
+  if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+    if [[ $REQUIRE_TOKEN == 1 ]]; then
+      die "GITLAB_TOKEN is unset or empty and --require-token was given"
+    fi
+    echo "SKIP: GITLAB_TOKEN unset — cannot reach the mirror, so parity is unverified."
+    echo "      Legitimate only on fork PRs, where secrets are withheld. A maintainer push"
+    echo "      or the scheduled run covers it; both pass --require-token."
+    exit 0
+  fi
+  SCRATCH="$(mktemp -d)" || die "mktemp -d failed"
+  GITLAB_DIR="$SCRATCH/mirror"
+  # Token goes through a credential helper rather than the URL, so it never lands in the
+  # remote URL, the reflog, or a CI log line on failure.
+  if ! git -c credential.helper='!f(){ echo username=oauth2; echo "password=${GITLAB_TOKEN}"; };f' \
+         clone --quiet --depth 1 --branch "$REF" "$MIRROR_URL" "$GITLAB_DIR" 2>"$SCRATCH/clone.err"; then
+    echo "--- clone stderr ---" >&2
+    # Defensive: the token should never appear here, but strip anything token-shaped anyway
+    # rather than trust that and echo a secret into a public log.
+    sed -E 's#://[^@]*@#://***@#g; s#glpat-[A-Za-z0-9._-]+#***#g' "$SCRATCH/clone.err" >&2
+    die "could not clone the mirror at ref '$REF'"
+  fi
+fi
+
+[[ -d "$GITLAB_DIR" ]] || die "gitlab dir not found: $GITLAB_DIR"
+
+# --- build both file sets ---------------------------------------------------------------
+# Ask git what is tracked (authoritative, and `git -C <dir> ls-files` already emits paths
+# relative to <dir>, so no prefix stripping is needed — and no path-spelling like
+# "./docker/mosaico" or a trailing slash can desynchronise the two lists). Fall back to a
+# plain listing so the script also works against an exported, non-git directory.
+# Symlinks are included in the fallback: the bundle has none today, but a symlink appearing
+# on one side only is drift, and -type f alone would silently ignore it.
+#
+# Both backends are read NUL-delimited. Plain `git ls-files` renders a non-ASCII or
+# quote-bearing name as a C-style quoted literal ("caf\303\251.md"), which is not a path
+# that exists on disk — the existence check below would then miss it and report false drift
+# on identical trees. `-z` emits raw bytes and sidesteps the quoting entirely. Note that
+# core.quotePath=off is NOT sufficient: it unquotes non-ASCII but still escapes " and \.
+# Emits raw NUL-delimited names. Must stay a pipeline source: a bash variable cannot hold
+# NUL, so capturing this with $(...) would silently discard every delimiter.
+emit_raw() {
+  local dir="$1"
+  if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$dir" ls-files -z
+  else
+    (cd "$dir" && find . \( -type f -o -type l \) -not -path './.git/*' -print0)
+  fi
+}
+
+list_files() {
+  local dir="$1" n_entries n_lines
+  n_entries="$(emit_raw "$dir" | tr -cd '\0' | wc -c | tr -d ' ')"
+  n_lines="$(emit_raw "$dir" | tr '\0' '\n' | grep -c '' || true)"
+  # Everything downstream (comm, the read loops) is line-based, so a filename containing a
+  # literal newline cannot be compared correctly. Refuse rather than emit a confident wrong
+  # verdict; the bundle has no such name, so this is a guard, not a workflow.
+  [[ "$n_lines" == "$n_entries" ]] \
+    || die "a filename in '$dir' contains a newline; this comparison is line-based and cannot represent it safely"
+  emit_raw "$dir" | tr '\0' '\n' | sed 's#^\./##' | LC_ALL=C sort
+}
+
+drop_allowlisted() {
+  local list="$1" f
+  for f in "${MIRROR_ONLY[@]}"; do
+    list="$(printf '%s\n' "$list" | grep -vxF "$f" || true)"
+  done
+  printf '%s\n' "$list"
+}
+
+# list_files runs in a command substitution, so a die() inside it only kills that subshell.
+# Without propagating the status here the script would carry on with an empty file list and
+# report the resulting phantom differences as drift (exit 1) instead of the real error.
+gh_raw="$(list_files "$GITHUB_DIR")" || exit $?
+gl_raw="$(list_files "$GITLAB_DIR")" || exit $?
+gh_files="$(drop_allowlisted "$gh_raw")"
+gl_files="$(drop_allowlisted "$gl_raw")"
+
+drift=0
+report() { printf '  %-8s %s\n' "$1" "$2"; }
+
+echo "Comparing  $GITHUB_DIR  <->  mirror ref '$REF'"
+echo
+
+only_gh="$(comm -23 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+only_gl="$(comm -13 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+
+if [[ -n "$only_gh" ]]; then
+  drift=1
+  while IFS= read -r f; do [[ -n "$f" ]] && report "GH-ONLY" "$f"; done <<<"$only_gh"
+fi
+if [[ -n "$only_gl" ]]; then
+  drift=1
+  while IFS= read -r f; do [[ -n "$f" ]] && report "GL-ONLY" "$f"; done <<<"$only_gl"
+fi
+
+# --- byte-compare everything present on both sides ---------------------------------------
+shared="$(comm -12 <(printf '%s\n' "$gh_files") <(printf '%s\n' "$gl_files"))"
+n_total=0
+n_same=0
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  n_total=$((n_total + 1))
+  # A file git still tracks but that is gone from the working tree (an uncommitted delete)
+  # is neither "same" nor a content difference; diff would just emit a bare "No such file"
+  # to stderr in the middle of the report. Name the real condition instead.
+  if [[ ! -e "$GITHUB_DIR/$f" ]]; then
+    drift=1; report "MISSING" "$f (tracked on GitHub side, absent from the working tree)"; continue
+  fi
+  if [[ ! -e "$GITLAB_DIR/$f" ]]; then
+    drift=1; report "MISSING" "$f (tracked on the mirror, absent from its working tree)"; continue
+  fi
+  if diff -q "$GITHUB_DIR/$f" "$GITLAB_DIR/$f" >/dev/null 2>&1; then
+    report "same" "$f"
+    n_same=$((n_same + 1))
+  else
+    drift=1
+    report "DIFFER" "$f"
+    diff -u "$GITHUB_DIR/$f" "$GITLAB_DIR/$f" \
+      --label "github/$GITHUB_DIR/$f" --label "gitlab/$f" 2>/dev/null | sed 's/^/    /'
+  fi
+done <<<"$shared"
+
+echo
+if [[ $drift == 0 ]]; then
+  if [[ $n_total == 0 ]]; then
+    die "compared 0 files — the bundle should never be empty; check --github-dir/--gitlab-dir"
+  fi
+  echo "PARITY OK — $n_same/$n_total files identical."
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+PARITY FAILED — docker/mosaico/ and the GitLab mirror have diverged.
+
+Resolve by direction:
+  * Change originated here (the normal case): port it to the mirror. Upstream is canonical,
+    so the mirror is brought up to this repo, never the reverse.
+  * Change originated on the mirror: port it back here FIRST, then re-sync the mirror, so
+    the fix is not stranded outside upstream. The bundle README says never to edit the
+    mirror directly, and a GL-ONLY line above means someone did.
+EOF
+exit 1

--- a/.github/scripts/mosaico_bundle_parity.sh
+++ b/.github/scripts/mosaico_bundle_parity.sh
@@ -116,7 +116,7 @@ emit_raw() {
 }
 
 list_files() {
-  local dir="$1" n_entries n_lines
+  local dir="$1" n_entries n_lines status
   # pipefail carries an emit_raw failure out to each pipeline below; turn it into exit 2.
   # A listing that failed partway - an unreadable subdirectory under the `find` fallback,
   # say - still prints the entries it did reach, and every name missing from that short list
@@ -126,8 +126,11 @@ list_files() {
     || die "could not list files in '$dir'"
   # `grep -c ''` exits 1 on empty input. That is an empty listing, not a failure: a real
   # emit_raw error already became exit 2 on the line above, and an empty bundle is caught by
-  # the "compared 0 files" guard at the end, which words it far better. Keep the `|| true`.
-  n_lines="$(emit_raw "$dir" | tr '\0' '\n' | grep -c '' || true)"
+  # the "compared 0 files" guard at the end, which words it far better. Above 1 is grep
+  # itself failing, which must not pass for a count of zero - hence the range test rather
+  # than a blanket `|| true`.
+  n_lines="$(emit_raw "$dir" | tr '\0' '\n' | grep -c '')"; status=$?
+  (( status <= 1 )) || die "could not count entries in '$dir'"
   # Everything downstream (comm, the read loops) is line-based, so a filename containing a
   # literal newline cannot be compared correctly. Refuse rather than emit a confident wrong
   # verdict; the bundle has no such name, so this is a guard, not a workflow.
@@ -138,20 +141,25 @@ list_files() {
 }
 
 drop_allowlisted() {
-  local list="$1" f
+  local list="$1" f status
   for f in "${MIRROR_ONLY[@]}"; do
-    list="$(printf '%s\n' "$list" | grep -vxF "$f" || true)"
+    # grep exits 1 when it selects nothing, which here means the allowlisted name was the
+    # only entry left - a legitimate empty list. Above 1 is grep failing, and swallowing
+    # that would hand back a truncated list whose missing names then read as one-sided.
+    list="$(printf '%s\n' "$list" | grep -vxF "$f")"; status=$?
+    (( status <= 1 )) || die "could not filter '$f' out of the file list"
   done
   printf '%s\n' "$list"
 }
 
-# list_files runs in a command substitution, so a die() inside it only kills that subshell.
-# Without propagating the status here the script would carry on with an empty file list and
-# report the resulting phantom differences as drift (exit 1) instead of the real error.
+# Both helpers run in a command substitution, so a die() inside one only kills that
+# subshell. Without propagating the status here the script would carry on with an empty file
+# list and report the resulting phantom differences as drift (exit 1) instead of the real
+# error. Every call below needs the `|| exit $?`, not just the list_files pair.
 gh_raw="$(list_files "$GITHUB_DIR")" || exit $?
 gl_raw="$(list_files "$GITLAB_DIR")" || exit $?
-gh_files="$(drop_allowlisted "$gh_raw")"
-gl_files="$(drop_allowlisted "$gl_raw")"
+gh_files="$(drop_allowlisted "$gh_raw")" || exit $?
+gl_files="$(drop_allowlisted "$gl_raw")" || exit $?
 
 drift=0
 report() { printf '  %-8s %s\n' "$1" "$2"; }
@@ -212,9 +220,15 @@ while IFS= read -r f; do
     fi
     continue
   fi
-  if diff -q "$gh_p" "$gl_p" >/dev/null 2>&1; then
+  # diff distinguishes "identical" (0) from "differs" (1) from "diff itself failed" (2+, an
+  # unreadable file or an I/O error). Folding 2 into the else branch would book an
+  # operational fault as drift and print an empty diff under it, so split the cases.
+  diff -q "$gh_p" "$gl_p" >/dev/null 2>&1; d_status=$?
+  if (( d_status == 0 )); then
     report "same" "$f"
     n_same=$((n_same + 1))
+  elif (( d_status > 1 )); then
+    die "diff failed on '$f' (exit $d_status); cannot tell whether it differs"
   else
     drift=1
     report "DIFFER" "$f"

--- a/.github/workflows/mosaico-bundle-parity.yaml
+++ b/.github/workflows/mosaico-bundle-parity.yaml
@@ -8,9 +8,9 @@ name: Mosaico-bundle-parity
 # Runs on PRs that touch the bundle (so drift is caught before merge), on merges to main,
 # and weekly (so an edit made directly on the mirror surfaces even if nothing changes here).
 #
-# Requires the GITLAB_MIRROR_TOKEN secret: a GitLab token with read_repository on that
-# project. Fork PRs get no secrets, so the script skips cleanly rather than failing — the
-# push-to-main and scheduled runs still cover those changes.
+# Needs no secret: the mirror is a public project, so the clone is anonymous. That also
+# means fork PRs are really checked rather than exempted, which is what they had to be back
+# when the only way to reach the mirror was a token forks never receive.
 
 on:
   pull_request:
@@ -34,9 +34,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
-# Checkout and compare, nothing else: the job reads this repo and reaches the mirror with a
-# separate GitLab token. Stated explicitly so the boundary does not move when the
-# repository or org default for GITHUB_TOKEN changes.
+# Checkout and compare, nothing else: the job reads this repo and clones a public mirror.
+# Stated explicitly so the boundary does not move when the repository or org default for
+# GITHUB_TOKEN changes.
 permissions:
   contents: read
 
@@ -51,15 +51,13 @@ jobs:
       - id: parity
         name: Compare docker/mosaico against the GitLab mirror
         env:
+          # Optional, and absent today. The mirror is public, so an unset or empty value
+          # takes the anonymous path; the line exists only so this job keeps working without
+          # edits if the project is ever made private and the secret is added then.
           GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
-          # Fork PRs are the only runs that legitimately have no secret.
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           chmod +x .github/scripts/mosaico_bundle_parity.sh
-          # Everywhere a secret IS expected, demand it. Without --require-token an expired
-          # or unset GITLAB_MIRROR_TOKEN would make the script skip and exit 0 on every
-          # scheduled run - a permanently green check that verifies nothing, which is worse
-          # than having no check at all.
-          args=()
-          [[ "$IS_FORK_PR" == "true" ]] || args+=(--require-token)
-          .github/scripts/mosaico_bundle_parity.sh "${args[@]}"
+          # No flags left to tune: the script cannot exit 0 without having compared the two
+          # trees, and a mirror it cannot reach is exit 2. There is no path by which this
+          # check goes green while verifying nothing.
+          .github/scripts/mosaico_bundle_parity.sh

--- a/.github/workflows/mosaico-bundle-parity.yaml
+++ b/.github/workflows/mosaico-bundle-parity.yaml
@@ -1,0 +1,56 @@
+name: Mosaico-bundle-parity
+
+# The MOSAICO deployment bundle in docker/mosaico/ is mirrored to
+# gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent,
+# where the Horizon Europe consortium consumes it. Upstream is canonical; the mirror must
+# never drift. This job makes "we keep it current" a mechanism rather than a promise.
+#
+# Runs on PRs that touch the bundle (so drift is caught before merge), on merges to main,
+# and weekly (so an edit made directly on the mirror surfaces even if nothing changes here).
+#
+# Requires the GITLAB_MIRROR_TOKEN secret: a GitLab token with read_repository on that
+# project. Fork PRs get no secrets, so the script skips cleanly rather than failing — the
+# push-to-main and scheduled runs still cover those changes.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docker/mosaico/**'
+      - '.github/scripts/mosaico_bundle_parity.sh'
+      - '.github/workflows/mosaico-bundle-parity.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/mosaico/**'
+      - '.github/scripts/mosaico_bundle_parity.sh'
+  schedule:
+    # Monday 06:00 UTC — catches drift introduced on the mirror between releases.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - id: parity
+        name: Compare docker/mosaico against the GitLab mirror
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
+          # Fork PRs are the only runs that legitimately have no secret.
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          chmod +x .github/scripts/mosaico_bundle_parity.sh
+          # Everywhere a secret IS expected, demand it. Without --require-token an expired
+          # or unset GITLAB_MIRROR_TOKEN would make the script skip and exit 0 on every
+          # scheduled run - a permanently green check that verifies nothing, which is worse
+          # than having no check at all.
+          args=()
+          [[ "$IS_FORK_PR" == "true" ]] || args+=(--require-token)
+          .github/scripts/mosaico_bundle_parity.sh "${args[@]}"

--- a/.github/workflows/mosaico-bundle-parity.yaml
+++ b/.github/workflows/mosaico-bundle-parity.yaml
@@ -1,16 +1,7 @@
 name: Mosaico-bundle-parity
 
-# The MOSAICO deployment bundle in docker/mosaico/ is mirrored to
-# gitlab.eclipse.org/eclipse-research-labs/mosaico-project/mosaico-extra/qodo-pr-agent,
-# where the Horizon Europe consortium consumes it. Upstream is canonical; the mirror must
-# never drift. This job makes "we keep it current" a mechanism rather than a promise.
-#
-# Runs on PRs that touch the bundle (so drift is caught before merge), on merges to main,
-# and weekly (so an edit made directly on the mirror surfaces even if nothing changes here).
-#
-# Needs no secret: the mirror is a public project, so the clone is anonymous. That also
-# means fork PRs are really checked rather than exempted, which is what they had to be back
-# when the only way to reach the mirror was a token forks never receive.
+# Keeps docker/mosaico/ in sync with the public GitLab mirror the MOSAICO consortium
+# deploys from. No secret needed, so fork PRs are checked too.
 
 on:
   pull_request:
@@ -26,17 +17,12 @@ on:
     paths:
       - 'docker/mosaico/**'
       - '.github/scripts/mosaico_bundle_parity.sh'
-      # Same list as the PR trigger. Omitting this file would let a workflow-only
-      # change land on main without the job it alters ever running there.
       - '.github/workflows/mosaico-bundle-parity.yaml'
   schedule:
-    # Monday 06:00 UTC — catches drift introduced on the mirror between releases.
+    # Catches drift introduced directly on the mirror between releases.
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
-# Checkout and compare, nothing else: the job reads this repo and clones a public mirror.
-# Stated explicitly so the boundary does not move when the repository or org default for
-# GITHUB_TOKEN changes.
 permissions:
   contents: read
 
@@ -51,13 +37,8 @@ jobs:
       - id: parity
         name: Compare docker/mosaico against the GitLab mirror
         env:
-          # Optional, and absent today. The mirror is public, so an unset or empty value
-          # takes the anonymous path; the line exists only so this job keeps working without
-          # edits if the project is ever made private and the secret is added then.
+          # Optional and absent today; only needed if the mirror is ever made private.
           GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
         run: |
           chmod +x .github/scripts/mosaico_bundle_parity.sh
-          # No flags left to tune: the script cannot exit 0 without having compared the two
-          # trees, and a mirror it cannot reach is exit 2. There is no path by which this
-          # check goes green while verifying nothing.
           .github/scripts/mosaico_bundle_parity.sh

--- a/.github/workflows/mosaico-bundle-parity.yaml
+++ b/.github/workflows/mosaico-bundle-parity.yaml
@@ -34,6 +34,12 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+# Checkout and compare, nothing else: the job reads this repo and reaches the mirror with a
+# separate GitLab token. Stated explicitly so the boundary does not move when the
+# repository or org default for GITHUB_TOKEN changes.
+permissions:
+  contents: read
+
 jobs:
   parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/mosaico-bundle-parity.yaml
+++ b/.github/workflows/mosaico-bundle-parity.yaml
@@ -26,6 +26,9 @@ on:
     paths:
       - 'docker/mosaico/**'
       - '.github/scripts/mosaico_bundle_parity.sh'
+      # Same list as the PR trigger. Omitting this file would let a workflow-only
+      # change land on main without the job it alters ever running there.
+      - '.github/workflows/mosaico-bundle-parity.yaml'
   schedule:
     # Monday 06:00 UTC — catches drift introduced on the mirror between releases.
     - cron: '0 6 * * 1'


### PR DESCRIPTION
`docker/mosaico/` is mirrored to the Eclipse GitLab project the MOSAICO consortium deploys from. Upstream here is canonical, but nothing enforced that — the two sides already drifted once, when a mirror merge landed ahead of the upstream PR it tracked and left two files stale.

This adds a parity check and wires it into CI, so keeping the mirror current is a mechanism rather than a promise.

## Both directions

`GH-ONLY` and `GL-ONLY` are reported separately. A consortium member editing the mirror directly — which the bundle README forbids — strands a fix outside this repo, and a one-way check would never see it. The failure text says which way to resolve.

The file **set** is compared as well as contents, so a file added to one side only is caught. `.gitignore` is allowlisted (the mirror is a standalone repo and carries its own) and filtered from both sides.

## Fails closed

The mirror is a public project, so the clone is anonymous and the check needs no secret. What it enforces is stronger than a token requirement: the script cannot exit 0 without having actually compared the two trees. A mirror it cannot reach is exit 2, never a skip, so "green" and "verified" are the same thing by construction.

Fork PRs are covered on the same terms as everything else. They were previously exempted for the sole reason that forks receive no secrets, and an anonymous clone works there.

`GITLAB_TOKEN` remains optional, so nothing needs changing should the project ever be made private. Unset or empty means anonymous. A token that *is* supplied must work: it is sent on every request and a rejected one fails the run, with no fallback to anonymous. On a public mirror a fallback would "succeed", which is exactly why it would be wrong — it would leave a stale or misconfigured secret looking healthy indefinitely.

**No setup required.**

## Notes

- Listings are read NUL-delimited. Plain `git ls-files` renders a non-ASCII or quote-bearing name as a C-style quoted literal that is not a path on disk, which reported false drift on identical trees.
- Symlinks are compared by `readlink`, not by the bytes they resolve to. `diff` dereferences, so a link repointed on the mirror read as identical whenever both targets held the same content. This also means outside-tree link targets are never read, so their content can no longer reach a public CI log.
- If a `GITLAB_TOKEN` is supplied, it goes through a git credential helper rather than the clone URL, so it cannot land in a remote URL, the reflog, or a failure log line. Clone stderr is scrubbed on top of that.

## Verification

Adversarially reviewed across five rounds. Nine defects were found and fixed, including two introduced while fixing earlier ones — most seriously a repointed symlink passing as parity, which is the exact failure the check exists to prevent. A later round established that the mirror is publicly readable, which removed the token dependency altogether and let the skip path be deleted rather than merely guarded.

Final round covers: content edits each side, one-sided additions and deletions, tracked-but-deleted files, whitespace-only and equal-length changes, non-ASCII/quote/backslash filenames on both backends, newline-in-filename, symlink vs file, symlinks to directories, chains, tree-escaping targets, absolute vs relative targets, empty sets, every exit code, and confirmation that no token leaks on any error path.

