### PR TITLE
fix(mosaico): pin pydantic-settings so Langfuse tracing actually loads

### DIFF
--- a/pr_agent/mosaico/card.py
+++ b/pr_agent/mosaico/card.py
@@ -1,8 +1,13 @@
 """Builds the MOSAICO A2A agent card for pr-agent.
 
-Mirrors docstring-agent/__main__.py:36-68. The observability extension is advertised
-as required=True; streaming is advertised as False (load-bearing: the reference agent
-selects message/send vs message/stream from capabilities.streaming)."""
+The observability extension is advertised as required=True because the AISP spec says so
+("AISP-specific extension: observability metadata ... Required: true" in the demonstrator's
+docs/agent-requirements.md). Do NOT relax it to match the peer agents: docstring-agent
+advertises required=False, ip-solution-agent and mini-swe-agent omit the flag entirely, and
+the reference agent's own card omits it too, but they are the ones out of spec.
+
+Streaming is advertised as False, which is load-bearing: the reference agent selects
+message/send vs message/stream from capabilities.streaming."""
 import os
 
 from a2a.types import (AgentCapabilities, AgentCard, AgentExtension,

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,10 @@ langfuse==3.14.5
 gunicorn==23.0.0
 pytest-cov==7.0.0
 pydantic==2.13.3
+# litellm 1.93.0 imports pydantic-settings unconditionally (litellm/integrations/otel/__init__.py) but declares it
+# only under its optional 'proxy' extra; without it the 'langfuse_otel' callback silently fails to load and no LLM
+# call is traced. Version matches litellm's own constraint (>=2.14.1,<3.0).
+pydantic-settings==2.14.2
 html2text==2024.2.26
 giteapy==1.0.8
 # Uncomment the following lines to enable the 'similar issue' tool

--- a/tests/unittest/test_mosaico_observability_deps.py
+++ b/tests/unittest/test_mosaico_observability_deps.py
@@ -41,11 +41,19 @@ def _import_error(module_name: str):
 
 @pytest.fixture
 def restore_in_memory_loggers():
-    """Constructing the callback appends it to litellm's module-global logger registry."""
+    """Constructing the callback appends it to litellm's module-global logger registry.
+
+    Reaching into litellm privates is unavoidable here -- there is no public API that
+    reports a callback litellm declined to build -- but it should never be the reason
+    this test fails. If the registry is renamed or removed upstream, skip the cleanup
+    rather than erroring: the assertions below still carry the signal we care about.
+    """
     from litellm.litellm_core_utils import litellm_logging
-    snapshot = list(litellm_logging._in_memory_loggers)
+    registry = getattr(litellm_logging, "_in_memory_loggers", None)
+    snapshot = list(registry) if registry is not None else None
     yield
-    litellm_logging._in_memory_loggers[:] = snapshot
+    if snapshot is not None:
+        registry[:] = snapshot
 
 
 class TestLangfuseOtelCallbackDeps:
@@ -72,6 +80,10 @@ class TestLangfuseOtelCallbackDeps:
             f"tracing is dead. The factory swallows the underlying error; the likely cause is "
             f"{_import_error('litellm.integrations.otel')!r}. {_REMEDY}"
         )
-        assert type(logger).__name__ == "LangfuseOtelLogger", (
-            f"Expected a LangfuseOtelLogger for the '{CALLBACK_NAME}' callback, got {type(logger).__name__}."
+        # Substring, not equality: `is not None` above is the assertion that catches the
+        # actual defect. This one only guards against litellm handing back some unrelated
+        # logger, so it should survive an upstream rename (LangfuseOtelLoggerV2 and the
+        # like) rather than failing CI over a refactor that changed nothing that matters.
+        assert "langfuse" in type(logger).__name__.lower(), (
+            f"Expected a Langfuse logger for the '{CALLBACK_NAME}' callback, got {type(logger).__name__}."
         )

--- a/tests/unittest/test_mosaico_observability_deps.py
+++ b/tests/unittest/test_mosaico_observability_deps.py
@@ -1,0 +1,77 @@
+"""Dependency-closure guard for the 'langfuse_otel' litellm callback.
+
+pr_agent/mosaico/env_bridge.py registers 'langfuse_otel' as the Langfuse callback
+(the legacy 'langfuse' callback raises a ``sdk_integration`` TypeError against
+langfuse 3.x). litellm imports pydantic-settings unconditionally from
+``litellm/integrations/otel/__init__.py`` but declares it only under its optional
+'proxy' extra, so an environment built from requirements.txt without that pin makes
+litellm's callback factory return None -- silently, because the factory swallows the
+ImportError -- and not a single LLM call is traced.
+
+These tests assert the environment, not pr-agent logic, hence a file of their own
+rather than an addition to test_mosaico_env_bridge.py. They are meaningful in CI:
+.github/workflows/build-and-test.yaml builds docker/Dockerfile's ``test`` target,
+whose dependencies come from requirements.txt via pyproject, and runs this suite
+inside that image -- the same base layer the shipped mosaico_agent image is built
+from. No network, no live LLM."""
+import importlib
+
+import pytest
+
+CALLBACK_NAME = "langfuse_otel"
+# Imported at module scope by litellm/integrations/otel/__init__.py, declared only under
+# litellm's 'proxy' extra, so it must be pinned explicitly in pr-agent's requirements.txt.
+UNDECLARED_LITELLM_DEP = "pydantic_settings"
+
+_REMEDY = (
+    f"'{UNDECLARED_LITELLM_DEP}' must be pinned in requirements.txt: litellm imports it "
+    f"unconditionally from litellm/integrations/otel/__init__.py but declares it only under "
+    f"its optional 'proxy' extra."
+)
+
+
+def _import_error(module_name: str):
+    """Return the ImportError raised by importing ``module_name``, or None on success."""
+    try:
+        importlib.import_module(module_name)
+    except ImportError as e:
+        return e
+    return None
+
+
+@pytest.fixture
+def restore_in_memory_loggers():
+    """Constructing the callback appends it to litellm's module-global logger registry."""
+    from litellm.litellm_core_utils import litellm_logging
+    snapshot = list(litellm_logging._in_memory_loggers)
+    yield
+    litellm_logging._in_memory_loggers[:] = snapshot
+
+
+class TestLangfuseOtelCallbackDeps:
+    def test_pydantic_settings_is_installed(self):
+        err = _import_error(UNDECLARED_LITELLM_DEP)
+        assert err is None, f"{_REMEDY} Import failed with: {err!r}"
+
+    def test_litellm_otel_integration_imports(self):
+        """The unconditional import site itself -- fails before the callback factory is reached."""
+        err = _import_error("litellm.integrations.otel")
+        assert err is None, f"litellm.integrations.otel is not importable ({err!r}). {_REMEDY}"
+
+    def test_langfuse_otel_callback_constructs(self, restore_in_memory_loggers):
+        """The behaviour MOSAICO actually depends on: env_bridge registers this callback name,
+        and litellm must be able to build a logger for it or every trace is dropped."""
+        from litellm.litellm_core_utils.litellm_logging import \
+            _init_custom_logger_compatible_class
+
+        logger = _init_custom_logger_compatible_class(
+            CALLBACK_NAME, internal_usage_cache=None, llm_router=None)
+
+        assert logger is not None, (
+            f"litellm returned no logger for the '{CALLBACK_NAME}' callback, so MOSAICO's Langfuse "
+            f"tracing is dead. The factory swallows the underlying error; the likely cause is "
+            f"{_import_error('litellm.integrations.otel')!r}. {_REMEDY}"
+        )
+        assert type(logger).__name__ == "LangfuseOtelLogger", (
+            f"Expected a LangfuseOtelLogger for the '{CALLBACK_NAME}' callback, got {type(logger).__name__}."
+        )


### PR DESCRIPTION
Langfuse observability is dead in the shipped `mosaico_agent` image. The MOSAICO agent card advertises the `mosaico-observability` extension with `required: true`, and not a single LLM call is traced.

```
# pragent/pr-agent:0.40.0-mosaico_agent
_init_custom_logger_compatible_class('langfuse_otel', ...) -> None
_init_custom_logger_compatible_class('langfuse', ...)      -> None
```

## Why it was silent

litellm 1.93.0 imports `pydantic-settings` unconditionally from `litellm/integrations/otel/__init__.py`, but declares it only under its optional `proxy` extra. `requirements.txt` never pinned it, so it is absent from the image — and litellm's callback factory swallows the resulting `ImportError` and returns `None`. The failure is silent by construction, which is why a fully green test suite sat alongside a dead deliverable.

`pr_agent/mosaico/env_bridge.py` registers `langfuse_otel` precisely to route around the legacy `langfuse` callback raising a `sdk_integration` TypeError under langfuse 3.x. With `pydantic-settings` missing, `langfuse_otel` could not load either — so the workaround was defeated and both paths were dead.

After the pin, `langfuse_otel` returns a `LangfuseOtelLogger`. The legacy callback still returns `None`; that is the unchanged 3.x incompatibility `env_bridge` exists to avoid, and is expected.

## Traces confirmed flowing, not just initialising

Against a loopback receiver, the rebuilt image emitted:

```
POST /api/public/otel/v1/traces
content-type: application/x-protobuf   bytes: 2335
service.name=litellm, deployment.environment=production, span: litellm_request
```

The `Proxy Server is not installed` warning that remains is benign — it comes from `_init_otel_logger_on_litellm_proxy()`, which runs *after* `_init_tracing()` and only registers the logger into the proxy server's own callback list.

Not verified: acceptance by a live Langfuse instance. The receiver was a local stub.

## The regression test

It asserts the *environment* rather than pr-agent logic, so it lives in its own file. It is meaningful in CI because `build-and-test.yaml` runs the suite inside the Docker `test` target, whose dependencies come from `requirements.txt` via pyproject — the same base layer the shipped `mosaico_agent` image is built from.

Verified both directions:
- **red** — all 3 fail inside pre-fix `0.40.0-mosaico_agent` with `ModuleNotFoundError: No module named 'pydantic_settings'`
- **green** — 3 pass locally and inside a freshly built `test` image

Suite goes 1485 → 1488 passed.
