### PR TITLE
fix(mosaico): route on the latest user turn of a forwarded conversation

### DIFF
--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -9,8 +9,7 @@ Three paths:
       on the context settings, run the verb via DiffInputProvider.
   (c) free-text with no PR URL and no diff -> honest guidance (ask needs a PR/diff).
 
-Inbound text may be a WHOLE forwarded conversation, one part per turn shaped
-"{role}: {content}"; intent then resolves from the latest user turn.
+Inbound text may be a whole forwarded conversation, one part per turn: "{role}: {content}".
 
 Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", "")
 (several tool paths never set it, and handle_request swallows exceptions -> False).

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -45,8 +45,6 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
-# Lines counting as raw-patch body; an unlisted git extended-header prefix leaks the rest of
-# the header into the prose that picks the verb.
 _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
@@ -56,12 +54,10 @@ _DIFF_BODY_LINE_RE = re.compile(
     r"|[ +\-\\]|$)"
 )
 
-# The live label is "agent", not "assistant"; matching only "assistant" would be a no-op in
-# production. Only a turn's first line carries a label.
+# The live label is "agent", not "assistant" — matching only "assistant" is a no-op live.
 _ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]*", re.IGNORECASE)
 _USER_ROLES = ("user",)
 
-# Adjacent-only by design: at most two words before the verb, no punctuation crossed.
 _NEGATION_RE = re.compile(
     r"\b(?:no|not|never|avoid|skip|without|don'?t|do\s+not|instead\s+of|rather\s+than)\b"
     r"(?:\s+\w+){0,2}\s*/?$",
@@ -90,8 +86,7 @@ class _Turn(NamedTuple):
 
 
 def _split_turns(text: str) -> list["_Turn"]:
-    """Turns oldest first, [] when not a blob. Conservative on purpose: the text must open
-    with a role label AND carry at least two."""
+    """Conservative on purpose: a blob must open with a role label AND carry at least two."""
     if not text:
         return []
     lines = text.split("\n")
@@ -111,8 +106,7 @@ def _split_turns(text: str) -> list["_Turn"]:
 
 
 def _explicit_verb(text: str) -> Optional[str]:
-    """The requested verb, by POSITION IN THE TEXT and not by _VALID_VERBS order. Negated
-    occurrences are skipped; None when no verb is requested."""
+    """The requested verb, by POSITION IN THE TEXT and not by _VALID_VERBS order."""
     low = (text or "").lower()
     best = None
     for verb in _VALID_VERBS:
@@ -122,7 +116,7 @@ def _explicit_verb(text: str) -> Optional[str]:
                 continue
             if best is None or at < best[0]:
                 best = (at, verb)
-            break  # only the first non-negated occurrence of this verb can be the earliest
+            break
     return best[1] if best else None
 
 
@@ -144,8 +138,6 @@ def _detect_verb(text: str) -> str:
 
 
 def _resolve_verb(user_segments: list) -> str:
-    """Verb from the LATEST user turn (segments newest first); an intentless turn falls back
-    to older USER turns. Agent turns are never consulted."""
     prose = [_diff_prose(seg) for seg in user_segments]
     if not prose:
         return _DEFAULT_VERB
@@ -175,7 +167,7 @@ def _looks_like_diff(text: str) -> bool:
 
 
 def _extract_diff(text: str) -> str:
-    """The unified-diff body, unwrapping a ```diff fence. With several fences the LAST wins."""
+    """Return the unified-diff body, unwrapping a ```diff fence if present."""
     fences = re.findall(r"```\s*diff\s*\n(.*?)```", text, re.IGNORECASE | re.DOTALL)
     if fences:
         return fences[-1]
@@ -191,7 +183,6 @@ def _diff_prose(text: str) -> str:
     without_fence = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
     if without_fence != text:
         return without_fence
-    # Raw diff: excise the body, keep prose on BOTH sides — the request often follows the patch.
     kept, in_diff = [], False
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):
@@ -394,14 +385,12 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
     try:
         text = user_text or ""
         turns = _split_turns(text)
-        # Newest first. Intent comes from user turns only; context may come from an agent turn.
         user_segments = [t.content for t in reversed(turns) if t.is_user] or [text]
         context_segments = [t.content for t in reversed(turns)] or [text]
 
         verb = _resolve_verb(user_segments)
         question = user_segments[0]
 
-        # Newest turn supplying context wins; within a turn a PR URL beats an inline diff.
         for segment in context_segments:
             pr_url = _find_pr_url(segment)
             if pr_url:

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -9,10 +9,8 @@ Three paths:
       on the context settings, run the verb via DiffInputProvider.
   (c) free-text with no PR URL and no diff -> honest guidance (ask needs a PR/diff).
 
-The inbound text is not always a single fresh request: the MOSAICO reference agent
-forwards the WHOLE conversation, one A2A text part per turn shaped "{role}: {content}",
-which the A2A SDK's get_user_input() joins with newlines. Routing therefore resolves
-intent from the LATEST user turn rather than from the blob as a whole.
+Inbound text may be a WHOLE forwarded conversation, one part per turn shaped
+"{role}: {content}"; intent then resolves from the latest user turn.
 
 Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", "")
 (several tool paths never set it, and handle_request swallows exceptions -> False).
@@ -48,12 +46,8 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
-# Where a raw (unfenced) patch body starts, and the lines that belong to it. Besides the
-# file/hunk headers this must list git's extended header (mode/rename/copy/similarity/binary),
-# which sits between "diff --git" and the first hunk: an unlisted line there ends body mode
-# and leaks the rest of the header into the prose that picks the verb, letting the patch
-# override the request. An empty line is a context line whose trailing space was stripped.
-# These only apply once a body is open, so they cannot swallow loose prose.
+# Lines counting as raw-patch body; an unlisted git extended-header prefix leaks the rest of
+# the header into the prose that picks the verb.
 _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
@@ -63,27 +57,19 @@ _DIFF_BODY_LINE_RE = re.compile(
     r"|[ +\-\\]|$)"
 )
 
-# Conversation-blob detection. The reference agent labels each forwarded turn with the raw
-# role from the client ("user"/"agent"); "assistant" is accepted too since sibling handlers
-# normalise to it. Only the FIRST line of a turn carries the label — a turn's content is
-# routinely multi-line (a pasted diff, or a whole review), so turns are delimited by label
-# lines, not by newlines. All whitespace after the colon is consumed: content that itself
-# starts with a space would otherwise leave "diff --git" indented, and parse_unified_diff
-# needs it at column 0.
+# The live label is "agent", not "assistant"; matching only "assistant" would be a no-op in
+# production. Only a turn's first line carries a label.
 _ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]*", re.IGNORECASE)
 _USER_ROLES = ("user",)
 
-# Negation immediately before a verb ("do not review", "instead of reviewing"): at most two
-# intervening words and no punctuation, so "there is no bug, review this" is NOT a negation.
-# Adjacency is the whole rule: anything wider is intent classification, not routing.
+# Adjacent-only by design: at most two words before the verb, no punctuation crossed.
 _NEGATION_RE = re.compile(
     r"\b(?:no|not|never|avoid|skip|without|don'?t|do\s+not|instead\s+of|rather\s+than)\b"
     r"(?:\s+\w+){0,2}\s*/?$",
     re.IGNORECASE,
 )
 
-# An interrogative opener, EXCEPT when it is negated ("do not review" is an instruction, not
-# a question; a real negated question still has its '?' to fall back on).
+# The "not" guard keeps "do not review" an instruction; a real question still has its '?'.
 _QUESTION_OPENER_RE = re.compile(
     r"\s*(what|why|how|when|where|who|which|is|are|does|do|can|should)\b(?!\s+not\b)", re.IGNORECASE
 )
@@ -96,7 +82,6 @@ class RouteResult(NamedTuple):
 
 
 class _Turn(NamedTuple):
-    """One forwarded conversation turn: a lowercased role and its (multi-line) content."""
     role: str
     content: str
 
@@ -106,12 +91,8 @@ class _Turn(NamedTuple):
 
 
 def _split_turns(text: str) -> list["_Turn"]:
-    """Split a forwarded conversation blob into turns (oldest first). Returns [] when the
-    text is not a blob, so a single-turn request keeps being handled as one whole segment.
-
-    Conservative on purpose — a blob must BOTH start with a role label (the reference agent
-    drops non-data parts, so the joined text always begins with one) AND carry at least two
-    of them. One stray 'user: ...' line inside an ordinary message is not enough."""
+    """Turns oldest first, [] when not a blob. Conservative on purpose: the text must open
+    with a role label AND carry at least two."""
     if not text:
         return []
     lines = text.split("\n")
@@ -131,9 +112,8 @@ def _split_turns(text: str) -> list["_Turn"]:
 
 
 def _explicit_verb(text: str) -> Optional[str]:
-    """The explicitly requested verb, chosen by POSITION IN THE TEXT and not by _VALID_VERBS
-    order — by that order 'now describe it, do not review' resolves to 'review'. Negated
-    occurrences are skipped. None when no verb is explicitly requested."""
+    """The requested verb, by POSITION IN THE TEXT and not by _VALID_VERBS order. Negated
+    occurrences are skipped; None when no verb is requested."""
     low = (text or "").lower()
     best = None
     for verb in _VALID_VERBS:
@@ -165,12 +145,8 @@ def _detect_verb(text: str) -> str:
 
 
 def _resolve_verb(user_segments: list) -> str:
-    """Resolve the verb from the LATEST user turn (segments are newest first).
-
-    Only when that turn expresses no intent at all — no explicit verb, no question — do we
-    look back at OLDER USER turns for one (e.g. 'describe this' followed by a bare corrected
-    diff). Agent turns are never consulted: pr-agent's own output is full of the word
-    'review', which would otherwise make the verb stick for the rest of the conversation."""
+    """Verb from the LATEST user turn (segments newest first); an intentless turn falls back
+    to older USER turns. Agent turns are never consulted."""
     prose = [_diff_prose(seg) for seg in user_segments]
     if not prose:
         return _DEFAULT_VERB
@@ -200,9 +176,7 @@ def _looks_like_diff(text: str) -> bool:
 
 
 def _extract_diff(text: str) -> str:
-    """Return the unified-diff body, unwrapping a ```diff fence if present. With several
-    fences the LAST one wins: a re-pasted diff supersedes the one it corrects. A raw
-    (unfenced) diff is returned whole, so a multi-file patch keeps all of its files."""
+    """The unified-diff body, unwrapping a ```diff fence. With several fences the LAST wins."""
     fences = re.findall(r"```\s*diff\s*\n(.*?)```", text, re.IGNORECASE | re.DOTALL)
     if fences:
         return fences[-1]
@@ -218,9 +192,7 @@ def _diff_prose(text: str) -> str:
     without_fence = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
     if without_fence != text:
         return without_fence
-    # Raw (unfenced) diff: drop the patch BODY but keep the prose on BOTH sides. The request
-    # is routinely written AFTER the pasted patch ("<diff>\nnow describe it"), so trimming at
-    # the first marker would discard it.
+    # Raw diff: excise the body, keep prose on BOTH sides — the request often follows the patch.
     kept, in_diff = [], False
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):
@@ -423,21 +395,15 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
     try:
         text = user_text or ""
         turns = _split_turns(text)
-        # Newest first. A non-blob request is one segment, so single-turn routing is unchanged.
-        # Intent comes from user turns only; the diff/PR to act on may legitimately come from
-        # an agent turn (a coding agent posts a patch, the user then asks for a review of it).
+        # Newest first. Intent comes from user turns only; context may come from an agent turn.
         user_segments = [t.content for t in reversed(turns) if t.is_user] or [text]
         context_segments = [t.content for t in reversed(turns)] or [text]
 
         verb = _resolve_verb(user_segments)
         question = user_segments[0]
 
-        # Take the PR URL / diff from the NEWEST turn that supplies one, so a fresh diff in the
-        # current turn beats a stale URL quoted earlier in the conversation. Within one turn an
-        # explicit PR URL still wins over an inline diff.
+        # Newest turn supplying context wins; within a turn a PR URL beats an inline diff.
         for segment in context_segments:
-            # Path (a): a host PR URL — fetch the public unified diff and route through
-            # the token-free mosaico_diff provider.
             pr_url = _find_pr_url(segment)
             if pr_url:
                 diff_body = await _fetch_public_diff(pr_url)
@@ -445,7 +411,6 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
                     return RouteResult(_pr_fetch_failed_fallback(pr_url), ok=False)
                 return await _run_on_diff(diff_body, verb, question, title=pr_url, empty_ok=False)
 
-            # Path (b): a supplied unified diff.
             if _looks_like_diff(segment):
                 return await _run_on_diff(_extract_diff(segment), verb, question, title="Supplied diff")
 

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -11,9 +11,8 @@ Three paths:
 
 The inbound text is not always a single fresh request: the MOSAICO reference agent
 forwards the WHOLE conversation, one A2A text part per turn shaped "{role}: {content}",
-which the A2A SDK's get_user_input() joins with newlines. Routing therefore resolves the
-LATEST user turn first (see _split_turns / _resolve_verb / route_and_run_result) instead
-of scanning the blob as if it were one fresh request.
+which the A2A SDK's get_user_input() joins with newlines. Routing therefore resolves
+intent from the LATEST user turn rather than from the blob as a whole.
 
 Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", "")
 (several tool paths never set it, and handle_request swallows exceptions -> False).
@@ -49,16 +48,12 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
-# Where a raw (unfenced) patch body starts, and the lines that belong to it: file/hunk
-# headers, git's extended header (mode/rename/copy/similarity/binary), plus the
-# context/added/removed lines that follow (an empty line is a context line whose trailing
-# space was stripped). Used to excise the body while keeping the prose.
-#
-# The extended-header alternatives matter because they sit between "diff --git" and the first
-# hunk: without them the first one ends body mode, and the `index`/`---`/`+++` lines after it
-# leak into the prose that decides the verb. A leaked "rename to improve.py" then routes an
-# explicit "review this" to /improve, and a '?' in a leaked path routes it to /ask. They are
-# only ever consulted once a patch body is already open, so they cannot swallow loose prose.
+# Where a raw (unfenced) patch body starts, and the lines that belong to it. Besides the
+# file/hunk headers this must list git's extended header (mode/rename/copy/similarity/binary),
+# which sits between "diff --git" and the first hunk: an unlisted line there ends body mode
+# and leaks the rest of the header into the prose that picks the verb, letting the patch
+# override the request. An empty line is a context line whose trailing space was stripped.
+# These only apply once a body is open, so they cannot swallow loose prose.
 _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
@@ -71,15 +66,16 @@ _DIFF_BODY_LINE_RE = re.compile(
 # Conversation-blob detection. The reference agent labels each forwarded turn with the raw
 # role from the client ("user"/"agent"); "assistant" is accepted too since sibling handlers
 # normalise to it. Only the FIRST line of a turn carries the label — a turn's content is
-# routinely multi-line (a pasted diff, or a whole review), so turns are delimited by
-# label lines rather than by newlines. All whitespace after the colon is consumed, not just
-# the single separator space: a turn whose own content starts with a space would otherwise
-# leave the patch header indented, and parse_unified_diff needs "diff --git" at column 0.
+# routinely multi-line (a pasted diff, or a whole review), so turns are delimited by label
+# lines, not by newlines. All whitespace after the colon is consumed: content that itself
+# starts with a space would otherwise leave "diff --git" indented, and parse_unified_diff
+# needs it at column 0.
 _ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]*", re.IGNORECASE)
 _USER_ROLES = ("user",)
 
 # Negation immediately before a verb ("do not review", "instead of reviewing"): at most two
 # intervening words and no punctuation, so "there is no bug, review this" is NOT a negation.
+# Adjacency is the whole rule: anything wider is intent classification, not routing.
 _NEGATION_RE = re.compile(
     r"\b(?:no|not|never|avoid|skip|without|don'?t|do\s+not|instead\s+of|rather\s+than)\b"
     r"(?:\s+\w+){0,2}\s*/?$",
@@ -135,9 +131,9 @@ def _split_turns(text: str) -> list["_Turn"]:
 
 
 def _explicit_verb(text: str) -> Optional[str]:
-    """The explicitly requested verb, chosen by POSITION IN THE TEXT (not by _VALID_VERBS
-    order, which used to make 'now describe it, do not review' resolve to 'review').
-    Negated occurrences are skipped. None when no verb is explicitly requested."""
+    """The explicitly requested verb, chosen by POSITION IN THE TEXT and not by _VALID_VERBS
+    order — by that order 'now describe it, do not review' resolves to 'review'. Negated
+    occurrences are skipped. None when no verb is explicitly requested."""
     low = (text or "").lower()
     best = None
     for verb in _VALID_VERBS:
@@ -173,8 +169,8 @@ def _resolve_verb(user_segments: list) -> str:
 
     Only when that turn expresses no intent at all — no explicit verb, no question — do we
     look back at OLDER USER turns for one (e.g. 'describe this' followed by a bare corrected
-    diff). Agent turns are never consulted: pr-agent's own review output is full of the word
-    'review', which is what made the verb stick to 'review' for the rest of a conversation."""
+    diff). Agent turns are never consulted: pr-agent's own output is full of the word
+    'review', which would otherwise make the verb stick for the rest of the conversation."""
     prose = [_diff_prose(seg) for seg in user_segments]
     if not prose:
         return _DEFAULT_VERB
@@ -222,9 +218,9 @@ def _diff_prose(text: str) -> str:
     without_fence = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
     if without_fence != text:
         return without_fence
-    # Raw (unfenced) diff: drop the patch BODY but keep the prose on BOTH sides. Keeping only
-    # the text before the first marker discarded everything after it — including the request
-    # itself, which is routinely written after the pasted patch ("<diff>\nnow describe it").
+    # Raw (unfenced) diff: drop the patch BODY but keep the prose on BOTH sides. The request
+    # is routinely written AFTER the pasted patch ("<diff>\nnow describe it"), so trimming at
+    # the first marker would discard it.
     kept, in_diff = [], False
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):
@@ -433,13 +429,12 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
         user_segments = [t.content for t in reversed(turns) if t.is_user] or [text]
         context_segments = [t.content for t in reversed(turns)] or [text]
 
-        # The verb is detected from the prose only: a '?' in a patch body must not flip review to ask.
         verb = _resolve_verb(user_segments)
         question = user_segments[0]
 
         # Take the PR URL / diff from the NEWEST turn that supplies one, so a fresh diff in the
-        # current turn beats a stale URL quoted earlier in the conversation. Within one turn the
-        # existing precedence holds: an explicit PR URL wins over an inline diff.
+        # current turn beats a stale URL quoted earlier in the conversation. Within one turn an
+        # explicit PR URL still wins over an inline diff.
         for segment in context_segments:
             # Path (a): a host PR URL — fetch the public unified diff and route through
             # the token-free mosaico_diff provider.

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -9,6 +9,12 @@ Three paths:
       on the context settings, run the verb via DiffInputProvider.
   (c) free-text with no PR URL and no diff -> honest guidance (ask needs a PR/diff).
 
+The inbound text is not always a single fresh request: the MOSAICO reference agent
+forwards the WHOLE conversation, one A2A text part per turn shaped "{role}: {content}",
+which the A2A SDK's get_user_input() joins with newlines. Routing therefore resolves the
+LATEST user turn first (see _split_turns / _resolve_verb / route_and_run_result) instead
+of scanning the blob as if it were one fresh request.
+
 Capture is DEFENSIVE everywhere: get_settings().get("data", {}).get("artifact", "")
 (several tool paths never set it, and handle_request swallows exceptions -> False).
 route_and_run NEVER raises; on failure/empty it returns an honest fallback string."""
@@ -43,6 +49,34 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
+# Where a raw (unfenced) patch body starts, and the lines that belong to it: file/hunk
+# headers plus the context/added/removed lines that follow (an empty line is a context line
+# whose trailing space was stripped). Used to excise the body while keeping the prose.
+_DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
+_DIFF_BODY_LINE_RE = re.compile(r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ |[ +\-\\]|$)")
+
+# Conversation-blob detection. The reference agent labels each forwarded turn with the raw
+# role from the client ("user"/"agent"); "assistant" is accepted too since sibling handlers
+# normalise to it. Only the FIRST line of a turn carries the label — a turn's content is
+# routinely multi-line (a pasted diff, or a whole review), so turns are delimited by
+# label lines rather than by newlines.
+_ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]?", re.IGNORECASE)
+_USER_ROLES = ("user",)
+
+# Negation immediately before a verb ("do not review", "instead of reviewing"): at most two
+# intervening words and no punctuation, so "there is no bug, review this" is NOT a negation.
+_NEGATION_RE = re.compile(
+    r"\b(?:no|not|never|avoid|skip|without|don'?t|do\s+not|instead\s+of|rather\s+than)\b"
+    r"(?:\s+\w+){0,2}\s*/?$",
+    re.IGNORECASE,
+)
+
+# An interrogative opener, EXCEPT when it is negated ("do not review" is an instruction, not
+# a question; a real negated question still has its '?' to fall back on).
+_QUESTION_OPENER_RE = re.compile(
+    r"\s*(what|why|how|when|where|who|which|is|are|does|do|can|should)\b(?!\s+not\b)", re.IGNORECASE
+)
+
 
 class RouteResult(NamedTuple):
     """Routing outcome: rendered text + whether it succeeded (drives A2A complete vs failed)."""
@@ -50,17 +84,94 @@ class RouteResult(NamedTuple):
     ok: bool
 
 
+class _Turn(NamedTuple):
+    """One forwarded conversation turn: a lowercased role and its (multi-line) content."""
+    role: str
+    content: str
+
+    @property
+    def is_user(self) -> bool:
+        return self.role in _USER_ROLES
+
+
+def _split_turns(text: str) -> list["_Turn"]:
+    """Split a forwarded conversation blob into turns (oldest first). Returns [] when the
+    text is not a blob, so a single-turn request keeps being handled as one whole segment.
+
+    Conservative on purpose — a blob must BOTH start with a role label (the reference agent
+    drops non-data parts, so the joined text always begins with one) AND carry at least two
+    of them. One stray 'user: ...' line inside an ordinary message is not enough."""
+    if not text:
+        return []
+    lines = text.split("\n")
+    starts = [i for i, line in enumerate(lines) if _ROLE_LINE_RE.match(line)]
+    if len(starts) < 2:
+        return []
+    first_content = next((i for i, line in enumerate(lines) if line.strip()), None)
+    if starts[0] != first_content:
+        return []
+    turns = []
+    for n, start in enumerate(starts):
+        end = starts[n + 1] if n + 1 < len(starts) else len(lines)
+        m = _ROLE_LINE_RE.match(lines[start])
+        body = "\n".join([lines[start][m.end():]] + lines[start + 1:end])
+        turns.append(_Turn(m.group(1).lower(), body.strip("\n")))
+    return turns
+
+
+def _explicit_verb(text: str) -> Optional[str]:
+    """The explicitly requested verb, chosen by POSITION IN THE TEXT (not by _VALID_VERBS
+    order, which used to make 'now describe it, do not review' resolve to 'review').
+    Negated occurrences are skipped. None when no verb is explicitly requested."""
+    low = (text or "").lower()
+    best = None
+    for verb in _VALID_VERBS:
+        for m in re.finditer(rf"(^|\s)/?{verb}\b", low):
+            at = m.end() - len(verb)
+            if _NEGATION_RE.search(low[:at]):
+                continue
+            if best is None or at < best[0]:
+                best = (at, verb)
+            break  # only the first non-negated occurrence of this verb can be the earliest
+    return best[1] if best else None
+
+
+def _reads_as_question(text: str) -> bool:
+    low = (text or "").lower()
+    return "?" in low or bool(_QUESTION_OPENER_RE.match(low))
+
+
 def _detect_verb(text: str) -> str:
     """Pick a verb from the text. Defaults to 'review'. 'ask' wins when the text reads
     like a question and no other explicit verb is present."""
-    low = (text or "").lower()
-    # explicit slash command takes precedence
-    for verb in _VALID_VERBS:
-        if re.search(rf"(^|\s)/?{verb}\b", low):
-            return verb
+    verb = _explicit_verb(text)
+    if verb:
+        return verb
     # heuristic: a question mark or interrogative opener -> ask
-    if "?" in low or re.match(r"\s*(what|why|how|when|where|who|which|is|are|does|do|can|should)\b", low):
+    if _reads_as_question(text):
         return "ask"
+    return _DEFAULT_VERB
+
+
+def _resolve_verb(user_segments: list) -> str:
+    """Resolve the verb from the LATEST user turn (segments are newest first).
+
+    Only when that turn expresses no intent at all — no explicit verb, no question — do we
+    look back at OLDER USER turns for one (e.g. 'describe this' followed by a bare corrected
+    diff). Agent turns are never consulted: pr-agent's own review output is full of the word
+    'review', which is what made the verb stick to 'review' for the rest of a conversation."""
+    prose = [_diff_prose(seg) for seg in user_segments]
+    if not prose:
+        return _DEFAULT_VERB
+    verb = _explicit_verb(prose[0])
+    if verb:
+        return verb
+    if _reads_as_question(prose[0]):
+        return "ask"
+    for older in prose[1:]:
+        verb = _explicit_verb(older)
+        if verb:
+            return verb
     return _DEFAULT_VERB
 
 
@@ -78,10 +189,12 @@ def _looks_like_diff(text: str) -> bool:
 
 
 def _extract_diff(text: str) -> str:
-    """Return the unified-diff body, unwrapping a ```diff fence if present."""
-    fence = re.search(r"```\s*diff\s*\n(.*?)```", text, re.IGNORECASE | re.DOTALL)
-    if fence:
-        return fence.group(1)
+    """Return the unified-diff body, unwrapping a ```diff fence if present. With several
+    fences the LAST one wins: a re-pasted diff supersedes the one it corrects. A raw
+    (unfenced) diff is returned whole, so a multi-file patch keeps all of its files."""
+    fences = re.findall(r"```\s*diff\s*\n(.*?)```", text, re.IGNORECASE | re.DOTALL)
+    if fences:
+        return fences[-1]
     return text
 
 
@@ -94,9 +207,20 @@ def _diff_prose(text: str) -> str:
     without_fence = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
     if without_fence != text:
         return without_fence
-    # Raw (unfenced) diff: keep only the text before the first diff/hunk header.
-    m = re.search(r"^(?:diff --git |@@ )", text, re.MULTILINE)
-    return text[:m.start()] if m else text
+    # Raw (unfenced) diff: drop the patch BODY but keep the prose on BOTH sides. Keeping only
+    # the text before the first marker discarded everything after it — including the request
+    # itself, which is routinely written after the pasted patch ("<diff>\nnow describe it").
+    kept, in_diff = [], False
+    for line in text.split("\n"):
+        if _DIFF_START_RE.match(line):
+            in_diff = True
+            continue
+        if in_diff:
+            if _DIFF_BODY_LINE_RE.match(line):
+                continue
+            in_diff = False
+        kept.append(line)
+    return "\n".join(kept)
 
 
 def _capture_artifact() -> str:
@@ -287,22 +411,33 @@ async def route_and_run_result(user_text: str) -> "RouteResult":
     """Route inbound text to a pr-agent command and return a RouteResult. Never raises."""
     try:
         text = user_text or ""
-        verb = _detect_verb(text)
+        turns = _split_turns(text)
+        # Newest first. A non-blob request is one segment, so single-turn routing is unchanged.
+        # Intent comes from user turns only; the diff/PR to act on may legitimately come from
+        # an agent turn (a coding agent posts a patch, the user then asks for a review of it).
+        user_segments = [t.content for t in reversed(turns) if t.is_user] or [text]
+        context_segments = [t.content for t in reversed(turns)] or [text]
 
-        # Path (a): a host PR URL — fetch the public unified diff and route through
-        # the token-free mosaico_diff provider.
-        pr_url = _find_pr_url(text)
-        if pr_url:
-            diff_body = await _fetch_public_diff(pr_url)
-            if not diff_body:
-                return RouteResult(_pr_fetch_failed_fallback(pr_url), ok=False)
-            return await _run_on_diff(diff_body, verb, text, title=pr_url, empty_ok=False)
+        # The verb is detected from the prose only: a '?' in a patch body must not flip review to ask.
+        verb = _resolve_verb(user_segments)
+        question = user_segments[0]
 
-        # Path (b): a supplied unified diff.
-        if _looks_like_diff(text):
-            # Detect the verb from the prose only: a '?' in the patch body must not flip review to ask.
-            verb = _detect_verb(_diff_prose(text))
-            return await _run_on_diff(_extract_diff(text), verb, text, title="Supplied diff")
+        # Take the PR URL / diff from the NEWEST turn that supplies one, so a fresh diff in the
+        # current turn beats a stale URL quoted earlier in the conversation. Within one turn the
+        # existing precedence holds: an explicit PR URL wins over an inline diff.
+        for segment in context_segments:
+            # Path (a): a host PR URL — fetch the public unified diff and route through
+            # the token-free mosaico_diff provider.
+            pr_url = _find_pr_url(segment)
+            if pr_url:
+                diff_body = await _fetch_public_diff(pr_url)
+                if not diff_body:
+                    return RouteResult(_pr_fetch_failed_fallback(pr_url), ok=False)
+                return await _run_on_diff(diff_body, verb, question, title=pr_url, empty_ok=False)
+
+            # Path (b): a supplied unified diff.
+            if _looks_like_diff(segment):
+                return await _run_on_diff(_extract_diff(segment), verb, question, title="Supplied diff")
 
         # Path (c): free-text with no PR URL and no supplied diff. PRQuestions needs a
         # diff/PR to answer, so return honest guidance rather than a false internal error.

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -50,17 +50,32 @@ _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
 # Where a raw (unfenced) patch body starts, and the lines that belong to it: file/hunk
-# headers plus the context/added/removed lines that follow (an empty line is a context line
-# whose trailing space was stripped). Used to excise the body while keeping the prose.
+# headers, git's extended header (mode/rename/copy/similarity/binary), plus the
+# context/added/removed lines that follow (an empty line is a context line whose trailing
+# space was stripped). Used to excise the body while keeping the prose.
+#
+# The extended-header alternatives matter because they sit between "diff --git" and the first
+# hunk: without them the first one ends body mode, and the `index`/`---`/`+++` lines after it
+# leak into the prose that decides the verb. A leaked "rename to improve.py" then routes an
+# explicit "review this" to /improve, and a '?' in a leaked path routes it to /ask. They are
+# only ever consulted once a patch body is already open, so they cannot swallow loose prose.
 _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
-_DIFF_BODY_LINE_RE = re.compile(r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ |[ +\-\\]|$)")
+_DIFF_BODY_LINE_RE = re.compile(
+    r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
+    r"|(?:old|new) mode \d|(?:new|deleted) file mode \d"
+    r"|(?:similarity|dissimilarity) index \d|rename (?:from|to) |copy (?:from|to) "
+    r"|Binary files .*differ$|GIT binary patch$"
+    r"|[ +\-\\]|$)"
+)
 
 # Conversation-blob detection. The reference agent labels each forwarded turn with the raw
 # role from the client ("user"/"agent"); "assistant" is accepted too since sibling handlers
 # normalise to it. Only the FIRST line of a turn carries the label — a turn's content is
 # routinely multi-line (a pasted diff, or a whole review), so turns are delimited by
-# label lines rather than by newlines.
-_ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]?", re.IGNORECASE)
+# label lines rather than by newlines. All whitespace after the colon is consumed, not just
+# the single separator space: a turn whose own content starts with a space would otherwise
+# leave the patch header indented, and parse_unified_diff needs "diff --git" at column 0.
+_ROLE_LINE_RE = re.compile(r"^(user|agent|assistant)[ \t]*:[ \t]*", re.IGNORECASE)
 _USER_ROLES = ("user",)
 
 # Negation immediately before a verb ("do not review", "instead of reviewing"): at most two

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -55,9 +55,9 @@ index 3333333..4444444 100644
 ```"""
 
 # Verbatim head of a real pr-agent review, captured from the deployed MOSAICO agent. The
-# token that makes the verb stick to 'review' is 'Estimated effort to review:' — that is what
-# the r'review\b' matcher hits. It is NOT the 'PR Reviewer Guide' heading: r'review\b' does
-# not match 'reviewer', so a blob carrying only that heading reaches _DEFAULT_VERB instead.
+# token that makes the verb stick is 'Estimated effort to review:' — that is what r'review\b'
+# hits. Trimming this down to the 'PR Reviewer Guide' heading alone would make every test
+# using it vacuous: r'review\b' does not match 'reviewer'.
 AGENT_REVIEW_OUTPUT = """## PR Reviewer Guide 🔍
 
 Here are some key observations to aid the review process:
@@ -66,8 +66,8 @@ Here are some key observations to aid the review process:
 
 ### 🧪 No relevant tests"""
 
-# Two semantically distinct patches: acting on the wrong one produces a confident answer
-# about entirely the wrong subject, with nothing to signal the mistake.
+# Two patches on unrelated subjects, so acting on the wrong one is visible in the assertion
+# rather than hidden behind similar-looking output.
 AUTH_DIFF = """```diff
 diff --git a/auth.py b/auth.py
 index 1111111..2222222 100644
@@ -90,7 +90,7 @@ index 3333333..4444444 100644
 +    return sum(i.price * i.quantity for i in items)
 ```"""
 
-# A raw (unfenced) patch, the shape that used to truncate everything written after it.
+# A raw (unfenced) patch: the shape where prose written after the body has to survive.
 RAW_DIFF_BODY = """diff --git a/bar.py b/bar.py
 index 3333333..4444444 100644
 --- a/bar.py
@@ -704,9 +704,8 @@ class TestPublishOutputForced:
 
 
 # ---------------------------------------------------------------------------
-# Forwarded conversation blobs: the MOSAICO reference agent sends the WHOLE conversation
-# as one "{role}: {content}" text part per turn, joined with newlines. Routing must act on
-# the LATEST user turn, not on the blob as if it were one fresh request.
+# Forwarded conversation blobs: the MOSAICO reference agent sends the WHOLE conversation as
+# one "{role}: {content}" text part per turn, joined with newlines.
 # ---------------------------------------------------------------------------
 def _blob(*turns) -> str:
     """Build a forwarded conversation blob from (role, content) pairs, exactly as the
@@ -792,8 +791,8 @@ class TestTurnSplitting:
 
 
 class TestConversationVerbRouting:
-    """Defect 1: the verb must come from the LATEST user turn, never from the agent's own
-    output (which is full of the word 'review')."""
+    """The verb comes from the LATEST user turn, never from the agent's own output (which is
+    full of the word 'review')."""
 
     @pytest.mark.asyncio
     async def test_review_history_does_not_stick_to_later_describe(self, monkeypatch, restore_settings):
@@ -831,7 +830,6 @@ class TestConversationVerbRouting:
 
     @pytest.mark.asyncio
     async def test_follow_up_question_routes_to_ask_with_latest_turn_only(self, monkeypatch, restore_settings):
-        """The ask path must receive the current question, not the whole conversation."""
         seen = _routed(monkeypatch)
         await route_and_run(_blob(("user", "review this"),
                                   ("agent", AGENT_REVIEW_OUTPUT),
@@ -842,8 +840,8 @@ class TestConversationVerbRouting:
 
 
 class TestVerbNegationAndPosition:
-    """Defect 1, single-turn half: the verb was picked by _VALID_VERBS tuple order, so any
-    mention of 'review' won — even one being negated."""
+    """Verbs resolve by position in the text, not by _VALID_VERBS order, and a negated
+    occurrence does not count at all."""
 
     @pytest.mark.parametrize("text, expected", [
         ("Now describe it instead, do not review", "describe"),
@@ -891,8 +889,8 @@ class TestStickyReviewToken:
 
 
 class TestProseAfterRawDiff:
-    """Defect 4: _diff_prose kept only the text BEFORE the first raw diff marker, so a
-    request written after the pasted patch was discarded before verb detection ran."""
+    """A request written after a pasted patch must survive _diff_prose and reach verb
+    detection; the patch body itself must not."""
 
     def test_prose_after_a_raw_diff_survives(self):
         prose = _diff_prose(f"here is the patch\n{RAW_DIFF_BODY}\nnow describe it please")
@@ -927,7 +925,7 @@ class TestProseAfterRawDiff:
 
     @pytest.mark.asyncio
     async def test_question_mark_inside_a_raw_patch_body_still_reviews(self, monkeypatch, restore_settings):
-        """The original reason _diff_prose exists: a '?' in the patch must not flip to ask."""
+        """Why _diff_prose exists: a '?' in the patch body must not flip the verb to ask."""
         seen = _routed(monkeypatch)
         raw_with_q = ("diff --git a/foo.py b/foo.py\n"
                       "@@ -1,2 +1,2 @@\n"
@@ -940,9 +938,9 @@ class TestProseAfterRawDiff:
 
 class TestExtendedHeaderNotLeaked:
     """git's extended header (mode/rename/copy/similarity/binary) sits between 'diff --git'
-    and the first hunk. When those lines did not count as patch body, the first one ended
-    body mode and the index/---/+++ lines after it leaked into the prose that picks the
-    verb — so the PATCH's own contents could override what the user actually asked for."""
+    and the first hunk. It all has to count as patch body: any line that does not ends body
+    mode and leaks the rest of the header into the prose that picks the verb, letting the
+    PATCH's own contents override what the user asked for."""
 
     RENAME_DIFF = ("diff --git a/a.py b/improve.py\n"
                    "similarity index 95%\n"
@@ -965,7 +963,7 @@ class TestExtendedHeaderNotLeaked:
         assert _diff_prose(self.NEW_FILE_DIFF).strip() == ""
 
     def test_renamed_path_does_not_override_the_request(self):
-        """'rename to improve.py' used to be read as an explicit /improve, beating the
+        """A leaked 'rename to improve.py' reads as an explicit /improve and would beat the
         user's own 'review this' on position."""
         assert _detect_verb(_diff_prose(self.RENAME_DIFF)) == "review"
 
@@ -973,15 +971,15 @@ class TestExtendedHeaderNotLeaked:
         assert _detect_verb(_diff_prose(self.NEW_FILE_DIFF)) == "review"
 
     def test_prose_after_an_extended_header_patch_still_survives(self):
-        """The excision must not be widened into 'swallow everything to the end' — the
-        request written after the patch is exactly what defect 4 was about."""
+        """Widening the excision into 'swallow everything to the end' would fix the leak and
+        destroy the request written after the patch. Both have to hold at once."""
         prose = _diff_prose(f"{self.NEW_FILE_DIFF}\nnow describe it")
         assert prose.strip() == "now describe it"
 
 
 class TestNewestContextWins:
-    """Defects 2 and 3: the router took the OLDEST diff in the blob, and consulted a stale
-    PR URL from history before a fresh diff in the current turn."""
+    """Context comes from the NEWEST turn that supplies one, so a fresh diff beats both an
+    older diff and a stale PR URL quoted earlier in the conversation."""
 
     @pytest.mark.asyncio
     async def test_newest_diff_wins(self, monkeypatch, restore_settings):
@@ -1000,10 +998,9 @@ class TestNewestContextWins:
     @pytest.mark.parametrize("stale_url", [DEAD_PR_URL, PRIVATE_PR_URL])
     @pytest.mark.asyncio
     async def test_fresh_diff_beats_stale_url_from_history(self, stale_url, monkeypatch, restore_settings):
-        """An unfetchable PR URL quoted earlier in the conversation must not fail the whole
-        request when the current turn supplies a perfectly good inline diff. The reason the
-        fetch would fail is irrelevant — a private repo poisons the conversation just as a
-        dead link does, and is the more common case."""
+        """An unfetchable PR URL quoted earlier must not fail the request when the current
+        turn supplies a good inline diff. Parametrised over both failure reasons because a
+        private repo poisons the conversation just as a dead link does, and is commoner."""
         seen = _routed(monkeypatch)
         result = await route_and_run_result(
             _blob(("user", f"review {stale_url}"),
@@ -1017,9 +1014,8 @@ class TestNewestContextWins:
 
     @pytest.mark.asyncio
     async def test_answers_about_the_newest_patch_not_the_oldest(self, monkeypatch, restore_settings):
-        """The worst failure mode: the router used to answer confidently about the OLDEST
-        patch in the conversation. The user gets a well-formed description of the wrong
-        subject entirely — no error, no warning, nothing to notice."""
+        """The failure this guards is silent: answering about a superseded patch produces a
+        well-formed description of the wrong subject, with no error to notice."""
         seen = _routed(monkeypatch)
         result = await route_and_run_result(
             _blob(("user", f"review this auth change\n{AUTH_DIFF}"),
@@ -1055,7 +1051,8 @@ class TestNewestContextWins:
 
 
 class TestSingleTurnUnchanged:
-    """Plain single-turn requests must route exactly as before the conversation handling."""
+    """Plain single-turn requests must route exactly as if conversation handling did not
+    exist. This is what the conservative blob detection buys."""
 
     @pytest.mark.asyncio
     async def test_single_turn_diff_unchanged(self, monkeypatch, restore_settings):

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -14,8 +14,7 @@ from pr_agent.mosaico import dispatch
 from pr_agent.mosaico.dispatch import (_detect_verb, _diff_prose,
                                        _empty_fallback, _error_fallback,
                                        _explicit_verb, _split_turns,
-                                       route_and_run, route_and_run_result,
-                                       RouteResult)
+                                       route_and_run, route_and_run_result)
 
 PR_URL = "https://github.com/org/repo/pull/123"
 DEAD_PR_URL = "https://github.com/org/repo/pull/999999999"

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -53,8 +53,7 @@ index 3333333..4444444 100644
  b = 3
 ```"""
 
-# Keep the 'Estimated effort to review:' line: r'review\b' does not match 'reviewer', so the
-# heading alone would make every test using this fixture vacuous.
+# Keep the 'Estimated effort to review:' line: r'review\b' does not match 'reviewer'.
 AGENT_REVIEW_OUTPUT = """## PR Reviewer Guide 🔍
 
 Here are some key observations to aid the review process:
@@ -697,9 +696,6 @@ class TestPublishOutputForced:
         )
 
 
-# ---------------------------------------------------------------------------
-# Forwarded conversation blobs
-# ---------------------------------------------------------------------------
 def _blob(*turns) -> str:
     return "\n".join(f"{role}: {content}" for role, content in turns)
 
@@ -745,7 +741,6 @@ class TestTurnSplitting:
                                    ("user", "now describe it")))
         assert [t.role for t in turns] == ["user", "agent", "user"]
         assert [t.is_user for t in turns] == [True, False, True]
-        # The agent turn's content is multi-line; only its first line carried the label.
         assert turns[1].content == AGENT_REVIEW_OUTPUT
         assert turns[2].content == "now describe it"
 

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -42,7 +42,6 @@ index 1111111..2222222 100644
  y = 3
 """
 
-# A second, distinct diff — used to prove which of two diffs in one conversation is acted on.
 CORRECTED_DIFF = """```diff
 diff --git a/bar.py b/bar.py
 index 3333333..4444444 100644
@@ -54,10 +53,8 @@ index 3333333..4444444 100644
  b = 3
 ```"""
 
-# Verbatim head of a real pr-agent review, captured from the deployed MOSAICO agent. The
-# token that makes the verb stick is 'Estimated effort to review:' — that is what r'review\b'
-# hits. Trimming this down to the 'PR Reviewer Guide' heading alone would make every test
-# using it vacuous: r'review\b' does not match 'reviewer'.
+# Keep the 'Estimated effort to review:' line: r'review\b' does not match 'reviewer', so the
+# heading alone would make every test using this fixture vacuous.
 AGENT_REVIEW_OUTPUT = """## PR Reviewer Guide 🔍
 
 Here are some key observations to aid the review process:
@@ -66,8 +63,6 @@ Here are some key observations to aid the review process:
 
 ### 🧪 No relevant tests"""
 
-# Two patches on unrelated subjects, so acting on the wrong one is visible in the assertion
-# rather than hidden behind similar-looking output.
 AUTH_DIFF = """```diff
 diff --git a/auth.py b/auth.py
 index 1111111..2222222 100644
@@ -90,7 +85,6 @@ index 3333333..4444444 100644
 +    return sum(i.price * i.quantity for i in items)
 ```"""
 
-# A raw (unfenced) patch: the shape where prose written after the body has to survive.
 RAW_DIFF_BODY = """diff --git a/bar.py b/bar.py
 index 3333333..4444444 100644
 --- a/bar.py
@@ -704,18 +698,13 @@ class TestPublishOutputForced:
 
 
 # ---------------------------------------------------------------------------
-# Forwarded conversation blobs: the MOSAICO reference agent sends the WHOLE conversation as
-# one "{role}: {content}" text part per turn, joined with newlines.
+# Forwarded conversation blobs
 # ---------------------------------------------------------------------------
 def _blob(*turns) -> str:
-    """Build a forwarded conversation blob from (role, content) pairs, exactly as the
-    reference agent's conversationDataToText + the A2A SDK's get_user_input() produce it."""
     return "\n".join(f"{role}: {content}" for role, content in turns)
 
 
 def _routed(monkeypatch):
-    """Stub the tool layer and report what the router decided to act on: the verb, the
-    files of the diff it installed, the title, and the question handed to the ask path."""
     seen = {"fetched": []}
 
     async def fake_handle_request(self, pr_url, request, notify=None):
@@ -750,9 +739,6 @@ def _routed(monkeypatch):
 
 
 class TestTurnSplitting:
-    """_split_turns is deliberately conservative: a blob must BOTH open with a role label
-    and carry at least two of them, so ordinary single-turn text is never segmented."""
-
     def test_splits_roles_and_keeps_multiline_content(self):
         turns = _split_turns(_blob(("user", "review this"),
                                    ("agent", AGENT_REVIEW_OUTPUT),
@@ -765,18 +751,15 @@ class TestTurnSplitting:
 
     @pytest.mark.parametrize("text", [
         "review this PR",
-        "user: alice\nplease review the config above",          # a single stray role line
-        "here is my config\nuser: alice\nagent: bob\nreview it",  # labels not at the start
-        "user: admin\npassword: hunter2\nreview this",            # yaml-ish, only one role label
+        "user: alice\nplease review the config above",
+        "here is my config\nuser: alice\nagent: bob\nreview it",
+        "user: admin\npassword: hunter2\nreview this",
         "",
     ])
     def test_not_a_conversation_blob(self, text):
         assert _split_turns(text) == []
 
     def test_content_indentation_after_the_label_is_dropped(self):
-        """A turn whose own content starts with a space arrives as 'user:  diff --git ...'.
-        parse_unified_diff needs 'diff --git' at column 0, so the label match consumes ALL
-        whitespace after the colon, not just the single separator space."""
         turns = _split_turns(_blob(("user", " diff --git a/x.py b/x.py"), ("agent", "ok")))
         assert turns[0].content == "diff --git a/x.py b/x.py"
 
@@ -791,9 +774,6 @@ class TestTurnSplitting:
 
 
 class TestConversationVerbRouting:
-    """The verb comes from the LATEST user turn, never from the agent's own output (which is
-    full of the word 'review')."""
-
     @pytest.mark.asyncio
     async def test_review_history_does_not_stick_to_later_describe(self, monkeypatch, restore_settings):
         seen = _routed(monkeypatch)
@@ -820,8 +800,6 @@ class TestConversationVerbRouting:
 
     @pytest.mark.asyncio
     async def test_bare_diff_turn_falls_back_to_earlier_user_verb(self, monkeypatch, restore_settings):
-        """A latest turn that expresses no intent at all (a bare re-paste) may inherit the
-        verb from an OLDER USER turn — never from an agent turn."""
         seen = _routed(monkeypatch)
         await route_and_run(_blob(("user", "describe this"),
                                   ("agent", AGENT_REVIEW_OUTPUT),
@@ -840,36 +818,29 @@ class TestConversationVerbRouting:
 
 
 class TestVerbNegationAndPosition:
-    """Verbs resolve by position in the text, not by _VALID_VERBS order, and a negated
-    occurrence does not count at all."""
-
     @pytest.mark.parametrize("text, expected", [
         ("Now describe it instead, do not review", "describe"),
         ("can you improve this? do not review", "improve"),
-        ("do not review, describe this", "describe"),          # negated verb comes FIRST
+        ("do not review, describe this", "describe"),
         ("skip the review, just describe", "describe"),
         ("instead of reviewing, describe this", "describe"),
-        ("describe this, then improve it", "describe"),        # plain position, no negation
+        ("describe this, then improve it", "describe"),
     ])
     def test_negated_and_positional_verbs(self, text, expected):
         assert _detect_verb(text) == expected
 
     @pytest.mark.parametrize("text, expected", [
-        ("there is no bug, review this", "review"),        # 'no' belongs to the prose, not the verb
+        ("there is no bug, review this", "review"),
         ("i do not have time, review this", "review"),
         ("nothing to improve here?", "improve"),
-        ("do not review", "review"),                       # every verb negated -> the default
+        ("do not review", "review"),
     ])
     def test_negation_does_not_fire_on_ordinary_prose(self, text, expected):
         assert _detect_verb(text) == expected
 
 
 class TestStickyReviewToken:
-    """Pins WHICH token in pr-agent's own output feeds back into verb detection, so the
-    stickiness regression tests cannot drift onto a false premise."""
-
     def test_reviewer_heading_alone_does_not_reach_the_matcher(self):
-        # r'review\b' does not match 'reviewer' — this heading resolves via _DEFAULT_VERB.
         assert _explicit_verb("## PR Reviewer Guide 🔍") is None
         assert _detect_verb("## PR Reviewer Guide 🔍") == "review"
 
@@ -878,8 +849,6 @@ class TestStickyReviewToken:
 
     @pytest.mark.asyncio
     async def test_real_review_output_in_history_does_not_capture_the_verb(self, monkeypatch, restore_settings):
-        """End to end with the verbatim review output: the matching token lives in an agent
-        turn, which intent resolution must never consult."""
         assert _explicit_verb(AGENT_REVIEW_OUTPUT) == "review", "guard: the constant must still be sticky"
         seen = _routed(monkeypatch)
         await route_and_run(_blob(("user", "review this"),
@@ -889,9 +858,6 @@ class TestStickyReviewToken:
 
 
 class TestProseAfterRawDiff:
-    """A request written after a pasted patch must survive _diff_prose and reach verb
-    detection; the patch body itself must not."""
-
     def test_prose_after_a_raw_diff_survives(self):
         prose = _diff_prose(f"here is the patch\n{RAW_DIFF_BODY}\nnow describe it please")
         assert "now describe it please" in prose
@@ -925,7 +891,6 @@ class TestProseAfterRawDiff:
 
     @pytest.mark.asyncio
     async def test_question_mark_inside_a_raw_patch_body_still_reviews(self, monkeypatch, restore_settings):
-        """Why _diff_prose exists: a '?' in the patch body must not flip the verb to ask."""
         seen = _routed(monkeypatch)
         raw_with_q = ("diff --git a/foo.py b/foo.py\n"
                       "@@ -1,2 +1,2 @@\n"
@@ -937,11 +902,6 @@ class TestProseAfterRawDiff:
 
 
 class TestExtendedHeaderNotLeaked:
-    """git's extended header (mode/rename/copy/similarity/binary) sits between 'diff --git'
-    and the first hunk. It all has to count as patch body: any line that does not ends body
-    mode and leaks the rest of the header into the prose that picks the verb, letting the
-    PATCH's own contents override what the user asked for."""
-
     RENAME_DIFF = ("diff --git a/a.py b/improve.py\n"
                    "similarity index 95%\n"
                    "rename from a.py\n"
@@ -963,24 +923,17 @@ class TestExtendedHeaderNotLeaked:
         assert _diff_prose(self.NEW_FILE_DIFF).strip() == ""
 
     def test_renamed_path_does_not_override_the_request(self):
-        """A leaked 'rename to improve.py' reads as an explicit /improve and would beat the
-        user's own 'review this' on position."""
         assert _detect_verb(_diff_prose(self.RENAME_DIFF)) == "review"
 
     def test_question_mark_in_a_leaked_path_does_not_flip_to_ask(self):
         assert _detect_verb(_diff_prose(self.NEW_FILE_DIFF)) == "review"
 
     def test_prose_after_an_extended_header_patch_still_survives(self):
-        """Widening the excision into 'swallow everything to the end' would fix the leak and
-        destroy the request written after the patch. Both have to hold at once."""
         prose = _diff_prose(f"{self.NEW_FILE_DIFF}\nnow describe it")
         assert prose.strip() == "now describe it"
 
 
 class TestNewestContextWins:
-    """Context comes from the NEWEST turn that supplies one, so a fresh diff beats both an
-    older diff and a stale PR URL quoted earlier in the conversation."""
-
     @pytest.mark.asyncio
     async def test_newest_diff_wins(self, monkeypatch, restore_settings):
         seen = _routed(monkeypatch)
@@ -998,9 +951,6 @@ class TestNewestContextWins:
     @pytest.mark.parametrize("stale_url", [DEAD_PR_URL, PRIVATE_PR_URL])
     @pytest.mark.asyncio
     async def test_fresh_diff_beats_stale_url_from_history(self, stale_url, monkeypatch, restore_settings):
-        """An unfetchable PR URL quoted earlier must not fail the request when the current
-        turn supplies a good inline diff. Parametrised over both failure reasons because a
-        private repo poisons the conversation just as a dead link does, and is commoner."""
         seen = _routed(monkeypatch)
         result = await route_and_run_result(
             _blob(("user", f"review {stale_url}"),
@@ -1014,8 +964,6 @@ class TestNewestContextWins:
 
     @pytest.mark.asyncio
     async def test_answers_about_the_newest_patch_not_the_oldest(self, monkeypatch, restore_settings):
-        """The failure this guards is silent: answering about a superseded patch produces a
-        well-formed description of the wrong subject, with no error to notice."""
         seen = _routed(monkeypatch)
         result = await route_and_run_result(
             _blob(("user", f"review this auth change\n{AUTH_DIFF}"),
@@ -1028,8 +976,6 @@ class TestNewestContextWins:
 
     @pytest.mark.asyncio
     async def test_diff_from_an_agent_turn_is_still_usable(self, monkeypatch, restore_settings):
-        """Intent comes from user turns only, but the patch to act on may legitimately have
-        been produced by another agent in the conversation."""
         seen = _routed(monkeypatch)
         await route_and_run(_blob(("user", "write me a patch"),
                                   ("agent", f"here you go\n{CORRECTED_DIFF}"),
@@ -1039,21 +985,16 @@ class TestNewestContextWins:
 
     @pytest.mark.asyncio
     async def test_current_turn_url_still_beats_older_diff(self, monkeypatch, restore_settings):
-        """The newest turn wins as a whole: an explicit URL in it is still preferred over a
-        diff from an earlier turn, and within one turn a URL still outranks an inline diff."""
         seen = _routed(monkeypatch)
         await route_and_run(_blob(("user", f"review this\n{CORRECTED_DIFF}"),
                                   ("agent", AGENT_REVIEW_OUTPUT),
                                   ("user", f"actually use {PR_URL}")))
         assert seen["fetched"] == [PR_URL]
         assert seen["title"] == PR_URL
-        assert seen["files"] == ["foo.py"]  # from the fetched diff, not the earlier paste
+        assert seen["files"] == ["foo.py"]
 
 
 class TestSingleTurnUnchanged:
-    """Plain single-turn requests must route exactly as if conversation handling did not
-    exist. This is what the conservative blob detection buys."""
-
     @pytest.mark.asyncio
     async def test_single_turn_diff_unchanged(self, monkeypatch, restore_settings):
         seen = _routed(monkeypatch)
@@ -1074,7 +1015,6 @@ class TestSingleTurnUnchanged:
 
     @pytest.mark.asyncio
     async def test_single_turn_unreachable_url_still_fails_honestly(self, monkeypatch, restore_settings):
-        """No diff anywhere to fall back on -> the honest fetch failure is preserved."""
         _routed(monkeypatch)
         result = await route_and_run_result(f"review {DEAD_PR_URL}")
         assert result.ok is False

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -774,6 +774,22 @@ class TestTurnSplitting:
     def test_not_a_conversation_blob(self, text):
         assert _split_turns(text) == []
 
+    def test_content_indentation_after_the_label_is_dropped(self):
+        """A turn whose own content starts with a space arrives as 'user:  diff --git ...'.
+        parse_unified_diff needs 'diff --git' at column 0, so the label match consumes ALL
+        whitespace after the colon, not just the single separator space."""
+        turns = _split_turns(_blob(("user", " diff --git a/x.py b/x.py"), ("agent", "ok")))
+        assert turns[0].content == "diff --git a/x.py b/x.py"
+
+    @pytest.mark.asyncio
+    async def test_indented_raw_diff_in_a_turn_still_routes(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "here is a patch"),
+                                  ("agent", "thanks"),
+                                  ("user", f" {RAW_DIFF_BODY}\nnow describe it")))
+        assert seen["verb"] == "describe"
+        assert seen["files"] == ["bar.py"]
+
 
 class TestConversationVerbRouting:
     """Defect 1: the verb must come from the LATEST user turn, never from the agent's own
@@ -920,6 +936,47 @@ class TestProseAfterRawDiff:
                       " z = 3")
         await route_and_run(raw_with_q)
         assert seen["verb"] == "review"
+
+
+class TestExtendedHeaderNotLeaked:
+    """git's extended header (mode/rename/copy/similarity/binary) sits between 'diff --git'
+    and the first hunk. When those lines did not count as patch body, the first one ended
+    body mode and the index/---/+++ lines after it leaked into the prose that picks the
+    verb — so the PATCH's own contents could override what the user actually asked for."""
+
+    RENAME_DIFF = ("diff --git a/a.py b/improve.py\n"
+                   "similarity index 95%\n"
+                   "rename from a.py\n"
+                   "rename to improve.py\n"
+                   "review this")
+
+    NEW_FILE_DIFF = ("diff --git a/x.py b/x.py\n"
+                     "new file mode 100644\n"
+                     "index 0000000..1111111\n"
+                     "--- /dev/null\n"
+                     "+++ b/is_it_ok?.py\n"
+                     "@@ -0,0 +1 @@\n"
+                     "+x = 1")
+
+    def test_rename_metadata_does_not_leak(self):
+        assert _diff_prose(self.RENAME_DIFF).strip() == "review this"
+
+    def test_new_file_metadata_does_not_leak(self):
+        assert _diff_prose(self.NEW_FILE_DIFF).strip() == ""
+
+    def test_renamed_path_does_not_override_the_request(self):
+        """'rename to improve.py' used to be read as an explicit /improve, beating the
+        user's own 'review this' on position."""
+        assert _detect_verb(_diff_prose(self.RENAME_DIFF)) == "review"
+
+    def test_question_mark_in_a_leaked_path_does_not_flip_to_ask(self):
+        assert _detect_verb(_diff_prose(self.NEW_FILE_DIFF)) == "review"
+
+    def test_prose_after_an_extended_header_patch_still_survives(self):
+        """The excision must not be widened into 'swallow everything to the end' — the
+        request written after the patch is exactly what defect 4 was about."""
+        prose = _diff_prose(f"{self.NEW_FILE_DIFF}\nnow describe it")
+        assert prose.strip() == "now describe it"
 
 
 class TestNewestContextWins:

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -11,11 +11,15 @@ import aiohttp
 
 from pr_agent.config_loader import global_settings
 from pr_agent.mosaico import dispatch
-from pr_agent.mosaico.dispatch import (_detect_verb, _empty_fallback,
-                                       _error_fallback, route_and_run,
-                                       route_and_run_result, RouteResult)
+from pr_agent.mosaico.dispatch import (_detect_verb, _diff_prose,
+                                       _empty_fallback, _error_fallback,
+                                       _explicit_verb, _split_turns,
+                                       route_and_run, route_and_run_result,
+                                       RouteResult)
 
 PR_URL = "https://github.com/org/repo/pull/123"
+DEAD_PR_URL = "https://github.com/org/repo/pull/999999999"
+PRIVATE_PR_URL = "https://github.com/acme/private-repo/pull/7"
 
 SAMPLE_DIFF = """```diff
 diff --git a/foo.py b/foo.py
@@ -38,6 +42,64 @@ index 1111111..2222222 100644
 +x = 2
  y = 3
 """
+
+# A second, distinct diff — used to prove which of two diffs in one conversation is acted on.
+CORRECTED_DIFF = """```diff
+diff --git a/bar.py b/bar.py
+index 3333333..4444444 100644
+--- a/bar.py
++++ b/bar.py
+@@ -1,2 +1,2 @@
+-a = 1
++a = 2
+ b = 3
+```"""
+
+# Verbatim head of a real pr-agent review, captured from the deployed MOSAICO agent. The
+# token that makes the verb stick to 'review' is 'Estimated effort to review:' — that is what
+# the r'review\b' matcher hits. It is NOT the 'PR Reviewer Guide' heading: r'review\b' does
+# not match 'reviewer', so a blob carrying only that heading reaches _DEFAULT_VERB instead.
+AGENT_REVIEW_OUTPUT = """## PR Reviewer Guide 🔍
+
+Here are some key observations to aid the review process:
+
+### ⏱️ Estimated effort to review: 1 🔵⚪⚪⚪⚪
+
+### 🧪 No relevant tests"""
+
+# Two semantically distinct patches: acting on the wrong one produces a confident answer
+# about entirely the wrong subject, with nothing to signal the mistake.
+AUTH_DIFF = """```diff
+diff --git a/auth.py b/auth.py
+index 1111111..2222222 100644
+--- a/auth.py
++++ b/auth.py
+@@ -1,3 +1,3 @@
+ def check_password(user, pw):
+-    return user.password == pw
++    return constant_time_compare(user.password_hash, hash_pw(pw))
+```"""
+
+BILLING_DIFF = """```diff
+diff --git a/billing/invoice.py b/billing/invoice.py
+index 3333333..4444444 100644
+--- a/billing/invoice.py
++++ b/billing/invoice.py
+@@ -1,3 +1,3 @@
+ def total(items):
+-    return sum(i.price for i in items)
++    return sum(i.price * i.quantity for i in items)
+```"""
+
+# A raw (unfenced) patch, the shape that used to truncate everything written after it.
+RAW_DIFF_BODY = """diff --git a/bar.py b/bar.py
+index 3333333..4444444 100644
+--- a/bar.py
++++ b/bar.py
+@@ -1,2 +1,2 @@
+-a = 1
++a = 2
+ b = 3"""
 
 _SENTINEL = object()
 
@@ -640,3 +702,335 @@ class TestPublishOutputForced:
             "CONFIG.PUBLISH_OUTPUT must be False when PRQuestions.run() is called; "
             "without this, run()'s publish guards post comments to the real PR."
         )
+
+
+# ---------------------------------------------------------------------------
+# Forwarded conversation blobs: the MOSAICO reference agent sends the WHOLE conversation
+# as one "{role}: {content}" text part per turn, joined with newlines. Routing must act on
+# the LATEST user turn, not on the blob as if it were one fresh request.
+# ---------------------------------------------------------------------------
+def _blob(*turns) -> str:
+    """Build a forwarded conversation blob from (role, content) pairs, exactly as the
+    reference agent's conversationDataToText + the A2A SDK's get_user_input() produce it."""
+    return "\n".join(f"{role}: {content}" for role, content in turns)
+
+
+def _routed(monkeypatch):
+    """Stub the tool layer and report what the router decided to act on: the verb, the
+    files of the diff it installed, the title, and the question handed to the ask path."""
+    seen = {"fetched": []}
+
+    async def fake_handle_request(self, pr_url, request, notify=None):
+        seen["verb"] = next((a.lstrip("/") for a in request if a.startswith("/")), None)
+        mosaico_input = global_settings.get("MOSAICO.INPUT") or {}
+        seen["files"] = [f.filename for f in mosaico_input.get("files", [])]
+        seen["title"] = mosaico_input.get("title")
+        _set_artifact("ROUTED")
+        return True
+
+    class FakePRQuestions:
+        def __init__(self, pr_url, args=None, ai_handler=None):
+            seen["verb"] = "ask"
+            seen["question"] = (args or [""])[0]
+            mosaico_input = global_settings.get("MOSAICO.INPUT") or {}
+            seen["files"] = [f.filename for f in mosaico_input.get("files", [])]
+            seen["title"] = mosaico_input.get("title")
+            self.prediction = "ROUTED"
+
+        async def run(self):
+            return ""
+
+    async def fake_fetch_public_diff(pr_url):
+        seen["fetched"].append(pr_url)
+        return SAMPLE_RAW_DIFF if pr_url == PR_URL else None
+
+    from pr_agent.agent.pr_agent import PRAgent
+    monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
+    monkeypatch.setattr("pr_agent.tools.pr_questions.PRQuestions", FakePRQuestions)
+    monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
+    return seen
+
+
+class TestTurnSplitting:
+    """_split_turns is deliberately conservative: a blob must BOTH open with a role label
+    and carry at least two of them, so ordinary single-turn text is never segmented."""
+
+    def test_splits_roles_and_keeps_multiline_content(self):
+        turns = _split_turns(_blob(("user", "review this"),
+                                   ("agent", AGENT_REVIEW_OUTPUT),
+                                   ("user", "now describe it")))
+        assert [t.role for t in turns] == ["user", "agent", "user"]
+        assert [t.is_user for t in turns] == [True, False, True]
+        # The agent turn's content is multi-line; only its first line carried the label.
+        assert turns[1].content == AGENT_REVIEW_OUTPUT
+        assert turns[2].content == "now describe it"
+
+    @pytest.mark.parametrize("text", [
+        "review this PR",
+        "user: alice\nplease review the config above",          # a single stray role line
+        "here is my config\nuser: alice\nagent: bob\nreview it",  # labels not at the start
+        "user: admin\npassword: hunter2\nreview this",            # yaml-ish, only one role label
+        "",
+    ])
+    def test_not_a_conversation_blob(self, text):
+        assert _split_turns(text) == []
+
+
+class TestConversationVerbRouting:
+    """Defect 1: the verb must come from the LATEST user turn, never from the agent's own
+    output (which is full of the word 'review')."""
+
+    @pytest.mark.asyncio
+    async def test_review_history_does_not_stick_to_later_describe(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "review this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"Now describe this diff\n{CORRECTED_DIFF}")))
+        assert seen["verb"] == "describe"
+
+    @pytest.mark.asyncio
+    async def test_describe_history_does_not_stick_to_later_review(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "describe this"),
+                                  ("agent", "### PR Type\nEnhancement"),
+                                  ("user", f"now review it\n{CORRECTED_DIFF}")))
+        assert seen["verb"] == "review"
+
+    @pytest.mark.asyncio
+    async def test_latest_turn_wins_over_earlier_user_verb(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "describe this"),
+                                  ("agent", "### PR Type\nEnhancement"),
+                                  ("user", f"now improve it\n{CORRECTED_DIFF}")))
+        assert seen["verb"] == "improve"
+
+    @pytest.mark.asyncio
+    async def test_bare_diff_turn_falls_back_to_earlier_user_verb(self, monkeypatch, restore_settings):
+        """A latest turn that expresses no intent at all (a bare re-paste) may inherit the
+        verb from an OLDER USER turn — never from an agent turn."""
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "describe this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", CORRECTED_DIFF)))
+        assert seen["verb"] == "describe"
+
+    @pytest.mark.asyncio
+    async def test_follow_up_question_routes_to_ask_with_latest_turn_only(self, monkeypatch, restore_settings):
+        """The ask path must receive the current question, not the whole conversation."""
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "review this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"why is that a bug?\n{CORRECTED_DIFF}")))
+        assert seen["verb"] == "ask"
+        assert seen["question"].startswith("why is that a bug?")
+        assert "PR Reviewer Guide" not in seen["question"]
+
+
+class TestVerbNegationAndPosition:
+    """Defect 1, single-turn half: the verb was picked by _VALID_VERBS tuple order, so any
+    mention of 'review' won — even one being negated."""
+
+    @pytest.mark.parametrize("text, expected", [
+        ("Now describe it instead, do not review", "describe"),
+        ("can you improve this? do not review", "improve"),
+        ("do not review, describe this", "describe"),          # negated verb comes FIRST
+        ("skip the review, just describe", "describe"),
+        ("instead of reviewing, describe this", "describe"),
+        ("describe this, then improve it", "describe"),        # plain position, no negation
+    ])
+    def test_negated_and_positional_verbs(self, text, expected):
+        assert _detect_verb(text) == expected
+
+    @pytest.mark.parametrize("text, expected", [
+        ("there is no bug, review this", "review"),        # 'no' belongs to the prose, not the verb
+        ("i do not have time, review this", "review"),
+        ("nothing to improve here?", "improve"),
+        ("do not review", "review"),                       # every verb negated -> the default
+    ])
+    def test_negation_does_not_fire_on_ordinary_prose(self, text, expected):
+        assert _detect_verb(text) == expected
+
+
+class TestStickyReviewToken:
+    """Pins WHICH token in pr-agent's own output feeds back into verb detection, so the
+    stickiness regression tests cannot drift onto a false premise."""
+
+    def test_reviewer_heading_alone_does_not_reach_the_matcher(self):
+        # r'review\b' does not match 'reviewer' — this heading resolves via _DEFAULT_VERB.
+        assert _explicit_verb("## PR Reviewer Guide 🔍") is None
+        assert _detect_verb("## PR Reviewer Guide 🔍") == "review"
+
+    def test_estimated_effort_line_is_the_token_that_matches(self):
+        assert _explicit_verb("### ⏱️ Estimated effort to review: 1 🔵⚪⚪⚪⚪") == "review"
+
+    @pytest.mark.asyncio
+    async def test_real_review_output_in_history_does_not_capture_the_verb(self, monkeypatch, restore_settings):
+        """End to end with the verbatim review output: the matching token lives in an agent
+        turn, which intent resolution must never consult."""
+        assert _explicit_verb(AGENT_REVIEW_OUTPUT) == "review", "guard: the constant must still be sticky"
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "review this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"now describe it\n{CORRECTED_DIFF}")))
+        assert seen["verb"] == "describe"
+
+
+class TestProseAfterRawDiff:
+    """Defect 4: _diff_prose kept only the text BEFORE the first raw diff marker, so a
+    request written after the pasted patch was discarded before verb detection ran."""
+
+    def test_prose_after_a_raw_diff_survives(self):
+        prose = _diff_prose(f"here is the patch\n{RAW_DIFF_BODY}\nnow describe it please")
+        assert "now describe it please" in prose
+        assert "here is the patch" in prose
+        assert "+a = 2" not in prose, "the patch body must still be excised"
+
+    def test_prose_after_a_blank_separated_raw_diff_survives(self):
+        prose = _diff_prose(f"{RAW_DIFF_BODY}\n\nnow describe it please")
+        assert "now describe it please" in prose
+
+    def test_fenced_diff_prose_is_unchanged(self):
+        prose = _diff_prose(f"what changed here?\n{SAMPLE_DIFF}")
+        assert "what changed here?" in prose
+        assert "+x = 2" not in prose
+
+    @pytest.mark.asyncio
+    async def test_verb_written_after_a_raw_diff_is_honoured(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(f"{RAW_DIFF_BODY}\n\nnow describe it please")
+        assert seen["verb"] == "describe"
+        assert seen["files"] == ["bar.py"]
+
+    @pytest.mark.asyncio
+    async def test_verb_after_a_raw_diff_in_the_latest_turn_is_honoured(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "review this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"{RAW_DIFF_BODY}\n\nnow describe it please")))
+        assert seen["verb"] == "describe"
+        assert seen["files"] == ["bar.py"]
+
+    @pytest.mark.asyncio
+    async def test_question_mark_inside_a_raw_patch_body_still_reviews(self, monkeypatch, restore_settings):
+        """The original reason _diff_prose exists: a '?' in the patch must not flip to ask."""
+        seen = _routed(monkeypatch)
+        raw_with_q = ("diff --git a/foo.py b/foo.py\n"
+                      "@@ -1,2 +1,2 @@\n"
+                      "-y = a if b else c\n"
+                      "+y = a ? b : c  # is this right?\n"
+                      " z = 3")
+        await route_and_run(raw_with_q)
+        assert seen["verb"] == "review"
+
+
+class TestNewestContextWins:
+    """Defects 2 and 3: the router took the OLDEST diff in the blob, and consulted a stale
+    PR URL from history before a fresh diff in the current turn."""
+
+    @pytest.mark.asyncio
+    async def test_newest_diff_wins(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", f"review this\n{SAMPLE_DIFF}"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"here is the corrected diff\n{CORRECTED_DIFF}")))
+        assert seen["files"] == ["bar.py"], "the corrected diff must supersede the one it replaces"
+
+    @pytest.mark.asyncio
+    async def test_last_diff_wins_within_a_single_turn(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(f"review this\n{SAMPLE_DIFF}\nsorry, this one:\n{CORRECTED_DIFF}")
+        assert seen["files"] == ["bar.py"]
+
+    @pytest.mark.parametrize("stale_url", [DEAD_PR_URL, PRIVATE_PR_URL])
+    @pytest.mark.asyncio
+    async def test_fresh_diff_beats_stale_url_from_history(self, stale_url, monkeypatch, restore_settings):
+        """An unfetchable PR URL quoted earlier in the conversation must not fail the whole
+        request when the current turn supplies a perfectly good inline diff. The reason the
+        fetch would fail is irrelevant — a private repo poisons the conversation just as a
+        dead link does, and is the more common case."""
+        seen = _routed(monkeypatch)
+        result = await route_and_run_result(
+            _blob(("user", f"review {stale_url}"),
+                  ("agent", AGENT_REVIEW_OUTPUT),
+                  ("user", f"that URL is wrong, here is the diff instead\n{CORRECTED_DIFF}")))
+        assert result.ok is True
+        assert result.text == "ROUTED"
+        assert seen["title"] == "Supplied diff"
+        assert seen["files"] == ["bar.py"]
+        assert seen["fetched"] == [], "the stale URL must never be fetched"
+
+    @pytest.mark.asyncio
+    async def test_answers_about_the_newest_patch_not_the_oldest(self, monkeypatch, restore_settings):
+        """The worst failure mode: the router used to answer confidently about the OLDEST
+        patch in the conversation. The user gets a well-formed description of the wrong
+        subject entirely — no error, no warning, nothing to notice."""
+        seen = _routed(monkeypatch)
+        result = await route_and_run_result(
+            _blob(("user", f"review this auth change\n{AUTH_DIFF}"),
+                  ("agent", AGENT_REVIEW_OUTPUT),
+                  ("user", f"forget that, describe this new billing patch instead\n{BILLING_DIFF}")))
+        assert result.ok is True
+        assert seen["verb"] == "describe"
+        assert seen["files"] == ["billing/invoice.py"]
+        assert "auth.py" not in seen["files"], "answering about the superseded patch is silent wrongness"
+
+    @pytest.mark.asyncio
+    async def test_diff_from_an_agent_turn_is_still_usable(self, monkeypatch, restore_settings):
+        """Intent comes from user turns only, but the patch to act on may legitimately have
+        been produced by another agent in the conversation."""
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "write me a patch"),
+                                  ("agent", f"here you go\n{CORRECTED_DIFF}"),
+                                  ("user", "review it")))
+        assert seen["verb"] == "review"
+        assert seen["files"] == ["bar.py"]
+
+    @pytest.mark.asyncio
+    async def test_current_turn_url_still_beats_older_diff(self, monkeypatch, restore_settings):
+        """The newest turn wins as a whole: an explicit URL in it is still preferred over a
+        diff from an earlier turn, and within one turn a URL still outranks an inline diff."""
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", f"review this\n{CORRECTED_DIFF}"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"actually use {PR_URL}")))
+        assert seen["fetched"] == [PR_URL]
+        assert seen["title"] == PR_URL
+        assert seen["files"] == ["foo.py"]  # from the fetched diff, not the earlier paste
+
+
+class TestSingleTurnUnchanged:
+    """Plain single-turn requests must route exactly as before the conversation handling."""
+
+    @pytest.mark.asyncio
+    async def test_single_turn_diff_unchanged(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        out = await route_and_run(f"review the following\n{SAMPLE_DIFF}")
+        assert out == "ROUTED"
+        assert seen["verb"] == "review"
+        assert seen["title"] == "Supplied diff"
+        assert seen["files"] == ["foo.py"]
+
+    @pytest.mark.asyncio
+    async def test_single_turn_pr_url_unchanged(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        out = await route_and_run(f"describe {PR_URL}")
+        assert out == "ROUTED"
+        assert seen["verb"] == "describe"
+        assert seen["fetched"] == [PR_URL]
+        assert seen["title"] == PR_URL
+
+    @pytest.mark.asyncio
+    async def test_single_turn_unreachable_url_still_fails_honestly(self, monkeypatch, restore_settings):
+        """No diff anywhere to fall back on -> the honest fetch failure is preserved."""
+        _routed(monkeypatch)
+        result = await route_and_run_result(f"review {DEAD_PR_URL}")
+        assert result.ok is False
+        assert "could not fetch" in result.text
+
+    @pytest.mark.asyncio
+    async def test_conversation_with_no_context_returns_guidance(self, monkeypatch, restore_settings):
+        _routed(monkeypatch)
+        out = await route_and_run(_blob(("user", "hello"),
+                                        ("agent", "hi, what can I do?"),
+                                        ("user", "review my code please")))
+        assert out == "PR-Agent requires a PR URL or a supplied diff."


### PR DESCRIPTION
The MOSAICO reference agent forwards the **whole conversation** as one text part per turn, shaped `{role}: {content}`, which the A2A SDK joins with newlines. Dispatch treated that blob as a single fresh request, which produced five distinct defects. All five were reproduced against the deployed agent.

## Worst first: the agent answers about the wrong patch, silently

`_extract_diff` used a non-greedy `re.search`, so the **oldest** fenced diff won. Live, before:

> blob = old `auth.py` diff, then new `billing/invoice.py` diff, final turn "forget that, describe this new billing patch instead"
> → `TASK_STATE_COMPLETED`, description entirely about password checking. No mention of invoice or billing.

A confident, well-formed answer about the wrong code, with nothing signalling the error. After: `### PR Type` + "Fixed invoice total calculation to include quantity."

## Verb selection ignored what the user asked

`_detect_verb` looped `_VALID_VERBS = ("review", "improve", "describe", "ask")` and returned the first entry found *anywhere*, so selection was by **tuple position**. This was never multi-turn-specific — single-turn requests broke too:

| input | before | after |
|---|---|---|
| `describe this PR` | describe | describe |
| `Now describe it instead, do not review` | **review** | describe |
| `can you improve this? do not review` | **review** | improve |
| `do not review, describe this` | **review** | describe |

Since pr-agent's own output contains `Estimated effort to review:`, one review made every later turn sticky — leaving 3 of 4 advertised skills unreachable.

## Three more

- A stale PR URL in history took unconditional precedence over a fresh inline diff. Live: `TASK_STATE_FAILED "could not fetch a public diff for .../pull/999999999"` with a perfectly good diff in the current turn. Fires on any private repo URL too, not just a 404.
- `_diff_prose` returned `text[:m.start()]`, discarding everything after the first raw diff marker — so the user's latest turn never reached the matcher.
- A raw diff opening a forwarded turn arrives as `user: diff --git ...`, so `parse_unified_diff` returned `[]` and the run empty-fell-back to "no output produced". Turn-splitting fixes this for free.
- `_DIFF_BODY_LINE_RE` did not recognise git's extended header (`rename from/to`, `similarity index`, `new/deleted file mode`, binary), so the first such line ended body mode and the `index`/`---`/`+++` lines after it leaked into the prose the verb matcher reads. A patch containing `rename to improve.py` overrode a user's explicit "review this" and routed to improve; a `?` in a leaked path routed to ask.

## Approach

Blob detection is deliberately conservative: the text must **both** open with a role label and carry at least two. Otherwise it is treated as one segment and behaves exactly as before. Verb resolves from the latest **user** turn by position in the text; agent turns are never consulted for intent. Context (diff or URL) comes from the newest turn supplying one, agent turns **included** — a coding agent may be the party that produced the patch.

Two details were taken from the running reference agent rather than assumed: turn content is multi-line, so only the first line of a turn carries a label; and labels are `user`/`agent`, not `user`/`assistant`. Matching only `assistant` would have been a no-op in production.

Negation is handled adjacently (negator within two words of the verb). Wider handling is intent classification and does not belong in a regex router. Guarded against false positives: `there is no bug, review this` and `i do not have time, review this` both still route to review.

## Verification

1485 → **1533 passed**, 1 skipped, 1 xfailed. 48 tests added, no existing test modified.

Live A/B ran against the deployed stack with only `dispatch.py` bind-mounted, after confirming the image's copy was byte-identical to `main`.

## Deliberately not fixed

Multiple fenced diffs in a *single* turn (last wins); prose immediately after a raw patch that begins with a markdown bullet, which is indistinguishable from a deletion line; non-adjacent negation. The `/improve` HTML-table and `diff_provider` capability issues are separate and out of scope here.
