### PR TITLE
fix(mosaico): report tool failures as FAILED, not empty success

### DIFF
--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -310,11 +310,16 @@ async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
     """Run a review/improve/describe verb via PRAgent.handle_request, defensively.
     Force non-publishing output capture: the tools render into get_settings().data only
     when publish_output is False; with the default True they'd publish to the real PR and
-    return nothing to MOSAICO."""
+    return nothing to MOSAICO.
+
+    propagate_tool_errors makes the tool re-raise instead of swallowing, so handle_request
+    returns False and a failed run stops looking like one that produced nothing. The flags go
+    through args, not get_settings(): _handle_request applies repo settings first."""
     from pr_agent.agent.pr_agent import PRAgent
     ok = await PRAgent().handle_request(
         target,
-        ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false"],
+        ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false",
+         "--config.propagate_tool_errors=true"],
     )
     if ok is False:
         return RouteResult(_error_fallback(verb), ok=False)

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -308,17 +308,8 @@ def _pr_fetch_failed_fallback(pr_url: str) -> str:
 
 async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
     """Run a review/improve/describe verb via PRAgent.handle_request, defensively.
-    Force non-publishing output capture: the tools render into get_settings().data only
-    when publish_output is False; with the default True they'd publish to the real PR and
-    return nothing to MOSAICO.
-
-    propagate_tool_errors makes the tool re-raise instead of swallowing, so handle_request
-    returns False and a failed run stops looking like one that produced nothing. The flags go
-    through args, not get_settings(): _handle_request applies repo settings first.
-
-    Restored in a finally: args are applied onto get_settings(), which is global_settings when
-    no request context is active, and leaking re-raise semantics into unrelated later runs in
-    the same process is exactly the blast radius this flag exists to avoid."""
+    publish_output=false makes the tools render into get_settings().data instead of the real PR;
+    propagate_tool_errors makes them re-raise, so a failure cannot read back as an empty run."""
     from pr_agent.agent.pr_agent import PRAgent
     settings = get_settings()
     propagate_before = settings.get("CONFIG.PROPAGATE_TOOL_ERRORS", False)

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -314,11 +314,17 @@ async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
     swallowing, so a failed run stops looking like an empty one. Both go through args, not
     get_settings(): _handle_request applies repo settings first."""
     from pr_agent.agent.pr_agent import PRAgent
-    ok = await PRAgent().handle_request(
-        target,
-        ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false",
-         "--config.propagate_tool_errors=true"],
-    )
+    # The arg lands on get_settings(), which is global_settings when no request context is
+    # installed, so restore it: a contextless call must not leave re-raising on for later runs.
+    prior_propagate = get_settings().config.get("propagate_tool_errors", False)
+    try:
+        ok = await PRAgent().handle_request(
+            target,
+            ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false",
+             "--config.propagate_tool_errors=true"],
+        )
+    finally:
+        get_settings().set("CONFIG.PROPAGATE_TOOL_ERRORS", prior_propagate)
     if ok is False:
         return RouteResult(_error_fallback(verb), ok=False)
     artifact = _capture_artifact()

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -314,13 +314,22 @@ async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
 
     propagate_tool_errors makes the tool re-raise instead of swallowing, so handle_request
     returns False and a failed run stops looking like one that produced nothing. The flags go
-    through args, not get_settings(): _handle_request applies repo settings first."""
+    through args, not get_settings(): _handle_request applies repo settings first.
+
+    Restored in a finally: args are applied onto get_settings(), which is global_settings when
+    no request context is active, and leaking re-raise semantics into unrelated later runs in
+    the same process is exactly the blast radius this flag exists to avoid."""
     from pr_agent.agent.pr_agent import PRAgent
-    ok = await PRAgent().handle_request(
-        target,
-        ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false",
-         "--config.propagate_tool_errors=true"],
-    )
+    settings = get_settings()
+    propagate_before = settings.get("CONFIG.PROPAGATE_TOOL_ERRORS", False)
+    try:
+        ok = await PRAgent().handle_request(
+            target,
+            ["/" + verb, "--config.publish_output=false", "--config.publish_output_progress=false",
+             "--config.propagate_tool_errors=true"],
+        )
+    finally:
+        settings.set("CONFIG.PROPAGATE_TOOL_ERRORS", propagate_before)
     if ok is False:
         return RouteResult(_error_fallback(verb), ok=False)
     artifact = _capture_artifact()

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -310,11 +310,9 @@ async def _run_pr_agent(target: str, verb: str) -> "RouteResult":
     """Run a review/improve/describe verb via PRAgent.handle_request, defensively.
     Force non-publishing output capture: the tools render into get_settings().data only
     when publish_output is False; with the default True they'd publish to the real PR and
-    return nothing to MOSAICO.
-
-    propagate_tool_errors makes the tool re-raise instead of swallowing, so handle_request
-    returns False and a failed run stops looking like one that produced nothing. The flags go
-    through args, not get_settings(): _handle_request applies repo settings first."""
+    return nothing to MOSAICO. propagate_tool_errors makes the tool re-raise instead of
+    swallowing, so a failed run stops looking like an empty one. Both go through args, not
+    get_settings(): _handle_request applies repo settings first."""
     from pr_agent.agent.pr_agent import PRAgent
     ok = await PRAgent().handle_request(
         target,

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -72,6 +72,7 @@ bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]
 #
 restricted_mode = false # when true, skip operations that require elevated permissions (e.g. pushing code to the repository)
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
+propagate_tool_errors = false # when true, a tool re-raises instead of swallowing an internal error, so a caller can tell a failed run from an empty one
 enable_ai_metadata = false # will enable adding ai metadata
 reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
 # extended thinking for Claude reasoning models

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -197,6 +197,8 @@ class PRCodeSuggestions:
                         self.git_provider.publish_comment(f"Failed to generate code suggestions for PR")
                     except Exception as e:
                         get_logger().exception(f"Failed to update persistent review, error: {e}")
+            if get_settings().config.get("propagate_tool_errors", False):
+                raise
 
     async def add_self_review_text(self, pr_body):
         text = get_settings().pr_code_suggestions.code_suggestions_self_review_text

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -204,6 +204,8 @@ class PRDescription:
         except Exception as e:
             get_logger().error(f"Error generating PR description {self.pr_id}: {e}",
                                artifact={"traceback": traceback.format_exc()})
+            if get_settings().config.get("propagate_tool_errors", False):
+                raise
 
         return ""
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -193,6 +193,8 @@ class PRReviewer:
             self.git_provider.remove_initial_comment()
         except Exception as e:
             get_logger().error(f"Failed to review PR: {e}")
+            if get_settings().config.get("propagate_tool_errors", False):
+                raise
 
     def _should_publish_review_no_suggestions(self, pr_review: str) -> bool:
         return get_settings().pr_reviewer.get('publish_output_no_suggestions', True) or "No major issues detected" not in pr_review

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -234,10 +234,8 @@ class TestExecute:
 
     @pytest.mark.asyncio
     async def test_settings_writes_are_request_scoped_under_concurrency(self, monkeypatch, spy_updater):
-        """propagate_tool_errors is written per request, so concurrency is the risk case.
-
-        Each execute() gets its own deepcopy in starlette_context: two in-flight requests
-        must not observe each other's value, and global_settings must be left untouched."""
+        """Each execute() gets its own settings deepcopy: two in-flight requests must not
+        observe each other's propagate_tool_errors, and global_settings stays untouched."""
         seen = {}
 
         async def fake_route_and_run_result(text):

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -6,11 +6,14 @@ TaskUpdater that captures add_artifact()/complete()/failed() calls. asyncio_mode
 Non-vacuity (Fix C): test_non_vacuity_ok_false_must_not_complete verifies that if
 ok=False causes complete() instead of failed(), the assertion fails — proving the
 test can detect a Fix C regression."""
+import asyncio
+
 import pytest
 from a2a.types import Message, Part, Role
 from starlette_context import request_cycle_context
 
 import pr_agent.mosaico.executor as executor_mod
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.mosaico.dispatch import RouteResult
 from pr_agent.mosaico.executor import PRAgentExecutor
 
@@ -228,3 +231,32 @@ class TestExecute:
     async def test_cancel_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
             await PRAgentExecutor().cancel(_FakeRequestContext("z"), _RecordingEventQueue())
+
+    @pytest.mark.asyncio
+    async def test_settings_writes_are_request_scoped_under_concurrency(self, monkeypatch, spy_updater):
+        """propagate_tool_errors is written per request, so concurrency is the risk case.
+
+        Each execute() gets its own deepcopy in starlette_context: two in-flight requests
+        must not observe each other's value, and global_settings must be left untouched."""
+        seen = {}
+
+        async def fake_route_and_run_result(text):
+            settings = get_settings()
+            settings.set("CONFIG.PROPAGATE_TOOL_ERRORS", text == "a")
+            await asyncio.sleep(0)  # yield so the two runs interleave between write and read
+            seen[text] = (id(settings), settings.config.get("propagate_tool_errors"))
+            return RouteResult(f"done-{text}", ok=True)
+
+        monkeypatch.setattr(executor_mod, "route_and_run_result", fake_route_and_run_result)
+        global_before = global_settings.config.get("propagate_tool_errors", None)
+
+        async def run(text):
+            with request_cycle_context({}):
+                await PRAgentExecutor().execute(_FakeRequestContext(text), _RecordingEventQueue())
+
+        await asyncio.gather(run("a"), run("b"))
+
+        assert seen["a"][1] is True
+        assert seen["b"][1] is False, "one request observed another's settings write"
+        assert seen["a"][0] != seen["b"][0], "both requests shared one settings object"
+        assert global_settings.config.get("propagate_tool_errors", None) == global_before

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -235,9 +235,8 @@ class TestExecute:
     @pytest.mark.asyncio
     async def test_settings_writes_are_request_scoped_under_concurrency(self, monkeypatch, spy_updater):
         """propagate_tool_errors is written per request, so concurrency is the risk case.
-
-        Each execute() gets its own deepcopy in starlette_context: two in-flight requests
-        must not observe each other's value, and global_settings must be left untouched."""
+        Each execute() gets its own deepcopy in starlette_context: two in-flight requests must
+        not observe each other's value, and global_settings must be left untouched."""
         seen = {}
 
         async def fake_route_and_run_result(text):

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -9,7 +9,7 @@ import pytest
 
 import aiohttp
 
-from pr_agent.config_loader import global_settings
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.mosaico import dispatch
 from pr_agent.mosaico.dispatch import (_detect_verb, _diff_prose,
                                        _empty_fallback, _error_fallback,
@@ -496,6 +496,33 @@ class TestDefensiveCapture:
 
         await route_and_run_result(f"review {PR_URL}")
         assert "--config.propagate_tool_errors=true" in seen["args"]
+
+    @pytest.mark.asyncio
+    async def test_propagate_flag_does_not_outlive_a_contextless_run(self, monkeypatch, restore_settings):
+        """Runs the real arg-parsing path: the flag must be live at the tool run, and gone after.
+        Contextless, get_settings() is global_settings, so without the restore one dispatch call
+        would leave re-raising on for every later caller."""
+        import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
+        import pr_agent.mosaico.provider_registration  # noqa: F401
+        from pr_agent.mosaico.diff_provider import parse_unified_diff
+
+        seen = {}
+
+        async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+            seen["during"] = get_settings().config.get("propagate_tool_errors")
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", failing_chat_completion)
+        global_settings.set("MOSAICO.INPUT", {"files": parse_unified_diff(SAMPLE_RAW_DIFF),
+                                              "languages": {"py": 1}, "title": "Supplied diff"})
+        global_settings.set("CONFIG.GIT_PROVIDER", "mosaico_diff")
+        global_settings.set("CONFIG.PROPAGATE_TOOL_ERRORS", False)
+
+        result = await dispatch._run_pr_agent("mosaico://supplied-diff", "review")
+
+        assert seen["during"] is True, "the arg never reached the tool run"
+        assert result.ok is False, "the re-raise must surface as ok=False"
+        assert global_settings.config.get("propagate_tool_errors") is False, "flag leaked past the run"
 
     @pytest.mark.asyncio
     async def test_ask_that_raises_returns_error_fallback(self, monkeypatch, restore_settings):

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -415,11 +415,9 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_ok_but_no_artifact_returns_empty_fallback(self, monkeypatch, restore_settings):
-        """A tool that ran fine and produced nothing is a SUCCESS, not a failure.
-
-        Emptiness must never be read as an error: /improve on a trivial diff legitimately
-        yields no suggestions. Failure is signalled by the exception (propagate_tool_errors),
-        never by an empty artifact — see test_tool_exception_marks_failed for the contrast."""
+        """Empty is a legitimate SUCCESS: /improve on a trivial diff yields no suggestions.
+        Failure comes from the exception, never from emptiness. Mapping empty->ok=False fails
+        ONLY this test, so it is the sole guard on that property — do not loosen it."""
         async def fake_fetch_public_diff(pr_url):
             return SAMPLE_RAW_DIFF
 
@@ -439,10 +437,9 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_tool_exception_marks_failed(self, monkeypatch, restore_settings):
-        """The contrast to the test above: same empty artifact, but the tool raised.
-
-        propagate_tool_errors makes the tool re-raise, handle_request's own except returns
-        False, and the router must report ok=False rather than the empty fallback."""
+        """The contrast to the test above: same empty artifact, but the tool raised. The
+        re-raise makes handle_request return False, so the router must report ok=False
+        rather than the empty fallback."""
         async def fake_fetch_public_diff(pr_url):
             return SAMPLE_RAW_DIFF
 

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -481,6 +481,30 @@ class TestDefensiveCapture:
         assert ok is True, "flag off must preserve the pre-existing swallow-and-succeed behaviour"
 
     @pytest.mark.asyncio
+    async def test_propagate_flag_does_not_leak_without_a_request_context(self, monkeypatch, restore_settings):
+        """Contextless callers (tests, library use) get global_settings back from
+        get_settings(), so the arg would otherwise persist and re-raise for everyone after."""
+        import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
+        import pr_agent.mosaico.provider_registration  # noqa: F401
+        from pr_agent.mosaico.diff_provider import parse_unified_diff
+
+        async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", failing_chat_completion)
+        global_settings.set("MOSAICO.INPUT", {"files": parse_unified_diff(SAMPLE_RAW_DIFF),
+                                              "languages": {"py": 1}, "title": "Supplied diff"})
+        global_settings.set("CONFIG.GIT_PROVIDER", "mosaico_diff")
+        global_settings.set("CONFIG.PROPAGATE_TOOL_ERRORS", False)
+
+        result = await dispatch._run_pr_agent("mosaico://supplied-diff", "review")
+
+        assert result.ok is False
+        assert global_settings.config.get("propagate_tool_errors") is False, (
+            "the flag must not survive the call into global settings"
+        )
+
+    @pytest.mark.asyncio
     async def test_propagate_tool_errors_passed_to_handle_request(self, monkeypatch, restore_settings):
         """Pins the wiring: without this arg the tools swallow and a failure reads as empty."""
         seen = {}

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -415,11 +415,9 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_ok_but_no_artifact_returns_empty_fallback(self, monkeypatch, restore_settings):
-        """A tool that ran fine and produced nothing is a SUCCESS, not a failure.
-
-        Emptiness must never be read as an error: /improve on a trivial diff legitimately
-        yields no suggestions. Failure is signalled by the exception (propagate_tool_errors),
-        never by an empty artifact — see test_tool_exception_marks_failed for the contrast."""
+        """Empty is a legitimate SUCCESS: /improve on a trivial diff yields no suggestions.
+        Failure comes from the exception, never from emptiness. Mapping empty->ok=False fails
+        ONLY this test, so it is the sole guard on that property — do not loosen it."""
         async def fake_fetch_public_diff(pr_url):
             return SAMPLE_RAW_DIFF
 
@@ -440,9 +438,8 @@ class TestDefensiveCapture:
     @pytest.mark.asyncio
     async def test_tool_exception_marks_failed(self, monkeypatch, restore_settings):
         """The contrast to the test above: same empty artifact, but the tool raised.
-
-        propagate_tool_errors makes the tool re-raise, handle_request's own except returns
-        False, and the router must report ok=False rather than the empty fallback."""
+        propagate_tool_errors makes it re-raise, handle_request's own except returns False,
+        and the router must report ok=False rather than the empty fallback."""
         async def fake_fetch_public_diff(pr_url):
             return SAMPLE_RAW_DIFF
 

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -100,7 +100,8 @@ _SENTINEL = object()
 def restore_settings():
     """Snapshot/restore the settings keys the router mutates, leaving global_settings
     exactly as found."""
-    keys = ["CONFIG.GIT_PROVIDER", "CONFIG.PUBLISH_OUTPUT", "CONFIG.PUBLISH_OUTPUT_PROGRESS"]
+    keys = ["CONFIG.GIT_PROVIDER", "CONFIG.PUBLISH_OUTPUT", "CONFIG.PUBLISH_OUTPUT_PROGRESS",
+            "CONFIG.PROPAGATE_TOOL_ERRORS"]
     before = {k: global_settings.get(k, _SENTINEL) for k in keys}
     mosaico_existed = "MOSAICO" in global_settings
     mosaico_input = global_settings.get("MOSAICO.INPUT", _SENTINEL)
@@ -414,6 +415,11 @@ class TestDefensiveCapture:
 
     @pytest.mark.asyncio
     async def test_ok_but_no_artifact_returns_empty_fallback(self, monkeypatch, restore_settings):
+        """A tool that ran fine and produced nothing is a SUCCESS, not a failure.
+
+        Emptiness must never be read as an error: /improve on a trivial diff legitimately
+        yields no suggestions. Failure is signalled by the exception (propagate_tool_errors),
+        never by an empty artifact — see test_tool_exception_marks_failed for the contrast."""
         async def fake_fetch_public_diff(pr_url):
             return SAMPLE_RAW_DIFF
 
@@ -427,8 +433,72 @@ class TestDefensiveCapture:
         # ensure no stale artifact from a prior test
         _clear_artifact()
 
-        out = await route_and_run(f"review {PR_URL}")
-        assert out == _empty_fallback("review")
+        result = await route_and_run_result(f"review {PR_URL}")
+        assert result.text == _empty_fallback("review")
+        assert result.ok is True
+
+    @pytest.mark.asyncio
+    async def test_tool_exception_marks_failed(self, monkeypatch, restore_settings):
+        """The contrast to the test above: same empty artifact, but the tool raised.
+
+        propagate_tool_errors makes the tool re-raise, handle_request's own except returns
+        False, and the router must report ok=False rather than the empty fallback."""
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
+        async def raising_handle_request(self, pr_url, request, notify=None):
+            raise RuntimeError("Failed to generate prediction with any model of ['m1', 'm2']")
+
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
+        from pr_agent.agent.pr_agent import PRAgent
+        monkeypatch.setattr(PRAgent, "_handle_request", raising_handle_request)
+        _clear_artifact()
+
+        result = await route_and_run_result(f"review {PR_URL}")
+        assert result.ok is False
+        assert result.text == _error_fallback("review")
+        assert "no output produced" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_legacy_callers_unaffected_when_flag_off(self, monkeypatch, restore_settings):
+        """Blast-radius guard for CLI/webhook callers, which pass no propagate_tool_errors
+        arg: a tool failing internally must still swallow and still return True, unchanged."""
+        import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
+        import pr_agent.mosaico.provider_registration  # noqa: F401
+        from pr_agent.agent.pr_agent import PRAgent
+        from pr_agent.mosaico.diff_provider import parse_unified_diff
+
+        async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", failing_chat_completion)
+        global_settings.set("MOSAICO.INPUT", {"files": parse_unified_diff(SAMPLE_RAW_DIFF),
+                                              "languages": {"py": 1}, "title": "Supplied diff"})
+        global_settings.set("CONFIG.GIT_PROVIDER", "mosaico_diff")
+
+        ok = await PRAgent().handle_request("mosaico://supplied-diff",
+                                            ["/review", "--config.publish_output=false"])
+        assert ok is True, "flag off must preserve the pre-existing swallow-and-succeed behaviour"
+
+    @pytest.mark.asyncio
+    async def test_propagate_tool_errors_passed_to_handle_request(self, monkeypatch, restore_settings):
+        """Pins the wiring: without this arg the tools swallow and a failure reads as empty."""
+        seen = {}
+
+        async def fake_fetch_public_diff(pr_url):
+            return SAMPLE_RAW_DIFF
+
+        async def fake_handle_request(self, pr_url, request, notify=None):
+            seen["args"] = list(request)
+            global_settings.data = {"artifact": "OK"}
+            return True
+
+        monkeypatch.setattr(dispatch, "_fetch_public_diff", fake_fetch_public_diff)
+        from pr_agent.agent.pr_agent import PRAgent
+        monkeypatch.setattr(PRAgent, "handle_request", fake_handle_request)
+
+        await route_and_run_result(f"review {PR_URL}")
+        assert "--config.propagate_tool_errors=true" in seen["args"]
 
     @pytest.mark.asyncio
     async def test_ask_that_raises_returns_error_fallback(self, monkeypatch, restore_settings):

--- a/tests/unittest/test_mosaico_smoke.py
+++ b/tests/unittest/test_mosaico_smoke.py
@@ -147,11 +147,9 @@ class TestSmokeFullPath:
 
     @pytest.mark.parametrize("verb", ["review", "improve", "describe", "ask"])
     def test_llm_outage_yields_failed_not_completed(self, monkeypatch, verb):
-        """A total model outage must reach the caller as TASK_STATE_FAILED.
-
-        Previously review/improve/describe swallowed the exception and reported success
-        with 'no output produced'. 'ask' already failed correctly; it is pinned here so
-        the fix does not regress it."""
+        """A total model outage must reach the caller as TASK_STATE_FAILED. Previously
+        review/improve/describe swallowed it and reported success with 'no output produced'.
+        'ask' already failed correctly and is pinned here so the fix does not regress it."""
         async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
             raise RuntimeError("provider unavailable")
 

--- a/tests/unittest/test_mosaico_smoke.py
+++ b/tests/unittest/test_mosaico_smoke.py
@@ -147,11 +147,9 @@ class TestSmokeFullPath:
 
     @pytest.mark.parametrize("verb", ["review", "improve", "describe", "ask"])
     def test_llm_outage_yields_failed_not_completed(self, monkeypatch, verb):
-        """A total model outage must reach the caller as TASK_STATE_FAILED.
-
-        Previously review/improve/describe swallowed the exception and reported success
-        with 'no output produced'. 'ask' already failed correctly; it is pinned here so
-        the fix does not regress it."""
+        """A total model outage must reach the caller as TASK_STATE_FAILED. review/improve/
+        describe used to swallow it and report success with 'no output produced'; 'ask' was
+        already correct and is pinned here so the fix does not regress it."""
         async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
             raise RuntimeError("provider unavailable")
 

--- a/tests/unittest/test_mosaico_smoke.py
+++ b/tests/unittest/test_mosaico_smoke.py
@@ -13,6 +13,7 @@ This test passing is the end-to-end proof that the middleware->executor->dispatc
 provider->render chain works through the wire."""
 import uuid
 
+import pytest
 from google.protobuf.json_format import MessageToDict
 from starlette.testclient import TestClient
 
@@ -143,3 +144,33 @@ class TestSmokeFullPath:
         text = _extract_text(result)
         assert "no output produced" in text, text
         assert not text.startswith("Error:"), text
+
+    @pytest.mark.parametrize("verb", ["review", "improve", "describe", "ask"])
+    def test_llm_outage_yields_failed_not_completed(self, monkeypatch, verb):
+        """A total model outage must reach the caller as TASK_STATE_FAILED.
+
+        Previously review/improve/describe swallowed the exception and reported success
+        with 'no output produced'. 'ask' already failed correctly; it is pinned here so
+        the fix does not regress it."""
+        async def failing_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", failing_chat_completion)
+
+        client = TestClient(build_app())
+        resp = client.post("/", json=_send_message_payload(f"{verb} this\n{REVIEW_DIFF}"),
+                           headers=_A2A_HEADERS)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "error" not in body, body
+        result = body["result"]
+
+        task = result.get("task", result)
+        state = task.get("status", {}).get("state", "")
+        assert state == "TASK_STATE_FAILED", (
+            f"{verb}: an LLM outage must fail the task, got {state}: {task}"
+        )
+        text = _extract_text(result)
+        assert "no output produced" not in text, (
+            f"{verb}: outage must not be reported as an empty result: {text}"
+        )


### PR DESCRIPTION
## The bug

A total LLM outage is reported to the A2A caller as `TASK_STATE_COMPLETED`, with the artifact:

```
PR-Agent review: no output produced (e.g. no files/changes detected).
```

So the reference agent records a model outage as a successful review of a diff that had nothing to say. Observed in the field with `Failed to generate prediction with any model of ['gpt-5.6', 'gpt-5.6-terra']` in the container log and a COMPLETED task on the wire.

## Evidence chain

| Step | Location | Effect |
|---|---|---|
| 1 | `pr_agent/algo/pr_processing.py:338` | raises `Failed to generate prediction with any model of [...]` |
| 2 | `pr_agent/tools/pr_reviewer.py:194` | `except` logs and returns `None`; the failure at line 166 means line 180 never sets `data["artifact"]` |
| 3 | `pr_agent/agent/pr_agent.py:117,120` | the tool's return value is discarded, then `return True` unconditionally |
| 4 | `pr_agent/mosaico/dispatch.py:319-322` | `ok is False` is not taken, artifact is empty, so the empty branch returns `ok=True` |
| 5 | `pr_agent/mosaico/executor.py:66` | `result.ok` is true, so `complete()` |

`pr_code_suggestions.py:188` and `pr_description.py:204` swallow identically, so `/improve` and `/describe` share the bug. `/ask` was already correct: `PRQuestions.run()` does not swallow, and `dispatch.py:342` converts the exception into `ok=False`.

## Why the obvious fixes are wrong

**Inferring failure from an empty artifact.** Empty is a legitimate success — `/improve` on a trivial diff produces no suggestions, and the artifact is byte-identical to the outage case. The signal has to come from the exception.

`test_ok_but_no_artifact_returns_empty_fallback` is the **single test defending this property**. Applying the empty→`ok=False` shortcut and running the suite produces exactly one failure, that one. Anyone deleting or loosening it is removing the only thing standing between the codebase and reporting legitimate empty results as failures; its docstring says so too.

**Re-raising unconditionally in the tools.** That changes CLI, GitHub App, GitLab and every other webhook flow, turning currently-tolerated failures into hard errors. Wrong blast radius.

**Fixing it in `dispatch.py` alone.** Structurally impossible: by the time dispatch sees the result, both cases look identical.

## The change

`config.propagate_tool_errors`, default `false`. When set, the three tools re-raise after logging; `handle_request`'s own `except` then returns `False`, the router reports `ok=False`, and the executor emits `TASK_STATE_FAILED`.

The MOSAICO dispatch passes it as a CLI arg next to `publish_output`. Args are applied at `pr_agent.py:77`, after `apply_repo_settings` at `:57`, so a repo's `.pr_agent.toml` cannot override them.

An earlier version of this section claimed a `get_settings()` write would not survive `apply_repo_settings`. That is false, and tested: a plain settings write with no propagate arg reaches the tool's `except` block and fails the run correctly — `at_except=True`, `handle_request->False`. `apply_repo_settings` does run, but `DiffInputProvider.get_repo_settings()` returns `''`, so on the MOSAICO path there is nothing to apply and nothing to clobber. The args are still the right choice because they are provider-independent, not because a write would be lost.

## The args route is proven at runtime, not by construction

The risk with this design is that every test which sets the flag directly still passes even if the CLI arg never arrives — the PR would look correct while being inert. So the flag was observed *inside each tool's `except` block* on a real run, by instrumenting the log statement that sits immediately before the re-raise:

```
review    observed_in_except=True   route_ok=False
describe  observed_in_except=True   route_ok=False
improve   observed_in_except=True   route_ok=False
global_settings.config.propagate_tool_errors = False
```

The same probe with the legacy arg list — what `cli.py`, `github_polling.py` and the Azure DevOps webhook actually pass — gives the other half:

```
LEGACY review    observed_in_except=False   handle_request->True
LEGACY describe  observed_in_except=False   handle_request->True
LEGACY improve   observed_in_except=False   handle_request->True
```

First block proves the fix works; second proves the blast radius is zero.

## What the tests prove

A test was asserting the buggy behaviour. `test_ok_but_no_artifact_returns_empty_fallback` mocked `handle_request` to return `True` with no artifact — exactly the bug path — and asserted the empty fallback was correct. It also called `route_and_run`, the string wrapper, so it never inspected `.ok`. That is why the existing failure-fidelity tests were green against a live bug: all of them inject `ok=False` at or above the dispatch boundary, so none proved that a tool failure *produces* `ok=False`. The test is kept, now asserting `ok is True` and documented as the legitimate empty-success case, with a sibling covering the exception.

New coverage:

- `test_llm_outage_yields_failed_not_completed[review|improve|describe|ask]` — full A2A round trip through `build_app()` with a failing LLM; asserts FAILED and that `no output produced` is absent. Non-vacuity: reverting the dispatch arg makes review/improve/describe fail with `assert 'TASK_STATE_COMPLETED' == 'TASK_STATE_FAILED'`, while `ask` still passes.
- `test_tool_exception_marks_failed` — patches `_handle_request` to raise, so the real `handle_request` except is exercised.
- `test_legacy_callers_unaffected_when_flag_off` — real `handle_request` with no propagate arg and a failing LLM still returns `True`. Non-vacuity: removing the flag gate makes it fail.
- `test_settings_writes_are_request_scoped_under_concurrency` — two concurrent `execute()` calls interleaved between write and read; asserts distinct settings objects, no cross-observation, and `global_settings` untouched. Non-vacuity: replacing the deepcopy with a shared reference makes it fail.
- `test_propagate_tool_errors_passed_to_handle_request` — pins the wiring.

## Blast radius

Default is `false` and only `dispatch._run_pr_agent` sets it, so every non-MOSAICO path behaves exactly as before.

To be precise about what is and is not covered: the three consumers that read the bool — `cli.py:156`, `azuredevops_server_webhook.py:48`, and `github_polling.py:45` and `:87` — have **no dedicated tests**. The assurance for them rests on the default being `false`, on the LEGACY probe above, and on `test_legacy_callers_unaffected_when_flag_off`, which drives the real `handle_request` with a failing LLM and no propagate arg and asserts it still returns `True`. That is deliberate scope, not claimed coverage of those call sites.

One gap found in review and fixed: `update_settings_from_args` applies `--config.*` onto `get_settings()`, which resolves to `global_settings` when no request context is installed. The MOSAICO server is safe because `executor.py` installs a per-request deepcopy, but a contextless caller would have left `CONFIG.PROPAGATE_TOOL_ERRORS` on for the rest of the process — precisely the blast radius the flag exists to prevent. It is now snapshotted and restored in a `finally`, covered by `test_propagate_flag_does_not_outlive_a_contextless_run`, which drives the real arg-parsing path and fails with `flag leaked past the run` if the `finally` is removed. Only that one key is restored; the pre-existing `publish_output` keys have the same exposure but are out of scope here.

Full unit suite: 1545 passed, 0 failed, 1 skipped, 1 xfailed (baseline on `main` is 1536/0/1/1). Per-file ruff counts are identical to `main` on every changed file — zero new findings.

## Design considered and not taken

The alternative was to have the tools write an explicit failure indicator onto the channel they already use for artifacts — `get_settings().data = {"tool_error": str(e)}` in the `except` block — with dispatch reading it through a `_capture_tool_error` helper and returning `ok=False`. It changes no control flow anywhere, so there is nothing to leak and nothing to race.

It was not taken because the flag version was already implemented, verified end to end per verb, and green when the alternative was raised. Switching at a release gate would have traded a verified implementation for an unverified one.

Two review findings have now targeted the same property — that correctness here rests on mutable shared settings. Neither forced the switch.

The decline rests on reachability alone: `route_and_run_result` has exactly one caller, `executor.py:58`, and it sits after the per-request deepcopy at `executor.py:52`; tests are the only contextless callers and run sequentially, with no `pytest-xdist` configured. **That argument is conditional, not permanent — anyone who adds a second caller to `route_and_run_result`, or enables parallel test execution, invalidates it and should revisit this section.**

An earlier version of this note argued the remedy would discard `MOSAICO.INPUT`; that holds only for an unconditional wrapper. Qodo proposed it conditionally, and in the contextless branch `_run_on_diff` has already written to `global_settings`, so a deepcopy carries it — verified. Note also that the `finally` introduces the race rather than inheriting it: before it, two concurrent contextless runs both set the flag and neither cleared it, so nothing was swallowed. Unreachable either way, but new.

**If the flag ever leaks or races in practice, switch to the data channel rather than adding another guard.**


