### PR TITLE
fix(mosaico): open a headerless diff on its '---'/'+++' file headers

### DIFF
--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -182,10 +182,9 @@ def _diff_prose(text: str) -> str:
     punctuation inside the patch body ('?' in a ternary/regex/comment) does not flip the
     default 'review' into 'ask'. A genuine question in the surrounding prose (e.g.
     'what changed here?') is preserved."""
-    # Drop a fenced ```diff ... ``` block entirely.
-    without_fence = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
-    if without_fence != text:
-        return without_fence
+    # Drop a fenced ```diff ... ``` block entirely, then scan what is left: a file header
+    # sitting OUTSIDE the fence would otherwise never be excised.
+    text = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
     kept, in_diff = [], False
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -45,7 +45,10 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
-_DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
+# '--- '/'+++ ' open a headerless diff (no 'diff --git'), whose file headers would
+# otherwise survive into the prose and let a filename pick the verb. The trailing space
+# is load-bearing: it is what keeps a markdown rule or setext underline ('---') out.
+_DIFF_START_RE = re.compile(r"^(?:diff --git |@@ |--- |\+\+\+ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
     r"|(?:old|new) mode \d|(?:new|deleted) file mode \d"

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -45,10 +45,13 @@ _DIFF_FENCE_RE = re.compile(r"```\s*diff", re.IGNORECASE)
 _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
-# '--- '/'+++ ' open a headerless diff (no 'diff --git'), whose file headers would
-# otherwise survive into the prose and let a filename pick the verb. The trailing space
+_DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
+# A headerless diff (no 'diff --git') would otherwise let its '--- '/'+++ ' file headers
+# survive into the prose and pick the verb. These are dropped on sight but deliberately do
+# NOT open diff mode: only the structural openers above do. Were they to open it, a request
+# on the next line starting '+'/'-'/a space would be eaten as diff body. The trailing space
 # is load-bearing: it is what keeps a markdown rule or setext underline ('---') out.
-_DIFF_START_RE = re.compile(r"^(?:diff --git |@@ |--- |\+\+\+ )")
+_DIFF_FILE_HEADER_RE = re.compile(r"^(?:--- |\+\+\+ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
     r"|(?:old|new) mode \d|(?:new|deleted) file mode \d"
@@ -189,6 +192,8 @@ def _diff_prose(text: str) -> str:
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):
             in_diff = True
+            continue
+        if _DIFF_FILE_HEADER_RE.match(line):
             continue
         if in_diff:
             if _DIFF_BODY_LINE_RE.match(line):

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -46,11 +46,9 @@ _DIFF_HEADER_RE = re.compile(r"^diff --git ", re.MULTILINE)
 _UNIFIED_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
 _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
-# A headerless diff (no 'diff --git') would otherwise let its '--- '/'+++ ' file headers
-# survive into the prose and pick the verb. These are dropped on sight but deliberately do
-# NOT open diff mode: only the structural openers above do. Were they to open it, a request
-# on the next line starting '+'/'-'/a space would be eaten as diff body. The trailing space
-# is load-bearing: it is what keeps a markdown rule or setext underline ('---') out.
+# Dropped on sight, but must NOT open diff mode: a request on the next line starting
+# '+'/'-'/a space would then be eaten as diff body. The trailing space is load-bearing,
+# keeping a markdown rule or setext underline ('---') out.
 _DIFF_FILE_HEADER_RE = re.compile(r"^(?:--- |\+\+\+ )")
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "

--- a/pr_agent/mosaico/dispatch.py
+++ b/pr_agent/mosaico/dispatch.py
@@ -50,6 +50,16 @@ _DIFF_START_RE = re.compile(r"^(?:diff --git |@@ )")
 # '+'/'-'/a space would then be eaten as diff body. The trailing space is load-bearing,
 # keeping a markdown rule or setext underline ('---') out.
 _DIFF_FILE_HEADER_RE = re.compile(r"^(?:--- |\+\+\+ )")
+# Metadata that follows a file header. Only consulted right after one, because a headerless
+# diff never opens diff mode and 'Binary files improve.py ... differ' would otherwise leak
+# its filename to the verb matcher. Excludes the '[ +\-\\]|$' arms below: those match
+# ordinary prose and may only be dropped once a hunk has actually opened the body.
+_DIFF_META_LINE_RE = re.compile(
+    r"^(?:index [0-9a-fA-F]"
+    r"|(?:old|new) mode \d|(?:new|deleted) file mode \d"
+    r"|(?:similarity|dissimilarity) index \d|rename (?:from|to) |copy (?:from|to) "
+    r"|Binary files .*differ$|GIT binary patch$)"
+)
 _DIFF_BODY_LINE_RE = re.compile(
     r"^(?:diff --git |index [0-9a-fA-F]|--- |\+\+\+ |@@ "
     r"|(?:old|new) mode \d|(?:new|deleted) file mode \d"
@@ -186,13 +196,17 @@ def _diff_prose(text: str) -> str:
     # Drop a fenced ```diff ... ``` block entirely, then scan what is left: a file header
     # sitting OUTSIDE the fence would otherwise never be excised.
     text = re.sub(r"```\s*diff\s*\n.*?```", " ", text, flags=re.IGNORECASE | re.DOTALL)
-    kept, in_diff = [], False
+    kept, in_diff, after_header = [], False, False
     for line in text.split("\n"):
         if _DIFF_START_RE.match(line):
-            in_diff = True
+            in_diff, after_header = True, False
             continue
         if _DIFF_FILE_HEADER_RE.match(line):
+            after_header = True
             continue
+        if after_header and _DIFF_META_LINE_RE.match(line):
+            continue
+        after_header = False
         if in_diff:
             if _DIFF_BODY_LINE_RE.match(line):
                 continue

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -989,6 +989,41 @@ class TestHeaderlessDiffNotLeaked:
         assert seen["verb"] == "review"
 
 
+class TestFileHeaderOutsideAFence:
+    """The fence is replaced and the remainder is still scanned, so a file header sitting
+    outside the fence cannot survive to pick the verb."""
+
+    @pytest.mark.parametrize("filename", [
+        "calc.py", "review.py", "reviews.py", "describe.py", "ask.py",
+        "improve.py", "improvements.py", "code_review.md", "IMPROVEMENTS.md",
+    ])
+    def test_filename_outside_a_fence_does_not_pick_the_verb(self, filename):
+        assert _detect_verb(_diff_prose(f"what changed here?\n--- {filename}\n{SAMPLE_DIFF}")) == "ask"
+
+    @pytest.mark.parametrize("trailer", [
+        "now describe it please",
+        "- now describe it please",
+        "  now describe it please",
+        "+1 please describe it",
+    ])
+    def test_prose_after_a_fence_survives(self, trailer):
+        prose = _diff_prose(f"{SAMPLE_DIFF}\n{trailer}")
+        assert trailer.strip() in prose
+        assert _detect_verb(prose) == "describe"
+
+    def test_a_header_before_a_fence_no_longer_overrides_the_request(self):
+        text = f"--- improve.py\n{SAMPLE_DIFF}\nnow describe it please"
+        assert _diff_prose(text).strip() == "now describe it please"
+        assert _detect_verb(_diff_prose(text)) == "describe"
+
+    @pytest.mark.asyncio
+    async def test_the_fenced_diff_is_still_the_content(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(f"what changed here?\n--- improve.py\n{SAMPLE_DIFF}")
+        assert seen["verb"] == "ask"
+        assert seen["files"] == ["foo.py"]
+
+
 class TestNewestContextWins:
     @pytest.mark.asyncio
     async def test_newest_diff_wins(self, monkeypatch, restore_settings):

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -928,6 +928,67 @@ class TestExtendedHeaderNotLeaked:
         assert prose.strip() == "now describe it"
 
 
+class TestHeaderlessDiffNotLeaked:
+    """A diff with no 'diff --git' line: its '--- '/'+++ ' file headers precede the first
+    hunk, so without them opening the diff the FILENAME reaches the verb detector."""
+
+    @staticmethod
+    def _headerless(filename: str) -> str:
+        return (f"what changed here?\n"
+                f"--- {filename}\n"
+                f"+++ {filename}\n"
+                f"@@ -1,2 +1,2 @@\n"
+                f"-x = 1\n"
+                f"+x = 2")
+
+    @pytest.mark.parametrize("filename", [
+        "calc.py", "review.py", "reviews.py", "describe.py", "ask.py",
+        "improve.py", "improvements.py", "code_review.md", "IMPROVEMENTS.md",
+    ])
+    def test_filename_does_not_pick_the_verb(self, filename):
+        assert _detect_verb(_diff_prose(self._headerless(filename))) == "ask"
+
+    def test_headerless_file_headers_are_excised(self):
+        assert _diff_prose(self._headerless("review.py")).strip() == "what changed here?"
+
+    @pytest.mark.parametrize("text, expected", [
+        ("review this diff\n---\nmore context here", "review"),
+        ("improve this diff\n---\nthanks", "improve"),
+        ("review this --- urgently", "review"),
+        ("review this —— urgently", "review"),
+    ])
+    def test_the_trailing_space_keeps_prose_rules_out(self, text, expected):
+        # Pins the trailing space in _DIFF_START_RE: '---' as a markdown rule, a setext
+        # underline, or mid-sentence must never open a diff.
+        assert _diff_prose(text) == text
+        assert _detect_verb(_diff_prose(text)) == expected
+
+    def test_quoted_changelog_bullets_do_not_pick_the_verb(self):
+        text = ("--- v1.2.0 ---\n"
+                "- fixed the review command\n"
+                "- describe now works\n"
+                "please improve this")
+        assert _diff_prose(text).strip() == "please improve this"
+        assert _detect_verb(_diff_prose(text)) == "improve"
+
+    @pytest.mark.asyncio
+    async def test_leaked_filename_no_longer_overrides_the_latest_turn(self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", f"review this\n{RAW_DIFF_BODY}"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", "--- improve.py\nwhat changed?")))
+        assert seen["verb"] == "ask"
+
+    @pytest.mark.asyncio
+    async def test_a_turn_opening_with_a_file_header_does_not_swallow_a_later_turn(
+            self, monkeypatch, restore_settings):
+        seen = _routed(monkeypatch)
+        await route_and_run(_blob(("user", "--- notes.md\n describe this"),
+                                  ("agent", AGENT_REVIEW_OUTPUT),
+                                  ("user", f"now review it\n{RAW_DIFF_BODY}")))
+        assert seen["verb"] == "review"
+
+
 class TestNewestContextWins:
     @pytest.mark.asyncio
     async def test_newest_diff_wins(self, monkeypatch, restore_settings):

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -963,13 +963,27 @@ class TestHeaderlessDiffNotLeaked:
         assert _diff_prose(text) == text
         assert _detect_verb(_diff_prose(text)) == expected
 
-    def test_quoted_changelog_bullets_do_not_pick_the_verb(self):
-        text = ("--- v1.2.0 ---\n"
-                "- fixed the review command\n"
-                "- describe now works\n"
-                "please improve this")
-        assert _diff_prose(text).strip() == "please improve this"
-        assert _detect_verb(_diff_prose(text)) == "improve"
+    @pytest.mark.parametrize("trailer, expected", [
+        ("+1 please describe it", "describe"),
+        ("- please improve the naming", "improve"),
+        ("- what changed here?", "ask"),
+        ("  now describe it please", "describe"),
+    ])
+    def test_a_file_header_does_not_swallow_the_request_after_it(self, trailer, expected):
+        # A file header is dropped on its own line but must not open diff mode: the user's
+        # request on the next line starts with '+'/'-'/a space, which the body pattern eats.
+        assert _detect_verb(_diff_prose(f"--- notes.md\n{trailer}")) == expected
+
+    def test_a_quoted_changelog_keeps_its_prose(self):
+        # '--- v1.2.0 ---' is excised as a file header, but the bullets are the user's own
+        # prose and survive. How that shape then routes is governed by verb selection, not
+        # by prose stripping: it matches the same changelog with no header line at all.
+        bullets = ("- fixed the review command\n"
+                   "- describe now works\n"
+                   "please improve this")
+        prose = _diff_prose(f"--- v1.2.0 ---\n{bullets}")
+        assert prose.strip() == bullets
+        assert _detect_verb(prose) == _detect_verb(_diff_prose(bullets))
 
     @pytest.mark.asyncio
     async def test_leaked_filename_no_longer_overrides_the_latest_turn(self, monkeypatch, restore_settings):
@@ -1010,6 +1024,12 @@ class TestFileHeaderOutsideAFence:
         prose = _diff_prose(f"{SAMPLE_DIFF}\n{trailer}")
         assert trailer.strip() in prose
         assert _detect_verb(prose) == "describe"
+
+    def test_a_header_after_a_fence_does_not_swallow_a_bulleted_request(self):
+        # Both mechanisms at once: the fence is replaced, then a real file header in the
+        # remainder must be dropped without eating the bullet that carries the only verb.
+        text = f"{SAMPLE_DIFF}\n--- notes.md\n- please improve the naming"
+        assert _detect_verb(_diff_prose(text)) == "improve"
 
     def test_a_header_before_a_fence_no_longer_overrides_the_request(self):
         text = f"--- improve.py\n{SAMPLE_DIFF}\nnow describe it please"

--- a/tests/unittest/test_mosaico_router.py
+++ b/tests/unittest/test_mosaico_router.py
@@ -974,6 +974,29 @@ class TestHeaderlessDiffNotLeaked:
         # request on the next line starts with '+'/'-'/a space, which the body pattern eats.
         assert _detect_verb(_diff_prose(f"--- notes.md\n{trailer}")) == expected
 
+    @pytest.mark.parametrize("meta", [
+        "Binary files improve.py and improve.py differ",
+        "old mode 100644\nnew mode 100755",
+        "index 1234567..89abcde 100644",
+        "rename from improve.py\nrename to improved.py",
+    ])
+    def test_metadata_after_a_header_does_not_leak_its_filename(self, meta):
+        # A headerless diff never opens diff mode, so metadata following the file header is
+        # only stripped by the after-header path. '--no-prefix' output is the live case:
+        # 'a/improve.py' cannot match the verb pattern but ' improve.py' can.
+        assert _detect_verb(_diff_prose(f"what changed here?\n--- improve.py\n+++ improve.py\n{meta}")) == "ask"
+
+    @pytest.mark.parametrize("text, expected", [
+        ("index 5 is wrong, please improve it", "improve"),
+        ("Binary files are annoying, please describe this", "describe"),
+        ("rename from foo, then improve it", "improve"),
+    ])
+    def test_metadata_shaped_prose_survives_without_a_header(self, text, expected):
+        # The after-header scope is what protects these: with no file header above them they
+        # are ordinary prose and must keep their verb.
+        assert _diff_prose(text) == text
+        assert _detect_verb(_diff_prose(text)) == expected
+
     def test_a_quoted_changelog_keeps_its_prose(self):
         # '--- v1.2.0 ---' is excised as a file header, but the bullets are the user's own
         # prose and survive. How that shape then routes is governed by verb selection, not


### PR DESCRIPTION
## Defect

`_diff_prose` strips a supplied diff so that its contents cannot pick the verb. Two holes let a **filename** pick it instead.

**1. Headerless diffs.** `_DIFF_START_RE` matched only `diff --git ` and `@@ `. In a diff with no `diff --git` line — `git diff --no-prefix`, `diff -u`, many pasted patches — the `--- `/`+++ ` file headers sit *before* the first hunk, so they never open diff mode and survive into the prose. `_looks_like_diff` accepts headerless diffs via its `@@ .* @@` branch, so this is a supported input shape.

**2. File headers outside a fence.** `_diff_prose` returned as soon as a ` ```diff ` fence was removed, before the line scan ran, so a `--- <file>` line outside the fence was never excised. Fenced diffs are the common paste shape.

Concrete failing input on `main`, where a real tool runs on the wrong verb:

```
user: review this
<diff --git ... patch ...>
agent: ...
user: --- improve.py
what changed?
```

The latest user turn asks a question, so this should route to `ask`. It routes to `improve`, chosen by the filename `improve.py`. The earlier turn's diff parses, so an improve run is actually delivered.

Scope note on severity: a *bare* headerless diff with nothing else is not affected in its output — `parse_unified_diff` returns `[]` for headerless input, so it reaches the empty fallback either way and only the verb named in that message changes. The defect delivers wrong work when the leaking line and a parseable diff are in different places, which multi-turn forwarding makes the normal case.

## Fix

Recognise `--- `/`+++ ` file headers, scan the post-fence remainder instead of returning early, drop those headers *without* opening diff mode, and strip the safe metadata that follows them.

That last part matters. Treating a file header as a diff *opener* (the first attempt here) also let a bare `--- notes.md` line in ordinary prose open diff mode, after which `_DIFF_BODY_LINE_RE` ate every following line starting `+`, `-`, or a space — deleting the user's actual request. `--- notes.md\n+1 please describe it` routed `review` instead of `describe`. So headers are now always-dropped and only the structural `diff --git `/`@@ ` open a diff.

The trailing space is load-bearing — it is what keeps a markdown horizontal rule, a setext underline and a mid-sentence `---` from opening a diff — and a test pins that property so it is not tidied away.

Nine filenames on the prompt `what changed here?` (want `ask`), in both shapes:

| filename | headerless before | fenced before | after (both) |
|---|---|---|---|
| calc.py | ask | ask | ask |
| review.py | **review** | **review** | ask |
| reviews.py | ask | ask | ask |
| describe.py | **describe** | **describe** | ask |
| ask.py | ask | ask | ask |
| improve.py | **improve** | **improve** | ask |
| improvements.py | ask | ask | ask |
| code_review.md | ask | ask | ask |
| IMPROVEMENTS.md | ask | ask | ask |

Measured for over-triggering:

- A 47-item prose corpus (natural phrasings, the card's own examples, the four skill descriptions): **no item changes result**.
- Nine legitimate-prose shapes: all unchanged.
- Prose following a fence still survives, including bullet, indented and `+` prefixed trailers, and so does a request following a file header.
- The fenced diff is still the parsed content; only the verb changes.

An earlier revision of this PR claimed the quoted-changelog shape (`--- v1.2.0 ---` then `-` bullets) as an improvement. That was wrong and the claim is withdrawn. It only "improved" because the header opened diff mode and deleted the bullets; the identical changelog with no `--- ` line at all already routes the same way, because `_explicit_verb` takes the first verb token it sees. That is pre-existing verb-selection behaviour, not something prose stripping should paper over, and `test_a_quoted_changelog_keeps_its_prose` now pins the equivalence instead of the artefact.

**Third hole, found by review of the second fix and corrected here.** An earlier revision of this description claimed the leftover `index …` / `Binary files … differ` residue was "cosmetic on current evidence". That was wrong. Dropping a file header without opening diff mode also means nothing strips the metadata beneath it, since `_DIFF_BODY_LINE_RE` is only consulted while `in_diff` is true:

```
what changed here?
--- improve.py
+++ improve.py
Binary files improve.py and improve.py differ
```

routed `improve`, and multi-turn `_resolve_verb` delivers a real improve run against an older parseable diff. The reason the earlier probe missed it is that it used `a/`-prefixed diffs: `_explicit_verb` needs `(^|\s)/?verb\b`, so `a/improve.py` cannot match but ` improve.py` can — and `git diff --no-prefix` emits exactly the unprefixed form this PR exists to serve.

`_DIFF_META_LINE_RE` now covers the always-safe metadata (`index`, mode, similarity, rename/copy, `Binary files`, `GIT binary patch`) and is consulted only for lines *following* a file header. It deliberately excludes the `[ +\-\\]|$` arms of `_DIFF_BODY_LINE_RE`, which match ordinary prose.

> **RETRACTED — this paragraph originally continued: "and the after-header scope keeps a plain `index 5 is wrong, please improve it` intact — both pinned by tests." That is false, and it names the very input that is broken.** `_DIFF_META_LINE_RE` matches on *prefixes*, so after a file header that line IS deleted and the user's verb is lost. The test that exists guards only the case with **no** preceding header; the after-header case was never pinned. Measured on clean checkouts of `--- notes.md\nindex 5 is wrong, please improve it` — `8245b55a` improve (correct), `7b8416ab` review (broken), `a64da835` improve (correct), `2c3dda1e` review (broken). The commit described above therefore reintroduced a class its predecessor had fixed. Reported by review as "Meta regex drops prose".

**This is why the PR is being abandoned rather than patched again.** The two defects are duals: strip metadata after a header and you delete metadata-shaped prose; do not strip it and you leak filenames. `a64da835` holds one horn, `2c3dda1e` holds the other, so there is no clean state on this branch to revert to. Both fall out of `_diff_prose` classifying lines by prefix with no notion of diff structure — by prefix, `index 1234567..89abcde 100644` and `index 5 is wrong, please improve it` are the same line. A fourth patch would trade one horn for the other. The defect and the full evidence are being filed as an issue for a deliberate redesign.

No interaction with the conversation router from #2561: `_resolve_verb` applies `_diff_prose` per user segment, so diff mode cannot bleed from one turn into a later one. Every #2561 case is unchanged, in both raw and fenced variants, plus two adversarial cases where a turn *begins* with `--- `.

## Scope

Independent of the separate question about the verb token pattern and its `\b` boundary. This changes only where a diff starts and ends, not how a verb is matched, and should not be conflated with it.

## Tests

44 added, one removed, in the existing table-driven style. Non-vacuity checked per commit by reverting the source change: 6 of the first 17 fail without the header fix, 5 of the next 15 fail without the fence change, 6 of the next 6 fail without the always-drop change, and 2 of the last 7 fail without the metadata fix; the rest are over-trigger guards that must pass either way.

Three mutations are pinned, each verified to fail the suite: tidying the trailing space to `\s*` (2 failures), re-merging the file headers back into `_DIFF_START_RE` (6 failures), and dropping the after-header scope so the metadata pattern applies everywhere (2 failures).

The removed test is `test_quoted_changelog_bullets_do_not_pick_the_verb`, which asserted the withdrawn claim above and passed only because of the swallowing bug. `test_a_quoted_changelog_keeps_its_prose` replaces it.

Full unit suite: 1580 passed, 0 failed, 1 skipped, 1 xfailed — baseline 1536 plus these 44, less the 1 removed.


