### PR TITLE
chore(mosaico): pin the deployment bundle to 0.41.0

### DIFF
--- a/docker/mosaico/README.md
+++ b/docker/mosaico/README.md
@@ -10,15 +10,15 @@ merged into `main` and ships in every release wheel and image starting at `v0.37
 
 This is not a fork and it never becomes one:
 
-- The MOSAICO A2A server is upstream code, released in tags `v0.37.0`–`v0.40.0`. This bundle
+- The MOSAICO A2A server is upstream code, released in tags `v0.37.0`–`v0.41.0`. This bundle
   holds zero Python — only a compose overlay, a registration template, an env template, a
   smoke test, and this README.
 - **Staying current is one line**: bump the pinned tag in `docker-compose.pr-agent.yml`, then
   re-run `./smoke_test.sh` to confirm the new image still boots and serves a valid card. That
   is the entire upgrade procedure:
   ```diff
-  -    image: pragent/pr-agent:0.40.0-mosaico_agent
-  +    image: pragent/pr-agent:0.41.0-mosaico_agent
+  -    image: pragent/pr-agent:0.41.0-mosaico_agent
+  +    image: pragent/pr-agent:0.42.0-mosaico_agent
   ```
 - Upstream publishes `pragent/pr-agent:<version>-mosaico_agent` for every release, from the
   same CI matrix that builds its other images — the MOSAICO target cannot silently stop being
@@ -31,12 +31,12 @@ This is not a fork and it never becomes one:
 Boots from a bare `docker pull` in a couple of seconds — no repo clone, no build:
 
 ```bash
-docker pull pragent/pr-agent:0.40.0-mosaico_agent
+docker pull pragent/pr-agent:0.41.0-mosaico_agent
 docker run -d --name pr-agent-mosaico -p 9000:9000 \
   -e API_BASE=https://your-openai-compatible-endpoint/v1 \
   -e API_KEY=sk-... \
   -e MODEL_NAME=openai/your-model-slug \
-  pragent/pr-agent:0.40.0-mosaico_agent
+  pragent/pr-agent:0.41.0-mosaico_agent
 
 curl -s http://localhost:9000/.well-known/agent-card.json | python3 -m json.tool
 ```

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -10,7 +10,7 @@ services:
     extends:
       file: base-definitions.yml
       service: agent
-    image: pragent/pr-agent:0.40.0-mosaico_agent
+    image: pragent/pr-agent:0.41.0-mosaico_agent
     ports:
       - ${PR_AGENT_PORT:-23000}:9000
     environment:

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -16,7 +16,7 @@
 #   MODEL_NAME=openrouter/mistralai/devstral-small
 set -uo pipefail
 
-IMAGE="${IMAGE:-pragent/pr-agent:0.40.0-mosaico_agent}"
+IMAGE="${IMAGE:-pragent/pr-agent:0.41.0-mosaico_agent}"
 PORT="${PORT:-9000}"
 CONTAINER="pr-agent-mosaico-test"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
The bundle pinned `0.40.0`, an image built before every MOSAICO fix merged since. Version tags are immutable, so the pin has to move for the consortium to receive them.

Missing from what they run today:
- **#2560** — `pydantic_settings` absent, so litellm's `langfuse_otel` callback resolves to `None` and every LLM call is silently untraced. The healthcheck cannot see this; the container reports healthy.
- **#2561** — forwarded multi-turn conversations route on the wrong turn.
- **#2563** — a total model outage reports `TASK_STATE_COMPLETED`.

### Verified against the published image before opening

| check | result |
|---|---|
| digest | `sha256:6cf24cd58c0c78bfcaa458e576eb9fb4a1fecb79cadfbfe92d9307486b89015f` |
| `dispatch.py` | carries `_split_turns` and `propagate_tool_errors` |
| `pydantic_settings` | imports, 2.14.2 |
| `langfuse_otel` callback | `LangfuseOtelLogger` — `0.40.0` returned `None` |
| `get_version()` | `0.41.0` |

### Seven lines

`docker-compose.pr-agent.yml:13`, `smoke_test.sh:19`, and `README.md:13,20,21,34,39`. The README upgrade example moves to `0.41.0` → `0.42.0`; left alone it would tell a reader to upgrade to the version they are already running.

### The parity check will fail on this PR, and that is correct

It compares `docker/mosaico/` against the GitLab mirror, which does not have these changes yet — nor #2562's, which are also still unsynced. Do not weaken the check to make CI green. The mirror is re-synced after merge, one sync covering both.