### PR TITLE
docs(usage-guide): add Neon AI Gateway model configuration

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -434,6 +434,37 @@ For `openrouter/...` models you can optionally restrict which upstream providers
 
 `provider_only` and `reasoning_effort = "none"` are useful to pin a specific provider and to bound the cost of reasoning models. See the Openrouter [provider routing](https://openrouter.ai/docs/features/provider-routing) and [reasoning tokens](https://openrouter.ai/docs/use-cases/reasoning-tokens) docs.
 
+### Neon AI Gateway
+
+[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference gateway. Each Neon branch has its own gateway host, so the base URL points at a single branch and not at an account. Neon publishes that host alongside the credential as `NEON_AI_GATEWAY_BASE_URL`. The value has no path, so append `/v1` to reach chat completions.
+
+To use a model served by a Neon branch, set:
+
+```toml
+[config] # in configuration.toml
+model = "openai/gpt-5-mini"
+fallback_models = ["openai/gpt-5-mini"]
+custom_model_max_tokens = 400000 # the context window Neon publishes for the model
+
+[openai] # in .secrets.toml
+api_base = "https://<your-neon-branch-host>/v1"
+key = "..." # your Neon AI Gateway credential
+```
+
+or use the environment variables (make sure to use double underscores `__`):
+
+```bash
+OPENAI__API_BASE=https://<your-neon-branch-host>/v1
+OPENAI__KEY=...
+```
+
+Keep the `openai/` prefix on the model name, whichever Neon model ID you use: the prefix routes the request through litellm's OpenAI-compatible path. A prefixed name is not in the `MAX_TOKENS` table [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py), so you also have to set `custom_model_max_tokens`. Take the value from Neon's [model catalog](https://neon.com/docs/ai-gateway/models).
+
+Create the credential per branch in the [Neon Console](https://console.neon.tech/) with the `ai_gateway:invoke` scope. The credential also works on branches descended from the one it was created on. The gateway is in beta and requires a paid Neon plan. It runs only in AWS US East (Ohio), `aws-us-east-2`.
+
+!!! note "Chat completions only"
+    Some model IDs in Neon's catalog are served through the OpenAI Responses API, which Neon exposes under `/openai/v1` instead of `/v1`. The configuration above points at the chat-completions endpoint, so it cannot reach those models. Neon also documents a few models that return `message.content` as an array of typed blocks rather than a string, and PR-Agent reads the reply as a string.
+
 ### Custom models
 
 If the relevant model doesn't appear [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py), you can still use it as a custom model:


### PR DESCRIPTION
## Description

Adds a `### Neon AI Gateway` section to `docs/docs/usage-guide/changing_a_model.md`, between `### Openrouter` and `### Custom models`.

[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) exposes an OpenAI-compatible endpoint, so it already works through the existing litellm OpenAI path — **this PR is documentation only and adds no code, no dependency, and no new provider branch.** The section documents the configuration that path already expects:

- the per-branch gateway host as `[openai] api_base`, with `/v1` appended (Neon publishes the host without a path)
- the credential as `[openai] key` in `.secrets.toml`, plus the `OPENAI__API_BASE` / `OPENAI__KEY` environment equivalents
- keeping the `openai/` prefix on the model name, and therefore setting `custom_model_max_tokens`, because a prefixed name is not in the `MAX_TOKENS` table
- a `!!! note` admonition limiting the section to chat completions

The one wrinkle worth documenting is that the gateway is scoped **per branch**, not per account, so the base URL is not a single shared host. That is why the example uses an explicit `<your-neon-branch-host>` placeholder rather than a realistic-looking URL.

There is no existing Neon section or open PR for this; `docs: ` scope and section placement follow the surrounding page.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How the configuration was verified

Claims in the section were checked against this repository's current source rather than assumed:

| Claim | Verified against |
| --- | --- |
| `[openai] api_base` reaches litellm | `litellm_ai_handler.py` sets `litellm.api_base` / `self.api_base` from `OPENAI.API_BASE` and passes it as the `api_base` kwarg |
| `[openai] key` | same handler sets `openai.api_key` / `litellm.openai_key` |
| `OPENAI__…` double-underscore form | Dynaconf nesting, matching how the rest of this page documents env vars |
| `custom_model_max_tokens` needed for prefixed names | `get_max_tokens()` in `algo/utils.py` falls back to `config.custom_model_max_tokens` when the model is absent from `MAX_TOKENS`, and raises otherwise |
| `400000` for the example model | the context window published in Neon's model catalog |
| beta / paid plan / `aws-us-east-2` / `ai_gateway:invoke` scope / descendant-branch validity | Neon's gateway documentation |

**Focused field probe.** `changing_a_model.md` recommends `openai/`-prefixed names, and the handler normalises that prefix away and then matches `gpt-5*`, which force-injects `reasoning_effort` (default `"medium"`) with `allowed_openai_params` and drops `temperature`. So the documented example only holds if the gateway tolerates that field. I sent a single minimal chat-completions request to a live gateway with exactly the fields that path produces — the example model, one short user message, and `reasoning_effort: "medium"`. It returned HTTP 200 with `finish_reason: stop` and `message.content` as a plain string, so the documented example is not silently broken by that injected field. The string-typed content is also what the admonition's second sentence is about.

**Docs build.** `mkdocs build -f docs/mkdocs.yml` with `mkdocs-material` and `mkdocs-glightbox`, as `docs-ci` installs them. The build's warning set is **byte-identical to the warning set from an unmodified checkout of `main`** (41 pre-existing warnings before and after), so this change introduces none. I also confirmed in the rendered HTML that the `#neon-ai-gateway` anchor and nav entry are generated, the admonition renders as a note with its title, both fences highlight, and the placeholder renders literally.

**Other checks.** The embedded TOML block parses with `tomllib`; the env block parses to the expected `openai.api_base` / `openai.key` keys; all four outbound links return 200; `git diff --check` is clean; no trailing whitespace and the file ends in a newline (matching the `trailing-whitespace` and `end-of-file-fixer` pre-commit hooks — the repo configures no markdown linter).

## Scope and limitations

- Deliberately limited to **text generation for PR-Agent's review/describe/improve style calls**. It makes no claim about tool calling, embeddings, image input, or native structured output.
- Models the catalog serves through the Responses API are **excluded**, and the admonition says so — Neon exposes those under `/openai/v1`, which this chat-completions configuration does not reach.
- The section does not claim native provider support; it documents reuse of the OpenAI-compatible path.
- **I did not run a full end-to-end PR-Agent command** (`/review`, `/describe`, `/improve`) against the gateway. The verification above is source inspection, a docs build, and the single focused request described — not a full agent run.
- I am not affiliated with Neon; this is based on their public documentation and a gateway I have access to.

## Checklist

- [x] Change is focused on a single topic
- [x] Follows the existing style and section structure of the page
- [x] Docs build passes with no new warnings
- [x] No secrets, credentials, or real hostnames added
- [x] No code changes, so no unit tests are required

---

*AI disclosure: this change was prepared with AI assistance. The wording, the source-level verification, and the checks above were reviewed by me before opening.*
