### PR TITLE
fix(gitea): resolve last_commit from PR commits, not repo commits

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -18,6 +18,15 @@ from pr_agent.git_providers.git_provider import (MAX_FILES_ALLOWED_FULL,
 from pr_agent.log import get_logger
 
 
+class _GiteaCommitAdapter:
+    """Mimics PyGithub `Commit` shape (.sha, .html_url) over a raw Gitea commit payload."""
+
+    def __init__(self, raw: Dict[str, Any]):
+        raw = raw or {}
+        self.sha = raw.get("sha", "")
+        self.html_url = raw.get("html_url", "")
+
+
 class GiteaProvider(GitProvider):
     def __init__(self, url: Optional[str] = None):
         super().__init__()
@@ -89,12 +98,7 @@ class GiteaProvider(GitProvider):
             self.sha = self.pr.head.sha if self.pr.head.sha else ""
             self.__add_file_content()
             self.__add_file_diff()
-            self.pr_commits = self.repo_api.list_all_commits(
-                owner=self.owner,
-                repo=self.repo
-            )
-            self.last_commit = self.pr_commits[-1]
-            self.last_commit_id = self.last_commit
+            self._set_pr_commits()
             self.base_sha = self.pr.base.sha if self.pr.base.sha else ""
             self.base_ref = self.pr.base.ref if self.pr.base.ref else ""
         elif "issues" in url:
@@ -103,6 +107,23 @@ class GiteaProvider(GitProvider):
             self.enabled_issue = True
         else:
             self.pr_commits = None
+
+    def _set_pr_commits(self):
+        """Load the commits of the PR itself, not the commits of the repository's default branch."""
+        raw_commits = self.repo_api.get_pr_commits(
+            owner=self.owner,
+            repo=self.repo,
+            pr_number=self.pr_number
+        ) or []
+        # Gitea returns PR commits newest-first; oldest-first matches GitHub iteration order.
+        self.pr_commits = [_GiteaCommitAdapter(commit) for commit in reversed(raw_commits)]
+        if not self.pr_commits:
+            self.logger.error("Failed to get PR commits")
+        self.last_commit = next(
+            (commit for commit in self.pr_commits if commit.sha and commit.sha == self.sha),
+            self.pr_commits[-1] if self.pr_commits else None
+        )
+        self.last_commit_id = self.last_commit
 
     def __add_file_content(self):
         for file in self.git_files:
@@ -227,7 +248,7 @@ class GiteaProvider(GitProvider):
         return self.issue_url
 
     def get_latest_commit_url(self) -> str:
-        return self.last_commit.html_url
+        return self.last_commit.html_url if self.last_commit else ""
 
     def get_comment_url(self, comment) -> str:
         return comment.html_url
@@ -440,7 +461,7 @@ class GiteaProvider(GitProvider):
         return self.repo_api.get_file_content(
             owner=self.owner,
             repo=self.repo,
-            commit_sha=self.last_commit.sha,
+            commit_sha=self.last_commit.sha if self.last_commit else self.sha,
             filepath=filename
         )
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -115,13 +115,21 @@ class GiteaProvider(GitProvider):
             repo=self.repo,
             pr_number=self.pr_number
         ) or []
+        if not isinstance(raw_commits, list):
+            self.logger.error(f"Unexpected PR commits payload type: {type(raw_commits)}")
+            raw_commits = []
         # Gitea returns PR commits newest-first; oldest-first matches GitHub iteration order.
-        self.pr_commits = [_GiteaCommitAdapter(commit) for commit in reversed(raw_commits)]
+        self.pr_commits = [
+            _GiteaCommitAdapter(commit) for commit in reversed(raw_commits) if isinstance(commit, dict)
+        ]
         if not self.pr_commits:
             self.logger.error("Failed to get PR commits")
+        # Fall back to a commit wrapping the PR head SHA (rather than None) so callers that
+        # dereference last_commit/last_commit_id (e.g. publish_inline_comments, the description
+        # header) always have a valid .sha, even when the commits endpoint returns nothing.
         self.last_commit = next(
             (commit for commit in self.pr_commits if commit.sha and commit.sha == self.sha),
-            self.pr_commits[-1] if self.pr_commits else None
+            self.pr_commits[-1] if self.pr_commits else _GiteaCommitAdapter({"sha": self.sha})
         )
         self.last_commit_id = self.last_commit
 

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -361,6 +361,90 @@ class TestGiteaProvider:
         provider.repo_api.get_file_content.assert_not_called()
 
 
+class TestGiteaProviderPRCommits:
+    """Regression tests for #2206: the provider must resolve ``last_commit`` from the
+    commits of the PR, not from the commits of the repository's default branch.
+
+    ``__init__`` performs network calls, so the instance is built with ``__new__`` and
+    only the attributes ``_set_pr_commits`` uses are wired up.
+    """
+
+    @staticmethod
+    def _provider(pr_commits, head_sha='head-sha'):
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = 'owner'
+        provider.repo = 'repo'
+        provider.pr_number = 123
+        provider.sha = head_sha
+        provider.repo_api = MagicMock()
+        provider.repo_api.get_pr_commits.return_value = pr_commits
+        return provider
+
+    def test_commits_are_fetched_from_the_pr_not_from_the_repository(self):
+        provider = self._provider([{'sha': 'head-sha', 'html_url': 'url/head-sha'}])
+
+        provider._set_pr_commits()
+
+        provider.repo_api.get_pr_commits.assert_called_once_with(
+            owner='owner',
+            repo='repo',
+            pr_number=123
+        )
+        provider.repo_api.list_all_commits.assert_not_called()
+
+    def test_last_commit_is_the_pr_head_although_gitea_returns_newest_first(self):
+        # Gitea returns PR commits newest-first, so the head commit comes first.
+        provider = self._provider([
+            {'sha': 'head-sha', 'html_url': 'url/head-sha'},
+            {'sha': 'older-sha', 'html_url': 'url/older-sha'},
+        ])
+
+        provider._set_pr_commits()
+
+        assert provider.last_commit.sha == 'head-sha'
+        assert provider.last_commit_id is provider.last_commit
+        assert provider.get_latest_commit_url() == 'url/head-sha'
+        # Stored oldest-first, matching the iteration order of the other providers.
+        assert [commit.sha for commit in provider.pr_commits] == ['older-sha', 'head-sha']
+
+    def test_last_commit_falls_back_to_newest_commit_when_head_sha_is_unknown(self):
+        provider = self._provider([
+            {'sha': 'newest-sha', 'html_url': 'url/newest-sha'},
+            {'sha': 'older-sha', 'html_url': 'url/older-sha'},
+        ], head_sha='')
+
+        provider._set_pr_commits()
+
+        assert provider.last_commit.sha == 'newest-sha'
+
+    def test_no_commits_leaves_last_commit_unset_without_raising(self):
+        provider = self._provider([])
+
+        provider._set_pr_commits()
+
+        assert provider.pr_commits == []
+        assert provider.last_commit is None
+        assert provider.get_latest_commit_url() == ""
+        provider.logger.error.assert_called_once()
+
+    def test_file_content_is_read_from_the_pr_head_commit(self):
+        provider = self._provider([{'sha': 'head-sha', 'html_url': 'url/head-sha'}])
+        provider.repo_api.get_file_content.return_value = "content"
+
+        provider._set_pr_commits()
+        provider._get_file_content_from_latest_commit("main.py")
+
+        provider.repo_api.get_file_content.assert_called_once_with(
+            owner='owner',
+            repo='repo',
+            commit_sha='head-sha',
+            filepath='main.py'
+        )
+
+
 class TestGiteaProviderAddFileDiff:
     """Tests for GiteaProvider.__add_file_diff diff parsing.
 

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -370,13 +370,13 @@ class TestGiteaProviderPRCommits:
     """
 
     @staticmethod
-    def _provider(pr_commits, head_sha='head-sha'):
+    def _provider(pr_commits, head_sha="head-sha"):
         from pr_agent.git_providers.gitea_provider import GiteaProvider
 
         provider = GiteaProvider.__new__(GiteaProvider)
         provider.logger = MagicMock()
-        provider.owner = 'owner'
-        provider.repo = 'repo'
+        provider.owner = "owner"
+        provider.repo = "repo"
         provider.pr_number = 123
         provider.sha = head_sha
         provider.repo_api = MagicMock()
@@ -384,13 +384,13 @@ class TestGiteaProviderPRCommits:
         return provider
 
     def test_commits_are_fetched_from_the_pr_not_from_the_repository(self):
-        provider = self._provider([{'sha': 'head-sha', 'html_url': 'url/head-sha'}])
+        provider = self._provider([{"sha": "head-sha", "html_url": "url/head-sha"}])
 
         provider._set_pr_commits()
 
         provider.repo_api.get_pr_commits.assert_called_once_with(
-            owner='owner',
-            repo='repo',
+            owner="owner",
+            repo="repo",
             pr_number=123
         )
         provider.repo_api.list_all_commits.assert_not_called()
@@ -398,50 +398,63 @@ class TestGiteaProviderPRCommits:
     def test_last_commit_is_the_pr_head_although_gitea_returns_newest_first(self):
         # Gitea returns PR commits newest-first, so the head commit comes first.
         provider = self._provider([
-            {'sha': 'head-sha', 'html_url': 'url/head-sha'},
-            {'sha': 'older-sha', 'html_url': 'url/older-sha'},
+            {"sha": "head-sha", "html_url": "url/head-sha"},
+            {"sha": "older-sha", "html_url": "url/older-sha"},
         ])
 
         provider._set_pr_commits()
 
-        assert provider.last_commit.sha == 'head-sha'
+        assert provider.last_commit.sha == "head-sha"
         assert provider.last_commit_id is provider.last_commit
-        assert provider.get_latest_commit_url() == 'url/head-sha'
+        assert provider.get_latest_commit_url() == "url/head-sha"
         # Stored oldest-first, matching the iteration order of the other providers.
-        assert [commit.sha for commit in provider.pr_commits] == ['older-sha', 'head-sha']
+        assert [commit.sha for commit in provider.pr_commits] == ["older-sha", "head-sha"]
 
     def test_last_commit_falls_back_to_newest_commit_when_head_sha_is_unknown(self):
         provider = self._provider([
-            {'sha': 'newest-sha', 'html_url': 'url/newest-sha'},
-            {'sha': 'older-sha', 'html_url': 'url/older-sha'},
-        ], head_sha='')
+            {"sha": "newest-sha", "html_url": "url/newest-sha"},
+            {"sha": "older-sha", "html_url": "url/older-sha"},
+        ], head_sha="")
 
         provider._set_pr_commits()
 
-        assert provider.last_commit.sha == 'newest-sha'
+        assert provider.last_commit.sha == "newest-sha"
 
-    def test_no_commits_leaves_last_commit_unset_without_raising(self):
+    def test_no_commits_falls_back_to_a_commit_wrapping_the_head_sha(self):
         provider = self._provider([])
 
         provider._set_pr_commits()
 
         assert provider.pr_commits == []
-        assert provider.last_commit is None
+        # last_commit must stay a valid object (never None) so callers that dereference
+        # last_commit.sha / last_commit_id.sha don't crash, and get a real SHA instead of "".
+        assert provider.last_commit is not None
+        assert provider.last_commit.sha == "head-sha"
+        assert provider.last_commit_id is provider.last_commit
         assert provider.get_latest_commit_url() == ""
         provider.logger.error.assert_called_once()
 
+    def test_non_list_commits_payload_is_treated_as_empty(self):
+        provider = self._provider({"message": "not found"})
+
+        provider._set_pr_commits()
+
+        assert provider.pr_commits == []
+        assert provider.last_commit.sha == "head-sha"
+        provider.logger.error.assert_called()
+
     def test_file_content_is_read_from_the_pr_head_commit(self):
-        provider = self._provider([{'sha': 'head-sha', 'html_url': 'url/head-sha'}])
+        provider = self._provider([{"sha": "head-sha", "html_url": "url/head-sha"}])
         provider.repo_api.get_file_content.return_value = "content"
 
         provider._set_pr_commits()
         provider._get_file_content_from_latest_commit("main.py")
 
         provider.repo_api.get_file_content.assert_called_once_with(
-            owner='owner',
-            repo='repo',
-            commit_sha='head-sha',
-            filepath='main.py'
+            owner="owner",
+            repo="repo",
+            commit_sha="head-sha",
+            filepath="main.py"
         )
 
 


### PR DESCRIPTION
## Problem

`GiteaProvider.__init__` populated `self.pr_commits` with `list_all_commits(owner, repo)`, which calls `GET /repos/{owner}/{repo}/commits` — the commits of the repository's **default branch**, not of the PR. It then took `[-1]` of that list; since Gitea returns commits newest-first, `last_commit` ended up being the *oldest* commit on the default branch.

Everything that reads `last_commit` was therefore pointing at a commit unrelated to the PR:

- `get_latest_commit_url()` returned a default-branch commit URL.
- `publish_inline_comments()` posted with a wrong `commit_id`.
- `_get_file_content_from_latest_commit()` read file content from the wrong commit.
- Because that SHA never changed between pushes, persistent review/suggestion headers kept reporting the same stale commit and did not register new work on the PR.

## Fix

Fetch the PR's own commits through the `get_pr_commits()` wrapper that already exists in `RepoApi` (`GET /repos/{owner}/{repo}/pulls/{pr_number}/commits`).

- Gitea returns PR commits newest-first, so they are reversed into the oldest-first order the GitHub and Azure DevOps providers use.
- `last_commit` is matched against the PR head SHA (`pr.head.sha`), so it does not silently depend on the ordering.
- `get_pr_commits()` returns raw JSON dicts, while the rest of the codebase expects attribute access on commit objects (for example `pr_description.py` uses `git_provider.last_commit_id.sha`). The payload is wrapped in a small `_GiteaCommitAdapter` exposing `.sha` / `.html_url`, mirroring `_AzureCommitAdapter` in `azuredevops_provider.py`.
- An empty commit list previously raised `IndexError` from `__init__`; now `last_commit` stays `None` and the getters degrade to the head SHA or an empty string.

`list_all_commits()` is left in place — it is a plain endpoint wrapper and removing it would widen the surface of a behaviour fix.

## Tests

Added `TestGiteaProviderPRCommits` in `tests/unittest/test_gitea_provider.py`, following the existing pattern in that file of building the provider with `__new__` and wiring only the attributes under test:

- the PR commits endpoint is called with `pr_number`, and `list_all_commits` is **not** called (this is the assertion that pins the regression);
- with a newest-first payload, `last_commit` is the PR head and `pr_commits` is stored oldest-first;
- with an unknown head SHA, `last_commit` falls back to the newest commit;
- an empty payload leaves `last_commit is None` and `get_latest_commit_url()` returns `""` instead of raising;
- `_get_file_content_from_latest_commit()` reads from the PR head SHA.

Run locally in a clean venv built from this repo:

```
PYTHONPATH=. pytest tests/unittest -q
1550 passed, 1 skipped, 1 xfailed
```

`ruff check` on both touched files reports the same pre-existing findings as on `main`, and none from this change.

## Notes

- I do not have a Gitea instance, so the fix is verified by unit tests and by reasoning about the Gitea API, not against a live server. The one assumption I could not verify end-to-end is that `/pulls/{index}/commits` returns commits newest-first; the head-SHA match means `last_commit` is correct either way, and only the order of `pr_commits` depends on it.
- Open PR #2147 also touches this file, but at a different layer — it rewrites the `RepoApi` wrappers for pagination, while this change is in the provider that consumes them. No functional overlap.

Closes #2206
