### PR TITLE
docs: refresh stale docs against the current release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,39 @@
-## 2023-08-03
+# Changelog
 
-### Optimized
+**Release notes now live on GitHub.** The authoritative, per-release changelog is the
+[Releases page](https://github.com/The-PR-Agent/pr-agent/releases), which is generated from the
+merged pull requests of each release. This file is no longer updated per release.
+
+To see what changed between two versions, use the compare view — for example
+[`v0.40.0...v0.41.0`](https://github.com/The-PR-Agent/pr-agent/compare/v0.40.0...v0.41.0).
+
+---
+
+## Archive
+
+The entries below are a partial, date-based log kept in this file during July–August 2023, before
+the project switched to GitHub Releases. They stop at `2023-08-03` and are retained for history
+only; they do **not** describe any release after that date.
+
+### 2023-08-03
+
+#### Optimized
 
 - Optimized PR diff processing by introducing caching for diff files, reducing the number of API calls.
 - Refactored `load_large_diff` function to generate a patch only when necessary.
 - Fixed a bug in the GitLab provider where the new file was not retrieved correctly.
 
-## 2023-08-02
+### 2023-08-02
 
-### Enhanced
+#### Enhanced
 
 - Updated several tools in the `pr_agent` package to use commit messages in their functionality.
 - Commit messages are now retrieved and stored in the `vars` dictionary for each tool.
 - Added a section to display the commit messages in the prompts of various tools.
 
-## 2023-08-01
+### 2023-08-01
 
-### Enhanced
+#### Enhanced
 
 - Introduced the ability to retrieve commit messages from pull requests across different git providers.
 - Implemented commit messages retrieval for GitHub and GitLab providers.
@@ -25,25 +42,25 @@
 - Implemented this feature for both GitHub and GitLab providers.
 - Added a new configuration option 'use_repo_settings_file' to enable or disable the use of a repo-specific settings file.
 
-## 2023-07-30
+### 2023-07-30
 
-### Enhanced
+#### Enhanced
 
 - Added the ability to modify any configuration parameter from 'configuration.toml' on-the-fly.
 - Updated the command line interface and bot commands to accept configuration changes as arguments.
 - Improved the PR agent to handle additional arguments for each action.
 
-## 2023-07-28
+### 2023-07-28
 
-### Improved
+#### Improved
 
 - Enhanced error handling and logging in the GitLab provider.
 - Improved handling of inline comments and code suggestions in GitLab.
 - Fixed a bug where an additional unneeded line was added to code suggestions in GitLab.
 
-## 2023-07-26
+### 2023-07-26
 
-### Added
+#### Added
 
 - New feature for updating the CHANGELOG.md based on the contents of a PR.
 - Added support for this feature for the Github provider.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,10 +34,13 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at dana.f@qodo.ai . All complaints will
-be reviewed and investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances. Maintainers are obligated to maintain confidentiality
-with regard to the reporter of an incident.
+contacting a project maintainer privately — the current maintainers are listed at
+[github.com/orgs/The-PR-Agent/people](https://github.com/orgs/The-PR-Agent/people). All
+complaints will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. Maintainers are obligated to maintain
+confidentiality with regard to the reporter of an incident. If the report concerns a
+maintainer, it may instead be raised with
+[GitHub Support](https://support.github.com/contact/report-abuse).
 
 This Code of Conduct is adapted from the
 [Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to the PR-Agent project!
 ## Getting Started
 
 1. Fork the repository and clone your fork
-2. Install Python 3.10 or higher
+2. Install Python 3.12 or higher (the interpreter requirement declared in `pyproject.toml`)
 3. Install dependencies (`requirements.txt` and `requirements-dev.txt`)
 4. Create a new branch for your contribution:
    - For new features: `git checkout -b feature/your-feature-name`
@@ -34,5 +34,5 @@ Thank you for your interest in contributing to the PR-Agent project!
 ## Questions or Need Help?
 
 - Ask questions or start a discussion in [GitHub Discussions](https://github.com/the-pr-agent/pr-agent/discussions)
-- Check the [documentation](https://qodo-merge-docs.qodo.ai/) for detailed information
+- Check the [documentation](https://docs.pr-agent.ai/) for detailed information
 - Report bugs or request features through [GitHub Issues](https://github.com/the-pr-agent/pr-agent/issues)

--- a/README.md
+++ b/README.md
@@ -101,40 +101,29 @@ pr-agent --pr_url https://github.com/owner/repo/pull/123 review
 - [BitBucket app installation](https://docs.pr-agent.ai/installation/bitbucket/)
 - [Azure DevOps setup](https://docs.pr-agent.ai/installation/azure/)
 
-[//]: # (## News and Updates)
+## News and Updates
 
-[//]: # ()
-[//]: # (## Aug 8, 2025)
+Full notes for every release are on the [Releases page](https://github.com/the-pr-agent/pr-agent/releases).
 
-[//]: # ()
-[//]: # ()
-[//]: # ()
-[//]: # (## Jul 1, 2025)
+### Jul 26, 2026 — [v0.41.0](https://github.com/the-pr-agent/pr-agent/releases/tag/v0.41.0)
 
-[//]: # (You can now receive automatic feedback from Qodo Merge in your local IDE after each commit. Read more about it [here]&#40;https://github.com/qodo-ai/agents/tree/main/agents/qodo-merge-post-commit&#41;.)
+Claude Opus 5 support, and `docker/mosaico` became a self-contained deployment bundle.
 
-[//]: # ()
-[//]: # ()
-[//]: # (## Jun 21, 2025)
+### Jul 25, 2026 — [v0.40.0](https://github.com/the-pr-agent/pr-agent/releases/tag/v0.40.0)
 
-[//]: # ()
-[//]: # (v0.30 was [released]&#40;https://github.com/the-pr-agent/pr-agent/releases&#41;)
+Default model moved to GPT-5.6, Gemini 3.6 support, persistent inline comments (no more duplicate
+suggestions across runs), an OpenRouter provider-routing/reasoning config, a tokenless
+[plain-diff provider](https://docs.pr-agent.ai/usage-guide/plain_diff_mode/), and CI artifact
+context injection.
 
-[//]: # ()
-[//]: # ()
-[//]: # (## Apr 30, 2025)
+### Jul 5, 2026 — [v0.39.0](https://github.com/the-pr-agent/pr-agent/releases/tag/v0.39.0)
 
-[//]: # ()
-[//]: # (A new feature is now available in the `/improve` tool for Qodo Merge 💎 - Chat on code suggestions.)
-
-[//]: # ()
-[//]: # (<img width="512" alt="image" src="https://codium.ai/images/pr_agent/improve_chat_on_code_suggestions_ask.png" />)
-
-[//]: # ()
-[//]: # (Read more about it [here]&#40;https://docs.pr-agent.ai/tools/improve/#chat-on-code-suggestions&#41;.)
-
-[//]: # ()
-[//]: # ()
+`AGENTS.md` and friends are now fed to `/review`, `/describe` and `/improve` **by default**, so the
+model picks up your project's conventions out of the box. Also:
+[Agent Skills (`SKILL.md`)](https://docs.pr-agent.ai/core-abilities/agent_skills/),
+[organization-level settings](https://docs.pr-agent.ai/usage-guide/configuration_options/),
+[restricted mode](https://docs.pr-agent.ai/usage-guide/additional_configurations/#restricted-mode)
+for reduced GitHub permissions, GitHub Checks as an output target, and Claude Sonnet 5 support.
 
 ## Why Use PR-Agent?
 
@@ -149,7 +138,7 @@ pr-agent --pr_url https://github.com/owner/repo/pull/123 review
 **Platform Agnostic**: 
 - **Git Providers**: GitHub, GitLab, BitBucket, Azure DevOps, Gitea
 - **Deployment**: CLI, GitHub Actions, Docker, self-hosted, webhooks
-- **AI Models**: OpenAI GPT, Claude, Deepseek, and more
+- **AI Models**: OpenAI GPT, Anthropic Claude, Google Gemini, DeepSeek, Mistral, and any other model reachable through LiteLLM (Azure OpenAI, AWS Bedrock, Vertex AI, Databricks, OpenRouter, Ollama, and more) — see [Changing a model](https://docs.pr-agent.ai/usage-guide/changing_a_model/)
 
 **Open Source Benefits**:
 - Full control over your data and infrastructure
@@ -170,7 +159,7 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |                                                         | [Improve](https://docs.pr-agent.ai/tools/improve/)                              |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
 |                                                         | [Ask](https://docs.pr-agent.ai/tools/ask/)                                      |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         | ⮑ [Ask on code lines](https://docs.pr-agent.ai/tools/ask/#ask-lines)            |   ✅   |   ✅   |           |              |       |
-|                                                         | [Help Docs](https://docs.pr-agent.ai/tools/help_docs/?h=auto#auto-approval)     |   ✅   |   ✅   |    ✅     |              |       |
+|                                                         | [Help Docs](https://docs.pr-agent.ai/tools/help_docs/) ⚠️                       |   —    |   —    |    —      |              |       |
 |                                                         | [Update CHANGELOG](https://docs.pr-agent.ai/tools/update_changelog/)            |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         |                                                                                                                     |        |        |           |              |       |
 | [USAGE](https://docs.pr-agent.ai/usage-guide/)   | [CLI](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#local-repo-cli)                            |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
@@ -179,6 +168,8 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |                                                         | [Actions](https://docs.pr-agent.ai/installation/github/#run-as-a-github-action)                              |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         |                                                                                                                     |        |        |           |              |       |
 | [CORE](https://docs.pr-agent.ai/core-abilities/) | [Adaptive and token-aware file patch fitting](https://docs.pr-agent.ai/core-abilities/compression_strategy/) |   ✅   |   ✅   |    ✅     |      ✅      |       |
+|                                                         | [Agent skills (`SKILL.md`)](https://docs.pr-agent.ai/core-abilities/agent_skills/)                           |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
+|                                                         | [Repo context files (`AGENTS.md`)](https://docs.pr-agent.ai/usage-guide/additional_configurations/#bringing-per-repo-context-files-to-pr-agent) |   ✅   |   ✅   |    ✅     |      ✅      |  ✅   |
 |                                                         | [Dynamic context](https://docs.pr-agent.ai/core-abilities/dynamic_context/)                                  |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         | [Fetching ticket context](https://docs.pr-agent.ai/core-abilities/fetching_ticket_context/)                  |   ✅    |  ✅    |     ✅     |              |       |
 |                                                         | [Interactivity](https://docs.pr-agent.ai/core-abilities/interactivity/)                                      |   ✅   |  ✅   |           |              |       |
@@ -186,6 +177,8 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |                                                         | [Multiple models support](https://docs.pr-agent.ai/usage-guide/changing_a_model/)                            |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         | [PR compression](https://docs.pr-agent.ai/core-abilities/compression_strategy/)                              |   ✅   |   ✅   |    ✅     |      ✅      |       |
 |                                                         | [Self reflection](https://docs.pr-agent.ai/core-abilities/self_reflection/)                                  |   ✅   |   ✅   |    ✅     |      ✅      |       |
+
+⚠️ `/help_docs` is temporarily disabled since `v0.36.1` pending a fix for a credential-exposure issue ([#2445](https://github.com/the-pr-agent/pr-agent/issues/2445)).
 
 [//]: # (- Support for additional git providers is described in [here]&#40;./docs/Full_environments.md&#41;)
 ___
@@ -256,7 +249,7 @@ https://openai.com/enterprise-privacy
 
 ## Contributing
 
-To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/b09eec265ef7d36c232063f76553efb6b53979ff/CONTRIBUTING.md).
+To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/main/CONTRIBUTING.md).
 
 
 ## Big News for PR-Agent
@@ -268,7 +261,7 @@ After years of building this tool alongside the community, Qodo has donated PR-A
 The project now lives in the PR-Agent org on GitHub, is fully community-owned, and is open for contributions and additional maintainers.
 
 What else changed: 
-- Docs moved to - www.pr-agent.ai
+- Docs moved to - [docs.pr-agent.ai](https://docs.pr-agent.ai/)
 - Qodo Merge (Qodo 1.0), the hosted URL, which was the enterprise version of PR-Agent, has been rebranded and evolved into Qodo (Qodo 2.0), a full AI code review platform.
 
 ## ❤️ Community

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,22 @@
-## [Version 0.11] - 2023-12-07
+# Release notes
+
+**Release notes now live on GitHub.** Notes for every release from `v0.12` onwards are published on
+the [Releases page](https://github.com/The-PR-Agent/pr-agent/releases), generated from the merged
+pull requests of each release. This file is no longer updated per release.
+
+Docker images for `0.34.2` and later are published under
+[`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). The `codiumai/pr-agent` tags listed
+in the archive below are a frozen namespace — no new images are pushed there.
+
+---
+
+## Archive
+
+The entries below cover `v0.7`–`v0.11` (September–December 2023), written while the project lived at
+`Codium-ai/pr-agent`. Their links point at that repository, which now redirects, and their Docker
+tags reference the frozen `codiumai/` namespace. They are retained for history only.
+
+### [Version 0.11] - 2023-12-07
 
 - codiumai/pr-agent:0.11
 - codiumai/pr-agent:0.11-github_app
@@ -7,18 +25,18 @@
 - codiumai/pr-agent:0.11-github_polling
 - codiumai/pr-agent:0.11-github_action
 
-### Added::Algo
+#### Added::Algo
 
 - New section in `/describe` tool - [PR changes walkthrough](https://github.com/Codium-ai/pr-agent/pull/509)
 - Improving PR Agent [prompts](https://github.com/Codium-ai/pr-agent/pull/501)
 - Persistent tools (`/review`, `/describe`) now send an [update message](https://github.com/Codium-ai/pr-agent/pull/499) after finishing
 - Add Amazon Bedrock [support](https://github.com/Codium-ai/pr-agent/pull/483)
 
-### Fixed
+#### Fixed
 
 - Update [dependencies](https://github.com/Codium-ai/pr-agent/pull/503) in requirements.txt for Python 3.12
 
-## [Version 0.10] - 2023-11-15
+### [Version 0.10] - 2023-11-15
 
 - codiumai/pr-agent:0.10
 - codiumai/pr-agent:0.10-github_app
@@ -27,7 +45,7 @@
 - codiumai/pr-agent:0.10-github_polling
 - codiumai/pr-agent:0.10-github_action
 
-### Added::Algo
+#### Added::Algo
 
 - Review tool now works with [persistent comments](https://github.com/Codium-ai/pr-agent/pull/451) by default
 - Bitbucket now publishes review suggestions with [code links](https://github.com/Codium-ai/pr-agent/pull/428)
@@ -37,13 +55,13 @@
 - Implementing [thresholds](https://github.com/Codium-ai/pr-agent/pull/423) for incremental PR reviews
 - Decoupled custom labels from [PR type](https://github.com/Codium-ai/pr-agent/pull/431)
 
-### Fixed
+#### Fixed
 
 - Fixed bug in [parsing quotes](https://github.com/Codium-ai/pr-agent/pull/446) in CLI
 - Preserve [user-added labels](https://github.com/Codium-ai/pr-agent/pull/433) in pull requests
 - Bug fixes in GitLab and BitBucket
 
-## [Version 0.9] - 2023-10-29
+### [Version 0.9] - 2023-10-29
 
 - codiumai/pr-agent:0.9
 - codiumai/pr-agent:0.9-github_app
@@ -52,7 +70,7 @@
 - codiumai/pr-agent:0.9-github_polling
 - codiumai/pr-agent:0.9-github_action
 
-### Added::Algo
+#### Added::Algo
 
 - New tool - [generate_labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/GENERATE_CUSTOM_LABELS.md)
 - New ability to use [customize labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/GENERATE_CUSTOM_LABELS.md#how-to-enable-custom-labels) on the `review` and `describe` tools.
@@ -62,17 +80,17 @@
 - Support custom domain URLs for Azure devops integration (see [link](https://github.com/Codium-ai/pr-agent/pull/381)).
 - PR Description default mode is now in [bullet points](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L35).
 
-### Added::Documentation
+#### Added::Documentation
 
 Significant documentation updates (see [Installation Guide](https://github.com/Codium-ai/pr-agent/blob/main/INSTALL.md), [Usage Guide](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md), and [Tools Guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md))
 
-### Fixed
+#### Fixed
 
 - Fixed support for BitBucket pipeline (see [link](https://github.com/Codium-ai/pr-agent/pull/386))
 - Fixed a bug in `review -i` tool
 - Added blacklist for specific file extensions in `add_docs` tool (see [link](https://github.com/Codium-ai/pr-agent/pull/385/))
 
-## [Version 0.8] - 2023-09-27
+### [Version 0.8] - 2023-09-27
 
 - codiumai/pr-agent:0.8
 - codiumai/pr-agent:0.8-github_app
@@ -81,18 +99,18 @@ Significant documentation updates (see [Installation Guide](https://github.com/C
 - codiumai/pr-agent:0.8-github_polling
 - codiumai/pr-agent:0.8-github_action
 
-### Added::Algo
+#### Added::Algo
 
 - GitHub Action: Can control which tools will run automatically when a new PR is created. (see usage guide: https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-action)
 - Code suggestion tool: Will try to avoid an 'add comments' suggestion  (see https://github.com/Codium-ai/pr-agent/pull/327)
 
-### Fixed
+#### Fixed
 
 - Gitlab: Fixed a bug of improper usage of pr_id
 
-## [Version 0.7] - 2023-09-20
+### [Version 0.7] - 2023-09-20
 
-### Docker Tags
+#### Docker Tags
 
 - codiumai/pr-agent:0.7
 - codiumai/pr-agent:0.7-github_app
@@ -101,18 +119,18 @@ Significant documentation updates (see [Installation Guide](https://github.com/C
 - codiumai/pr-agent:0.7-github_polling
 - codiumai/pr-agent:0.7-github_action
 
-### Added::Algo
+#### Added::Algo
 
 - New tool /similar_issue - Currently on GitHub app and CLI: indexes the issues in the repo, find the most similar issues to the target issue.
 - Describe markers: Empower the /describe tool with a templating capability (see more details in https://github.com/Codium-ai/pr-agent/pull/273).
 - New feature in the /review tool - added an estimated effort estimation to the review (https://github.com/Codium-ai/pr-agent/pull/306).
 
-### Added::Infrastructure
+#### Added::Infrastructure
 
 - Implementation of a GitLab webhook.
 - Implementation of a BitBucket app.
 
-### Fixed
+#### Fixed
 
 - Protection against no code suggestions generated.
 - Resilience to repositories where the languages cannot be automatically detected.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policy
 
-PR-Agent is an open-source tool to help efficiently review and handle pull requests. Qodo Merge is a paid version of PR-Agent, designed for companies and teams that require additional features and capabilities.
+PR-Agent is an open-source tool to help efficiently review and handle pull requests.
 
-This document describes the security policy of PR-Agent. For Qodo Merge's security policy, see [here](https://qodo-merge-docs.qodo.ai/overview/data_privacy/#qodo-merge).
+This document describes the security policy of the open-source PR-Agent project. It does not cover [Qodo](https://www.qodo.ai/), the separate commercial product that evolved out of the hosted Qodo Merge offering — for that, see Qodo's own security policy.
 
 ## PR-Agent Self-Hosted Solutions
 
-When using PR-Agent with your OpenAI (or other LLM provider) API key, the security relationship is directly between you and the provider. We do not send your code to Qodo servers.
+When using PR-Agent with your OpenAI (or other LLM provider) API key, the security relationship is directly between you and the provider. PR-Agent does not send your code to any servers operated by the project.
 
-Types of [self-hosted solutions](https://qodo-merge-docs.qodo.ai/installation):
+Types of [self-hosted solutions](https://docs.pr-agent.ai/installation/):
 
 - Locally
 - GitHub integration
@@ -41,18 +41,26 @@ For example, to github action:
 steps:
   - name: PR Agent action step
     id: pragent
-    uses: docker://pragent/pr-agent:0.34.2-github_action
+    uses: docker://pragent/pr-agent:0.41.0-github_action
 ```
+
+Version tags are immutable — once published, `0.41.0-github_action` always resolves to the same image. Rolling tags such as `latest` and `github_action` are not; see the "Immutable releases and version tags" note on the [Installation page](https://docs.pr-agent.ai/installation/).
 
 #### Enhanced Security with Docker Digest
 
-For maximum security, you can specify the Docker image using its digest:
+For maximum security, you can specify the Docker image using its digest. Resolve the digest for the version you want to pin:
+
+```sh
+docker buildx imagetools inspect pragent/pr-agent:0.41.0-github_action --format '{{.Manifest.Digest}}'
+```
+
+Then reference it instead of the tag:
 
 ```yaml
 steps:
   - name: PR Agent action step
     id: pragent
-    uses: docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c
+    uses: docker://pragent/pr-agent@sha256:<digest>
 ```
 
 Official Docker Hub release images also publish GitHub Artifact Attestations, so you can verify a pinned digest before using it:
@@ -65,8 +73,10 @@ gh attestation verify \
 
 ## Reporting a Vulnerability
 
-We take the security of PR-Agent seriously. If you discover a security vulnerability, please report it immediately to:
+We take the security of PR-Agent seriously. If you discover a security vulnerability, please report it privately through GitHub's private vulnerability reporting, which is enabled on this repository:
 
-Email: security@qodo.ai
+[**Report a vulnerability**](https://github.com/The-PR-Agent/pr-agent/security/advisories/new)
 
 Please include a description of the vulnerability, steps to reproduce, and the affected PR-Agent version.
+
+Do not open a public issue for a security report — a public issue discloses the vulnerability before a fix is available.

--- a/docker/mosaico/README.md
+++ b/docker/mosaico/README.md
@@ -2,15 +2,15 @@
 
 Deployment assets for running **PR-Agent** as a [MOSAICO](https://mosaico-project.eu/) A2A
 *solution agent*. This directory contains no Python and no pr-agent source — it consumes
-PR-Agent as a published, version-pinned Docker image. The agent's source lives upstream in
-[`qodo-ai/pr-agent`](https://github.com/qodo-ai/pr-agent), under `pr_agent/mosaico/`; it is
-merged into `main` and ships in every release wheel and image starting at `v0.37.0`.
+PR-Agent as a published, version-pinned Docker image. The agent's source lives in
+[`The-PR-Agent/pr-agent`](https://github.com/The-PR-Agent/pr-agent), under `pr_agent/mosaico/`;
+it is merged into `main` and ships in every release wheel and image starting at `v0.37.0`.
 
-## Relationship to upstream
+## Relationship to the PR-Agent repository
 
 This is not a fork and it never becomes one:
 
-- The MOSAICO A2A server is upstream code, released in tags `v0.37.0`–`v0.41.0`. This bundle
+- The MOSAICO A2A server is PR-Agent code, released in tags `v0.37.0` onwards. This bundle
   holds zero Python — only a compose overlay, a registration template, an env template, a
   smoke test, and this README.
 - **Staying current is one line**: bump the pinned tag in `docker-compose.pr-agent.yml`, then
@@ -20,11 +20,12 @@ This is not a fork and it never becomes one:
   -    image: pragent/pr-agent:0.41.0-mosaico_agent
   +    image: pragent/pr-agent:0.42.0-mosaico_agent
   ```
-- Upstream publishes `pragent/pr-agent:<version>-mosaico_agent` for every release, from the
-  same CI matrix that builds its other images — the MOSAICO target cannot silently stop being
-  built without the whole release failing.
+- The release workflow publishes `pragent/pr-agent:<version>-mosaico_agent` for every release,
+  from the same CI matrix that builds its other images — the MOSAICO target cannot silently
+  stop being built without the whole release failing.
 - Canonical source of every file in this bundle is `docker/mosaico/` in
-  `github.com/qodo-ai/pr-agent`. Edit there, copy here. Never edit here directly.
+  `github.com/The-PR-Agent/pr-agent` — this directory. The GitLab deployment mirror holds
+  verbatim copies; edit here, and re-copy there. Never edit the mirror directly.
 
 ## Quick start (standalone, no demonstrator)
 
@@ -145,4 +146,4 @@ Two outcomes:
 
 ## License
 
-MIT — see the bundled [`LICENSE`](./LICENSE). Upstream `qodo-ai/pr-agent` is MIT-licensed too.
+MIT — see the bundled [`LICENSE`](./LICENSE). `The-PR-Agent/pr-agent` is MIT-licensed too.

--- a/docker/mosaico/docker-compose.pr-agent.yml
+++ b/docker/mosaico/docker-compose.pr-agent.yml
@@ -1,5 +1,5 @@
 # PR-Agent MOSAICO solution-agent overlay. Canonical source is docker/mosaico/ in
-# github.com/qodo-ai/pr-agent - edit it there, never in a copy.
+# github.com/The-PR-Agent/pr-agent - edit it there, never in a copy.
 # Copy into the demonstrator's `compose/` dir, next to `base-definitions.yml`, so the
 # `extends:` refs resolve; see ./README.md for the full wiring steps.
 #

--- a/docker/mosaico/smoke_test.sh
+++ b/docker/mosaico/smoke_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Pull and test-run the MOSAICO A2A solution-agent image published by the
-# upstream qodo-ai/pr-agent release workflow (Docker target `mosaico_agent`).
+# The-PR-Agent/pr-agent release workflow (Docker target `mosaico_agent`).
 #
 #   Smoke (always):       boot the container and validate the A2A agent card.
 #   Full round-trip:      when LLM creds are present, also exercise GET /health

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-# [Visit Our Docs Portal](https://qodo-merge-docs.qodo.ai/)
+# [Visit Our Docs Portal](https://docs.pr-agent.ai/)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,7 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |       | [Generate Labels](./tools/generate_labels.md)                                         |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       | [Similar Issues](./tools/similar_issues.md)                                           |   ✅   |        |           |              |       |
 |       | [Help](./tools/help.md)                                                               |   ✅   |   ✅   |    ✅     |      ✅       |       |
-|       | [Help Docs](./tools/help_docs.md)                                                     |   ✅   |   ✅   |    ✅     |              |       |
+|       | [Help Docs](./tools/help_docs.md) ⚠️                                                   |   —    |   —    |    —      |              |       |
 |       | [Update CHANGELOG](./tools/update_changelog.md)                                       |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       |                                                                                       |        |        |           |              |       |
 | [USAGE](./usage-guide/index.md) | [CLI](./usage-guide/automations_and_usage.md#local-repo-cli)      |   ✅   |   ✅   |    ✅     |      ✅       |  ✅   |
@@ -40,6 +40,8 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |       | [Actions](./installation/github.md#run-as-a-github-action)                            |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       |                                                                                       |        |        |           |              |       |
 | [CORE](./core-abilities/index.md) | [Adaptive and token-aware file patch fitting](./core-abilities/compression_strategy.md) |   ✅   |   ✅   |    ✅     |      ✅       |       |
+|       | [Agent skills (`SKILL.md`)](./core-abilities/agent_skills.md)                         |   ✅   |   ✅   |    ✅     |      ✅       |  ✅   |
+|       | [Repo context files (`AGENTS.md`)](./usage-guide/additional_configurations.md#bringing-per-repo-context-files-to-pr-agent) |   ✅   |   ✅   |    ✅     |      ✅       |  ✅   |
 |       | [Chat on code suggestions](./core-abilities/interactivity.md)                         |   ✅   |  ✅   |           |              |       |
 |       | [Compression strategy](./core-abilities/compression_strategy.md)                      |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       | [Dynamic context](./core-abilities/dynamic_context.md)                                |   ✅   |   ✅   |    ✅     |      ✅       |       |
@@ -48,6 +50,8 @@ PR-Agent offers comprehensive pull request functionalities integrated with vario
 |       | [Local and global metadata](./core-abilities/metadata.md)                             |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       | [Multiple models support](./usage-guide/changing_a_model.md)                          |   ✅   |   ✅   |    ✅     |      ✅       |       |
 |       | [Self reflection](./core-abilities/self_reflection.md)                                |   ✅   |   ✅   |    ✅     |      ✅       |       |
+
+⚠️ `/help_docs` is temporarily disabled since v0.36.1 pending a fix for a credential-exposure issue ([#2445](https://github.com/The-PR-Agent/pr-agent/issues/2445)); see [Help Docs](./tools/help_docs.md).
 
 ## Example Results
 

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -397,6 +397,44 @@ Run only specific tools automatically:
         github_action_config.pr_actions: '["opened", "reopened"]'
 ```
 
+##### CI artifact context
+
+A file produced by an earlier CI step — a test report, a coverage summary, a linter or SAST output — can be injected into the prompts of `/review`, `/describe` and `/improve`, so the model reviews the PR with your pipeline's own findings in hand.
+
+Point the action at the file with the `artifact_path` input. The path is resolved relative to `GITHUB_WORKSPACE` (an absolute path also works), so the file must already exist in the workspace when PR-Agent runs — produce it in a previous step, or download it with `actions/download-artifact`:
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: pytest --junitxml=reports/pytest.xml || true
+      - name: PR Agent action step
+        uses: the-pr-agent/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          artifact_path: reports/pytest.xml
+          artifact_instructions: "These are the failing tests from this PR's CI run. Call out any suggestion that would not fix them."
+```
+
+Setting `artifact_path` turns the feature on by itself; there is no separate enable switch to flip in the workflow. The file contents are wrapped in a labelled `CI Artifact` block and appended to the `extra_instructions` of each target tool.
+
+The remaining knobs live in the `[artifacts]` section of your configuration:
+
+```toml
+[artifacts]
+enable = false                                              # auto-enabled when artifact_path is set
+artifact_path = ""                                          # relative to GITHUB_WORKSPACE, or absolute
+artifact_instructions = ""                                  # empty = a generic "treat this as CI context" instruction
+artifact_label = ""                                         # empty = the file's name
+target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
+max_artifact_size = 50000                                   # characters; longer files are truncated with a marker
+```
+
+!!! note
+    A path that resolves outside `GITHUB_WORKSPACE` is rejected, and a missing or unreadable file is skipped with a warning — in both cases the tools still run, just without the artifact context.
+
 #### Using Configuration Files
 
 Instead of setting all options via environment variables, you can use a `.pr_agent.toml` file in your repository root:
@@ -559,23 +597,23 @@ For more detailed configuration options, see:
 ### Using a specific release
 
 !!! tip ""
-    if you want to pin your action to a specific release (v0.34.2 for example) for stability reasons, use:
+    if you want to pin your action to a specific release (v0.41.0 for example) for stability reasons, use:
     ```yaml
     ...
         steps:
           - name: PR Agent action step
             id: pragent
-            uses: docker://pragent/pr-agent:0.34.2-github_action
+            uses: docker://pragent/pr-agent:0.41.0-github_action
     ...
     ```
 
-    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/repository/docker/pragent/pr-agent/tags):
+    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/repository/docker/pragent/pr-agent/tags). Resolve the digest for the version you are pinning with `docker buildx imagetools inspect pragent/pr-agent:0.41.0-github_action --format '{{.Manifest.Digest}}'`, then use it in place of the tag:
     ```yaml
     ...
         steps:
           - name: PR Agent action step
             id: pragent
-            uses: docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c
+            uses: docker://pragent/pr-agent@sha256:<digest>
     ...
     ```
 

--- a/docs/docs/summary.md
+++ b/docs/docs/summary.md
@@ -17,6 +17,7 @@
 * [Managing Mail Notifications](usage-guide/mail_notifications.md)
 * [Changing a Model](usage-guide/changing_a_model.md)
 * [Additional Configurations](usage-guide/additional_configurations.md)
+* [Plain-Diff Mode](usage-guide/plain_diff_mode.md)
 * [Frequently Asked Questions](faq/index.md)
 
 ## Tools
@@ -36,7 +37,7 @@
 ## Core Abilities
 
 * [Core Abilities](core-abilities/index.md)
-* [Chat on code suggestions](core-abilities/interactivity.md)
+* [Agent skills](core-abilities/agent_skills.md)
 * [Compression strategy](core-abilities/compression_strategy.md)
 * [Dynamic context](core-abilities/dynamic_context.md)
 * [Fetching ticket context](core-abilities/fetching_ticket_context.md)

--- a/docs/docs/tools/help_docs.md
+++ b/docs/docs/tools/help_docs.md
@@ -1,3 +1,13 @@
+!!! warning "`/help_docs` is currently disabled"
+    As of **v0.36.1**, the `/help_docs` command is temporarily disabled as a mitigation for a
+    credential-exposure vulnerability ([#2445](https://github.com/The-PR-Agent/pr-agent/issues/2445)):
+    the command accepted an untrusted runtime override of its git clone target, and the clone-URL
+    host validation only checked substring containment, so a host that merely *contained* the
+    allowed host could receive the git provider token.
+
+    The command is not registered in `PRAgent`, so invoking it has no effect on any provider. The
+    page below documents the tool as it behaves once it is re-enabled.
+
 ## Overview
 
 The `help_docs` tool can answer a free-text question based on a git documentation folder.

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -282,7 +282,7 @@ Set `AWS_USE_IMDS=true` in the environment. PR-Agent will resolve credentials vi
 Minimal GitHub Actions workflow (no AWS secret keys required):
 
 ```yaml
-- uses: Codium-ai/pr-agent@main
+- uses: the-pr-agent/pr-agent@main
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     AWS_USE_IMDS: "true"


### PR DESCRIPTION
Tracking issue: #2572

## What

An audit of the repository's markdown against the [Releases page](https://github.com/The-PR-Agent/pr-agent/releases) (currently `v0.41.0`) turned up documentation that is stale, contradicts shipped code, or points at resources the project no longer controls. This PR fixes the in-repo items.

Four commits, each independently reviewable.

### 1. Release history — `docs: point release history at GitHub Releases`

`CHANGELOG.md` stops at `2023-08-03`. `RELEASE_NOTES.md` stops at `[Version 0.11] - 2023-12-07`, lists `codiumai/pr-agent:*` Docker tags (frozen at `v0.31`) and links to `Codium-ai/pr-agent`.

Rather than backfill 30 releases by hand, both files now say up front that GitHub Releases is the source of truth, and their existing content is demoted to a labelled `## Archive` section (kept verbatim, headings demoted one level).

### 2. `docs(readme): refresh for v0.39-v0.41`

- **News and Updates** was entirely HTML-commented out; the newest hidden entry announced `v0.30`. Restored with `v0.39.0`–`v0.41.0` highlights.
- **Feature table**: `/help_docs` marked as disabled (see below); added rows for Agent skills (`SKILL.md`) and repo context files (`AGENTS.md`), both from `v0.39.0`.
- **AI Models** line widened beyond "OpenAI GPT, Claude, Deepseek".
- Contributing link pointed at a pinned commit (`b09eec26`) instead of `main`.
- "Docs moved to - www.pr-agent.ai" while every link in the file uses `docs.pr-agent.ai`.

### 3. `docs: fix stale org, contact and version references`

| Where | Was | Now |
|---|---|---|
| `CONTRIBUTING.md`, `docs/README.md`, `SECURITY.md` | `qodo-merge-docs.qodo.ai` | `docs.pr-agent.ai` |
| `SECURITY.md` | `security@qodo.ai` | GitHub private vulnerability reporting (verified enabled on this repo) |
| `CODE_OF_CONDUCT.md` | `dana.f@qodo.ai` | maintainer list + GitHub Support escalation |
| `CONTRIBUTING.md` | "Install Python 3.10 or higher" | 3.12, matching `pyproject.toml` |
| `changing_a_model.md:285` | `uses: Codium-ai/pr-agent@main` | `the-pr-agent/pr-agent@main` — the last surviving `Codium-ai` action reference, missed by #2392 |
| `docker/mosaico/` | "Canonical source is `qodo-ai/pr-agent`… never edit here directly" | inverted — this directory *is* canonical since #2556, and #2567 dropped the mirror parity check |
| `SECURITY.md` | `0.34.2-github_action` + a hardcoded digest | `0.41.0-github_action` + the command to resolve a digest |

### 4. `docs: cover the help_docs disablement, agent skills and CI artifacts`

- **`/help_docs` is unregistered** in [`pr_agent/agent/pr_agent.py:42`](https://github.com/The-PR-Agent/pr-agent/blob/main/pr_agent/agent/pr_agent.py#L42) since `v0.36.1` as a mitigation for #2445, but `docs/docs/tools/help_docs.md` still documented it as usable and both feature tables listed it as ✅ on three providers. The page now leads with a warning explaining why; the table rows are marked.
- **`docs/docs/summary.md`** had drifted from the mkdocs nav — missing `agent_skills.md` and `plain_diff_mode.md`, and still carrying a duplicate `interactivity.md` entry the nav dropped.
- **CI artifact context injection** (#2494, `v0.40.0`) had no documentation anywhere. The `[artifacts]` config block and the action's `artifact_path` / `artifact_instructions` inputs are now documented under the GitHub Action section, including the `GITHUB_WORKSPACE` containment check and the truncation behaviour.
- Release pin example in `installation/github.md` bumped `0.34.2` → `0.41.0`.

## Notes for maintainers

- **Contact addresses are the one judgement call here.** `security@qodo.ai` and `dana.f@qodo.ai` were replaced with GitHub-native channels rather than invented addresses. If the project has real replacements, please substitute them.
- **Not fixed, deliberately out of scope** — tracked in #2572:
  - Runtime strings in `pr_agent/` emit user-visible links to `Codium-ai/pr-agent` in published PR comments: `pr_agent/servers/help.py` (3×), `pr_agent/algo/utils.py:1283`, `pr_agent/tools/pr_reviewer.py:449`, plus `cli_pip.py` and the e2e/health tests.
  - `.github/workflows/pr-agent-review.yaml:23` still runs `Codium-ai/pr-agent@e13da4fd`.
  - ~40 doc images are hosted on `codium.ai` / `qodo.ai` CDNs, including a `diagram-v0.9.png` architecture diagram. Rehosting needs the assets.

## Testing

Markdown-only (plus three comment lines in `docker/mosaico/`); no code paths touched. `docs-ci` builds mkdocs on push to `main`, and no Python toolchain was available in this environment, so the mkdocs build has **not** been run locally. Anchors used in new links were checked against the target headings by hand; the one anchor that would not have resolved (`#immutable-releases-and-version-tags`, an admonition title rather than a heading) was replaced with a plain page link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

