### PR TITLE
ci(publish): authenticate to PyPI via Trusted Publishing (BLOCKED on PyPI-side registration)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,11 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     environment: release
+    # A job-level block replaces the workflow-level `contents: read` outright,
+    # so checkout's read access has to be restated alongside the OIDC token.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
@@ -79,9 +84,11 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build
 
+      # Authenticates via Trusted Publishing (OIDC) — no API token. Passing an
+      # explicit password would disable it, and would also silently suppress the
+      # PEP 740 attestations the action publishes by default.
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           # Re-running the workflow for the same version (e.g. after a
           # transient registry failure) should not fail because the wheel
           # already exists on PyPI.


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until the trusted publisher is registered on PyPI.** Merging first turns the current failure into a different one (`invalid-publisher` instead of the email 403). The registration is step 1 below and needs a PyPI **owner** of the `pr-agent` project — I don't have that access, so this PR is ready and waiting on it.

Fixes the root cause of #2573.

## Why

`PYPI_API_TOKEN` is a **user-scoped** token. The PyPI account behind it lost its verified primary email between `v0.39.0` (2026-07-05, published fine) and `v0.40.0` (2026-07-25), and PyPI refuses uploads from such a token regardless of its permissions on the project:

```
403 User 'talrid23', associated with the API token used, does not have a
verified primary email address.
```

Both `v0.40.0` and `v0.41.0` failed identically ([run 30166768266](https://github.com/The-PR-Agent/pr-agent/actions/runs/30166768266), [run 30213550140](https://github.com/The-PR-Agent/pr-agent/actions/runs/30213550140)). The wheels built successfully both times; only the upload was rejected. Images went to Docker Hub, so `pip install pr-agent` still resolves to `0.39.0` while `docker pull pragent/pr-agent:0.41.0` works.

Re-issuing a token papers over it. Any user-scoped credential re-introduces the same failure mode the moment that person's account changes state — and this project no longer has a natural owner for such an account.

## What this changes

Two edits to `publish-pypi`:

```diff
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
```
```diff
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
```

The runner exchanges a GitHub OIDC token for a short-lived, single-use PyPI upload token. Nothing long-lived to keep valid.

A job-level `permissions:` block *replaces* the workflow-level `contents: read` rather than extending it, hence restating it — `publish-docker` already uses this same pattern.

**Side benefit:** PEP 740 build attestations start working. They're published by default and are currently suppressed, as the failing runs warn:

> The workflow was run with the 'attestations: true' input, but an explicit password was also set, disabling Trusted Publishing. As a result, the attestations input is ignored.

## What a maintainer needs to do

**1. Register the trusted publisher (blocking, PyPI owner role only — maintainer is not sufficient).**

PyPI → `pr-agent` → Manage project → Publishing → *Add a new publisher* → GitHub:

| Field | Value |
|---|---|
| Owner | `The-PR-Agent` |
| Repository name | `pr-agent` |
| Workflow name | `publish.yml` |
| Environment name | `release` |

- Workflow name is the **filename**, not the `name:` key — `publish.yml`, not `Publish`.
- Environment is case-sensitive and must match `environment: release` on the job. Leaving it blank would accept a token minted from *any* environment in this repo, so filling it in is the tighter configuration. The `release` environment already exists on the repo with no protection rules.
- This is the existing-project flow, not "pending publisher" — that one is only for names not yet on PyPI.

**2. Merge this PR.**

**3. Republish the two missing versions** by re-running only the failed jobs. No new tags, no new releases:

```sh
gh run rerun 30166768266 --job 89701051217   # v0.40.0
gh run rerun 30213550140 --job 89823722603   # v0.41.0
```

Each job re-checks out `prepare.outputs.sha` — the exact commit the images were built from — and re-runs `set_pyproject_version.py`, so the rebuilt artifacts match. `skip-existing: true` keeps it idempotent.

> [!NOTE]
> A re-run uses the workflow file **as of that run's commit**, not `main`. Since these runs predate this PR, their re-runs would still use the token path. So either register the publisher *and* fix the account email for the two re-runs, or publish `0.40.0`/`0.41.0` through `workflow_dispatch` after merging — the dispatch path takes a version input, and `finalize` skips release creation when the release already exists.

**4. Delete the `PYPI_API_TOKEN` secret** — after the first successful OIDC publish, not before.

## Testing

Cannot be exercised from a fork: OIDC claims carry the fork's repository, and the `release` environment and its secrets don't exist there. First real validation is the next publish run on `main`. It fails closed — a misconfigured or absent publisher gives an explicit `invalid-publisher` error rather than publishing something unintended.

The YAML change is 8 added lines and 1 removed; no other job is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
