### PR TITLE
fix: fall back to old path when diff_item.b_path is None in LocalGitProvider

### DIFF
--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -89,7 +89,7 @@ class LocalGitProvider(GitProvider):
                 FilePatchInfo(original_file_content_str,
                               new_file_content_str,
                               diff_item.diff.decode('utf-8'),
-                              diff_item.b_path,
+                              diff_item.b_path or diff_item.a_path,
                               edit_type=edit_type,
                               old_filename=None if diff_item.a_path == diff_item.b_path else diff_item.a_path
                               )

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -1,5 +1,6 @@
 import git
 
+from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.git_providers.local_git_provider import LocalGitProvider
 
 
@@ -54,3 +55,29 @@ def test_get_languages_matches_full_names_and_multipart_extensions(tmp_path):
     # One file each -> ~33.33% apiece, and none dropped as "unknown".
     assert set(languages) == {"Dockerfile", "CMake", "Python"}
     assert all(abs(v - 100 / 3) < 1e-6 for v in languages.values())
+
+
+def test_get_diff_files_deleted_file_falls_back_to_old_path(tmp_path):
+    # A plain deletion has no "new side": GitPython sets diff_item.b_path to None.
+    # The filename must fall back to a_path (the old path) instead of None, or
+    # downstream consumers keying on file.filename (e.g. set_file_languages'
+    # file.filename.rsplit('.')) hit AttributeError on NoneType. See issue #2580.
+    repo = _make_repo(tmp_path, ["keep.py", "gone.py"])
+    target_branch_name = repo.active_branch.name  # the branch that still has gone.py
+    repo.git.checkout("-b", "feature")
+    (tmp_path / "gone.py").unlink()
+    repo.index.remove(["gone.py"])
+    repo.index.commit("remove gone.py")
+
+    provider = object.__new__(LocalGitProvider)  # bypass heavy __init__
+    provider.repo = repo
+    provider.target_branch_name = target_branch_name
+
+    diff_files = provider.get_diff_files()  # must not raise
+
+    deleted = [f for f in diff_files if f.edit_type == EDIT_TYPE.DELETED]
+    assert len(deleted) == 1
+    # filename falls back to the old path rather than being None.
+    assert deleted[0].filename == "gone.py"
+    # every diff file exposes a usable filename for downstream consumers.
+    assert all(f.filename is not None for f in diff_files)


### PR DESCRIPTION
## What

Fixes a crash in `LocalGitProvider.get_diff_files()` when a review/describe diff
deletes a tracked file.

For a plain deletion, GitPython sets `diff_item.b_path` (the "new side" path) to
`None`. The `FilePatchInfo.filename` was built directly from `b_path`, so it
became `None`. Downstream consumers that key on `file.filename` — e.g.
`set_file_languages()` in `pr_agent/algo/utils.py` (`file.filename.rsplit('.')`)
— then raise `AttributeError: 'NoneType' object has no attribute 'rsplit'`.

The fix falls back to `diff_item.a_path` (the old path), mirroring how the
adjacent `old_filename` argument already accounts for this asymmetry:

```python
diff_item.b_path or diff_item.a_path,
```

## Reproduction

Any local-provider run (`git_provider=local`) of `/review` or `/describe` on a
diff that deletes a tracked file relative to the target branch.

## Tests

Added `test_get_diff_files_deleted_file_falls_back_to_old_path` in
`tests/unittest/test_local_git_provider.py`. It builds a repo with a branch that
deletes a tracked file and asserts `get_diff_files()` does not raise and that the
deleted file's `filename` falls back to the old path instead of `None`.
Verified the test fails without the fix (`assert None == 'gone.py'`) and passes
with it.

Fixes #2580