### PR TITLE
feat: support the /improve command for the local git provider

### DIFF
--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -26,7 +26,8 @@ class LocalGitProvider(GitProvider):
     It mimics the PR functionality of the GitProvider interface,
     but does not require a hosted git repository.
     Instead of providing a PR url, the user provides a local branch path to generate a diff-patch.
-    For the MVP it only supports the /review and /describe capabilities.
+    It supports the /review, /describe and /improve capabilities; each writes its output to a
+    file (review.md, description.md, improve.md) since there is no hosted PR to comment on.
     """
 
     def __init__(self, target_branch_name, incremental=False):
@@ -43,6 +44,8 @@ class LocalGitProvider(GitProvider):
             if get_settings().get('local.description_path') is not None else self.repo_path / 'description.md'
         self.review_path = get_settings().get('local.review_path') \
             if get_settings().get('local.review_path') is not None else self.repo_path / 'review.md'
+        self.improve_path = get_settings().get('local.improve_path') \
+            if get_settings().get('local.improve_path') is not None else self.repo_path / 'improve.md'
         # inline code comments are not supported for local git repositories
         get_settings().pr_reviewer.inline_code_comments = False
 
@@ -115,7 +118,11 @@ class LocalGitProvider(GitProvider):
             file.write(title + '\n' + pr_body)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
-        with open(self.review_path, "w") as file:
+        # Temporary comments (e.g. "Preparing suggestions...") have no place to live
+        # locally and would otherwise clobber the persisted review.md; skip them.
+        if is_temporary:
+            return
+        with open(self.review_path, "w", encoding="utf-8") as file:
             # Write the string to the file
             file.write(pr_comment)
 
@@ -130,7 +137,31 @@ class LocalGitProvider(GitProvider):
         raise NotImplementedError('Publishing code suggestions is not implemented for the local git provider')
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
-        raise NotImplementedError('Publishing code suggestions is not implemented for the local git provider')
+        """
+        Write /improve output to a file (improve.md by default).
+
+        There is no hosted PR to attach inline suggestions to, so the suggestions the
+        tool built for inline publishing are rendered as a single markdown document,
+        mirroring how /review and /describe persist their output locally. Each entry
+        carries a rendered 'body' plus its file and line range; format them into a
+        readable section per suggestion. Returns True so the caller does not fall back
+        to publishing suggestions one by one.
+        """
+        sections = []
+        for suggestion in code_suggestions:
+            relevant_file = suggestion.get('relevant_file', '').strip()
+            start = suggestion.get('relevant_lines_start')
+            end = suggestion.get('relevant_lines_end')
+            location = relevant_file
+            if start is not None:
+                location += f" [{start}-{end}]" if end is not None and end != start else f" [{start}]"
+            header = f"### {location}" if location else "### Suggestion"
+            sections.append(f"{header}\n\n{suggestion.get('body', '').strip()}")
+        pr_body = "# PR Code Suggestions ✨\n\n" + "\n\n".join(sections) if sections \
+            else "# PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
+        with open(self.improve_path, "w", encoding="utf-8") as file:
+            file.write(pr_body)
+        return True
 
     def publish_labels(self, labels):
         pass  # Not applicable to the local git provider, but required by the interface

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -323,6 +323,7 @@ avoid_full_files = false
 # LocalGitProvider settings - uncomment to use paths other than default
 # description_path= "path/to/description.md"
 # review_path= "path/to/review.md"
+# improve_path= "path/to/improve.md"
 
 [gerrit]
 # endpoint to the gerrit service

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -54,3 +54,50 @@ def test_get_languages_matches_full_names_and_multipart_extensions(tmp_path):
     # One file each -> ~33.33% apiece, and none dropped as "unknown".
     assert set(languages) == {"Dockerfile", "CMake", "Python"}
     assert all(abs(v - 100 / 3) < 1e-6 for v in languages.values())
+
+
+def test_publish_code_suggestions_writes_improve_file(tmp_path):
+    # /improve has no hosted PR to attach inline comments to, so the suggestions
+    # built for inline publishing are rendered to improve.md, mirroring how
+    # /review and /describe persist their output locally.
+    improve_path = tmp_path / "improve.md"
+    provider = object.__new__(LocalGitProvider)  # bypass heavy __init__
+    provider.improve_path = improve_path
+
+    code_suggestions = [
+        {"body": "**Suggestion:** rename x\n```suggestion\ny = 1\n```",
+         "relevant_file": "a.py", "relevant_lines_start": 3, "relevant_lines_end": 5},
+        {"body": "**Suggestion:** add guard\n```suggestion\nif y:\n```",
+         "relevant_file": "b.py", "relevant_lines_start": 7, "relevant_lines_end": 7},
+    ]
+
+    assert provider.publish_code_suggestions(code_suggestions) is True
+    content = improve_path.read_text()
+    # each suggestion's file, line range and rendered body make it into the file.
+    assert "### a.py [3-5]" in content
+    assert "### b.py [7]" in content  # single-line range collapses to one number
+    assert "rename x" in content
+    assert "add guard" in content
+
+
+def test_publish_code_suggestions_no_suggestions(tmp_path):
+    improve_path = tmp_path / "improve.md"
+    provider = object.__new__(LocalGitProvider)
+    provider.improve_path = improve_path
+
+    assert provider.publish_code_suggestions([]) is True
+    assert "No code suggestions found" in improve_path.read_text()
+
+
+def test_publish_comment_skips_temporary(tmp_path):
+    # Temporary progress comments ("Preparing suggestions...") must not clobber
+    # the persisted review.md; only real output is written.
+    review_path = tmp_path / "review.md"
+    provider = object.__new__(LocalGitProvider)
+    provider.review_path = review_path
+
+    provider.publish_comment("Preparing suggestions...", is_temporary=True)
+    assert not review_path.exists()
+
+    provider.publish_comment("real review body")
+    assert review_path.read_text() == "real review body"


### PR DESCRIPTION
## What

Adds support for the `/improve` command to the local git provider
(`git_provider=local`).

Previously `LocalGitProvider` implemented only `/review` and `/describe`;
running `/improve` raised `NotImplementedError` at publish time. Because the
local provider does not advertise `gfm_markdown`, `/improve` is routed to the
inline-suggestion path in `pr_agent/tools/pr_code_suggestions.py`, which calls
`publish_code_suggestions()` — a stub that raised.

This PR implements that method so `/improve` persists its output to a file,
mirroring how `/review` (`review.md`) and `/describe` (`description.md`) already
behave locally.

## Changes

- **`publish_code_suggestions()`** — renders the suggestions the tool already
  built for inline publishing (file, line range, suggestion body) into a single
  markdown document and writes it to `improve.md`. Returns `True` so the caller
  does not fall back to publishing suggestions one by one.
- **`local.improve_path`** — new optional setting (default `improve.md`),
  alongside the existing `local.description_path` / `local.review_path`; added
  to the `[local]` section of `configuration.toml`.
- **`publish_comment(is_temporary=True)`** — now a no-op locally, so the
  transient "Preparing suggestions..." progress message no longer clobbers
  `review.md`.
- Output files touched here are written as UTF-8.
- Updated the class docstring to reflect the supported commands.

No changes to the shared tool logic (`pr_agent/tools/pr_code_suggestions.py`)
are required — only the local provider fills in the previously-stubbed method.

## Tests

Added focused unit tests in `tests/unittest/test_local_git_provider.py`:

- `test_publish_code_suggestions_writes_improve_file` — suggestions are rendered
  to `improve.md` with each file, line range and body; single-line ranges
  collapse to one number.
- `test_publish_code_suggestions_no_suggestions` — empty input still writes a
  well-formed "no suggestions" file and returns `True`.
- `test_publish_comment_skips_temporary` — temporary progress comments do not
  create/overwrite `review.md`; real output still writes.

All local-provider unit tests pass; `flake8` and `isort` are clean on the
changed files.

## Notes / limitations

- Inline, commit-ready suggestions attached to specific lines are intentionally
  not supported locally — there is no hosted PR to attach them to.
- When the model returns *zero* suggestions, the tool's `publish_no_suggestions`
  path routes through the generic `publish_comment`, so that notice lands in
  `review.md` rather than `improve.md`. The primary path (suggestions present)
  correctly writes `improve.md`. Aligning the empty case would require a
  tool-side change and is left out to keep this PR focused on the provider.

Closes #2582
