### PR TITLE
feat: optional provider-side request attribution via the OpenAI user field

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -120,6 +120,28 @@ log_level = "DEBUG"  # Options: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 
 The default log level is "DEBUG", which provides detailed output of all operations. If you prefer less verbose logs, you can set higher log levels like "INFO" or "WARNING".
 
+## Attributing requests to a PR on the provider side
+
+When `add_user_to_requests` is enabled, PR-Agent sends the current command and PR URL in the
+OpenAI-compatible `user` request field, as a compact JSON string:
+
+```
+{"command":"improve","pr_url":"https://gitlab.example.com/group/project/-/merge_requests/171"}
+```
+
+Providers that record this field per request (for example OpenRouter, which shows it as
+`external_user` in the generation details and includes it in the activity export) can then
+attribute every request, its cost and its outcome to a specific PR and command, without
+timestamp correlation.
+
+```
+[config]
+add_user_to_requests = true
+```
+
+The setting is disabled by default, since it shares request-attribution data with the model
+provider: enabling it is an explicit operator choice.
+
 ## Integrating with Logging Observability Platforms
 
 Various logging observability tools can be used out-of-the box when using the default LiteLLM AI Handler. Simply configure the LiteLLM callback settings in `configuration.toml` and set environment variables according to the LiteLLM [documentation](https://docs.litellm.ai/docs/).

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -431,20 +431,29 @@ class LiteLLMAIHandler(BaseAiHandler):
         e.g. {"command":"improve","pr_url":"https://..."}. Returns an empty string when
         no context is available.
         """
+        # The probe record is matched by identity, so a concurrent request adding
+        # its own sink at the same time cannot capture this request's context nor
+        # leak its own into it.
+        probe = object()
         captured_extra = []
 
         def capture_logs(message):
-            record = message.record
+            extra = message.record.get("extra") or {}
+            if extra.get("user_field_probe") is not probe:
+                return
             log_entry = {}
-            if record.get("extra", None).get("command", None) is not None:
-                log_entry.update({"command": record["extra"]["command"]})
-            if record.get("extra", {}).get("pr_url", None) is not None:
-                log_entry.update({"pr_url": record["extra"]["pr_url"]})
+            if extra.get("command") is not None:
+                log_entry.update({"command": extra["command"]})
+            if extra.get("pr_url") is not None:
+                log_entry.update({"pr_url": extra["pr_url"]})
             captured_extra.append(log_entry)
 
         handler_id = get_logger().add(capture_logs)
-        get_logger().debug("Capturing logs for the request user field")
-        get_logger().remove(handler_id)
+        try:
+            get_logger().debug("Capturing the request context for the user field",
+                               user_field_probe=probe)
+        finally:
+            get_logger().remove(handler_id)
 
         context = captured_extra[0] if len(captured_extra) > 0 else {}
         if not context:
@@ -669,7 +678,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                             # litellm.drop_params is off: skip the field instead of
                             # breaking the call.
                             get_logger().debug(
-                                f"add_user_to_requests: 'user' not supported for model {model}, skipping")
+                                f"add_user_to_requests: user field unsupported for {model}, skipped")
 
                 # Support for Bedrock custom inference profile via model_id
                 model_id = get_settings().get("litellm.model_id")

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -424,6 +424,33 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         return kwargs
 
+    def _get_request_user_field(self) -> str:
+        """
+        Build the value for the OpenAI-compatible "user" request field from the current
+        logging context: a compact JSON string carrying the command and the PR URL,
+        e.g. {"command":"improve","pr_url":"https://..."}. Returns an empty string when
+        no context is available.
+        """
+        captured_extra = []
+
+        def capture_logs(message):
+            record = message.record
+            log_entry = {}
+            if record.get('extra', None).get('command', None) is not None:
+                log_entry.update({"command": record['extra']["command"]})
+            if record.get('extra', {}).get('pr_url', None) is not None:
+                log_entry.update({"pr_url": record['extra']["pr_url"]})
+            captured_extra.append(log_entry)
+
+        handler_id = get_logger().add(capture_logs)
+        get_logger().debug("Capturing logs for the request user field")
+        get_logger().remove(handler_id)
+
+        context = captured_extra[0] if len(captured_extra) > 0 else {}
+        if not context:
+            return ""
+        return json.dumps(context, separators=(",", ":"))[:256]
+
     @property
     def deployment_id(self):
         """
@@ -605,6 +632,36 @@ class LiteLLMAIHandler(BaseAiHandler):
 
                 # Support for custom OpenAI body fields (e.g., Flex Processing)
                 kwargs = _process_litellm_extra_body(kwargs)
+
+                # Optional provider-side request attribution: when config.add_user_to_requests
+                # is enabled, send the current command and PR URL in the OpenAI-compatible
+                # "user" field, so provider logs and usage exports can be attributed to a
+                # specific PR without timestamp correlation (OpenRouter shows it as
+                # "external_user" and includes it in the activity export). Disabled by
+                # default: it shares request-attribution data with the model provider.
+                if get_settings().config.get("add_user_to_requests", False):
+                    request_user = self._get_request_user_field()
+                    if request_user:
+                        try:
+                            supported_params = litellm.get_supported_openai_params(model=model) or []
+                        except Exception:
+                            supported_params = []
+                        if "user" in supported_params:
+                            kwargs["user"] = request_user
+                        elif isinstance(model, str) and model.startswith("openrouter/"):
+                            # LiteLLM's OpenRouter transformation does not forward the
+                            # standard "user" parameter; extra_body reaches the
+                            # OpenAI-compatible request body verbatim.
+                            user_extra_body = kwargs.get("extra_body") or {}
+                            user_extra_body["user"] = request_user
+                            kwargs["extra_body"] = user_extra_body
+                        else:
+                            # Providers whose parameter mapping does not accept "user"
+                            # (e.g. gemini, deepseek) would reject the request when
+                            # litellm.drop_params is off: skip the field instead of
+                            # breaking the call.
+                            get_logger().debug(
+                                f"add_user_to_requests: 'user' not supported for model {model}, skipping")
 
                 # Support for Bedrock custom inference profile via model_id
                 model_id = get_settings().get("litellm.model_id")

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -436,10 +436,10 @@ class LiteLLMAIHandler(BaseAiHandler):
         def capture_logs(message):
             record = message.record
             log_entry = {}
-            if record.get('extra', None).get('command', None) is not None:
-                log_entry.update({"command": record['extra']["command"]})
-            if record.get('extra', {}).get('pr_url', None) is not None:
-                log_entry.update({"pr_url": record['extra']["pr_url"]})
+            if record.get("extra", None).get("command", None) is not None:
+                log_entry.update({"command": record["extra"]["command"]})
+            if record.get("extra", {}).get("pr_url", None) is not None:
+                log_entry.update({"pr_url": record["extra"]["pr_url"]})
             captured_extra.append(log_entry)
 
         handler_id = get_logger().add(capture_logs)
@@ -449,7 +449,15 @@ class LiteLLMAIHandler(BaseAiHandler):
         context = captured_extra[0] if len(captured_extra) > 0 else {}
         if not context:
             return ""
-        return json.dumps(context, separators=(",", ":"))[:256]
+        # Cap the individual values before serialization, so the result stays
+        # valid JSON: slicing the serialized string could cut through closing
+        # quotes and braces. 30 chars cover every tool command; 200 chars of
+        # pr_url keep the total under 256 with the JSON overhead.
+        for key, max_len in (("command", 30), ("pr_url", 200)):
+            value = context.get(key)
+            if isinstance(value, str) and len(value) > max_len:
+                context[key] = value[:max_len]
+        return json.dumps(context, separators=(",", ":"))
 
     @property
     def deployment_id(self):

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -74,6 +74,7 @@ restricted_mode = false # when true, skip operations that require elevated permi
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 propagate_tool_errors = false # when true, a tool re-raises instead of swallowing an internal error, so a caller can tell a failed run from an empty one
 enable_ai_metadata = false # will enable adding ai metadata
+add_user_to_requests = false # send the current command and PR URL in the OpenAI-compatible "user" request field, for provider-side attribution of requests (e.g. OpenRouter "external_user")
 reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh"
 # extended thinking for Claude reasoning models
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature

--- a/tests/unittest/test_litellm_request_user_field.py
+++ b/tests/unittest/test_litellm_request_user_field.py
@@ -100,6 +100,16 @@ class TestRequestUserField:
         assert json.loads(kwargs["extra_body"]["user"])["command"] == "review"
 
     @pytest.mark.asyncio
+    async def test_long_pr_url_keeps_valid_json_under_cap(self, monkeypatch):
+        long_url = "https://gitlab.example.com/group/" + "x" * 400 + "/-/merge_requests/9"
+        kwargs = await _run(monkeypatch, "gpt-4o", True,
+                            log_context={"command": "improve", "pr_url": long_url})
+        assert len(kwargs["user"]) <= 256
+        payload = json.loads(kwargs["user"])
+        assert payload["command"] == "improve"
+        assert long_url.startswith(payload["pr_url"])
+
+    @pytest.mark.asyncio
     async def test_unsupported_provider_is_skipped(self, monkeypatch):
         # gemini's parameter mapping does not accept "user": the field is skipped
         # instead of breaking the call when litellm.drop_params is off.

--- a/tests/unittest/test_litellm_request_user_field.py
+++ b/tests/unittest/test_litellm_request_user_field.py
@@ -110,6 +110,28 @@ class TestRequestUserField:
         assert long_url.startswith(payload["pr_url"])
 
     @pytest.mark.asyncio
+    async def test_concurrent_requests_do_not_cross_attribute(self, monkeypatch):
+        import asyncio
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings(True))
+        with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+                   new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = _mock_response()
+            handler = litellm_handler.LiteLLMAIHandler()
+
+            async def run(command, pr_url):
+                with get_logger().contextualize(command=command, pr_url=pr_url):
+                    await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+            await asyncio.gather(
+                run("improve", "https://gitlab.example.com/a/-/merge_requests/1"),
+                run("review", "https://gitlab.example.com/b/-/merge_requests/2"),
+            )
+        payloads = [json.loads(c.kwargs["user"]) for c in mock_call.call_args_list]
+        by_command = {p["command"]: p["pr_url"] for p in payloads}
+        assert by_command["improve"].endswith("/a/-/merge_requests/1")
+        assert by_command["review"].endswith("/b/-/merge_requests/2")
+
+    @pytest.mark.asyncio
     async def test_unsupported_provider_is_skipped(self, monkeypatch):
         # gemini's parameter mapping does not accept "user": the field is skipped
         # instead of breaking the call when litellm.drop_params is off.

--- a/tests/unittest/test_litellm_request_user_field.py
+++ b/tests/unittest/test_litellm_request_user_field.py
@@ -1,0 +1,109 @@
+"""
+Tests for the optional provider-side request attribution in
+LiteLLMAIHandler.chat_completion.
+
+When config.add_user_to_requests is enabled, the current command and PR URL
+(read from the logging context set by PRAgent.handle_request) are sent in the
+OpenAI-compatible "user" request field as a compact JSON string. For
+"openrouter/..." models the value is also placed in extra_body, because
+LiteLLM's OpenRouter transformation does not forward the standard "user"
+parameter. Disabled (the default), the block is a no-op.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+from pr_agent.log import get_logger
+
+PR_URL = "https://gitlab.example.com/group/project/-/merge_requests/171"
+
+
+def _make_settings(add_user_to_requests):
+    def config_get(self, key, default=None):
+        if key == "add_user_to_requests":
+            return add_user_to_requests
+        return default
+
+    return type("Settings", (), {
+        "config": type("Config", (), {
+            "ai_timeout": 30,
+            "custom_reasoning_model": False,
+            "max_model_tokens": 32000,
+            "verbosity_level": 0,
+            "seed": -1,
+            "reasoning_effort": None,
+            "get": config_get,
+        })(),
+        "litellm": type("LiteLLM", (), {
+            "get": lambda self, key, default=None: default,
+        })(),
+        "get": lambda self, key, default=None: default,
+    })()
+
+
+def _mock_response():
+    mock = MagicMock()
+    response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    mock.__getitem__.side_effect = response.__getitem__
+    mock.dict.return_value = response
+    return mock
+
+
+async def _run(monkeypatch, model, add_user_to_requests, log_context=None):
+    monkeypatch.setattr(litellm_handler, "get_settings",
+                        lambda: _make_settings(add_user_to_requests))
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+               new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        if log_context:
+            with get_logger().contextualize(**log_context):
+                await handler.chat_completion(model=model, system="sys", user="usr")
+        else:
+            await handler.chat_completion(model=model, system="sys", user="usr")
+    return mock_call.call_args[1]
+
+
+class TestRequestUserField:
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_is_noop(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "gpt-4o", False,
+                            log_context={"command": "improve", "pr_url": PR_URL})
+        assert "user" not in kwargs
+        assert "extra_body" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_enabled_sets_user_field(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "gpt-4o", True,
+                            log_context={"command": "improve", "pr_url": PR_URL})
+        payload = json.loads(kwargs["user"])
+        assert payload == {"command": "improve", "pr_url": PR_URL}
+        assert "extra_body" not in kwargs
+
+
+    @pytest.mark.asyncio
+    async def test_enabled_without_context_is_noop(self, monkeypatch):
+        kwargs = await _run(monkeypatch, "gpt-4o", True)
+        assert "user" not in kwargs
+        assert "extra_body" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_openrouter_uses_extra_body_not_user_kwarg(self, monkeypatch):
+        # LiteLLM does not list "user" among OpenRouter's supported params, so the
+        # value must travel in extra_body only.
+        kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-4.5", True,
+                            log_context={"command": "review", "pr_url": PR_URL})
+        assert "user" not in kwargs
+        assert json.loads(kwargs["extra_body"]["user"])["command"] == "review"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_provider_is_skipped(self, monkeypatch):
+        # gemini's parameter mapping does not accept "user": the field is skipped
+        # instead of breaking the call when litellm.drop_params is off.
+        kwargs = await _run(monkeypatch, "gemini/gemini-2.5-pro", True,
+                            log_context={"command": "improve", "pr_url": PR_URL})
+        assert "user" not in kwargs
+        assert "extra_body" not in kwargs


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @FabrizioCafolla._

## Why

Requests recorded on the provider side carry no link back to the PR that generated them. Attributing cost or debugging a single PR against a provider's activity log requires timestamp correlation between PR-Agent logs and the provider dashboard, which breaks down on deployments serving many repositories: one PR event alone produces several calls (describe, review, improve, retries, fallbacks).

PR-Agent already knows the command and the PR URL at call time, in the logging context that `PRAgent.handle_request` sets. This PR forwards that information to the provider, opt-in.

## What

```toml
[config]
add_user_to_requests = false  # default: off, requests unchanged
```

When enabled, `chat_completion` sends the current command and PR URL in the OpenAI-compatible `user` request field, as a compact JSON string:

```
{"command":"improve","pr_url":"https://gitlab.example.com/group/project/-/merge_requests/171"}
```

OpenRouter records it as `external_user` in the generation details and in the activity export; other providers that persist the field get the same benefit. When the setting is off, requests are byte-identical to today's (unit-tested).

## How

The context is read with the same loguru-sink mechanism `add_litellm_callbacks` uses, so it works from the webhook servers and from the CLI, with no extra API calls.

Where the field goes depends on what LiteLLM supports for the target model, checked at runtime via `litellm.get_supported_openai_params(model)`:

| Provider | Behavior |
| --- | --- |
| OpenAI, Azure, Anthropic, Bedrock | standard `user` parameter |
| `openrouter/*` | `extra_body` (LiteLLM's OpenRouter transformation drops the `user` parameter; `extra_body` reaches the request body verbatim) |
| Providers without `user` support (e.g. Gemini, DeepSeek) | skipped with a debug log, so the setting can never break a call regardless of `litellm.drop_params` |

The value is truncated to 256 characters as a defensive bound.

## Privacy

Enabling the setting shares the PR URL with the model provider, so it is off by default and documented as an explicit operator choice (`docs/docs/usage-guide/additional_configurations.md`).

## Testing

- 5 unit tests in `tests/unittest/test_litellm_request_user_field.py` (off-by-default no-op, field set with context, `extra_body` routing for `openrouter/*`, unsupported-provider skip, no-context no-op), mirroring the style of `test_litellm_openrouter_controls.py`.
- Full unit suite: 1550 passed. Ruff: no new findings.
- Exercised end to end against OpenRouter from the CLI: the generation log records the payload in `external_user`.
