### PR TITLE
fix(litellm): surface the real provider error instead of RetryError

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -478,6 +478,11 @@ class LiteLLMAIHandler(BaseAiHandler):
     @retry(
         retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
         stop=stop_after_attempt(MODEL_RETRIES),
+        # Without reraise, tenacity replaces the provider's exception with RetryError, whose message
+        # is just "RetryError[<Future ... raised BadRequestError>]" - the actionable text (e.g.
+        # "LLM Provider NOT provided. You passed model=...") is lost, so a misconfigured model looks
+        # like a silent failure. Re-raise the last underlying error instead.
+        reraise=True,
     )
     async def chat_completion(self, model: str, system: str, user: str, temperature: float = 0.2, img_path: str = None):
         # Serialize env-var mutation + Bedrock call for IMDS mode to prevent concurrent
@@ -784,7 +789,14 @@ class LiteLLMAIHandler(BaseAiHandler):
                     raise
             except Exception as e:
                 get_logger().warning(f"Unknown error during LLM inference: {e}")
-                raise openai.APIError from e
+                # Wrap in APIError so the retry/fallback logic can classify it, but carry the
+                # original text over: raising the bare class instead fails to instantiate
+                # ("missing 2 required positional arguments") and loses the reason entirely.
+                raise openai.APIError(
+                    str(e),
+                    request=httpx.Request("POST", model),
+                    body=None,
+                ) from e
 
             get_logger().debug(f"\nAI response:\n{resp}")
 
@@ -814,7 +826,11 @@ class LiteLLMAIHandler(BaseAiHandler):
         else:
             response = await acompletion(**kwargs)
             if response is None or len(response["choices"]) == 0:
-                raise openai.APIError
+                raise openai.APIError(
+                    f"No choices in model response from {model}",
+                    request=httpx.Request("POST", model),
+                    body=None,
+                )
             content = response["choices"][0]['message']['content']
             finish_reason = response["choices"][0]["finish_reason"]
             if not content:

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -478,11 +478,7 @@ class LiteLLMAIHandler(BaseAiHandler):
     @retry(
         retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
         stop=stop_after_attempt(MODEL_RETRIES),
-        # Without reraise, tenacity replaces the provider's exception with RetryError, whose message
-        # is just "RetryError[<Future ... raised BadRequestError>]" - the actionable text (e.g.
-        # "LLM Provider NOT provided. You passed model=...") is lost, so a misconfigured model looks
-        # like a silent failure. Re-raise the last underlying error instead.
-        reraise=True,
+        reraise=True,  # surface the provider's error; RetryError hides the reason
     )
     async def chat_completion(self, model: str, system: str, user: str, temperature: float = 0.2, img_path: str = None):
         # Serialize env-var mutation + Bedrock call for IMDS mode to prevent concurrent
@@ -789,9 +785,6 @@ class LiteLLMAIHandler(BaseAiHandler):
                     raise
             except Exception as e:
                 get_logger().warning(f"Unknown error during LLM inference: {e}")
-                # Wrap in APIError so the retry/fallback logic can classify it, but carry the
-                # original text over: raising the bare class instead fails to instantiate
-                # ("missing 2 required positional arguments") and loses the reason entirely.
                 raise openai.APIError(
                     str(e),
                     request=httpx.Request("POST", model),

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -58,8 +58,7 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
 @pytest.mark.asyncio
 async def test_chat_completion_rejects_seed_for_claude_opus_4_8_default_temperature(monkeypatch):
     class FakeAPIError(Exception):
-        # Mirrors openai.APIError's signature: the handler constructs it with a message and
-        # request/body so the original failure text survives the wrapping (see issue #2576).
+        # same signature as openai.APIError, which the handler constructs with a message
         def __init__(self, message="", request=None, body=None):
             super().__init__(message)
             self.request = request

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -58,7 +58,12 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
 @pytest.mark.asyncio
 async def test_chat_completion_rejects_seed_for_claude_opus_4_8_default_temperature(monkeypatch):
     class FakeAPIError(Exception):
-        pass
+        # Mirrors openai.APIError's signature: the handler constructs it with a message and
+        # request/body so the original failure text survives the wrapping (see issue #2576).
+        def __init__(self, message="", request=None, body=None):
+            super().__init__(message)
+            self.request = request
+            self.body = body
 
     monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings(config_values={"seed": 123}))
     monkeypatch.setattr(litellm_handler.openai, "APIError", FakeAPIError)

--- a/tests/unittest/test_litellm_error_surfacing.py
+++ b/tests/unittest/test_litellm_error_surfacing.py
@@ -1,11 +1,4 @@
-"""Regression tests for issue #2576: a misconfigured model looked like a silent failure.
-
-Two separate defects destroyed the provider's error message before it reached the user:
-  1. tenacity's @retry wrapped the real exception in RetryError, whose str() is only
-     "RetryError[<Future ... raised BadRequestError>]" - the actionable text was gone.
-  2. `raise openai.APIError` raised the CLASS, so Python's instantiation failed with
-     "TypeError: __init__() missing 2 required positional arguments" and dropped __cause__.
-"""
+"""Errors from the model call must reach the caller with their message intact (issue #2576)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,11 +39,10 @@ class FakeSettings:
 
 
 def _api_error(message):
-    """A real openai.APIError, matching what litellm raises for bad model/provider config."""
     return openai.APIError(message, request=httpx.Request("POST", "http://test"), body=None)
 
 
-# The message litellm produces when it cannot infer a provider - the exact case in issue #2576.
+# what litellm raises when it cannot infer a provider
 PROVIDER_ERROR = (
     "litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are "
     "trying to call. You passed model=gpt-5.6-terra Learn more: "
@@ -60,10 +52,7 @@ PROVIDER_ERROR = (
 
 @pytest.mark.asyncio
 async def test_provider_error_survives_retry_instead_of_becoming_retryerror(monkeypatch):
-    # Retries are exhausted, so tenacity must re-raise the provider's own exception. Without
-    # reraise=True it raises RetryError, whose message names only the exception CLASS and drops
-    # the model name and the reason - which is what made #2576 look like a silent failure.
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
 
     with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                new_callable=AsyncMock) as mock_call:
@@ -74,19 +63,14 @@ async def test_provider_error_survives_retry_instead_of_becoming_retryerror(monk
             await handler.chat_completion(model="gpt-5.6-terra", system="sys", user="usr")
 
     assert not isinstance(exc_info.value, tenacity.RetryError)
-    # The caller can see which model failed and why, not just an exception class name.
     assert "gpt-5.6-terra" in str(exc_info.value)
     assert "LLM Provider NOT provided" in str(exc_info.value)
-    # It really did retry; the error survived the retry wrapper rather than bypassing it.
-    assert mock_call.call_count == litellm_handler.MODEL_RETRIES
+    assert mock_call.call_count == litellm_handler.MODEL_RETRIES  # it did retry first
 
 
 @pytest.mark.asyncio
 async def test_empty_choices_raises_usable_api_error_not_typeerror(monkeypatch):
-    # A response with no choices must surface as a real APIError carrying a message. Raising the
-    # bare class instead produced "TypeError: missing 2 required positional arguments", which
-    # tells the user nothing about what actually went wrong.
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
 
     empty = MagicMock()
     response = {"choices": []}
@@ -101,15 +85,12 @@ async def test_empty_choices_raises_usable_api_error_not_typeerror(monkeypatch):
             await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
 
     assert not isinstance(exc_info.value, TypeError)
-    assert str(exc_info.value)  # a non-empty, human-readable reason
     assert "gpt-4o" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_non_api_error_is_wrapped_but_keeps_message_and_cause(monkeypatch):
-    # Non-APIError failures are re-raised as APIError so the retry/fallback logic can classify
-    # them, but the original text and __cause__ must survive the conversion.
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
 
     original = ValueError("upstream exploded: bad endpoint")
 

--- a/tests/unittest/test_litellm_error_surfacing.py
+++ b/tests/unittest/test_litellm_error_surfacing.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #2576: a misconfigured model looked like a silent failure.
+
+Two separate defects destroyed the provider's error message before it reached the user:
+  1. tenacity's @retry wrapped the real exception in RetryError, whose str() is only
+     "RetryError[<Future ... raised BadRequestError>]" - the actionable text was gone.
+  2. `raise openai.APIError` raised the CLASS, so Python's instantiation failed with
+     "TypeError: __init__() missing 2 required positional arguments" and dropped __cause__.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import openai
+import pytest
+import tenacity
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+
+
+class FakeBox:
+    def __init__(self, values=None, **attrs):
+        self._values = values or {}
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+class FakeSettings:
+    def __init__(self, config_values=None, settings_values=None):
+        self.config = FakeBox(
+            config_values or {},
+            reasoning_effort=None,
+            ai_timeout=30,
+            custom_reasoning_model=False,
+            max_model_tokens=32000,
+            verbosity_level=0,
+            model="gpt-4o",
+        )
+        self.litellm = FakeBox()
+        self._settings_values = settings_values or {}
+
+    def get(self, key, default=None):
+        return self._settings_values.get(key, default)
+
+
+def _api_error(message):
+    """A real openai.APIError, matching what litellm raises for bad model/provider config."""
+    return openai.APIError(message, request=httpx.Request("POST", "http://test"), body=None)
+
+
+# The message litellm produces when it cannot infer a provider - the exact case in issue #2576.
+PROVIDER_ERROR = (
+    "litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are "
+    "trying to call. You passed model=gpt-5.6-terra Learn more: "
+    "https://docs.litellm.ai/docs/providers"
+)
+
+
+@pytest.mark.asyncio
+async def test_provider_error_survives_retry_instead_of_becoming_retryerror(monkeypatch):
+    # Retries are exhausted, so tenacity must re-raise the provider's own exception. Without
+    # reraise=True it raises RetryError, whose message names only the exception CLASS and drops
+    # the model name and the reason - which is what made #2576 look like a silent failure.
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+               new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = _api_error(PROVIDER_ERROR)
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        with pytest.raises(openai.APIError) as exc_info:
+            await handler.chat_completion(model="gpt-5.6-terra", system="sys", user="usr")
+
+    assert not isinstance(exc_info.value, tenacity.RetryError)
+    # The caller can see which model failed and why, not just an exception class name.
+    assert "gpt-5.6-terra" in str(exc_info.value)
+    assert "LLM Provider NOT provided" in str(exc_info.value)
+    # It really did retry; the error survived the retry wrapper rather than bypassing it.
+    assert mock_call.call_count == litellm_handler.MODEL_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_empty_choices_raises_usable_api_error_not_typeerror(monkeypatch):
+    # A response with no choices must surface as a real APIError carrying a message. Raising the
+    # bare class instead produced "TypeError: missing 2 required positional arguments", which
+    # tells the user nothing about what actually went wrong.
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+
+    empty = MagicMock()
+    response = {"choices": []}
+    empty.__getitem__.side_effect = response.__getitem__
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+               new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = empty
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        with pytest.raises(openai.APIError) as exc_info:
+            await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+    assert not isinstance(exc_info.value, TypeError)
+    assert str(exc_info.value)  # a non-empty, human-readable reason
+    assert "gpt-4o" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_non_api_error_is_wrapped_but_keeps_message_and_cause(monkeypatch):
+    # Non-APIError failures are re-raised as APIError so the retry/fallback logic can classify
+    # them, but the original text and __cause__ must survive the conversion.
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: FakeSettings())
+
+    original = ValueError("upstream exploded: bad endpoint")
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+               new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = original
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        with pytest.raises(openai.APIError) as exc_info:
+            await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+    assert not isinstance(exc_info.value, TypeError)
+    assert "upstream exploded: bad endpoint" in str(exc_info.value)
+    assert exc_info.value.__cause__ is original


### PR DESCRIPTION
## Problem

Reported in #2576: switching `config.model` to a model whose configuration is wrong produces no usable diagnostics. The run prints a stray red line that is a fragment of litellm's own stderr output (`Provider List: https://docs.litellm.ai/docs/providers`), then publishes "No suggestions". Nothing in pr-agent's log names the model or the reason, so the tool looks like it silently did nothing.

Note that the reporter's model itself is fine: `gpt-5.6-terra` has been in `MAX_TOKENS` since #2517 and is the default fallback model in 0.41.0, and litellm 1.93.0 resolves it to `provider=openai`. The real failure was in their endpoint/credential configuration — pr-agent just never showed it to them.

## Root cause

Two layers discarded the provider's error before it reached the caller.

**1. `@retry` had no `reraise`.** Once retries were exhausted, tenacity replaced the provider's exception with `RetryError`, whose message is only the exception *class name*:

```
tenacity.RetryError: RetryError[<Future at 0x… state=finished raised BadRequestError>]
```

The actionable text — `LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-5.6-terra` — never made it out. `RetryError` is also not an `openai.APIError`, so downstream handling could not classify it either.

**2. Two `raise openai.APIError` statements raised the class, not an instance.** Python then failed to instantiate it:

```
TypeError: APIError.__init__() missing 2 required positional arguments: 'message' and 'request'
```

Because the failure happens during instantiation, `from e` never applies — `__cause__` comes out as `None`, so the original error is lost completely rather than merely wrapped.

## Fix

- Add `reraise=True` to the `chat_completion` retry decorator so the last underlying exception propagates instead of `RetryError`.
- Construct `openai.APIError` with a message at both bare-class sites, matching the pattern already used for the empty-content case a few lines below.

After the change, the same reproduction surfaces:

```
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are
trying to call. You passed model=gpt-5.6-terra …
```

and the root cause arrives at the tool layer as `__cause__` in the logged traceback.

## Tests

`tests/unittest/test_litellm_error_surfacing.py` covers all three paths: a provider error surviving retry exhaustion, an empty-choices response, and a non-`APIError` failure keeping its message and `__cause__`. All three were confirmed to fail against the unfixed code before the fix was applied.

One existing test needed updating: `test_chat_completion_rejects_seed_for_claude_opus_4_8_default_temperature` monkeypatches `openai.APIError` with a bare `Exception` subclass, and was only passing because that fake was constructible with no arguments — which masked defect 2 from the suite. Its fake now mirrors the real signature.

Full unit suite: 1397 passed, 1 xfailed. Ruff output on the handler is identical to the `main` baseline (no new findings).

Fixes #2576
