### PR TITLE
feat(review): surface files excluded from review coverage

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -71,6 +71,10 @@ extra_instructions = "..."
         <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
       </tr>
       <tr>
+        <td><b>enable_review_coverage_footer</b></td>
+        <td>If set to true, the tool will display a review coverage footer when the token budget leaves files out of the review. Default is true.</td>
+      </tr>
+      <tr>
         <td><b>num_max_findings</b></td>
         <td>Number of maximum returned findings. Default is 3.</td>
       </tr>
@@ -176,7 +180,7 @@ extra_instructions = "..."
 
 ### Extra instructions
 
-!!! tip "" 
+!!! tip ""
 
     Extra instructions are important.
     The `review` tool can be configured with extra instructions, which can be used to guide the model to a feedback tailored to the needs of your project.

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -7,12 +7,13 @@ from github import RateLimitExceededException
 
 from pr_agent.algo.file_filter import filter_ignored
 from pr_agent.algo.git_patch_processing import (
-    extend_patch, handle_patch_deletions,
-    decouple_and_convert_to_hunks_with_lines_numbers)
+    decouple_and_convert_to_hunks_with_lines_numbers, extend_patch,
+    handle_patch_deletions)
 from pr_agent.algo.language_handler import sort_files_by_main_languages
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
-from pr_agent.algo.utils import ModelType, clip_tokens, get_max_tokens, get_model
+from pr_agent.algo.utils import (ModelType, clip_tokens, get_max_tokens,
+                                 get_model)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.log import get_logger
@@ -292,6 +293,7 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
         # Hard Stop, no more tokens
         if total_tokens > max_tokens_model - OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD:
             get_logger().warning(f"File was fully skipped, no more tokens: {filename}.")
+            remaining_files_list_new.append(filename)
             continue
 
         # If the patch is too large, just show the file name

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -119,6 +119,7 @@ minimal_commits_for_incremental_review=0
 minimal_minutes_for_incremental_review=0
 enable_intro_text=true
 enable_help_text=false # Determines whether to include help text in the PR review. Enabled by default.
+enable_review_coverage_footer=true
 
 [pr_description] # /describe #
 publish_labels=false

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -282,10 +282,10 @@ class PRReviewer:
                                                git_provider=self.git_provider,
                                                files=self.git_provider.get_diff_files())
 
-        if self.remaining_files_list:
+        if self.remaining_files_list and get_settings().pr_reviewer.enable_review_coverage_footer:
             displayed_files = self.remaining_files_list[:MAX_REVIEW_COVERAGE_FILES]
             markdown_text += (
-                "\n\n---\n\n"
+                "\n\n<hr>\n\n"
                 "⚠️ **Review coverage:** The following files were not included in this review "
                 "because of the token budget:\n"
                 + "\n".join(f"- `{file}`" for file in displayed_files)

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -282,6 +282,18 @@ class PRReviewer:
                                                git_provider=self.git_provider,
                                                files=self.git_provider.get_diff_files())
 
+        if self.remaining_files_list:
+            displayed_files = self.remaining_files_list[:MAX_REVIEW_COVERAGE_FILES]
+            markdown_text += (
+                "\n\n---\n\n"
+                "⚠️ **Review coverage:** The following files were not included in this review "
+                "because of the token budget:\n"
+                + "\n".join(f"- `{file}`" for file in displayed_files)
+            )
+            remaining_count = len(self.remaining_files_list) - len(displayed_files)
+            if remaining_count:
+                markdown_text += f"\n... and {remaining_count} more"
+
         # Add help text if gfm_markdown is supported
         if self.git_provider.is_supported("gfm_markdown") and get_settings().pr_reviewer.enable_help_text:
             markdown_text += "<hr>\n\n<details> <summary><strong>💡 Tool usage guide:</strong></summary><hr> \n\n"
@@ -294,18 +306,6 @@ class PRReviewer:
 
         # Add custom labels from the review prediction (effort, security)
         self.set_review_labels(data)
-
-        if self.remaining_files_list:
-            displayed_files = self.remaining_files_list[:MAX_REVIEW_COVERAGE_FILES]
-            markdown_text += (
-                "\n\n---\n\n"
-                "⚠️ **Review coverage:** The following files were not included in this review "
-                "because of the token budget:\n"
-                + "\n".join(f"- `{file}`" for file in displayed_files)
-            )
-            remaining_count = len(self.remaining_files_list) - len(displayed_files)
-            if remaining_count:
-                markdown_text += f"\n... and {remaining_count} more"
 
         if markdown_text == None or len(markdown_text) == 0:
             markdown_text = ""

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -12,8 +12,8 @@ from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
                                          get_pr_diff,
                                          retry_with_fallback_models)
-from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.repo_context import build_repo_context
+from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, PRReviewHeader,
                                  convert_to_markdown_v2, github_action_output,
@@ -64,6 +64,7 @@ class PRReviewer:
         self.ai_handler = ai_handler()
         self.ai_handler.main_pr_language = self.main_language
         self.patches_diff = None
+        self.remaining_files_list = []
         self.prediction = None
         question_str, answer_str = self._get_user_answers()
         self.pr_description, self.pr_description_files = (
@@ -200,11 +201,17 @@ class PRReviewer:
         return get_settings().pr_reviewer.get('publish_output_no_suggestions', True) or "No major issues detected" not in pr_review
 
     async def _prepare_prediction(self, model: str) -> None:
-        self.patches_diff = get_pr_diff(self.git_provider,
-                                        self.token_handler,
-                                        model,
-                                        add_line_numbers_to_hunks=True,
-                                        disable_extra_lines=False,)
+        output = get_pr_diff(self.git_provider,
+                             self.token_handler,
+                             model,
+                             add_line_numbers_to_hunks=True,
+                             disable_extra_lines=False,
+                             return_remaining_files=True,)
+        if isinstance(output, tuple):
+            self.patches_diff, self.remaining_files_list = output
+        else:
+            self.patches_diff = output
+            self.remaining_files_list = []
 
         if self.patches_diff:
             get_logger().debug(f"PR diff", diff=self.patches_diff)
@@ -285,6 +292,14 @@ class PRReviewer:
 
         # Add custom labels from the review prediction (effort, security)
         self.set_review_labels(data)
+
+        if self.remaining_files_list:
+            markdown_text += (
+                "\n\n---\n\n"
+                "⚠️ **Review coverage:** The following files were not included in this review "
+                "because of the token budget:\n"
+                + "\n".join(f"- `{file}`" for file in self.remaining_files_list)
+            )
 
         if markdown_text == None or len(markdown_text) == 0:
             markdown_text = ""

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -28,6 +28,8 @@ from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.ticket_pr_compliance_check import (
     extract_and_cache_pr_tickets, extract_tickets)
 
+MAX_REVIEW_COVERAGE_FILES = 50
+
 
 class PRReviewer:
     """
@@ -294,12 +296,16 @@ class PRReviewer:
         self.set_review_labels(data)
 
         if self.remaining_files_list:
+            displayed_files = self.remaining_files_list[:MAX_REVIEW_COVERAGE_FILES]
             markdown_text += (
                 "\n\n---\n\n"
                 "⚠️ **Review coverage:** The following files were not included in this review "
                 "because of the token budget:\n"
-                + "\n".join(f"- `{file}`" for file in self.remaining_files_list)
+                + "\n".join(f"- `{file}`" for file in displayed_files)
             )
+            remaining_count = len(self.remaining_files_list) - len(displayed_files)
+            if remaining_count:
+                markdown_text += f"\n... and {remaining_count} more"
 
         if markdown_text == None or len(markdown_text) == 0:
             markdown_text = ""

--- a/tests/unittest/test_diff_pipeline_core.py
+++ b/tests/unittest/test_diff_pipeline_core.py
@@ -12,11 +12,12 @@ rather than on full golden strings, so they remain robust to minor
 formatting tweaks.
 """
 
+from unittest.mock import patch
+
 import pr_agent.algo.pr_processing as pr_processing
 from pr_agent.algo.git_patch_processing import (
     decouple_and_convert_to_hunks_with_lines_numbers,
-    extract_hunk_lines_from_patch,
-)
+    extract_hunk_lines_from_patch)
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 # ---------------------------------------------------------------------------
@@ -400,6 +401,73 @@ class TestPrGenerateCompressedDiff:
             assert files_in_patches_list == [["f0.py"], ["f1.py"], ["f2.py"]]
             assert remaining_files_list == []
             assert deleted_files_list == []
+        finally:
+            settings.pr_description.max_ai_calls = original_max_ai_calls
+
+    def test_large_pr_handling_retries_file_after_hard_stop(self, monkeypatch):
+        """A hard-stopped file remains eligible for the next large-PR iteration."""
+
+        prompt_tokens = 100
+        max_tokens = 3_000
+        monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: max_tokens)
+
+        class HardStopAcrossIterationsTokenHandler(FakeTokenHandler):
+            def __init__(self):
+                super().__init__(prompt_tokens=prompt_tokens)
+                self.first_marker_calls = 0
+
+            def count_tokens(self, patch):
+                if "FIRST_MARKER" in patch:
+                    self.first_marker_calls += 1
+                    # The compressed file entry fits, and its final rendered
+                    # patch count crosses the hard-stop threshold after the
+                    # first file is included.
+                    return {1: 100, 2: 2_500}[self.first_marker_calls]
+                return super().count_tokens(patch)
+
+        token_handler = HardStopAcrossIterationsTokenHandler()
+        settings = self._settings()
+        original_max_ai_calls = settings.pr_description.max_ai_calls
+        settings.pr_description.max_ai_calls = 3
+
+        try:
+            files = [
+                _make_file(
+                    filename="first.py",
+                    patch="@@ -1 +1 @@\n+FIRST_MARKER\n",
+                    tokens=10,
+                ),
+                _make_file(
+                    filename="hard_stop.py",
+                    patch="@@ -1 +1 @@\n+SECOND_MARKER\n",
+                    tokens=5,
+                ),
+            ]
+
+            with patch.object(pr_processing, "get_logger") as logger:
+                (patches_list, _, deleted_files_list, remaining_files_list,
+                 file_dict, files_in_patches_list) = \
+                    pr_processing.pr_generate_compressed_diff(
+                        top_langs=[{"files": files}],
+                        token_handler=token_handler,
+                        model="some-model",
+                        convert_hunks_to_line_numbers=False,
+                        large_pr_handling=True,
+                    )
+
+            assert token_handler.first_marker_calls == 2
+            assert prompt_tokens + 2_500 > max_tokens - pr_processing.OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD
+            logger.return_value.warning.assert_any_call(
+                "File was fully skipped, no more tokens: hard_stop.py."
+            )
+            assert file_dict["first.py"]["tokens"] == 100
+            assert len(patches_list) == 2
+            assert files_in_patches_list == [["first.py"], ["hard_stop.py"]]
+            assert remaining_files_list == []
+            assert deleted_files_list == []
+            processed_files = [filename for batch in files_in_patches_list for filename in batch]
+            assert processed_files == ["first.py", "hard_stop.py"]
+            assert len(processed_files) == len(set(processed_files))
         finally:
             settings.pr_description.max_ai_calls = original_max_ai_calls
 

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -54,6 +54,56 @@ def test_generate_full_patch_keeps_remaining_files_when_patch_exceeds_soft_budge
         settings.config.verbosity_level = original_verbosity_level
 
 
+def test_generate_full_patch_records_files_after_hard_token_stop():
+    class HardStopTokenHandler(FakeTokenHandler):
+        def count_tokens(self, patch):
+            if "first.py" in patch:
+                return 2_000
+            return super().count_tokens(patch)
+
+    token_handler = HardStopTokenHandler(prompt_tokens=100)
+    file_dict = {
+        "first.py": {"patch": "+ first change", "tokens": 1, "edit_type": EDIT_TYPE.MODIFIED},
+        "hard_stop.py": {"patch": "+ hard stop change", "tokens": 1, "edit_type": EDIT_TYPE.MODIFIED},
+        "after_stop.py": {"patch": "+ after stop change", "tokens": 1, "edit_type": EDIT_TYPE.MODIFIED},
+    }
+
+    total_tokens, patches, remaining_files, files_in_patch = pr_processing.generate_full_patch(
+        convert_hunks_to_line_numbers=False,
+        file_dict=file_dict,
+        max_tokens_model=3_000,
+        remaining_files_list_prev=list(file_dict),
+        token_handler=token_handler,
+    )
+
+    assert total_tokens > 3_000 - pr_processing.OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD
+    assert files_in_patch == ["first.py"]
+    assert remaining_files == ["hard_stop.py", "after_stop.py"]
+    assert len(patches) == 1
+
+
+def test_generate_full_patch_records_too_large_patch_files():
+    token_handler = FakeTokenHandler(prompt_tokens=100)
+    file_dict = {
+        "included.py": {"patch": "+ included change", "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
+        "too_large.py": {"patch": "+ too large change", "tokens": 5_000, "edit_type": EDIT_TYPE.MODIFIED},
+        "after_large.py": {"patch": "+ after large change", "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
+    }
+
+    total_tokens, patches, remaining_files, files_in_patch = pr_processing.generate_full_patch(
+        convert_hunks_to_line_numbers=False,
+        file_dict=file_dict,
+        max_tokens_model=4_000,
+        remaining_files_list_prev=list(file_dict),
+        token_handler=token_handler,
+    )
+
+    assert total_tokens > token_handler.prompt_tokens
+    assert files_in_patch == ["included.py", "after_large.py"]
+    assert remaining_files == ["too_large.py"]
+    assert len(patches) == 2
+
+
 def test_get_all_models_uses_requested_model_type_and_string_fallbacks():
     settings = get_settings()
     original = {

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -86,25 +86,51 @@ def _render_review(reviewer, remaining_files, supports_gfm_markdown=False):
 
 def test_prepare_pr_review_appends_complete_coverage_footer():
     reviewer = _make_prediction_reviewer()
+    settings = get_settings()
+    original_enable_review_coverage_footer = settings.pr_reviewer.enable_review_coverage_footer
 
-    review = _render_review(reviewer, ["src/one.py", "nested/two.md"])
+    try:
+        settings.pr_reviewer.enable_review_coverage_footer = True
+        review = _render_review(reviewer, ["src/one.py", "nested/two.md"])
+    finally:
+        settings.pr_reviewer.enable_review_coverage_footer = original_enable_review_coverage_footer
 
     assert review.startswith("original review")
     assert "⚠️ **Review coverage:**" in review
     assert "- `src/one.py`" in review
     assert "- `nested/two.md`" in review
+    assert "\n\n<hr>\n\n" in review
+    assert "\n\n---\n\n" not in review
+
+
+def test_prepare_pr_review_hides_coverage_footer_when_disabled():
+    reviewer = _make_prediction_reviewer()
+    settings = get_settings()
+    original_enable_review_coverage_footer = settings.pr_reviewer.enable_review_coverage_footer
+
+    try:
+        settings.pr_reviewer.enable_review_coverage_footer = False
+        review = _render_review(reviewer, ["skipped.py"])
+    finally:
+        settings.pr_reviewer.enable_review_coverage_footer = original_enable_review_coverage_footer
+
+    assert review == "original review"
+    assert "Review coverage" not in review
 
 
 def test_prepare_pr_review_places_coverage_footer_before_help_text():
     reviewer = _make_prediction_reviewer()
     settings = get_settings()
+    original_enable_review_coverage_footer = settings.pr_reviewer.enable_review_coverage_footer
     original_enable_help_text = settings.pr_reviewer.enable_help_text
-    settings.pr_reviewer.enable_help_text = True
 
     try:
+        settings.pr_reviewer.enable_review_coverage_footer = True
+        settings.pr_reviewer.enable_help_text = True
         with patch("pr_agent.tools.pr_reviewer.HelpMessage.get_review_usage_guide", return_value="help text"):
             review = _render_review(reviewer, ["skipped.py"], supports_gfm_markdown=True)
     finally:
+        settings.pr_reviewer.enable_review_coverage_footer = original_enable_review_coverage_footer
         settings.pr_reviewer.enable_help_text = original_enable_help_text
 
     assert review.index("⚠️ **Review coverage:**") < review.index("help text")

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -104,6 +104,28 @@ def test_prepare_pr_review_leaves_original_content_unchanged_without_remaining_f
     assert "Review coverage" not in review
 
 
+def test_prepare_pr_review_limits_coverage_footer_to_50_files():
+    reviewer = _make_prediction_reviewer()
+    remaining_files = [f"file_{index}.py" for index in range(51)]
+
+    review = _render_review(reviewer, remaining_files)
+
+    assert review.count("- `file_") == 50
+    assert "- `file_0.py`" in review
+    assert "- `file_49.py`" in review
+    assert "- `file_50.py`" not in review
+
+
+def test_prepare_pr_review_reports_number_of_files_beyond_coverage_limit():
+    reviewer = _make_prediction_reviewer()
+    remaining_files = [f"file_{index}.py" for index in range(53)]
+
+    review = _render_review(reviewer, remaining_files)
+
+    assert "... and 3 more" in review
+    assert "- `file_50.py`" not in review
+
+
 def test_should_publish_review_no_suggestions_respects_config():
     reviewer = _make_reviewer()
     settings = get_settings()

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -10,6 +10,98 @@ def _make_reviewer(git_provider=None):
     reviewer.git_provider = git_provider or MagicMock()
     reviewer.pr_url = "https://example/pr/1"
     return reviewer
+
+
+def _make_prediction_reviewer(git_provider=None):
+    reviewer = _make_reviewer(git_provider)
+    reviewer.token_handler = MagicMock()
+    reviewer.remaining_files_list = []
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.prediction = None
+    return reviewer
+
+
+async def test_prepare_prediction_requests_remaining_files_and_preserves_tuple_result():
+    reviewer = _make_prediction_reviewer()
+    reviewer._get_prediction = AsyncMock(return_value="prediction")
+
+    with patch(
+        "pr_agent.tools.pr_reviewer.get_pr_diff",
+        return_value=("diff", ["src/one.py", "docs/two.md"]),
+    ) as get_pr_diff:
+        await reviewer._prepare_prediction("model")
+
+    get_pr_diff.assert_called_once_with(
+        reviewer.git_provider,
+        reviewer.token_handler,
+        "model",
+        add_line_numbers_to_hunks=True,
+        disable_extra_lines=False,
+        return_remaining_files=True,
+    )
+    assert reviewer.patches_diff == "diff"
+    assert reviewer.remaining_files_list == ["src/one.py", "docs/two.md"]
+    assert reviewer.prediction == "prediction"
+
+
+async def test_prepare_prediction_accepts_full_diff_string_when_token_budget_is_sufficient():
+    reviewer = _make_prediction_reviewer()
+    reviewer._get_prediction = AsyncMock(return_value="prediction")
+
+    with patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value="diff"):
+        await reviewer._prepare_prediction("model")
+
+    assert reviewer.patches_diff == "diff"
+    assert reviewer.remaining_files_list == []
+    assert reviewer.prediction == "prediction"
+
+
+async def test_prepare_prediction_keeps_incremental_review_compatible_with_tuple_result():
+    reviewer = _make_prediction_reviewer()
+    reviewer.incremental = SimpleNamespace(is_incremental=True)
+    reviewer._get_prediction = AsyncMock(return_value="prediction")
+
+    with patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["skipped.py"])):
+        await reviewer._prepare_prediction("model")
+
+    assert reviewer.patches_diff == "diff"
+    assert reviewer.remaining_files_list == ["skipped.py"]
+    assert reviewer.prediction == "prediction"
+
+
+def _render_review(reviewer, remaining_files):
+    reviewer.prediction = "review: {}"
+    reviewer.remaining_files_list = remaining_files
+    reviewer.git_provider.get_diff_files.return_value = []
+    reviewer.git_provider.is_supported.return_value = False
+    reviewer.set_review_labels = MagicMock()
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value={"review": {}}),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch("pr_agent.tools.pr_reviewer.convert_to_markdown_v2", return_value="original review"),
+    ):
+        return reviewer._prepare_pr_review()
+
+
+def test_prepare_pr_review_appends_complete_coverage_footer():
+    reviewer = _make_prediction_reviewer()
+
+    review = _render_review(reviewer, ["src/one.py", "nested/two.md"])
+
+    assert review.startswith("original review")
+    assert "⚠️ **Review coverage:**" in review
+    assert "- `src/one.py`" in review
+    assert "- `nested/two.md`" in review
+
+
+def test_prepare_pr_review_leaves_original_content_unchanged_without_remaining_files():
+    reviewer = _make_prediction_reviewer()
+
+    review = _render_review(reviewer, [])
+
+    assert review == "original review"
+    assert "Review coverage" not in review
 
 
 def test_should_publish_review_no_suggestions_respects_config():

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -69,11 +69,11 @@ async def test_prepare_prediction_keeps_incremental_review_compatible_with_tuple
     assert reviewer.prediction == "prediction"
 
 
-def _render_review(reviewer, remaining_files):
+def _render_review(reviewer, remaining_files, supports_gfm_markdown=False):
     reviewer.prediction = "review: {}"
     reviewer.remaining_files_list = remaining_files
     reviewer.git_provider.get_diff_files.return_value = []
-    reviewer.git_provider.is_supported.return_value = False
+    reviewer.git_provider.is_supported.return_value = supports_gfm_markdown
     reviewer.set_review_labels = MagicMock()
 
     with (
@@ -93,6 +93,21 @@ def test_prepare_pr_review_appends_complete_coverage_footer():
     assert "⚠️ **Review coverage:**" in review
     assert "- `src/one.py`" in review
     assert "- `nested/two.md`" in review
+
+
+def test_prepare_pr_review_places_coverage_footer_before_help_text():
+    reviewer = _make_prediction_reviewer()
+    settings = get_settings()
+    original_enable_help_text = settings.pr_reviewer.enable_help_text
+    settings.pr_reviewer.enable_help_text = True
+
+    try:
+        with patch("pr_agent.tools.pr_reviewer.HelpMessage.get_review_usage_guide", return_value="help text"):
+            review = _render_review(reviewer, ["skipped.py"], supports_gfm_markdown=True)
+    finally:
+        settings.pr_reviewer.enable_help_text = original_enable_help_text
+
+    assert review.index("⚠️ **Review coverage:**") < review.index("help text")
 
 
 def test_prepare_pr_review_leaves_original_content_unchanged_without_remaining_files():


### PR DESCRIPTION
### Background

`get_pr_diff` already returns `remaining_files_list` when the token budget excludes files, but `/review` discarded it. Reviewers therefore could not see which files were omitted.

### Implementation

* `/review` now calls `get_pr_diff(..., return_remaining_files=True)`.
* The returned `remaining_files_list` is stored while preserving compatibility with both tuple returns and the legacy full-diff string return.
* Files skipped by the hard token stop are now added to `remaining_files_list`.
* A coverage footer is appended when files remain, listing their full paths.
* The footer is configurable through `enable_review_coverage_footer` in the `[pr_reviewer]` section and is enabled by default.
* The configuration option is documented in `docs/docs/tools/review.md`.
* The footer displays at most 50 files and appends `... and N more` when additional files are omitted.
* The footer uses `<hr>` to match the existing help-text formatting and remains positioned before the help-text block.
* The original review content remains unchanged when no files are omitted or when the footer is disabled.
* `generate_full_patch` is shared by `/review` and `/describe`. When `large_pr_handling=true`, `pr_generate_compressed_diff` carries `remaining_files_list` into subsequent large-PR processing iterations, so files retained after a hard token stop can be retried later and may ultimately appear in `/describe`'s “Additional unprocessed files” list.
* A regression test now verifies that a hard-stopped file is retained and processed in the next large-PR iteration without duplication or omission.

### Tests

* Focused test suite: 44 passed.
* Full unit suite: 1577 passed, 1 skipped, 1 xfailed.
* Pre-commit hooks and `git diff --check` passed.

### Scope

This first cut does not implement `reviewed partially` tracking or `large_patch_policy="clip"` truncation tracking. It also does not add coverage percentages, thresholds, exclusion-reason categories, or unrelated refactoring.

Partially addresses #2565