### PR TITLE
docs: reference the official skills repository in agent skills page

### DIFF
--- a/docs/docs/core-abilities/agent_skills.md
+++ b/docs/docs/core-abilities/agent_skills.md
@@ -57,7 +57,7 @@ In short, PR-Agent supports **text-only** agent skills.
 
 An official collection of curated skills is maintained at [The-PR-Agent/skills](https://github.com/The-PR-Agent/skills). The repository hosts ready-to-use skills contributed by the community and maintainers, including:
 
-- **GitHub Action configuration** — a skill that helps developers generate the correct `.github/workflows/pr_agent.yml` file for their PR-Agent deployment, covering triggers, permissions, model selection, and environment variable setup.
+- **GitHub Action configuration** — a skill that helps developers generate the correct `.github/workflows/pr-agent.yml` file for their PR-Agent deployment, covering triggers, permissions, model selection, and environment variable setup.
 - Additional skills for common review scenarios.
 
 To use skills from the official repository, clone it to your PR-Agent host and add its path to `skills.paths`:

--- a/docs/docs/core-abilities/agent_skills.md
+++ b/docs/docs/core-abilities/agent_skills.md
@@ -53,6 +53,23 @@ The agent-skills standard supports bundled files alongside `SKILL.md`. PR-Agent 
 
 In short, PR-Agent supports **text-only** agent skills.
 
+## Official skills repository
+
+An official collection of curated skills is maintained at [The-PR-Agent/skills](https://github.com/The-PR-Agent/skills). The repository hosts ready-to-use skills contributed by the community and maintainers, including:
+
+- **GitHub Action configuration** — a skill that helps developers generate the correct `.github/workflows/pr_agent.yml` file for their PR-Agent deployment, covering triggers, permissions, model selection, and environment variable setup.
+- Additional skills for common review scenarios.
+
+To use skills from the official repository, clone it to your PR-Agent host and add its path to `skills.paths`:
+
+```toml
+[skills]
+enabled = true
+paths = ["/path/to/the-pr-agent-skills"]
+```
+
+Contributions of new skills are welcome — see the repository's README for guidelines on submitting your own.
+
 ## Limitations
 
 PR-Agent dispatches single-shot model calls, so the agent-skills standard's *progressive disclosure* model (the model reads `SKILL.md` only after selecting it by `description`, and reads `references/*.md` only on demand) is not implementable on the current architecture — an architecture change to support this is planned for the future. Until then, every enabled skill's text is loaded into every PR's prompt, bounded by `max_skills_tokens`. Skills that depend on script execution or binary assets will not work.

--- a/docs/docs/core-abilities/agent_skills.md
+++ b/docs/docs/core-abilities/agent_skills.md
@@ -60,7 +60,7 @@ An official collection of curated skills is maintained at [The-PR-Agent/skills](
 - **GitHub Action configuration** — a skill that helps developers generate the correct `.github/workflows/pr-agent.yml` file for their PR-Agent deployment, covering triggers, permissions, model selection, and environment variable setup.
 - Additional skills for common review scenarios.
 
-To use skills from the official repository, clone it to your PR-Agent host and add its path to `skills.paths`:
+To use skills from the official repository, clone it to your PR-Agent host and add its path to `skills.paths` in your **host-level** `configuration.toml` (not `.pr_agent.toml` — see the warning above about why `skills.paths` is host-level only):
 
 ```toml
 [skills]


### PR DESCRIPTION
## What

Issue #2579 requested documentation updates for PR-Agent skills. A community member created a skill that helps developers configure their AI agent to create the yml files for the GitHub Action. The maintainer (@naorpeled) responded by creating an official skills repository at [The-PR-Agent/skills](https://github.com/The-PR-Agent/skills).

## Changes

- Add an "Official skills repository" section to `docs/docs/core-abilities/agent_skills.md` linking to the curated skills collection
- Mention the GitHub Action configuration skill as an example of what the repository provides
- Show how to add the skills repository to `skills.paths` in configuration

## Notes

Documentation-only change. No code, tests, or dependencies affected. The new section follows the existing style and heading hierarchy of the page.

Closes #2579