### PR TITLE
feat(describe): make the changes-diagram direction configurable and adaptive

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -144,7 +144,7 @@ The direction of the diagram adapts to its shape. A diagram whose longest chain 
       </tr>
       <tr>
         <td><b>enable_pr_diagram</b></td>
-        <td>If set to true, the tool will generate a horizontal Mermaid flowchart summarizing the main pull request changes. This field remains empty if not applicable. Default is true.</td>
+        <td>If set to true, the tool will generate a Mermaid flowchart summarizing the main pull request changes. This field remains empty if not applicable. Default is true.</td>
       </tr>
       <tr>
         <td><b>pr_diagram_direction</b></td>

--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -66,6 +66,8 @@ The `/describe` tool includes a Mermaid sequence diagram showing component/funct
 
 This option is enabled by default via the `pr_description.enable_pr_diagram` param.
 
+The direction of the diagram adapts to its shape. A diagram whose longest chain of nodes exceeds `pr_description.pr_diagram_direction_threshold` is drawn top-down rather than left-to-right, so that wide diagrams are not scaled down until they become unreadable. Set `pr_description.pr_diagram_direction` to `LR` or `TD` to pin the direction instead.
+
 
 [//]: # (### How to enable\disable)
 
@@ -143,6 +145,14 @@ This option is enabled by default via the `pr_description.enable_pr_diagram` par
       <tr>
         <td><b>enable_pr_diagram</b></td>
         <td>If set to true, the tool will generate a horizontal Mermaid flowchart summarizing the main pull request changes. This field remains empty if not applicable. Default is true.</td>
+      </tr>
+      <tr>
+        <td><b>pr_diagram_direction</b></td>
+        <td>Direction of the generated Mermaid flowchart: <b>adaptive</b>, <b>LR</b> or <b>TD</b>. With adaptive, the direction is chosen from the shape of the diagram. Default is adaptive.</td>
+      </tr>
+      <tr>
+        <td><b>pr_diagram_direction_threshold</b></td>
+        <td>With <b>adaptive</b> direction, a diagram whose longest chain exceeds this many nodes is drawn top-down instead of left-to-right. Default is 5.</td>
       </tr>
       <tr>
         <td><b>auto_create_ticket</b></td>

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -131,6 +131,8 @@ final_update_message = true
 enable_help_text=false
 enable_help_comment=false
 enable_pr_diagram=true # adds a section with a diagram of the PR changes
+pr_diagram_direction='adaptive' # 'adaptive', 'LR', 'TD'. 'adaptive' picks the direction from the shape of the diagram
+pr_diagram_direction_threshold=5 # with 'adaptive', a chain longer than this many nodes is drawn top-down
 # describe as comment
 publish_description_as_comment=false
 publish_description_as_comment_persistent=true

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -804,6 +804,84 @@ def sanitize_diagram(diagram_raw: str) -> str:
     return '\n' + '\n'.join(result)
 
 
+DIAGRAM_HEADER_PATTERN = re.compile(r'^(\s*)(flowchart|graph)(\s+)(TB|TD|BT|RL|LR)\b(.*)$')
+DIAGRAM_CONNECTOR_PATTERN = re.compile(r'<?[-=.~]{2,}[->ox]?')
+DIAGRAM_NODE_ID_PATTERN = re.compile(r'[A-Za-z0-9_]+')
+DIAGRAM_STATEMENT_KEYWORDS = ('subgraph', 'end', 'direction', 'style', 'classDef', 'linkStyle', 'click')
+
+
+def _strip_diagram_labels(line: str) -> str:
+    """Remove label text, so that arrows written inside a label are not read as edges."""
+    line = re.sub(r'"[^"]*"', '', line)  # quoted labels, which is what the prompt asks the model for
+    line = re.sub(r'\|[^|]*\|', '', line)  # pipe-form edge labels: -->|text|
+    for pattern in (r'\[[^\[\]]*\]', r'\([^()]*\)', r'\{[^{}]*\}'):
+        previous = None
+        while previous != line:  # nested shapes such as [[...]] need more than one pass
+            previous = line
+            line = re.sub(pattern, '', line)
+    return line
+
+
+def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
+    """Extract the directed edges of a mermaid flowchart body, tolerating its syntax variants."""
+    edges = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith('%%'):
+            continue
+        if line.split(' ')[0].rstrip(';') in DIAGRAM_STATEMENT_KEYWORDS:
+            continue
+
+        cleaned = _strip_diagram_labels(line)
+        if not DIAGRAM_CONNECTOR_PATTERN.search(cleaned):
+            continue
+
+        # Split on connectors; each remaining chunk holds one or more node ids joined by '&'.
+        # Chunks left empty once labels are stripped collapse away, which is what makes
+        # `A -- "text" --> B` read as the single edge A -> B.
+        node_groups = []
+        for chunk in DIAGRAM_CONNECTOR_PATTERN.split(cleaned):
+            node_ids = []
+            for token in chunk.split('&'):
+                match = DIAGRAM_NODE_ID_PATTERN.match(token.strip().lstrip(';'))
+                if match:
+                    node_ids.append(match.group(0))
+            if node_ids:
+                node_groups.append(node_ids)
+
+        for left, right in zip(node_groups, node_groups[1:]):
+            edges.extend((source, target) for source in left for target in right)
+    return edges
+
+
+def _longest_diagram_chain(edges: List[Tuple[str, str]]) -> int:
+    """Length, in nodes, of the longest path through the graph. Raises ValueError on a cycle."""
+    adjacency = {}
+    nodes = set()
+    for source, target in edges:
+        adjacency.setdefault(source, []).append(target)
+        nodes.add(source)
+        nodes.add(target)
+
+    longest_from = {}
+    in_progress = set()
+
+    def walk(node: str) -> int:
+        if node in in_progress:
+            raise ValueError(f"cycle detected at node '{node}'")
+        if node in longest_from:
+            return longest_from[node]
+        in_progress.add(node)
+        longest = 1
+        for neighbour in adjacency.get(node, []):
+            longest = max(longest, 1 + walk(neighbour))
+        in_progress.discard(node)
+        longest_from[node] = longest
+        return longest
+
+    return max((walk(node) for node in nodes), default=0)
+
+
 def count_chars_without_html(string):
     if '<' not in string:
         return len(string)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -476,9 +476,8 @@ class PRDescription:
                 description_settings = get_settings().pr_description
                 self.data['changes_diagram'] = apply_diagram_direction(
                     sanitized,
-                    description_settings.get("pr_diagram_direction", DEFAULT_DIAGRAM_DIRECTION),
-                    description_settings.get("pr_diagram_direction_threshold",
-                                             DEFAULT_DIAGRAM_DIRECTION_THRESHOLD),
+                    description_settings.pr_diagram_direction,
+                    description_settings.pr_diagram_direction_threshold,
                 )
         if 'pr_files' in self.data:
             self.data['pr_files'] = self.data.pop('pr_files')
@@ -812,13 +811,14 @@ def sanitize_diagram(diagram_raw: str) -> str:
 
 
 DIAGRAM_HEADER_PATTERN = re.compile(r'^(\s*(?:flowchart|graph)\s+)(?:TB|TD|BT|RL|LR)\b(.*)$')
-DIAGRAM_CONNECTOR_PATTERN = re.compile(r'<?[-=.~]{2,}[->ox]?')
+DIAGRAM_CONNECTOR_PATTERN = re.compile(r'(<?[-=.~]{2,}[->ox]?)')
 DIAGRAM_NODE_ID_PATTERN = re.compile(r'[A-Za-z0-9_]+')
 DIAGRAM_QUOTED_LABEL_PATTERN = re.compile(r'"[^"]*"')
 DIAGRAM_PIPE_LABEL_PATTERN = re.compile(r'\|[^|]*\|')  # pipe-form edge labels: -->|text|
 DIAGRAM_SHAPE_PATTERN = re.compile(r'\[[^\[\]]*\]|\([^()]*\)|\{[^{}]*\}')
-DEFAULT_DIAGRAM_DIRECTION = 'adaptive'
-DEFAULT_DIAGRAM_DIRECTION_THRESHOLD = 5
+# A two-character connector opens a middle label (`A -- text --> B`); a longer one is a real link,
+# so `A --- B --> C` still reads as a three-node chain.
+DIAGRAM_LABEL_OPENERS = ('--', '==', '-.')
 
 
 def _strip_diagram_labels(line: str) -> str:
@@ -846,11 +846,13 @@ def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
         if not DIAGRAM_CONNECTOR_PATTERN.search(cleaned):
             continue
 
-        # Split on connectors; each remaining chunk holds one or more node ids joined by '&'.
-        # Chunks left empty once labels are stripped collapse away, which is what makes
-        # `A -- "text" --> B` read as the single edge A -> B.
+        # The capturing split yields chunk, connector, chunk, connector, ... Each chunk holds one
+        # or more node ids joined by '&', unless the connector before it opened a middle label.
+        parts = DIAGRAM_CONNECTOR_PATTERN.split(cleaned)
         node_groups = []
-        for chunk in DIAGRAM_CONNECTOR_PATTERN.split(cleaned):
+        for index, chunk in enumerate(parts[::2]):
+            if index and parts[index * 2 - 1] in DIAGRAM_LABEL_OPENERS:
+                continue  # `A -- text --> B`: this chunk is the edge label, not a node
             node_ids = []
             for token in chunk.split('&'):
                 match = DIAGRAM_NODE_ID_PATTERN.search(token)
@@ -877,14 +879,13 @@ def _longest_diagram_chain(edges: List[Tuple[str, str]]) -> int:
     return max(longest.values(), default=0)
 
 
-def apply_diagram_direction(diagram: str,
-                            direction: str = DEFAULT_DIAGRAM_DIRECTION,
-                            threshold: int = DEFAULT_DIAGRAM_DIRECTION_THRESHOLD) -> str:
+def apply_diagram_direction(diagram: str, direction: str, threshold: int) -> str:
     """Set the flowchart direction, adapting it to the shape of the graph unless one is pinned.
 
     Width in an LR flowchart is set by the longest path rather than by the node count, so the
-    longest chain is what decides. Anything unexpected - no flowchart header, no edges, a cycle,
-    an unusable setting - returns the diagram untouched.
+    longest chain is what decides. 'LR' or 'TD' pins the result; any other value is treated as
+    'adaptive'. Anything unexpected - no flowchart header, no edges, a cycle, an unusable
+    threshold - returns the diagram untouched.
     """
     try:
         lines = diagram.split('\n')
@@ -898,6 +899,8 @@ def apply_diagram_direction(diagram: str,
         if requested in ('LR', 'TD'):
             chosen = requested
         else:
+            if requested != 'ADAPTIVE':
+                get_logger().debug(f"Unknown pr_diagram_direction '{direction}', using adaptive")
             edges = _parse_diagram_edges(lines[header_index + 1:])
             if not edges:
                 return diagram

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -472,7 +472,11 @@ class PRDescription:
         if 'changes_diagram' in self.data:
             sanitized = sanitize_diagram(self.data.pop('changes_diagram'))
             if sanitized:
-                self.data['changes_diagram'] = sanitized
+                self.data['changes_diagram'] = apply_diagram_direction(
+                    sanitized,
+                    get_settings().pr_description.get("pr_diagram_direction", "adaptive"),
+                    get_settings().pr_description.get("pr_diagram_direction_threshold", 5),
+                )
         if 'pr_files' in self.data:
             self.data['pr_files'] = self.data.pop('pr_files')
 
@@ -849,7 +853,7 @@ def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
             if node_ids:
                 node_groups.append(node_ids)
 
-        for left, right in zip(node_groups, node_groups[1:]):
+        for left, right in zip(node_groups, node_groups[1:], strict=False):
             edges.extend((source, target) for source in left for target in right)
     return edges
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -900,7 +900,7 @@ def apply_diagram_direction(diagram: str, direction: str, threshold: int) -> str
             chosen = requested
         else:
             if requested != 'ADAPTIVE':
-                get_logger().debug(f"Unknown pr_diagram_direction '{direction}', using adaptive")
+                get_logger().warning(f"Unknown pr_diagram_direction '{direction}', using adaptive")
             edges = _parse_diagram_edges(lines[header_index + 1:])
             if not edges:
                 return diagram

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -3,6 +3,7 @@ import copy
 import re
 import traceback
 from functools import partial
+from graphlib import TopologicalSorter
 from typing import List, Tuple
 
 import yaml
@@ -472,10 +473,12 @@ class PRDescription:
         if 'changes_diagram' in self.data:
             sanitized = sanitize_diagram(self.data.pop('changes_diagram'))
             if sanitized:
+                description_settings = get_settings().pr_description
                 self.data['changes_diagram'] = apply_diagram_direction(
                     sanitized,
-                    get_settings().pr_description.get("pr_diagram_direction", "adaptive"),
-                    get_settings().pr_description.get("pr_diagram_direction_threshold", 5),
+                    description_settings.get("pr_diagram_direction", DEFAULT_DIAGRAM_DIRECTION),
+                    description_settings.get("pr_diagram_direction_threshold",
+                                             DEFAULT_DIAGRAM_DIRECTION_THRESHOLD),
                 )
         if 'pr_files' in self.data:
             self.data['pr_files'] = self.data.pop('pr_files')
@@ -808,21 +811,24 @@ def sanitize_diagram(diagram_raw: str) -> str:
     return '\n' + '\n'.join(result)
 
 
-DIAGRAM_HEADER_PATTERN = re.compile(r'^(\s*)(flowchart|graph)(\s+)(TB|TD|BT|RL|LR)\b(.*)$')
+DIAGRAM_HEADER_PATTERN = re.compile(r'^(\s*(?:flowchart|graph)\s+)(?:TB|TD|BT|RL|LR)\b(.*)$')
 DIAGRAM_CONNECTOR_PATTERN = re.compile(r'<?[-=.~]{2,}[->ox]?')
 DIAGRAM_NODE_ID_PATTERN = re.compile(r'[A-Za-z0-9_]+')
-DIAGRAM_STATEMENT_KEYWORDS = ('subgraph', 'end', 'direction', 'style', 'classDef', 'linkStyle', 'click')
+DIAGRAM_QUOTED_LABEL_PATTERN = re.compile(r'"[^"]*"')
+DIAGRAM_PIPE_LABEL_PATTERN = re.compile(r'\|[^|]*\|')  # pipe-form edge labels: -->|text|
+DIAGRAM_SHAPE_PATTERN = re.compile(r'\[[^\[\]]*\]|\([^()]*\)|\{[^{}]*\}')
+DEFAULT_DIAGRAM_DIRECTION = 'adaptive'
+DEFAULT_DIAGRAM_DIRECTION_THRESHOLD = 5
 
 
 def _strip_diagram_labels(line: str) -> str:
     """Remove label text, so that arrows written inside a label are not read as edges."""
-    line = re.sub(r'"[^"]*"', '', line)  # quoted labels, which is what the prompt asks the model for
-    line = re.sub(r'\|[^|]*\|', '', line)  # pipe-form edge labels: -->|text|
-    for pattern in (r'\[[^\[\]]*\]', r'\([^()]*\)', r'\{[^{}]*\}'):
-        previous = None
-        while previous != line:  # nested shapes such as [[...]] need more than one pass
-            previous = line
-            line = re.sub(pattern, '', line)
+    line = DIAGRAM_QUOTED_LABEL_PATTERN.sub('', line)
+    line = DIAGRAM_PIPE_LABEL_PATTERN.sub('', line)
+    previous = None
+    while previous != line:  # nested shapes such as [[...]] need more than one pass
+        previous = line
+        line = DIAGRAM_SHAPE_PATTERN.sub('', line)
     return line
 
 
@@ -831,12 +837,12 @@ def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
     edges = []
     for raw_line in lines:
         line = raw_line.strip()
-        if not line or line.startswith('%%'):
-            continue
-        if line.split(' ')[0].rstrip(';') in DIAGRAM_STATEMENT_KEYWORDS:
+        if not line or line.startswith('%%'):  # a comment can still hold arrow-looking text
             continue
 
         cleaned = _strip_diagram_labels(line)
+        # No connector left also means no edge, which is how subgraph/style/classDef/direction
+        # statements drop out without needing a keyword list to keep in sync with mermaid.
         if not DIAGRAM_CONNECTOR_PATTERN.search(cleaned):
             continue
 
@@ -847,7 +853,7 @@ def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
         for chunk in DIAGRAM_CONNECTOR_PATTERN.split(cleaned):
             node_ids = []
             for token in chunk.split('&'):
-                match = DIAGRAM_NODE_ID_PATTERN.match(token.strip().lstrip(';'))
+                match = DIAGRAM_NODE_ID_PATTERN.search(token)
                 if match:
                     node_ids.append(match.group(0))
             if node_ids:
@@ -860,33 +866,20 @@ def _parse_diagram_edges(lines: List[str]) -> List[Tuple[str, str]]:
 
 def _longest_diagram_chain(edges: List[Tuple[str, str]]) -> int:
     """Length, in nodes, of the longest path through the graph. Raises ValueError on a cycle."""
-    adjacency = {}
-    nodes = set()
+    predecessors = {}
     for source, target in edges:
-        adjacency.setdefault(source, []).append(target)
-        nodes.add(source)
-        nodes.add(target)
+        predecessors.setdefault(source, set())
+        predecessors.setdefault(target, set()).add(source)
 
-    longest_from = {}
-    in_progress = set()
-
-    def walk(node: str) -> int:
-        if node in in_progress:
-            raise ValueError(f"cycle detected at node '{node}'")
-        if node in longest_from:
-            return longest_from[node]
-        in_progress.add(node)
-        longest = 1
-        for neighbour in adjacency.get(node, []):
-            longest = max(longest, 1 + walk(neighbour))
-        in_progress.discard(node)
-        longest_from[node] = longest
-        return longest
-
-    return max((walk(node) for node in nodes), default=0)
+    longest = {}
+    for node in TopologicalSorter(predecessors).static_order():  # CycleError is a ValueError
+        longest[node] = 1 + max((longest[p] for p in predecessors[node]), default=0)
+    return max(longest.values(), default=0)
 
 
-def apply_diagram_direction(diagram: str, direction: str = 'adaptive', threshold: int = 5) -> str:
+def apply_diagram_direction(diagram: str,
+                            direction: str = DEFAULT_DIAGRAM_DIRECTION,
+                            threshold: int = DEFAULT_DIAGRAM_DIRECTION_THRESHOLD) -> str:
     """Set the flowchart direction, adapting it to the shape of the graph unless one is pinned.
 
     Width in an LR flowchart is set by the longest path rather than by the node count, so the
@@ -895,14 +888,11 @@ def apply_diagram_direction(diagram: str, direction: str = 'adaptive', threshold
     """
     try:
         lines = diagram.split('\n')
-        header_index, header_match = None, None
-        for index, line in enumerate(lines):
-            header_match = DIAGRAM_HEADER_PATTERN.match(line)
-            if header_match:
-                header_index = index
-                break
-        if header_index is None:
+        header = next(((index, match) for index, line in enumerate(lines)
+                       if (match := DIAGRAM_HEADER_PATTERN.match(line))), None)
+        if header is None:
             return diagram
+        header_index, header_match = header
 
         requested = str(direction).strip().upper()
         if requested in ('LR', 'TD'):
@@ -913,8 +903,7 @@ def apply_diagram_direction(diagram: str, direction: str = 'adaptive', threshold
                 return diagram
             chosen = 'LR' if _longest_diagram_chain(edges) <= int(threshold) else 'TD'
 
-        lines[header_index] = (f"{header_match.group(1)}{header_match.group(2)}"
-                               f"{header_match.group(3)}{chosen}{header_match.group(5)}")
+        lines[header_index] = f"{header_match.group(1)}{chosen}{header_match.group(2)}"
         return '\n'.join(lines)
     except Exception as e:
         get_logger().debug(f"Failed to adapt the diagram direction: {e}")

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -882,6 +882,41 @@ def _longest_diagram_chain(edges: List[Tuple[str, str]]) -> int:
     return max((walk(node) for node in nodes), default=0)
 
 
+def apply_diagram_direction(diagram: str, direction: str = 'adaptive', threshold: int = 5) -> str:
+    """Set the flowchart direction, adapting it to the shape of the graph unless one is pinned.
+
+    Width in an LR flowchart is set by the longest path rather than by the node count, so the
+    longest chain is what decides. Anything unexpected - no flowchart header, no edges, a cycle,
+    an unusable setting - returns the diagram untouched.
+    """
+    try:
+        lines = diagram.split('\n')
+        header_index, header_match = None, None
+        for index, line in enumerate(lines):
+            header_match = DIAGRAM_HEADER_PATTERN.match(line)
+            if header_match:
+                header_index = index
+                break
+        if header_index is None:
+            return diagram
+
+        requested = str(direction).strip().upper()
+        if requested in ('LR', 'TD'):
+            chosen = requested
+        else:
+            edges = _parse_diagram_edges(lines[header_index + 1:])
+            if not edges:
+                return diagram
+            chosen = 'LR' if _longest_diagram_chain(edges) <= int(threshold) else 'TD'
+
+        lines[header_index] = (f"{header_match.group(1)}{header_match.group(2)}"
+                               f"{header_match.group(3)}{chosen}{header_match.group(5)}")
+        return '\n'.join(lines)
+    except Exception as e:
+        get_logger().debug(f"Failed to adapt the diagram direction: {e}")
+        return diagram
+
+
 def count_chars_without_html(string):
     if '<' not in string:
         return len(string)

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -14,6 +14,11 @@ from pr_agent.tools.pr_description import (
 
 KEYS_FIX = ["filename:", "language:", "changes_summary:", "changes_title:", "description:", "title:"]
 
+# Chains named relative to the default pr_diagram_direction_threshold of 5 nodes.
+SHORT_CHAIN = 'A --> B --> C'
+THRESHOLD_CHAIN = 'A --> B --> C --> D --> E'
+LONG_CHAIN = 'A --> B --> C --> D --> E --> F'
+
 def _make_instance(prediction_yaml: str):
     """Create a PRDescription instance, bypassing __init__."""
     with patch.object(PRDescription, '__init__', lambda self, *a, **kw: None):
@@ -84,7 +89,7 @@ class TestPRDescriptionDiagram:
     @patch('pr_agent.tools.pr_description.get_settings')
     def test_long_chain_diagram_is_flipped_during_prepare_data(self, mock_get_settings):
         mock_get_settings.return_value = _mock_settings()
-        body = 'A --> B --> C --> D --> E --> F'
+        body = LONG_CHAIN
         obj = _make_instance(_prediction_with_diagram(f'```mermaid\nflowchart LR\n{body}\n```'))
         obj._prepare_data()
         assert obj.data['changes_diagram'] == f'\n```mermaid\nflowchart TD\n{body}\n```'
@@ -92,7 +97,7 @@ class TestPRDescriptionDiagram:
     @patch('pr_agent.tools.pr_description.get_settings')
     def test_pinned_direction_is_respected_during_prepare_data(self, mock_get_settings):
         mock_get_settings.return_value = _mock_settings(pr_diagram_direction='LR')
-        body = 'A --> B --> C --> D --> E --> F'
+        body = LONG_CHAIN
         obj = _make_instance(_prediction_with_diagram(f'```mermaid\nflowchart LR\n{body}\n```'))
         obj._prepare_data()
         assert obj.data['changes_diagram'] == f'\n```mermaid\nflowchart LR\n{body}\n```'
@@ -258,59 +263,42 @@ def _fenced(body: str) -> str:
 
 class TestApplyDiagramDirection:
 
-    def test_short_chain_stays_horizontal(self):
-        diagram = _fenced('flowchart LR\nA --> B --> C')
+    @pytest.mark.parametrize('body', [
+        pytest.param(f'flowchart LR\n{SHORT_CHAIN}', id='short_chain'),
+        pytest.param(f'flowchart LR\n{THRESHOLD_CHAIN}', id='chain_exactly_at_threshold'),
+        pytest.param('flowchart LR\n' + '\n'.join(f'A --> {node}' for node in 'BCDEFGHI'), id='wide_fan_out'),
+        pytest.param('sequenceDiagram\nA->>B: hello', id='not_a_flowchart'),
+        pytest.param('flowchart LR\nA["only a node"]', id='no_edges'),
+        pytest.param(f'flowchart LR\n{LONG_CHAIN} --> A', id='cycle'),
+    ])
+    def test_diagram_is_left_untouched(self, body):
+        diagram = _fenced(body)
         assert apply_diagram_direction(diagram) == diagram
 
-    def test_long_chain_becomes_vertical(self):
-        body = 'A --> B --> C --> D --> E --> F'
-        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}')) == _fenced(f'flowchart TD\n{body}')
-
-    def test_chain_exactly_at_threshold_stays_horizontal(self):
-        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E')
-        assert apply_diagram_direction(diagram) == diagram
-
-    def test_wide_fan_out_stays_horizontal(self):
-        body = 'A --> B\nA --> C\nA --> D\nA --> E\nA --> F\nA --> G\nA --> H\nA --> I'
-        diagram = _fenced(f'flowchart LR\n{body}')
-        assert apply_diagram_direction(diagram) == diagram
-
-    def test_graph_alias_is_rewritten_too(self):
-        body = 'A --> B --> C --> D --> E --> F'
-        assert apply_diagram_direction(_fenced(f'graph LR\n{body}')) == _fenced(f'graph TD\n{body}')
+    @pytest.mark.parametrize('header_in, header_out', [
+        pytest.param('flowchart LR', 'flowchart TD', id='flowchart'),
+        pytest.param('graph LR', 'graph TD', id='graph_alias'),
+        pytest.param('  graph LR;', '  graph TD;', id='indent_and_semicolon_preserved'),
+    ])
+    def test_long_chain_becomes_vertical(self, header_in, header_out):
+        assert apply_diagram_direction(_fenced(f'{header_in}\n{LONG_CHAIN}')) == \
+            _fenced(f'{header_out}\n{LONG_CHAIN}')
 
     def test_vertical_short_diagram_is_flipped_back_to_horizontal(self):
         assert apply_diagram_direction(_fenced('flowchart TD\nA --> B')) == _fenced('flowchart LR\nA --> B')
 
     def test_explicit_direction_pins_and_ignores_shape(self):
-        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F')
+        diagram = _fenced(f'flowchart LR\n{LONG_CHAIN}')
         assert apply_diagram_direction(diagram, direction='LR') == diagram
         assert apply_diagram_direction(_fenced('flowchart LR\nA --> B'), direction='TD') == \
             _fenced('flowchart TD\nA --> B')
 
     def test_custom_threshold_is_honoured(self):
-        body = 'A --> B --> C'
-        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}'), threshold=2) == \
-            _fenced(f'flowchart TD\n{body}')
-
-    def test_indentation_and_trailing_semicolon_are_preserved(self):
-        body = 'A --> B --> C --> D --> E --> F'
-        assert apply_diagram_direction(_fenced(f'  graph LR;\n{body}')) == _fenced(f'  graph TD;\n{body}')
-
-    def test_sequence_diagram_is_untouched(self):
-        diagram = _fenced('sequenceDiagram\nA->>B: hello')
-        assert apply_diagram_direction(diagram) == diagram
-
-    def test_diagram_without_edges_is_untouched(self):
-        diagram = _fenced('flowchart LR\nA["only a node"]')
-        assert apply_diagram_direction(diagram) == diagram
-
-    def test_cyclic_graph_is_untouched(self):
-        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F --> A')
-        assert apply_diagram_direction(diagram) == diagram
+        assert apply_diagram_direction(_fenced(f'flowchart LR\n{SHORT_CHAIN}'), threshold=2) == \
+            _fenced(f'flowchart TD\n{SHORT_CHAIN}')
 
     def test_unparseable_threshold_leaves_diagram_untouched(self):
-        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F')
+        diagram = _fenced(f'flowchart LR\n{LONG_CHAIN}')
         assert apply_diagram_direction(diagram, threshold='not-a-number') == diagram
 
     def test_subgraph_edges_are_counted(self):

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -7,6 +7,7 @@ from pr_agent.algo.types import FilePatchInfo
 from pr_agent.tools.pr_description import (PRDescription,
                                            _longest_diagram_chain,
                                            _parse_diagram_edges,
+                                           apply_diagram_direction,
                                            sanitize_diagram)
 
 KEYS_FIX = ["filename:", "language:", "changes_summary:", "changes_title:", "description:", "title:"]
@@ -227,3 +228,69 @@ class TestLongestDiagramChain:
     def test_cycle_raises(self):
         with pytest.raises(ValueError):
             _longest_diagram_chain([('A', 'B'), ('B', 'A')])
+
+
+def _fenced(body: str) -> str:
+    return f'\n```mermaid\n{body}\n```'
+
+
+class TestApplyDiagramDirection:
+
+    def test_short_chain_stays_horizontal(self):
+        diagram = _fenced('flowchart LR\nA --> B --> C')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_long_chain_becomes_vertical(self):
+        body = 'A --> B --> C --> D --> E --> F'
+        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}')) == _fenced(f'flowchart TD\n{body}')
+
+    def test_chain_exactly_at_threshold_stays_horizontal(self):
+        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_wide_fan_out_stays_horizontal(self):
+        body = 'A --> B\nA --> C\nA --> D\nA --> E\nA --> F\nA --> G\nA --> H\nA --> I'
+        diagram = _fenced(f'flowchart LR\n{body}')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_graph_alias_is_rewritten_too(self):
+        body = 'A --> B --> C --> D --> E --> F'
+        assert apply_diagram_direction(_fenced(f'graph LR\n{body}')) == _fenced(f'graph TD\n{body}')
+
+    def test_vertical_short_diagram_is_flipped_back_to_horizontal(self):
+        assert apply_diagram_direction(_fenced('flowchart TD\nA --> B')) == _fenced('flowchart LR\nA --> B')
+
+    def test_explicit_direction_pins_and_ignores_shape(self):
+        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F')
+        assert apply_diagram_direction(diagram, direction='LR') == diagram
+        assert apply_diagram_direction(_fenced('flowchart LR\nA --> B'), direction='TD') == \
+            _fenced('flowchart TD\nA --> B')
+
+    def test_custom_threshold_is_honoured(self):
+        body = 'A --> B --> C'
+        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}'), threshold=2) == \
+            _fenced(f'flowchart TD\n{body}')
+
+    def test_indentation_and_trailing_semicolon_are_preserved(self):
+        body = 'A --> B --> C --> D --> E --> F'
+        assert apply_diagram_direction(_fenced(f'  graph LR;\n{body}')) == _fenced(f'  graph TD;\n{body}')
+
+    def test_sequence_diagram_is_untouched(self):
+        diagram = _fenced('sequenceDiagram\nA->>B: hello')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_diagram_without_edges_is_untouched(self):
+        diagram = _fenced('flowchart LR\nA["only a node"]')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_cyclic_graph_is_untouched(self):
+        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F --> A')
+        assert apply_diagram_direction(diagram) == diagram
+
+    def test_unparseable_threshold_leaves_diagram_untouched(self):
+        diagram = _fenced('flowchart LR\nA --> B --> C --> D --> E --> F')
+        assert apply_diagram_direction(diagram, threshold='not-a-number') == diagram
+
+    def test_subgraph_edges_are_counted(self):
+        body = 'subgraph one\nA --> B --> C\nend\nsubgraph two\nC --> D --> E --> F\nend'
+        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}')) == _fenced(f'flowchart TD\n{body}')

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -4,7 +4,10 @@ import pytest
 import yaml
 
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.tools.pr_description import PRDescription, sanitize_diagram
+from pr_agent.tools.pr_description import (PRDescription,
+                                           _longest_diagram_chain,
+                                           _parse_diagram_edges,
+                                           sanitize_diagram)
 
 KEYS_FIX = ["filename:", "language:", "changes_summary:", "changes_title:", "description:", "title:"]
 
@@ -169,3 +172,58 @@ pr_files:
 
         assert [file["filename"].strip() for file in loaded["pr_files"]] == ["shown.py", "missing.py"]
         assert loaded["pr_files"][1]["label"].strip() == "additional files"
+
+
+class TestDiagramEdgeParsing:
+
+    def test_simple_edge(self):
+        assert _parse_diagram_edges(['A --> B']) == [('A', 'B')]
+
+    def test_chained_statement_becomes_consecutive_edges(self):
+        assert _parse_diagram_edges(['A --> B --> C']) == [('A', 'B'), ('B', 'C')]
+
+    def test_node_shapes_are_stripped(self):
+        assert _parse_diagram_edges(['A["file.py"] --> B("output")']) == [('A', 'B')]
+
+    def test_quoted_middle_label_does_not_create_a_node(self):
+        assert _parse_diagram_edges(['A -- "calls" --> B']) == [('A', 'B')]
+
+    def test_pipe_edge_label_does_not_create_a_node(self):
+        assert _parse_diagram_edges(['A -->|calls| B']) == [('A', 'B')]
+
+    def test_arrow_inside_a_label_is_not_an_edge(self):
+        assert _parse_diagram_edges(['A["a --> b"]']) == []
+
+    @pytest.mark.parametrize('line', ['A --- B', 'A -.-> B', 'A ==> B', 'A --o B'])
+    def test_arrow_variants(self, line):
+        assert _parse_diagram_edges([line]) == [('A', 'B')]
+
+    def test_fan_out_shorthand_expands(self):
+        assert _parse_diagram_edges(['A --> B & C']) == [('A', 'B'), ('A', 'C')]
+
+    def test_structural_statements_are_ignored(self):
+        lines = ['subgraph one', 'direction LR', 'A --> B', 'end', 'style A fill:#fff', '%% A --> Z']
+        assert _parse_diagram_edges(lines) == [('A', 'B')]
+
+    def test_fence_and_frontmatter_lines_produce_no_edges(self):
+        assert _parse_diagram_edges(['```', '---', 'config:', '---']) == []
+
+
+class TestLongestDiagramChain:
+
+    def test_empty_graph_is_zero(self):
+        assert _longest_diagram_chain([]) == 0
+
+    def test_chain_length_counts_nodes(self):
+        assert _longest_diagram_chain([('A', 'B'), ('B', 'C')]) == 3
+
+    def test_fan_out_is_two_regardless_of_width(self):
+        edges = [('A', chr(ord('B') + i)) for i in range(8)]
+        assert _longest_diagram_chain(edges) == 2
+
+    def test_longest_branch_wins(self):
+        assert _longest_diagram_chain([('A', 'B'), ('B', 'C'), ('C', 'D'), ('A', 'E')]) == 4
+
+    def test_cycle_raises(self):
+        with pytest.raises(ValueError):
+            _longest_diagram_chain([('A', 'B'), ('B', 'A')])

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -4,11 +4,13 @@ import pytest
 import yaml
 
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.tools.pr_description import (PRDescription,
-                                           _longest_diagram_chain,
-                                           _parse_diagram_edges,
-                                           apply_diagram_direction,
-                                           sanitize_diagram)
+from pr_agent.tools.pr_description import (
+    PRDescription,
+    _longest_diagram_chain,
+    _parse_diagram_edges,
+    apply_diagram_direction,
+    sanitize_diagram,
+)
 
 KEYS_FIX = ["filename:", "language:", "changes_summary:", "changes_title:", "description:", "title:"]
 
@@ -22,10 +24,14 @@ def _make_instance(prediction_yaml: str):
     return obj
 
 
-def _mock_settings():
+def _mock_settings(pr_diagram_direction: str = 'adaptive', pr_diagram_direction_threshold: int = 5):
     """Mock get_settings used by _prepare_data."""
     settings = MagicMock()
     settings.pr_description.add_original_user_description = False
+    settings.pr_description.get.side_effect = lambda key, default=None: {
+        'pr_diagram_direction': pr_diagram_direction,
+        'pr_diagram_direction_threshold': pr_diagram_direction_threshold,
+    }.get(key, default)
     return settings
 
 
@@ -74,6 +80,22 @@ class TestPRDescriptionDiagram:
         obj = _make_instance(_prediction_with_diagram('```mermaid\ngraph LR\nA["file.py"] --> B["output"]\n```'))
         obj._prepare_data()
         assert obj.data['changes_diagram'] == '\n```mermaid\ngraph LR\nA["file.py"] --> B["output"]\n```'
+
+    @patch('pr_agent.tools.pr_description.get_settings')
+    def test_long_chain_diagram_is_flipped_during_prepare_data(self, mock_get_settings):
+        mock_get_settings.return_value = _mock_settings()
+        body = 'A --> B --> C --> D --> E --> F'
+        obj = _make_instance(_prediction_with_diagram(f'```mermaid\nflowchart LR\n{body}\n```'))
+        obj._prepare_data()
+        assert obj.data['changes_diagram'] == f'\n```mermaid\nflowchart TD\n{body}\n```'
+
+    @patch('pr_agent.tools.pr_description.get_settings')
+    def test_pinned_direction_is_respected_during_prepare_data(self, mock_get_settings):
+        mock_get_settings.return_value = _mock_settings(pr_diagram_direction='LR')
+        body = 'A --> B --> C --> D --> E --> F'
+        obj = _make_instance(_prediction_with_diagram(f'```mermaid\nflowchart LR\n{body}\n```'))
+        obj._prepare_data()
+        assert obj.data['changes_diagram'] == f'\n```mermaid\nflowchart LR\n{body}\n```'
 
     def test_none_input_returns_empty(self):
         assert sanitize_diagram(None) == ''

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -33,10 +33,8 @@ def _mock_settings(pr_diagram_direction: str = 'adaptive', pr_diagram_direction_
     """Mock get_settings used by _prepare_data."""
     settings = MagicMock()
     settings.pr_description.add_original_user_description = False
-    settings.pr_description.get.side_effect = lambda key, default=None: {
-        'pr_diagram_direction': pr_diagram_direction,
-        'pr_diagram_direction_threshold': pr_diagram_direction_threshold,
-    }.get(key, default)
+    settings.pr_description.pr_diagram_direction = pr_diagram_direction
+    settings.pr_description.pr_diagram_direction_threshold = pr_diagram_direction_threshold
     return settings
 
 
@@ -216,6 +214,13 @@ class TestDiagramEdgeParsing:
     def test_quoted_middle_label_does_not_create_a_node(self):
         assert _parse_diagram_edges(['A -- "calls" --> B']) == [('A', 'B')]
 
+    def test_unquoted_middle_label_does_not_create_a_node(self):
+        assert _parse_diagram_edges(['A -- calls --> B']) == [('A', 'B')]
+
+    def test_open_link_still_chains(self):
+        # `---` is a real link rather than a label opener, so B stays a node.
+        assert _parse_diagram_edges(['A --- B --> C']) == [('A', 'B'), ('B', 'C')]
+
     def test_pipe_edge_label_does_not_create_a_node(self):
         assert _parse_diagram_edges(['A -->|calls| B']) == [('A', 'B')]
 
@@ -261,6 +266,18 @@ def _fenced(body: str) -> str:
     return f'\n```mermaid\n{body}\n```'
 
 
+def _adapt(diagram: str, direction: str = 'adaptive', threshold: int = 5) -> str:
+    """Call the SUT with the settings configuration.toml ships, unless a test overrides them."""
+    return apply_diagram_direction(diagram, direction, threshold)
+
+
+def test_shipped_defaults_match_what_these_tests_assume():
+    """Guards the test defaults above against drift in configuration.toml."""
+    from pr_agent.config_loader import get_settings
+    assert get_settings().pr_description.pr_diagram_direction == 'adaptive'
+    assert get_settings().pr_description.pr_diagram_direction_threshold == 5
+
+
 class TestApplyDiagramDirection:
 
     @pytest.mark.parametrize('body', [
@@ -273,7 +290,7 @@ class TestApplyDiagramDirection:
     ])
     def test_diagram_is_left_untouched(self, body):
         diagram = _fenced(body)
-        assert apply_diagram_direction(diagram) == diagram
+        assert _adapt(diagram) == diagram
 
     @pytest.mark.parametrize('header_in, header_out', [
         pytest.param('flowchart LR', 'flowchart TD', id='flowchart'),
@@ -281,26 +298,35 @@ class TestApplyDiagramDirection:
         pytest.param('  graph LR;', '  graph TD;', id='indent_and_semicolon_preserved'),
     ])
     def test_long_chain_becomes_vertical(self, header_in, header_out):
-        assert apply_diagram_direction(_fenced(f'{header_in}\n{LONG_CHAIN}')) == \
-            _fenced(f'{header_out}\n{LONG_CHAIN}')
+        assert _adapt(_fenced(f'{header_in}\n{LONG_CHAIN}')) == _fenced(f'{header_out}\n{LONG_CHAIN}')
 
     def test_vertical_short_diagram_is_flipped_back_to_horizontal(self):
-        assert apply_diagram_direction(_fenced('flowchart TD\nA --> B')) == _fenced('flowchart LR\nA --> B')
+        assert _adapt(_fenced('flowchart TD\nA --> B')) == _fenced('flowchart LR\nA --> B')
 
     def test_explicit_direction_pins_and_ignores_shape(self):
         diagram = _fenced(f'flowchart LR\n{LONG_CHAIN}')
-        assert apply_diagram_direction(diagram, direction='LR') == diagram
-        assert apply_diagram_direction(_fenced('flowchart LR\nA --> B'), direction='TD') == \
-            _fenced('flowchart TD\nA --> B')
+        assert _adapt(diagram, direction='LR') == diagram
+        assert _adapt(_fenced('flowchart LR\nA --> B'), direction='TD') == _fenced('flowchart TD\nA --> B')
+
+    @pytest.mark.parametrize('direction', ['adaptive', 'ADAPTIVE', ' adaptive ', 'sideways', '', None])
+    def test_unrecognised_direction_falls_back_to_adaptive(self, direction):
+        assert _adapt(_fenced(f'flowchart LR\n{LONG_CHAIN}'), direction=direction) == \
+            _fenced(f'flowchart TD\n{LONG_CHAIN}')
 
     def test_custom_threshold_is_honoured(self):
-        assert apply_diagram_direction(_fenced(f'flowchart LR\n{SHORT_CHAIN}'), threshold=2) == \
+        assert _adapt(_fenced(f'flowchart LR\n{SHORT_CHAIN}'), threshold=2) == \
             _fenced(f'flowchart TD\n{SHORT_CHAIN}')
 
     def test_unparseable_threshold_leaves_diagram_untouched(self):
         diagram = _fenced(f'flowchart LR\n{LONG_CHAIN}')
-        assert apply_diagram_direction(diagram, threshold='not-a-number') == diagram
+        assert _adapt(diagram, threshold='not-a-number') == diagram
 
     def test_subgraph_edges_are_counted(self):
         body = 'subgraph one\nA --> B --> C\nend\nsubgraph two\nC --> D --> E --> F\nend'
-        assert apply_diagram_direction(_fenced(f'flowchart LR\n{body}')) == _fenced(f'flowchart TD\n{body}')
+        assert _adapt(_fenced(f'flowchart LR\n{body}')) == _fenced(f'flowchart TD\n{body}')
+
+    def test_unquoted_edge_labels_do_not_inflate_the_chain(self):
+        # Five real nodes joined by unquoted labels: the labels must not count as nodes.
+        body = 'A -- calls --> B -- reads --> C -- writes --> D -- returns --> E'
+        diagram = _fenced(f'flowchart LR\n{body}')
+        assert _adapt(diagram) == diagram


### PR DESCRIPTION
Picks the `/describe` changes-diagram direction from the shape of the graph instead of
hard-coding `LR`. A diagram whose longest chain exceeds
`pr_description.pr_diagram_direction_threshold` (default 5) is drawn top-down, so wide diagrams
stop being scaled down until unreadable on GitLab. `pr_description.pr_diagram_direction` pins it
to `LR` or `TD` instead.

Deterministic post-processing next to `sanitize_diagram()` — no prompt or token-cost change. Any
parse failure, cycle or non-flowchart diagram is returned untouched.

One open question: I've defaulted to `adaptive`. The conservative choice is `LR`, which preserves
today's behaviour exactly and makes this opt-in. I leaned the other way because GitLab has no
expand control on a rendered diagram — once it's scaled down there's no way to see it, so the
status quo fails silently for the people it affects most. Happy to flip the default if you'd
rather ship it opt-in.

Closes #2597
