### PR TITLE
fix(gitlab): report get_issue_comments as supported so /answer works

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -291,7 +291,7 @@ class GitLabProvider(GitProvider):
         return out
 
     def is_supported(self, capability: str) -> bool:
-        if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments',
+        if capability in ['create_inline_comment', 'publish_inline_comments',
             'publish_file_comments']: # gfm_markdown is supported in gitlab !
             return False
         if capability == "push_code" and get_settings().config.restricted_mode:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -304,7 +304,9 @@ class PRReviewer:
         if self.is_answer:
             discussion_messages = self.git_provider.get_issue_comments()
 
-            for message in discussion_messages.reversed:
+            # providers return the comments oldest-first, as either a PyGithub PaginatedList or a plain
+            # list; materialise before reversing so both shapes are walked newest-first.
+            for message in reversed(list(discussion_messages)):
                 if "Questions to better understand the PR:" in message.body:
                     question_str = message.body
                 elif '/answer' in message.body:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -304,9 +304,13 @@ class PRReviewer:
         if self.is_answer:
             discussion_messages = self.git_provider.get_issue_comments()
 
-            # providers return the comments oldest-first, as either a PyGithub PaginatedList or a plain
-            # list; materialise before reversing so both shapes are walked newest-first.
-            for message in reversed(list(discussion_messages)):
+            # providers return the comments oldest-first. PyGithub's PaginatedList reverses lazily,
+            # so prefer it and only materialise the plain lists other providers return.
+            newest_first = getattr(discussion_messages, "reversed", None)
+            if newest_first is None:
+                newest_first = reversed(list(discussion_messages))
+
+            for message in newest_first:
                 if "Questions to better understand the PR:" in message.body:
                     question_str = message.body
                 elif '/answer' in message.body:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -504,3 +504,33 @@ class TestGitLabGlobalSettings:
             provider._get_global_repo_settings()
         # Only one lookup for the settings project despite two calls (cached).
         assert provider.gl.projects.get.call_count == 1
+
+
+class TestGitLabCapabilities:
+    def _provider(self):
+        provider = GitLabProvider.__new__(GitLabProvider)
+        provider.mr = MagicMock()
+        return provider
+
+    def test_get_issue_comments_is_reported_as_supported(self):
+        """The capability flag used to contradict the working implementation below it,
+        which was the only thing blocking ``/answer`` on GitLab."""
+        assert self._provider().is_supported("get_issue_comments") is True
+
+    def test_get_issue_comments_returns_notes_oldest_first(self):
+        provider = self._provider()
+        # GitLab's notes API returns newest-first; the provider flips it to match GitHub.
+        provider.mr.notes.list.return_value = ["newest", "middle", "oldest"]
+
+        assert provider.get_issue_comments() == ["oldest", "middle", "newest"]
+
+    @pytest.mark.parametrize("capability", [
+        "create_inline_comment",
+        "publish_inline_comments",
+        "publish_file_comments",
+    ])
+    def test_unimplemented_capabilities_stay_unsupported(self, capability):
+        assert self._provider().is_supported(capability) is False
+
+    def test_gfm_markdown_is_supported(self):
+        assert self._provider().is_supported("gfm_markdown") is True

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -174,6 +174,33 @@ def test_answer_mode_reads_comments_from_a_non_list_iterable(monkeypatch):
     assert reviewer.vars["answer_str"] == "/answer Because it fixes production."
 
 
+def test_answer_mode_uses_the_lazy_reversed_view_when_the_provider_offers_one(monkeypatch):
+    """PyGithub reverses a PaginatedList lazily, walking pages from the end.
+
+    Materialising it instead would page the whole thread just to read the last exchange,
+    so the lazy view must win when it exists.
+    """
+
+    class _LazyPaginated:
+        def __init__(self, items):
+            self._items = items
+
+        @property
+        def reversed(self):
+            return list(reversed(self._items))
+
+        def __iter__(self):
+            raise AssertionError("the lazy reversed view should have been used")
+
+    reviewer = _build_answer_mode_reviewer(monkeypatch, _LazyPaginated([
+        SimpleNamespace(body="Questions to better understand the PR:\n- Why?"),
+        SimpleNamespace(body="/answer Because it fixes production."),
+    ]))
+
+    assert reviewer.vars["question_str"] == "Questions to better understand the PR:\n- Why?"
+    assert reviewer.vars["answer_str"] == "/answer Because it fixes production."
+
+
 def test_answer_mode_prefers_the_newest_question_and_answer(monkeypatch):
     """Comments arrive oldest-first, so the walk must run newest-first to pick the latest exchange."""
     reviewer = _build_answer_mode_reviewer(monkeypatch, [

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -78,11 +78,11 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
 
 def test_get_user_answers_collects_question_and_answer_from_issue_comments():
     git_provider = MagicMock()
-    git_provider.get_issue_comments.return_value = SimpleNamespace(reversed=[
+    git_provider.get_issue_comments.return_value = [
         SimpleNamespace(body="Unrelated"),
         SimpleNamespace(body="Questions to better understand the PR:\n- Why?"),
         SimpleNamespace(body="/answer Because it fixes production."),
-    ])
+    ]
     reviewer = _make_reviewer(git_provider)
     reviewer.is_answer = True
 
@@ -109,10 +109,10 @@ def test_init_maps_user_question_and_answer_to_correct_prompt_vars(monkeypatch):
     provider.is_supported.return_value = True
     provider.get_languages.return_value = {}
     provider.get_files.return_value = []
-    provider.get_issue_comments.return_value = SimpleNamespace(reversed=[
+    provider.get_issue_comments.return_value = [
         SimpleNamespace(body="Questions to better understand the PR:\n- Why?"),
         SimpleNamespace(body="/answer Because it fixes production."),
-    ])
+    ]
     provider.get_pr_description.return_value = ("desc", [])
 
     monkeypatch.setattr(pr_reviewer_module, "get_git_provider_with_context", lambda pr_url: provider)
@@ -127,3 +127,61 @@ def test_init_maps_user_question_and_answer_to_correct_prompt_vars(monkeypatch):
 
     assert reviewer.vars["question_str"] == "Questions to better understand the PR:\n- Why?"
     assert reviewer.vars["answer_str"] == "/answer Because it fixes production."
+
+
+def _build_answer_mode_reviewer(monkeypatch, issue_comments):
+    """Drive the real ``PRReviewer.__init__`` in answer mode over ``issue_comments``."""
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    provider = MagicMock()
+    provider.is_supported.return_value = True
+    provider.get_languages.return_value = {}
+    provider.get_files.return_value = []
+    provider.get_issue_comments.return_value = issue_comments
+    provider.get_pr_description.return_value = ("desc", [])
+
+    monkeypatch.setattr(pr_reviewer_module, "get_git_provider_with_context", lambda pr_url: provider)
+    monkeypatch.setattr(pr_reviewer_module, "get_main_pr_language", lambda languages, files: "Python")
+    monkeypatch.setattr(pr_reviewer_module, "TokenHandler", MagicMock())
+
+    return PRReviewer(
+        "https://example/pr/1",
+        is_answer=True,
+        ai_handler=lambda: SimpleNamespace(main_pr_language=None),
+    )
+
+
+def test_answer_mode_reads_comments_from_a_non_list_iterable(monkeypatch):
+    """GitHub hands back a PyGithub ``PaginatedList``, GitLab a plain list.
+
+    Answer mode used to reach for the PyGithub-only ``.reversed`` property, which meant
+    it could only ever consume the GitHub shape. Any lazily-paginated iterable must work.
+    """
+
+    class _Paginated:
+        def __init__(self, items):
+            self._items = items
+
+        def __iter__(self):
+            return iter(self._items)
+
+    reviewer = _build_answer_mode_reviewer(monkeypatch, _Paginated([
+        SimpleNamespace(body="Questions to better understand the PR:\n- Why?"),
+        SimpleNamespace(body="/answer Because it fixes production."),
+    ]))
+
+    assert reviewer.vars["question_str"] == "Questions to better understand the PR:\n- Why?"
+    assert reviewer.vars["answer_str"] == "/answer Because it fixes production."
+
+
+def test_answer_mode_prefers_the_newest_question_and_answer(monkeypatch):
+    """Comments arrive oldest-first, so the walk must run newest-first to pick the latest exchange."""
+    reviewer = _build_answer_mode_reviewer(monkeypatch, [
+        SimpleNamespace(body="Questions to better understand the PR:\n- Stale question?"),
+        SimpleNamespace(body="/answer Stale answer."),
+        SimpleNamespace(body="Questions to better understand the PR:\n- Current question?"),
+        SimpleNamespace(body="/answer Current answer."),
+    ])
+
+    assert reviewer.vars["question_str"] == "Questions to better understand the PR:\n- Current question?"
+    assert reviewer.vars["answer_str"] == "/answer Current answer."


### PR DESCRIPTION
GitLab's `is_supported` listed `get_issue_comments` as unsupported while the provider implements it directly below, which was the only thing refusing `/answer` on GitLab. Answer mode also reached for PyGithub's `.reversed`, so the comments are now materialised before reversing to accept both the paginated and plain-list provider shapes.
