### PR TITLE
fix(gitlab): anchor inline comments to the latest diff version

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -348,7 +348,8 @@ class GitLabProvider(GitProvider):
         self.id_project, self.id_mr = self._parse_merge_request_url(merge_request_url)
         self.mr = self._get_merge_request()
         try:
-            self.last_diff = self.mr.diffs.list(get_all=True)[-1]
+            # the versions endpoint is ordered newest-first, so the latest diff is the first entry
+            self.last_diff = self.mr.diffs.list(get_all=True)[0]
         except IndexError as e:
             get_logger().error(f"Could not get diff for merge request {self.id_mr}")
             raise DiffNotFoundError(f"Could not get diff for merge request {self.id_mr}") from e
@@ -679,13 +680,12 @@ class GitLabProvider(GitProvider):
         if not all_diffs:
             get_logger().error('No diffs found for the merge request.')
             return None
-        for diff in all_diffs:
-            for change in changes['changes']:
-                if change['new_path'] == relevant_file and relevant_line_in_file in change['diff']:
-                    return diff
-            get_logger().debug(
-                f'No relevant diff found for {relevant_file} {relevant_line_in_file}. Falling back to last diff.')
-        return self.last_diff  # fallback to last_diff if no relevant diff is found
+        for change in changes['changes']:
+            if change['new_path'] == relevant_file and relevant_line_in_file in change['diff']:
+                return all_diffs[0]
+        get_logger().debug(
+            f'No relevant diff found for {relevant_file} {relevant_line_in_file}. Falling back to latest diff.')
+        return self.last_diff  # fallback to the latest diff if no relevant diff is found
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         for suggestion in code_suggestions:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -504,3 +504,53 @@ class TestGitLabGlobalSettings:
             provider._get_global_repo_settings()
         # Only one lookup for the settings project despite two calls (cached).
         assert provider.gl.projects.get.call_count == 1
+
+
+class TestGitLabRelevantDiff:
+    """Inline comment positions are pinned to a diff version's SHAs, so picking the wrong
+    version anchors the comment to a superseded diff — the state a force-push leaves behind."""
+
+    # the versions endpoint is ordered newest-first
+    VERSIONS = ["newest", "older", "oldest"]
+
+    def _provider(self, changes):
+        provider = GitLabProvider.__new__(GitLabProvider)
+        provider.mr = MagicMock()
+        provider.mr.diffs.list.return_value = list(self.VERSIONS)
+        provider.mr.changes.return_value = {"changes": changes}
+        provider.last_diff = "latest-at-construction"
+        return provider
+
+    def test_matching_change_resolves_to_the_newest_version(self):
+        provider = self._provider([{"new_path": "app.py", "diff": "@@\n+added line\n"}])
+
+        assert provider.get_relevant_diff("app.py", "+added line") == "newest"
+
+    def test_fallback_uses_the_latest_version_not_the_oldest(self):
+        provider = self._provider([{"new_path": "other.py", "diff": "@@\n+unrelated\n"}])
+
+        assert provider.get_relevant_diff("app.py", "+added line") == "latest-at-construction"
+
+    def test_returns_none_when_the_mr_has_no_diff_versions(self):
+        provider = self._provider([{"new_path": "app.py", "diff": "@@\n+added line\n"}])
+        provider.mr.diffs.list.return_value = []
+
+        assert provider.get_relevant_diff("app.py", "+added line") is None
+
+    def test_set_merge_request_snapshots_the_newest_version(self):
+        provider = GitLabProvider.__new__(GitLabProvider)
+        mr = MagicMock()
+        mr.diffs.list.return_value = list(self.VERSIONS)
+        with patch.object(GitLabProvider, "_parse_merge_request_url", return_value=("group/repo", 1)), \
+             patch.object(GitLabProvider, "_get_merge_request", return_value=mr):
+            provider._set_merge_request("https://gitlab.com/group/repo/-/merge_requests/1")
+
+        assert provider.last_diff == "newest"
+
+    def test_fallback_is_logged_once_not_once_per_version(self):
+        provider = self._provider([{"new_path": "other.py", "diff": "@@\n+unrelated\n"}])
+
+        with patch("pr_agent.git_providers.gitlab_provider.get_logger") as mock_logger:
+            provider.get_relevant_diff("app.py", "+added line")
+
+        assert mock_logger.return_value.debug.call_count == 1

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -23,6 +23,7 @@ def _make_prediction_reviewer(git_provider=None):
     return reviewer
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_requests_remaining_files_and_preserves_tuple_result():
     reviewer = _make_prediction_reviewer()
     reviewer._get_prediction = AsyncMock(return_value="prediction")
@@ -46,6 +47,7 @@ async def test_prepare_prediction_requests_remaining_files_and_preserves_tuple_r
     assert reviewer.prediction == "prediction"
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_accepts_full_diff_string_when_token_budget_is_sufficient():
     reviewer = _make_prediction_reviewer()
     reviewer._get_prediction = AsyncMock(return_value="prediction")
@@ -58,6 +60,7 @@ async def test_prepare_prediction_accepts_full_diff_string_when_token_budget_is_
     assert reviewer.prediction == "prediction"
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_keeps_incremental_review_compatible_with_tuple_result():
     reviewer = _make_prediction_reviewer()
     reviewer.incremental = SimpleNamespace(is_incremental=True)


### PR DESCRIPTION
GitLab's diff-versions endpoint is ordered newest-first, so `[-1]` snapshotted the oldest version and inline comment positions fell back to pre-rebase SHAs. Also drops the outer loop in `get_relevant_diff`, whose body never referenced the version it iterated and which logged the fallback once per version.
