### PR TITLE
fix(tests): mark the review-coverage async tests so they run in the docker test image

### DIFF
--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -23,6 +23,7 @@ def _make_prediction_reviewer(git_provider=None):
     return reviewer
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_requests_remaining_files_and_preserves_tuple_result():
     reviewer = _make_prediction_reviewer()
     reviewer._get_prediction = AsyncMock(return_value="prediction")
@@ -46,6 +47,7 @@ async def test_prepare_prediction_requests_remaining_files_and_preserves_tuple_r
     assert reviewer.prediction == "prediction"
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_accepts_full_diff_string_when_token_budget_is_sufficient():
     reviewer = _make_prediction_reviewer()
     reviewer._get_prediction = AsyncMock(return_value="prediction")
@@ -58,6 +60,7 @@ async def test_prepare_prediction_accepts_full_diff_string_when_token_budget_is_
     assert reviewer.prediction == "prediction"
 
 
+@pytest.mark.asyncio
 async def test_prepare_prediction_keeps_incremental_review_compatible_with_tuple_result():
     reviewer = _make_prediction_reviewer()
     reviewer.incremental = SimpleNamespace(is_incremental=True)


### PR DESCRIPTION
`main`'s `build-and-test` job is currently red. The three `_prepare_prediction` tests added in #2589 rely on `asyncio_mode = "auto"` from `pyproject.toml`, but the docker `test` target never copies that file, so pytest runs in strict mode inside the image and rejects them with "async def functions are not natively supported". This adds the explicit `@pytest.mark.asyncio` marker that every other async test in the suite already carries.

Reproduce with `PYTHONPATH=. pytest tests/unittest -o asyncio_mode=strict` — 3 failed before, 1667 passed after.
