### PR TITLE
feat: add GLM-5.2, Kimi K3, Qwen3.8 and MiMo v2.5 model support

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -344,6 +344,84 @@ key = ...
 
 (you can obtain a deepseek-v4 key from [here](https://platform.deepseek.com/api_keys))
 
+### GLM (Z.AI)
+
+To use GLM models with Z.AI (Zhipu), for example, set:
+
+```toml
+[config] # in configuration.toml
+model = "zai/glm-5.2"
+fallback_models=["zai/glm-5.2"]
+```
+
+and fill up your key
+
+```toml
+[zai] # in .secrets.toml
+key = ...
+```
+
+(you can obtain a Z.AI API key from [here](https://z.ai/))
+
+### Kimi (Moonshot)
+
+To use Kimi models with Moonshot, for example, set:
+
+```toml
+[config] # in configuration.toml
+model = "moonshot/kimi-k3"
+fallback_models=["moonshot/kimi-k3"]
+```
+
+and fill up your key
+
+```toml
+[moonshot] # in .secrets.toml
+key = ...
+```
+
+(you can obtain a Moonshot API key from [here](https://platform.moonshot.ai/))
+
+If you are on the China endpoint instead, add `api_base = "https://api.moonshot.cn/v1"` under `[moonshot]`.
+
+### Qwen (DashScope)
+
+To use Qwen models with Alibaba DashScope, for example, set:
+
+```toml
+[config] # in configuration.toml
+model = "dashscope/qwen3.8-max"
+fallback_models=["dashscope/qwen3.8-max"]
+```
+
+and fill up your key
+
+```toml
+[dashscope] # in .secrets.toml
+key = ...
+```
+
+(you can obtain a DashScope API key from [here](https://dashscope.console.aliyun.com/))
+
+### Xiaomi MiMo
+
+To use Xiaomi MiMo models, for example, set:
+
+```toml
+[config] # in configuration.toml
+model = "xiaomi_mimo/mimo-v2.5"
+fallback_models=["xiaomi_mimo/mimo-v2.5"]
+```
+
+and fill up your key
+
+```toml
+[xiaomi_mimo] # in .secrets.toml
+key = ...
+```
+
+(you can obtain a Xiaomi MiMo API key from [here](https://platform.xiaomimimo.com/#/docs))
+
 ### DeepInfra
 
 To use DeepSeek model with DeepInfra, for example, set:

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -74,6 +74,8 @@ MAX_TOKENS = {
     'deepseek/deepseek-reasoner': 64000,  # 64K, but may be limited by config.max_model_tokens
     'deepseek/deepseek-v4-pro': 1000000,  # 1M, but may be limited by config.max_model_tokens
     'deepseek/deepseek-v4-flash': 1000000,  # 1M, but may be limited by config.max_model_tokens
+    'zai/glm-5.2': 200000,  # 200K, matching the Z.AI GLM-5/5.1 lineage, but may be limited by config.max_model_tokens
+    'moonshot/kimi-k3': 262144,  # 256K, matching the Moonshot Kimi-k2.5/k2.6 lineage, but may be limited by config.max_model_tokens
     'openai/qwq-plus': 131072,  # 131K context length, but may be limited by config.max_model_tokens
     'replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1': 4096,
     'meta-llama/Llama-2-7b-chat-hf': 4096,
@@ -266,6 +268,7 @@ MAX_TOKENS = {
     'groq/openai/gpt-oss-120b': 131072,
     'groq/openai/gpt-oss-20b': 131072,
     'groq/qwen/qwen3-32b': 131000,
+    'dashscope/qwen3.8-max': 1000000,  # 1M, qwen3.8-max is the actual DashScope model id (context_window 1M per QwenCode metadata), but may be limited by config.max_model_tokens
     'groq/moonshotai/kimi-k2-instruct': 131072,
     'groq/deepseek-r1-distill-llama-70b': 128000,
     'groq/meta-llama/llama-4-maverick-17b-128e-instruct': 131072,
@@ -313,6 +316,8 @@ MAX_TOKENS = {
     "mistral/codestral-mamba-latest": 256000,
     "codestral/codestral-latest": 8191,
     "codestral/codestral-2405": 8191,
+    'xiaomi_mimo/mimo-v2.5': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5, xiaomi_mimo/ is the native LiteLLM Xiaomi provider, but may be limited by config.max_model_tokens
+    'xiaomi_mimo/mimo-v2.5-pro': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5-pro, but may be limited by config.max_model_tokens
 }
 
 USER_MESSAGE_ONLY_MODELS = [

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -201,6 +201,25 @@ class LiteLLMAIHandler(BaseAiHandler):
         if get_settings().get("DEEPSEEK.KEY", None):
             os.environ['DEEPSEEK_API_KEY'] = get_settings().get("DEEPSEEK.KEY")
 
+        # Support GLM (Z.AI / Zhipu) models
+        if get_settings().get("ZAI.KEY", None):
+            os.environ['ZAI_API_KEY'] = get_settings().get("ZAI.KEY")
+
+        # Support Moonshot (Kimi) models
+        if get_settings().get("MOONSHOT.KEY", None):
+            os.environ['MOONSHOT_API_KEY'] = get_settings().get("MOONSHOT.KEY")
+        # Optional Moonshot endpoint override (e.g. China: https://api.moonshot.cn/v1)
+        if get_settings().get("MOONSHOT.API_BASE", None):
+            os.environ['MOONSHOT_API_BASE'] = get_settings().get("MOONSHOT.API_BASE")
+
+        # Support Qwen (Alibaba DashScope) models
+        if get_settings().get("DASHSCOPE.KEY", None):
+            os.environ['DASHSCOPE_API_KEY'] = get_settings().get("DASHSCOPE.KEY")
+
+        # Support Xiaomi MiMo models
+        if get_settings().get("XIAOMI_MIMO.KEY", None):
+            os.environ['XIAOMI_MIMO_API_KEY'] = get_settings().get("XIAOMI_MIMO.KEY")
+
         # Support deepinfra models
         if get_settings().get("DEEPINFRA.KEY", None):
             os.environ['DEEPINFRA_API_KEY'] = get_settings().get("DEEPINFRA.KEY")

--- a/pr_agent/settings/.secrets_template.toml
+++ b/pr_agent/settings/.secrets_template.toml
@@ -118,6 +118,20 @@ pat = ""
 [deepseek]
 key = ""
 
+[zai]
+key = ""  # GLM (Z.AI / Zhipu). Acquire through https://z.ai/
+
+[moonshot]
+key = ""  # Kimi (Moonshot AI). Acquire through https://platform.moonshot.ai/
+# api_base = "https://api.moonshot.cn/v1"  # Optional: override endpoint (e.g. China)
+
+[dashscope]
+key = ""  # Qwen (Alibaba DashScope). Acquire through https://dashscope.console.aliyun.com/
+
+[xiaomi_mimo]
+key = ""  # Xiaomi MiMo. Acquire through https://platform.xiaomimimo.com/#/docs
+
+
 [deepinfra]
 key = ""
 

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -333,3 +333,95 @@ class TestGetMaxTokens:
         monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
 
         assert get_max_tokens(model) == 200000
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "zai/glm-5.2",
+        ],
+    )
+    def test_zai_glm_5_2_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 200000
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "moonshot/kimi-k3",
+        ],
+    )
+    def test_moonshot_kimi_k3_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 262144
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "dashscope/qwen3.8-max",
+        ],
+    )
+    def test_qwen_3_8_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1000000
+
+
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "xiaomi_mimo/mimo-v2.5",
+        ],
+    )
+    def test_xiaomi_mimo_v2_5_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1048576
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "xiaomi_mimo/mimo-v2.5-pro",
+        ],
+    )
+    def test_xiaomi_mimo_v2_5_pro_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1048576


### PR DESCRIPTION
This pull request adds support for several new LLM providers—GLM (Z.AI), Kimi (Moonshot), Qwen (DashScope), and Xiaomi MiMo—by updating documentation, configuration templates, environment variable handling, model context window settings, and unit tests. These changes make it easier to use these providers in the project and ensure their maximum token limits are correctly handled.

**Provider Support Additions:**

* Added support for GLM (Z.AI), Kimi (Moonshot), Qwen (DashScope), and Xiaomi MiMo models, including instructions in `changing_a_model.md` for configuring these providers and obtaining API keys.
* Updated `.secrets_template.toml` to include sections for the new providers, with placeholders and instructions for API keys and custom endpoints.
* Modified `litellm_ai_handler.py` to set environment variables for the new providers’ API keys and, for Moonshot, optionally override the API base endpoint.

**Model Context Window Updates:**

* Added entries to the `MODEL_CONTEXT_WINDOW` dictionary for the new models, specifying their maximum token limits to ensure correct handling during inference. [[1]](diffhunk://#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692bR77-R78) [[2]](diffhunk://#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692bR271) [[3]](diffhunk://#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692bR319-R320)

**Testing Enhancements:**

* Introduced unit tests in `test_get_max_tokens.py` to verify that the correct maximum token limits are returned for each new provider/model.