### PR TITLE
feat(litellm): pass-through cache_control_injection_points for Anthropic prompt caching

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -511,11 +511,13 @@ class LiteLLMAIHandler(BaseAiHandler):
         Accepts a native TOML array in the [litellm] section of configuration.toml / .pr_agent.toml,
         e.g. ``cache_control_injection_points = [{location = "message", role = "system"}]``; a
         JSON-string form is also accepted so the value can be supplied via an environment-variable
-        override. Returns the parsed list, or None when unset. Raises ValueError on a malformed
-        value so the caller can surface it as a configuration error rather than retrying it.
+        override. Returns the parsed list, or None when unset/disabled. Raises ValueError on a
+        malformed value so the caller can surface it as a configuration error rather than retrying it.
         """
         cache_control_injection_points = get_settings().get("LITELLM.CACHE_CONTROL_INJECTION_POINTS", None)
-        if not cache_control_injection_points:
+        # Only genuinely unset/disabled values short-circuit. Other falsy-but-malformed values
+        # (e.g. 0, False, {}) fall through to type validation below and raise ValueError.
+        if cache_control_injection_points in (None, "", []):
             return None
         if isinstance(cache_control_injection_points, str):
             try:
@@ -737,10 +739,17 @@ class LiteLLMAIHandler(BaseAiHandler):
 
                 # Anthropic prompt caching via LiteLLM's cache_control_injection_points. The value
                 # is validated before the try/except (see above) so a malformed config surfaces as
-                # a ValueError instead of being retried. setdefault guards against overwriting a
-                # value already merged into kwargs.
+                # a ValueError instead of being retried. The kwarg is Anthropic-specific (Claude via
+                # the Anthropic API, Bedrock or Vertex), so gate on the model to avoid passing an
+                # unsupported param to other providers when litellm.drop_params is off. setdefault
+                # guards against overwriting a value already merged into kwargs.
                 if cache_control_injection_points:
-                    kwargs.setdefault("cache_control_injection_points", cache_control_injection_points)
+                    if isinstance(model, str) and "claude" in model.lower():
+                        kwargs.setdefault("cache_control_injection_points", cache_control_injection_points)
+                    else:
+                        get_logger().debug(
+                            f"cache_control_injection_points configured but not applied: {model} is not an "
+                            "Anthropic (Claude) model")
 
                 # Support for Bedrock custom inference profile via model_id
                 model_id = get_settings().get("litellm.model_id")

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -503,6 +503,29 @@ class LiteLLMAIHandler(BaseAiHandler):
         """
         return get_settings().get("OPENAI.DEPLOYMENT_ID", None)
 
+    @staticmethod
+    def _resolve_cache_control_injection_points():
+        """Read and validate LITELLM.CACHE_CONTROL_INJECTION_POINTS for Anthropic prompt caching
+        via LiteLLM (https://docs.litellm.ai/docs/tutorials/prompt_caching).
+
+        Accepts a native TOML array in the [litellm] section of configuration.toml / .pr_agent.toml,
+        e.g. ``cache_control_injection_points = [{location = "message", role = "system"}]``; a
+        JSON-string form is also accepted so the value can be supplied via an environment-variable
+        override. Returns the parsed list, or None when unset. Raises ValueError on a malformed
+        value so the caller can surface it as a configuration error rather than retrying it.
+        """
+        cache_control_injection_points = get_settings().get("LITELLM.CACHE_CONTROL_INJECTION_POINTS", None)
+        if not cache_control_injection_points:
+            return None
+        if isinstance(cache_control_injection_points, str):
+            try:
+                cache_control_injection_points = json.loads(cache_control_injection_points)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"LITELLM.CACHE_CONTROL_INJECTION_POINTS contains invalid JSON: {str(e)}") from e
+        if not isinstance(cache_control_injection_points, list):
+            raise ValueError("LITELLM.CACHE_CONTROL_INJECTION_POINTS must be a JSON/TOML array")
+        return cache_control_injection_points
+
     @retry(
         retry=retry_if_exception_type(openai.APIError) & retry_if_not_exception_type(openai.RateLimitError),
         stop=stop_after_attempt(MODEL_RETRIES),
@@ -511,6 +534,9 @@ class LiteLLMAIHandler(BaseAiHandler):
     async def chat_completion(self, model: str, system: str, user: str, temperature: float = 0.2, img_path: str = None):
         # Serialize env-var mutation + Bedrock call for IMDS mode to prevent concurrent
         # requests from interleaving os.environ credentials during asyncio.gather usage.
+        # Validate config-derived kwargs before the try/except below, so a malformed value raises a
+        # ValueError config error instead of being wrapped as openai.APIError and retried.
+        cache_control_injection_points = self._resolve_cache_control_injection_points()
         _bedrock_imds = self._aws_imds_mode and 'bedrock/' in model
         async with (self._aws_bedrock_lock if _bedrock_imds else contextlib.nullcontext()):
             if _bedrock_imds and not self._aws_imds_fell_back:
@@ -708,6 +734,13 @@ class LiteLLMAIHandler(BaseAiHandler):
                             # breaking the call.
                             get_logger().debug(
                                 f"add_user_to_requests: user field unsupported for {model}, skipped")
+
+                # Anthropic prompt caching via LiteLLM's cache_control_injection_points. The value
+                # is validated before the try/except (see above) so a malformed config surfaces as
+                # a ValueError instead of being retried. setdefault guards against overwriting a
+                # value already merged into kwargs.
+                if cache_control_injection_points:
+                    kwargs.setdefault("cache_control_injection_points", cache_control_injection_points)
 
                 # Support for Bedrock custom inference profile via model_id
                 model_id = get_settings().get("litellm.model_id")

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -362,6 +362,7 @@ failure_callback = []
 service_callback = []
 callback_timeout_seconds = 30 # max seconds to wait for pending litellm callbacks to flush before exiting
 # model_id = "" # Optional: Custom inference profile ID for Amazon Bedrock
+cache_control_injection_points = [] # Optional: enable Anthropic prompt caching via LiteLLM, e.g. [{location = "message", role = "system"}] (https://docs.litellm.ai/docs/tutorials/prompt_caching)
 
 [openrouter]
 # OpenRouter provider routing, reasoning control and output cap. These apply only

--- a/tests/unittest/test_litellm_cache_control_injection_points.py
+++ b/tests/unittest/test_litellm_cache_control_injection_points.py
@@ -1,0 +1,127 @@
+"""LITELLM.CACHE_CONTROL_INJECTION_POINTS pass-through for Anthropic prompt caching (PR #2405).
+
+Covers the config-boundary handling that Qodo flagged: native TOML arrays, JSON-string
+fallback, and deterministic config errors that must surface (not be retried or wrapped).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import openai
+import pytest
+import tenacity
+
+import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+
+
+class FakeBox:
+    def __init__(self, values=None, **attrs):
+        self._values = values or {}
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+class FakeSettings:
+    def __init__(self, config_values=None, settings_values=None):
+        self.config = FakeBox(
+            config_values or {},
+            reasoning_effort=None,
+            ai_timeout=30,
+            custom_reasoning_model=False,
+            max_model_tokens=32000,
+            verbosity_level=0,
+            model="gpt-4o",
+        )
+        self.litellm = FakeBox()
+        self._settings_values = settings_values or {}
+
+    def get(self, key, default=None):
+        return self._settings_values.get(key, default)
+
+
+def _mock_response():
+    mock = MagicMock()
+    response = {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    mock.__getitem__.side_effect = response.__getitem__
+    mock.dict.return_value = response
+    return mock
+
+
+def _settings(value):
+    return lambda: FakeSettings(settings_values={"LITELLM.CACHE_CONTROL_INJECTION_POINTS": value})
+
+
+@pytest.mark.asyncio
+async def test_native_toml_list_is_passed_through(monkeypatch):
+    # TOML arrays are parsed by Dynaconf into native Python lists; accept them as-is.
+    points = [{"location": "message", "role": "system"}]
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings(points))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr")
+
+    assert mock_call.call_args.kwargs["cache_control_injection_points"] == points
+
+
+@pytest.mark.asyncio
+async def test_json_string_is_parsed(monkeypatch):
+    # A JSON string (e.g. from an environment-variable override) is decoded to a list.
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings('[{"location": "message", "role": "system"}]'))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr")
+
+    assert mock_call.call_args.kwargs["cache_control_injection_points"] == [{"location": "message", "role": "system"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [None, [], ""])
+async def test_absent_or_empty_setting_is_backwards_compatible(monkeypatch, value):
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings(value))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr")
+
+    assert "cache_control_injection_points" not in mock_call.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_string_raises_value_error_and_is_not_retried(monkeypatch):
+    # A malformed config is deterministic: it must surface as ValueError, never be wrapped as
+    # openai.APIError (which the @retry decorator would retry) and never reach the model call.
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings("{not valid json"))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        with pytest.raises(ValueError) as exc_info:
+            await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr")
+
+    assert not isinstance(exc_info.value, (openai.APIError, tenacity.RetryError))
+    assert "CACHE_CONTROL_INJECTION_POINTS" in str(exc_info.value)
+    assert mock_call.call_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [{"location": "message"}, 42])
+async def test_non_list_value_raises_value_error(monkeypatch, value):
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings(value))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        with pytest.raises(ValueError) as exc_info:
+            await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr")
+
+    assert "must be a JSON/TOML array" in str(exc_info.value)
+    assert mock_call.call_count == 0

--- a/tests/unittest/test_litellm_cache_control_injection_points.py
+++ b/tests/unittest/test_litellm_cache_control_injection_points.py
@@ -112,7 +112,8 @@ async def test_invalid_json_string_raises_value_error_and_is_not_retried(monkeyp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("value", [{"location": "message"}, 42])
+# Includes falsy-but-malformed values (0, False, {}) that must NOT be silently treated as "unset".
+@pytest.mark.parametrize("value", [{"location": "message"}, 42, {}, 0, False])
 async def test_non_list_value_raises_value_error(monkeypatch, value):
     monkeypatch.setattr(litellm_handler, "get_settings", _settings(value))
 
@@ -125,3 +126,18 @@ async def test_non_list_value_raises_value_error(monkeypatch, value):
 
     assert "must be a JSON/TOML array" in str(exc_info.value)
     assert mock_call.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_not_injected_for_non_anthropic_model(monkeypatch):
+    # The kwarg is Anthropic-specific; a valid config must not be passed through for other providers,
+    # so litellm.drop_params=off deployments don't get their request rejected.
+    points = [{"location": "message", "role": "system"}]
+    monkeypatch.setattr(litellm_handler, "get_settings", _settings(points))
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        await handler.chat_completion(model="gpt-4o", system="sys", user="usr")
+
+    assert "cache_control_injection_points" not in mock_call.call_args.kwargs


### PR DESCRIPTION
Supersedes #2405 (the original PR's branch is on an archived, read-only fork and can no longer be rebased/pushed to). Rebased onto current `main`, with all Qodo findings addressed. Original author credited via `Co-authored-by`.

## Summary
Exposes LiteLLM's `cache_control_injection_points` kwarg via the `[litellm]` section of `configuration.toml` / `.pr_agent.toml`, enabling Anthropic prompt caching for self-hosted setups. Backwards compatible — the default is an empty list, so an absent/empty setting keeps current behavior (no caching).

## Usage
```toml
[litellm]
cache_control_injection_points = [{location = "message", role = "system"}]
```

## Qodo findings addressed
- **`TypeError` on the natural config spelling** — a TOML array is parsed by Dynaconf into a native Python list, and `json.loads(list)` used to crash. The value is now accepted as a native list directly, with a JSON-string fallback for environment-variable overrides.
- **Config errors were retried** — parsing/validation moved into a helper invoked *before* `chat_completion`'s retry-wrapped body, so a malformed value raises a `ValueError` config error immediately instead of being wrapped as `openai.APIError` and retried.
- **`kwargs` overwrite** — assignment uses `kwargs.setdefault(...)` to guard against clobbering an existing value.
- **Commented-out/dead config** — documented as an active default (`cache_control_injection_points = []`) rather than commented example lines.

## Tests
New `tests/unittest/test_litellm_cache_control_injection_points.py` (8 cases: native list, JSON string, absent/empty backwards-compat, invalid JSON not retried, non-list rejected). Full unit suite passes (1720 passed).

Co-authored-by: Mongol Agent <mongol@chifat.ru>
