### PR TITLE
test: isolate Gunicorn tests from runner CPU affinity

### DIFF
--- a/tests/unittest/test_gunicorn_config.py
+++ b/tests/unittest/test_gunicorn_config.py
@@ -5,9 +5,10 @@ from pr_agent.servers import gunicorn_config
 
 @pytest.fixture(autouse=True)
 def isolated_env(monkeypatch, tmp_path):
-    """Detach every test from the host's env vars and real cgroup files."""
+    """Detach every test from the host's env vars, CPU affinity, and real cgroup files."""
     monkeypatch.delenv("GUNICORN_WORKERS", raising=False)
     monkeypatch.delenv("GUNICORN_MAX_WORKERS", raising=False)
+    monkeypatch.setattr(gunicorn_config.os, "sched_getaffinity", lambda pid: set(range(64)), raising=False)
     for attr in ("CGROUP_V2_CPU_MAX", "CGROUP_V1_CPU_QUOTA", "CGROUP_V1_CPU_PERIOD"):
         monkeypatch.setattr(gunicorn_config, attr, str(tmp_path / "missing"))
 
@@ -56,6 +57,7 @@ class TestCgroupCpuLimit:
 class TestAvailableCpus:
     def test_prefers_cgroup_limit_over_host_cores(self, monkeypatch, tmp_path):
         write_cgroup_v2(monkeypatch, tmp_path, "400000 100000\n")
+        monkeypatch.delattr(gunicorn_config.os, "sched_getaffinity", raising=False)
         monkeypatch.setattr(gunicorn_config.os, "cpu_count", lambda: 64)
         assert gunicorn_config.available_cpus() == 4
 


### PR DESCRIPTION
## Summary

- isolate Gunicorn CPU tests from the runner's process affinity
- preserve coverage of the `os.cpu_count()` fallback path

## Why

Some tests simulate a three- or four-CPU cgroup quota, but `available_cpus()` also considers `os.sched_getaffinity()` and uses the lower value. On runners restricted to fewer CPUs, those assertions can therefore depend on the runner rather than only on the inputs arranged by the test.

Give the shared fixture a stable affinity value, while explicitly removing the affinity API in the test that exercises the `os.cpu_count()` fallback.

## Validation

- `PYTHONPATH=. ./.venv/bin/pytest tests/unittest/test_gunicorn_config.py -q` (`28 passed`)
- `PYTHONPATH=. ./.venv/bin/pytest tests/unittest -q` (`1727 passed, 1 skipped, 1 xfailed`)
- Build-and-test and code coverage workflows passed