### PR TITLE
fix(github-app): read ignore_bot_pr from the section it ships in

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -240,8 +240,13 @@ def get_log_context(body, event, action, build_number):
 
 def is_bot_user(sender, sender_type):
     try:
-        # logic to ignore PRs opened by bot
-        if get_settings().get("GITHUB.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        # logic to ignore PRs opened by bot.
+        # `ignore_bot_pr` ships under [github]; the [github_app] spelling this lookup
+        # used to read is still honoured for deployments that set it.
+        ignore_bot_pr = get_settings().get("GITHUB_APP.IGNORE_BOT_PR", None)
+        if ignore_bot_pr is None:
+            ignore_bot_pr = get_settings().get("GITHUB.IGNORE_BOT_PR", False)
+        if ignore_bot_pr and sender_type == "Bot":
             if 'pr-agent' not in sender:
                 get_logger().info(f"Ignoring PR from '{sender=}' because it is a bot")
             return True

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -241,7 +241,7 @@ def get_log_context(body, event, action, build_number):
 def is_bot_user(sender, sender_type):
     try:
         # logic to ignore PRs opened by bot
-        if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        if get_settings().get("GITHUB.IGNORE_BOT_PR", False) and sender_type == "Bot":
             if 'pr-agent' not in sender:
                 get_logger().info(f"Ignoring PR from '{sender=}' because it is a bot")
             return True

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -240,9 +240,7 @@ def get_log_context(body, event, action, build_number):
 
 def is_bot_user(sender, sender_type):
     try:
-        # logic to ignore PRs opened by bot.
-        # `ignore_bot_pr` ships under [github]; the [github_app] spelling this lookup
-        # used to read is still honoured for deployments that set it.
+        # logic to ignore PRs opened by bot
         ignore_bot_pr = get_settings().get("GITHUB_APP.IGNORE_BOT_PR", None)
         if ignore_bot_pr is None:
             ignore_bot_pr = get_settings().get("GITHUB.IGNORE_BOT_PR", False)

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -505,11 +505,34 @@ class TestIsBotUser:
     silently inert.
     """
 
-    def test_reads_the_shipped_configuration_key(self):
+    def test_option_ships_under_the_github_section(self):
+        import tomllib
+        from pathlib import Path
+
+        import pr_agent
+
+        config_path = Path(pr_agent.__file__).parent / "settings" / "configuration.toml"
+        with config_path.open("rb") as handle:
+            shipped = tomllib.load(handle)
+
+        # Read the file rather than the merged settings so environment overrides
+        # cannot skew this: it pins where the option is defined, which is what the
+        # lookup in is_bot_user has to agree with.
+        assert "ignore_bot_pr" in shipped["github"]
+        assert "ignore_bot_pr" not in shipped.get("github_app", {})
+
+    def test_legacy_github_app_override_is_honoured(self):
         from pr_agent.config_loader import get_settings
 
-        # Guards against the lookup drifting away from configuration.toml again.
-        assert get_settings().get("GITHUB.IGNORE_BOT_PR") is True
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR")
+        settings.set("GITHUB.IGNORE_BOT_PR", True)
+        settings.set("GITHUB_APP.IGNORE_BOT_PR", False)
+        try:
+            assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)
+            settings.set("GITHUB_APP.IGNORE_BOT_PR", None)
 
     def test_bot_sender_is_ignored_when_enabled(self):
         from pr_agent.config_loader import get_settings

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -500,12 +500,8 @@ class TestPushTriggerDedupe:
 
 @pytest.fixture
 def bot_pr_settings():
-    """Isolate the ``ignore_bot_pr`` lookup from the shared global settings.
-
-    Dynaconf's ``unset`` does not remove a dotted key, so a test that adds
-    ``GITHUB_APP.IGNORE_BOT_PR`` cannot take it back off again.  Both sections are
-    therefore snapshotted and restored wholesale, which does drop keys the test
-    introduced.
+    """Snapshot both sections wholesale: Dynaconf's ``unset`` does not remove a
+    dotted key, so a key a test adds can only be dropped by restoring its section.
     """
     from pr_agent.config_loader import get_settings
 
@@ -522,13 +518,6 @@ def bot_pr_settings():
 
 
 class TestIsBotUser:
-    """``is_bot_user`` must read ``ignore_bot_pr`` from the section it ships in.
-
-    The option is defined under ``[github]`` in configuration.toml, so a lookup
-    against any other section resolves to the default and leaves the filter
-    silently inert.
-    """
-
     def test_option_ships_under_the_github_section(self):
         import tomllib
         from pathlib import Path
@@ -539,9 +528,7 @@ class TestIsBotUser:
         with config_path.open("rb") as handle:
             shipped = tomllib.load(handle)
 
-        # Read the file rather than the merged settings so environment overrides
-        # cannot skew this: it pins where the option is defined, which is what the
-        # lookup in is_bot_user has to agree with.
+        # Read the file, not the merged settings, so env overrides cannot skew this.
         assert "ignore_bot_pr" in shipped["github"]
         assert "ignore_bot_pr" not in shipped.get("github_app", {})
 

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -7,6 +7,7 @@ Time-dependent behavior is exercised by monkeypatching ``time.monotonic`` on the
 """
 
 import asyncio
+import copy
 from types import SimpleNamespace
 
 import pytest
@@ -497,6 +498,29 @@ class TestPushTriggerDedupe:
         assert push_trigger_env["count"] == 0
 
 
+@pytest.fixture
+def bot_pr_settings():
+    """Isolate the ``ignore_bot_pr`` lookup from the shared global settings.
+
+    Dynaconf's ``unset`` does not remove a dotted key, so a test that adds
+    ``GITHUB_APP.IGNORE_BOT_PR`` cannot take it back off again.  Both sections are
+    therefore snapshotted and restored wholesale, which does drop keys the test
+    introduced.
+    """
+    from pr_agent.config_loader import get_settings
+
+    settings = get_settings()
+    originals = {
+        name: copy.deepcopy(settings.get(name)) for name in ("GITHUB", "GITHUB_APP")
+    }
+    try:
+        yield settings
+    finally:
+        for name, original in originals.items():
+            settings.unset(name, force=True)
+            settings.set(name, original)
+
+
 class TestIsBotUser:
     """``is_bot_user`` must read ``ignore_bot_pr`` from the section it ships in.
 
@@ -521,48 +545,23 @@ class TestIsBotUser:
         assert "ignore_bot_pr" in shipped["github"]
         assert "ignore_bot_pr" not in shipped.get("github_app", {})
 
-    def test_legacy_github_app_override_is_honoured(self):
-        from pr_agent.config_loader import get_settings
+    def test_legacy_github_app_override_is_honoured(self, bot_pr_settings):
+        bot_pr_settings.set("GITHUB.IGNORE_BOT_PR", True)
+        bot_pr_settings.set("GITHUB_APP.IGNORE_BOT_PR", False)
 
-        settings = get_settings()
-        original = settings.get("GITHUB.IGNORE_BOT_PR")
-        settings.set("GITHUB.IGNORE_BOT_PR", True)
-        settings.set("GITHUB_APP.IGNORE_BOT_PR", False)
-        try:
-            assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
-        finally:
-            settings.set("GITHUB.IGNORE_BOT_PR", original)
-            settings.set("GITHUB_APP.IGNORE_BOT_PR", None)
+        assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
 
-    def test_bot_sender_is_ignored_when_enabled(self):
-        from pr_agent.config_loader import get_settings
+    def test_bot_sender_is_ignored_when_enabled(self, bot_pr_settings):
+        bot_pr_settings.set("GITHUB.IGNORE_BOT_PR", True)
 
-        settings = get_settings()
-        original = settings.get("GITHUB.IGNORE_BOT_PR")
-        settings.set("GITHUB.IGNORE_BOT_PR", True)
-        try:
-            assert github_app.is_bot_user("dependabot[bot]", "Bot") is True
-        finally:
-            settings.set("GITHUB.IGNORE_BOT_PR", original)
+        assert github_app.is_bot_user("dependabot[bot]", "Bot") is True
 
-    def test_bot_sender_is_processed_when_disabled(self):
-        from pr_agent.config_loader import get_settings
+    def test_bot_sender_is_processed_when_disabled(self, bot_pr_settings):
+        bot_pr_settings.set("GITHUB.IGNORE_BOT_PR", False)
 
-        settings = get_settings()
-        original = settings.get("GITHUB.IGNORE_BOT_PR")
-        settings.set("GITHUB.IGNORE_BOT_PR", False)
-        try:
-            assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
-        finally:
-            settings.set("GITHUB.IGNORE_BOT_PR", original)
+        assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
 
-    def test_human_sender_is_never_ignored(self):
-        from pr_agent.config_loader import get_settings
+    def test_human_sender_is_never_ignored(self, bot_pr_settings):
+        bot_pr_settings.set("GITHUB.IGNORE_BOT_PR", True)
 
-        settings = get_settings()
-        original = settings.get("GITHUB.IGNORE_BOT_PR")
-        settings.set("GITHUB.IGNORE_BOT_PR", True)
-        try:
-            assert github_app.is_bot_user("alice", "User") is False
-        finally:
-            settings.set("GITHUB.IGNORE_BOT_PR", original)
+        assert github_app.is_bot_user("alice", "User") is False

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -495,3 +495,51 @@ class TestPushTriggerDedupe:
         )
 
         assert push_trigger_env["count"] == 0
+
+
+class TestIsBotUser:
+    """``is_bot_user`` must read ``ignore_bot_pr`` from the section it ships in.
+
+    The option is defined under ``[github]`` in configuration.toml, so a lookup
+    against any other section resolves to the default and leaves the filter
+    silently inert.
+    """
+
+    def test_reads_the_shipped_configuration_key(self):
+        from pr_agent.config_loader import get_settings
+
+        # Guards against the lookup drifting away from configuration.toml again.
+        assert get_settings().get("GITHUB.IGNORE_BOT_PR") is True
+
+    def test_bot_sender_is_ignored_when_enabled(self):
+        from pr_agent.config_loader import get_settings
+
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR")
+        settings.set("GITHUB.IGNORE_BOT_PR", True)
+        try:
+            assert github_app.is_bot_user("dependabot[bot]", "Bot") is True
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)
+
+    def test_bot_sender_is_processed_when_disabled(self):
+        from pr_agent.config_loader import get_settings
+
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR")
+        settings.set("GITHUB.IGNORE_BOT_PR", False)
+        try:
+            assert github_app.is_bot_user("dependabot[bot]", "Bot") is False
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)
+
+    def test_human_sender_is_never_ignored(self):
+        from pr_agent.config_loader import get_settings
+
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR")
+        settings.set("GITHUB.IGNORE_BOT_PR", True)
+        try:
+            assert github_app.is_bot_user("alice", "User") is False
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)


### PR DESCRIPTION
`is_bot_user` reads `GITHUB_APP.IGNORE_BOT_PR`, but the option ships as `ignore_bot_pr` under `[github]` (`configuration.toml:255`), so the lookup falls back to the default and the filter has never run. Both lines came in together in `80a793a2` (2024-03-18), so this has been inert since it was added.

Fixes the lookup rather than moving the key, since `configuration.toml` is the documented list users copy from. Adds tests that fail without the change.

Reviewer note: this activates the shipped default, so bot-authored PRs (dependabot, renovate) will now actually be skipped. That is the documented intent, but it is a behaviour change for anyone who has been relying on them being reviewed. Happy to flip the default to `false` instead if you would rather keep today's effective behaviour.