### PR TITLE
fix(gitea): use user-facing base URL for links published in comments

### DIFF
--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -40,6 +40,7 @@
     GITEA__PERSONAL_ACCESS_TOKEN=<personal_access_token>
     GITEA__WEBHOOK_SECRET=<webhook_secret>
     GITEA__URL=https://gitea.com # Or self host
+    GITEA__WEB_URL=https://git.example.com # Optional: user-facing URL for links, if it differs from GITEA__URL
     OPENAI__KEY=<your_openai_api_key>
     GITEA__SKIP_SSL_VERIFICATION=false # or true
     GITEA__SSL_CA_CERT=/path/to/cacert.pem

--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -40,11 +40,16 @@
     GITEA__PERSONAL_ACCESS_TOKEN=<personal_access_token>
     GITEA__WEBHOOK_SECRET=<webhook_secret>
     GITEA__URL=https://gitea.com # Or self host
-    GITEA__WEB_URL=https://git.example.com # Optional: user-facing URL for links, if it differs from GITEA__URL
+    GITEA__WEB_URL=https://git.example.com # Optional: user-facing URL for links published in comments (see below)
     OPENAI__KEY=<your_openai_api_key>
     GITEA__SKIP_SSL_VERIFICATION=false # or true
     GITEA__SSL_CA_CERT=/path/to/cacert.pem
     ```
+
+    Links published in comments are built from `GITEA__WEB_URL` when set, else from `GITEA__URL`,
+    else derived from the PR's `html_url` (which Gitea/Forgejo builds from its own `ROOT_URL`).
+    Set `GITEA__WEB_URL` explicitly when `GITEA__URL` is an internal address users cannot browse
+    (e.g. a Docker service name), or when the server's `ROOT_URL` is misconfigured.
 
 8. Create a webhook in your Gitea project. Set the URL to `http[s]://<PR_AGENT_HOSTNAME>/api/v1/gitea_webhooks`, the secret token to the generated secret from step 3, and enable the triggers `push`, `comments` and `merge request events`.
 

--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -46,8 +46,9 @@
     GITEA__SSL_CA_CERT=/path/to/cacert.pem
     ```
 
-    Links published in comments are built from `GITEA__WEB_URL` when set, else from `GITEA__URL`,
-    else derived from the PR's `html_url` (which Gitea/Forgejo builds from its own `ROOT_URL`).
+    Links published in comments are built from `GITEA__WEB_URL` when set, else from `GITEA__URL`
+    when it differs from the shipped default (`https://gitea.com`), else derived from the PR's
+    `html_url` (which Gitea/Forgejo builds from its own `ROOT_URL`).
     Set `GITEA__WEB_URL` explicitly when `GITEA__URL` is an internal address users cannot browse
     (e.g. a Docker service name), or when the server's `ROOT_URL` is misconfigured.
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -17,6 +17,12 @@ from pr_agent.git_providers.git_provider import (MAX_FILES_ALLOWED_FULL,
                                                  IncrementalPR)
 from pr_agent.log import get_logger
 
+# Shipped default for the [gitea] url setting in configuration.toml. A value
+# equal to this must be treated as "unset" when resolving the user-facing base
+# URL: the default is always present in production, so a bare truthiness check
+# on GITEA.URL would make the pr.html_url derivation unreachable.
+DEFAULT_GITEA_URL = "https://gitea.com"
+
 
 class _GiteaCommitAdapter:
     """Mimics PyGithub `Commit` shape (.sha, .html_url) over a raw Gitea commit payload."""
@@ -36,7 +42,7 @@ class GiteaProvider(GitProvider):
             self.logger.error("PR URL not provided.")
             raise ValueError("PR URL not provided.")
 
-        self.base_url = get_settings().get("GITEA.URL", "https://gitea.com").rstrip("/")
+        self.base_url = get_settings().get("GITEA.URL", DEFAULT_GITEA_URL).rstrip("/")
         self.pr_url = ""
         self.issue_url = ""
 
@@ -121,6 +127,9 @@ class GiteaProvider(GitProvider):
         2. An explicitly configured ``GITEA.URL``: an operator-set value wins
            over the server's self-reported ``ROOT_URL``, which ``pr.html_url``
            is built from and which may still be the default on some instances.
+           The shipped default (``DEFAULT_GITEA_URL``) does not count here -
+           configuration.toml always provides it, so a plain truthiness check
+           would leave the derivation below unreachable.
         3. Derived from ``pr.html_url``, which Gitea/Forgejo builds from its
            own external ``ROOT_URL``.
         4. ``base_url``, so existing single-URL deployments are unaffected.
@@ -128,7 +137,8 @@ class GiteaProvider(GitProvider):
         web_url = (get_settings().get("GITEA.WEB_URL", "") or "").rstrip("/")
         if web_url:
             return web_url
-        if get_settings().get("GITEA.URL", None):
+        configured_url = (get_settings().get("GITEA.URL", "") or "").rstrip("/")
+        if configured_url and configured_url != DEFAULT_GITEA_URL:
             return self.base_url
         pr_html_url = getattr(self.pr, "html_url", "") if self.pr else ""
         pr_url_suffix = f"/{self.owner}/{self.repo}/pulls/{self.pr_number}"

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -108,6 +108,29 @@ class GiteaProvider(GitProvider):
         else:
             self.pr_commits = None
 
+        self.base_url_html = self._resolve_base_url_html()
+
+    def _resolve_base_url_html(self) -> str:
+        """User-facing base URL interpolated into links published in comments.
+
+        ``base_url`` is where PR-Agent reaches the API, which may be an internal
+        address (Docker service name, cluster DNS) that users cannot browse, so
+        generated links must not be built from it. Resolution order:
+
+        1. The optional ``GITEA.WEB_URL`` setting.
+        2. Derived from ``pr.html_url``, which Gitea/Forgejo builds from its own
+           external ``ROOT_URL``.
+        3. ``base_url``, so existing single-URL deployments are unaffected.
+        """
+        web_url = (get_settings().get("GITEA.WEB_URL", "") or "").rstrip("/")
+        if web_url:
+            return web_url
+        pr_html_url = getattr(self.pr, "html_url", "") if self.pr else ""
+        pr_url_suffix = f"/{self.owner}/{self.repo}/pulls/{self.pr_number}"
+        if pr_html_url and pr_html_url.endswith(pr_url_suffix):
+            return pr_html_url[: -len(pr_url_suffix)]
+        return self.base_url
+
     def _set_pr_commits(self):
         """Load the commits of the PR itself, not the commits of the repository's default branch."""
         raw_commits = self.repo_api.get_pr_commits(
@@ -250,6 +273,10 @@ class GiteaProvider(GitProvider):
             self.logger.error(f"Unexpected error: {str(e)}")
 
     def get_pr_url(self) -> str:
+        # pr.html_url is the user-facing page; self.pr_url may carry the API-form
+        # URL (e.g. when the run was triggered by a webhook payload).
+        if self.pr and getattr(self.pr, "html_url", ""):
+            return self.pr.html_url
         return self.pr_url
 
     def get_issue_url(self) -> str:
@@ -550,12 +577,13 @@ class GiteaProvider(GitProvider):
         return diff_files
 
     def get_line_link(self, relevant_file, relevant_line_start, relevant_line_end = None) -> str:
+        link = f"{self.base_url_html}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}"
         if relevant_line_start == -1:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}"
+            pass
         elif relevant_line_end:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}#L{relevant_line_start}-L{relevant_line_end}"
+            link += f"#L{relevant_line_start}-L{relevant_line_end}"
         else:
-            link = f"{self.base_url}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}#L{relevant_line_start}"
+            link += f"#L{relevant_line_start}"
 
         self.logger.info(f"Generated link: {link}")
         return link

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -118,13 +118,18 @@ class GiteaProvider(GitProvider):
         generated links must not be built from it. Resolution order:
 
         1. The optional ``GITEA.WEB_URL`` setting.
-        2. Derived from ``pr.html_url``, which Gitea/Forgejo builds from its own
-           external ``ROOT_URL``.
-        3. ``base_url``, so existing single-URL deployments are unaffected.
+        2. An explicitly configured ``GITEA.URL``: an operator-set value wins
+           over the server's self-reported ``ROOT_URL``, which ``pr.html_url``
+           is built from and which may still be the default on some instances.
+        3. Derived from ``pr.html_url``, which Gitea/Forgejo builds from its
+           own external ``ROOT_URL``.
+        4. ``base_url``, so existing single-URL deployments are unaffected.
         """
         web_url = (get_settings().get("GITEA.WEB_URL", "") or "").rstrip("/")
         if web_url:
             return web_url
+        if get_settings().get("GITEA.URL", None):
+            return self.base_url
         pr_html_url = getattr(self.pr, "html_url", "") if self.pr else ""
         pr_url_suffix = f"/{self.owner}/{self.repo}/pulls/{self.pr_number}"
         if pr_html_url and pr_html_url.endswith(pr_url_suffix):
@@ -273,10 +278,14 @@ class GiteaProvider(GitProvider):
             self.logger.error(f"Unexpected error: {str(e)}")
 
     def get_pr_url(self) -> str:
-        # pr.html_url is the user-facing page; self.pr_url may carry the API-form
-        # URL (e.g. when the run was triggered by a webhook payload).
-        if self.pr and getattr(self.pr, "html_url", ""):
-            return self.pr.html_url
+        # Gitea sets url and html_url identically on the PR payload (the
+        # user-facing page), and self.pr_url comes from _parse_pr_url, which
+        # rejects the API form - so rebuild the page URL from base_url_html,
+        # letting a configured GITEA.WEB_URL reach the links built from here.
+        # Call sites are user-facing output only (pr_description, pr_reviewer,
+        # pr_update_changelog); API and clone paths use base_url directly.
+        if self.owner and self.repo and self.pr_number:
+            return f"{self.base_url_html}/{self.owner}/{self.repo}/pulls/{self.pr_number}"
         return self.pr_url
 
     def get_issue_url(self) -> str:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -311,7 +311,8 @@ url = "https://gitea.com"
 # Optional user-facing base URL used to build links published in comments, for
 # self-hosted instances where the API is reached via an internal address but
 # users browse a different external URL, or where the server's own ROOT_URL is
-# misconfigured. Defaults to `url` when set, else derived from the PR's html_url.
+# misconfigured. Defaults to `url` when it differs from the shipped default
+# above, else derived from the PR's html_url.
 # Like `url`, this is read when the provider is constructed, before repo-level
 # .pr_agent.toml settings are merged, so a per-repo override does not apply to
 # /describe, /review and /improve - set it globally or via GITEA__WEB_URL.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -310,7 +310,11 @@ push_commands = [
 url = "https://gitea.com"
 # Optional user-facing base URL used to build links published in comments, for
 # self-hosted instances where the API is reached via an internal address but
-# users browse a different external URL. Defaults to `url`.
+# users browse a different external URL, or where the server's own ROOT_URL is
+# misconfigured. Defaults to `url` when set, else derived from the PR's html_url.
+# Like `url`, this is read when the provider is constructed, before repo-level
+# .pr_agent.toml settings are merged, so a per-repo override does not apply to
+# /describe, /review and /improve - set it globally or via GITEA__WEB_URL.
 # web_url = ""
 handle_push_trigger = false
 pr_commands = [

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -308,6 +308,10 @@ push_commands = [
 
 [gitea]
 url = "https://gitea.com"
+# Optional user-facing base URL used to build links published in comments, for
+# self-hosted instances where the API is reached via an internal address but
+# users browse a different external URL. Defaults to `url`.
+# web_url = ""
 handle_push_trigger = false
 pr_commands = [
     "/describe",

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -634,35 +634,51 @@ class TestGiteaProviderUserFacingLinks:
     ``__init__`` performs network calls, so instances are built with ``__new__``
     and only the attributes under test are wired up. ``base_url`` below stands
     in for an internal address (e.g. a Docker service name) that users cannot
-    browse.
+    browse. ``pr_url`` uses the user-facing form throughout: ``_parse_pr_url``
+    rejects the API form, so a constructed provider could never carry it, and
+    Gitea sets ``url``/``html_url`` on the PR payload to the user-facing page.
     """
 
     @staticmethod
-    def _provider(pr_html_url="", pr_url="http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"):
+    def _provider(pr_html_url="", pr_url="http://forgejo:3000/owner/repo/pulls/4", pr_number=4):
         from pr_agent.git_providers.gitea_provider import GiteaProvider
 
         provider = GiteaProvider.__new__(GiteaProvider)
         provider.logger = MagicMock()
         provider.owner = "owner"
         provider.repo = "repo"
-        provider.pr_number = 4
+        provider.pr_number = pr_number
         provider.base_url = "http://forgejo:3000"
         provider.pr_url = pr_url
         provider.pr = None if pr_html_url is None else MagicMock(html_url=pr_html_url)
         return provider
 
     @staticmethod
-    def _settings(web_url=""):
+    def _settings(web_url="", configured_url=None):
+        # configured_url=None leaves GITEA.URL unset, exercising the derivation path.
         settings = MagicMock()
-        settings.get.side_effect = lambda k, d=None: {"GITEA.WEB_URL": web_url}.get(k, d)
+        values = {"GITEA.WEB_URL": web_url}
+        if configured_url is not None:
+            values["GITEA.URL"] = configured_url
+        settings.get.side_effect = lambda k, d=None: values.get(k, d)
         return settings
 
     @patch("pr_agent.git_providers.gitea_provider.get_settings")
     def test_web_url_setting_takes_precedence(self, mock_get_settings):
-        mock_get_settings.return_value = self._settings("https://git.example.com/forgejo/")
+        mock_get_settings.return_value = self._settings(
+            web_url="https://git.example.com/forgejo/", configured_url="http://forgejo:3000")
         provider = self._provider(pr_html_url="https://other.example.com/owner/repo/pulls/4")
 
         assert provider._resolve_base_url_html() == "https://git.example.com/forgejo"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_configured_url_preferred_over_pr_html_url(self, mock_get_settings):
+        # An operator-set GITEA.URL wins over html_url, which the server builds from
+        # its own ROOT_URL - still the (wrong) default on some instances.
+        mock_get_settings.return_value = self._settings(configured_url="http://forgejo:3000")
+        provider = self._provider(pr_html_url="http://localhost:3000/owner/repo/pulls/4")
+
+        assert provider._resolve_base_url_html() == "http://forgejo:3000"
 
     @patch("pr_agent.git_providers.gitea_provider.get_settings")
     def test_derives_base_url_from_pr_html_url(self, mock_get_settings):
@@ -689,9 +705,12 @@ class TestGiteaProviderUserFacingLinks:
         foreign = self._provider(pr_html_url="https://ci.example.com/artifacts/owner/repo")
         assert foreign._resolve_base_url_html() == "http://forgejo:3000"
 
-    def test_get_line_link_uses_user_facing_base_url(self):
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_get_line_link_uses_user_facing_base_url(self, mock_get_settings):
+        mock_get_settings.return_value = self._settings(web_url="https://git.example.com/forgejo")
         provider = self._provider()
-        provider.base_url_html = "https://git.example.com/forgejo"
+        # Mirror __init__ so the resolver wiring (self.base_url_html assignment) is covered too.
+        provider.base_url_html = provider._resolve_base_url_html()
         provider.get_pr_branch = MagicMock(return_value="feat/retry")
 
         prefix = "https://git.example.com/forgejo/owner/repo/src/branch/feat/retry/app/storage.py"
@@ -699,13 +718,28 @@ class TestGiteaProviderUserFacingLinks:
         assert provider.get_line_link("app/storage.py", 24, 30) == f"{prefix}#L24-L30"
         assert provider.get_line_link("app/storage.py", -1) == prefix
 
-    def test_get_pr_url_prefers_html_url(self):
-        provider = self._provider(pr_html_url="https://git.example.com/forgejo/owner/repo/pulls/4")
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_get_pr_url_uses_user_facing_base_url(self, mock_get_settings):
+        # html_url here comes from a stale ROOT_URL; the configured WEB_URL must win.
+        mock_get_settings.return_value = self._settings(web_url="https://git.example.com/forgejo")
+        provider = self._provider(pr_html_url="http://localhost:3000/owner/repo/pulls/4")
+        provider.base_url_html = provider._resolve_base_url_html()
 
         assert provider.get_pr_url() == "https://git.example.com/forgejo/owner/repo/pulls/4"
 
-    def test_get_pr_url_falls_back_to_raw_pr_url(self):
-        assert self._provider(pr_html_url=None).get_pr_url() == \
-            "http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"
-        assert self._provider(pr_html_url="").get_pr_url() == \
-            "http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_get_pr_url_uses_configured_base_url(self, mock_get_settings):
+        mock_get_settings.return_value = self._settings(configured_url="http://forgejo:3000")
+        provider = self._provider(pr_html_url="http://localhost:3000/owner/repo/pulls/4")
+        provider.base_url_html = provider._resolve_base_url_html()
+
+        assert provider.get_pr_url() == "http://forgejo:3000/owner/repo/pulls/4"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_get_pr_url_falls_back_to_raw_pr_url(self, mock_get_settings):
+        # Issue flow has no PR number; get_pr_url returns the raw URL unchanged.
+        mock_get_settings.return_value = self._settings()
+        provider = self._provider(pr_html_url=None, pr_number=None)
+        provider.base_url_html = provider._resolve_base_url_html()
+
+        assert provider.get_pr_url() == "http://forgejo:3000/owner/repo/pulls/4"

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -625,3 +625,87 @@ class TestGiteaProviderAddFileDiff:
             index=123,
             body={"body": "Updated description", "title": "Updated title"}
         )
+
+
+class TestGiteaProviderUserFacingLinks:
+    """Regression tests for #2612: links published in comments must use the
+    user-facing base URL, not the (possibly internal) API base URL.
+
+    ``__init__`` performs network calls, so instances are built with ``__new__``
+    and only the attributes under test are wired up. ``base_url`` below stands
+    in for an internal address (e.g. a Docker service name) that users cannot
+    browse.
+    """
+
+    @staticmethod
+    def _provider(pr_html_url="", pr_url="http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"):
+        from pr_agent.git_providers.gitea_provider import GiteaProvider
+
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.pr_number = 4
+        provider.base_url = "http://forgejo:3000"
+        provider.pr_url = pr_url
+        provider.pr = None if pr_html_url is None else MagicMock(html_url=pr_html_url)
+        return provider
+
+    @staticmethod
+    def _settings(web_url=""):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: {"GITEA.WEB_URL": web_url}.get(k, d)
+        return settings
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_web_url_setting_takes_precedence(self, mock_get_settings):
+        mock_get_settings.return_value = self._settings("https://git.example.com/forgejo/")
+        provider = self._provider(pr_html_url="https://other.example.com/owner/repo/pulls/4")
+
+        assert provider._resolve_base_url_html() == "https://git.example.com/forgejo"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_derives_base_url_from_pr_html_url(self, mock_get_settings):
+        # Zero-config case: Forgejo/Gitea builds html_url from its external ROOT_URL,
+        # so the user-facing base URL can be derived even without a web_url setting.
+        mock_get_settings.return_value = self._settings()
+        provider = self._provider(pr_html_url="https://git.example.com/forgejo/owner/repo/pulls/4")
+
+        assert provider._resolve_base_url_html() == "https://git.example.com/forgejo"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_falls_back_to_base_url_without_pr(self, mock_get_settings):
+        # Issue flow has no PR object; existing single-URL deployments stay unchanged.
+        mock_get_settings.return_value = self._settings()
+        provider = self._provider(pr_html_url=None)
+
+        assert provider._resolve_base_url_html() == "http://forgejo:3000"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_falls_back_to_base_url_when_html_url_missing_or_foreign(self, mock_get_settings):
+        mock_get_settings.return_value = self._settings()
+
+        assert self._provider(pr_html_url="")._resolve_base_url_html() == "http://forgejo:3000"
+        foreign = self._provider(pr_html_url="https://ci.example.com/artifacts/owner/repo")
+        assert foreign._resolve_base_url_html() == "http://forgejo:3000"
+
+    def test_get_line_link_uses_user_facing_base_url(self):
+        provider = self._provider()
+        provider.base_url_html = "https://git.example.com/forgejo"
+        provider.get_pr_branch = MagicMock(return_value="feat/retry")
+
+        prefix = "https://git.example.com/forgejo/owner/repo/src/branch/feat/retry/app/storage.py"
+        assert provider.get_line_link("app/storage.py", 24) == f"{prefix}#L24"
+        assert provider.get_line_link("app/storage.py", 24, 30) == f"{prefix}#L24-L30"
+        assert provider.get_line_link("app/storage.py", -1) == prefix
+
+    def test_get_pr_url_prefers_html_url(self):
+        provider = self._provider(pr_html_url="https://git.example.com/forgejo/owner/repo/pulls/4")
+
+        assert provider.get_pr_url() == "https://git.example.com/forgejo/owner/repo/pulls/4"
+
+    def test_get_pr_url_falls_back_to_raw_pr_url(self):
+        assert self._provider(pr_html_url=None).get_pr_url() == \
+            "http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"
+        assert self._provider(pr_html_url="").get_pr_url() == \
+            "http://forgejo:3000/api/v1/repos/owner/repo/pulls/4"

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -681,6 +681,23 @@ class TestGiteaProviderUserFacingLinks:
         assert provider._resolve_base_url_html() == "http://forgejo:3000"
 
     @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_shipped_default_url_does_not_shadow_pr_html_url(self, mock_get_settings):
+        # configuration.toml always ships url = "https://gitea.com", so the default must not
+        # count as operator-set - otherwise the html_url derivation is unreachable in
+        # production and the #2612 scenario regresses (review feedback on #2617).
+        mock_get_settings.return_value = self._settings(configured_url="https://gitea.com")
+        provider = self._provider(pr_html_url="https://git.example.com/forgejo/owner/repo/pulls/4")
+
+        assert provider._resolve_base_url_html() == "https://git.example.com/forgejo"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_shipped_default_url_with_trailing_slash_does_not_shadow(self, mock_get_settings):
+        mock_get_settings.return_value = self._settings(configured_url="https://gitea.com/")
+        provider = self._provider(pr_html_url="https://git.example.com/forgejo/owner/repo/pulls/4")
+
+        assert provider._resolve_base_url_html() == "https://git.example.com/forgejo"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
     def test_derives_base_url_from_pr_html_url(self, mock_get_settings):
         # Zero-config case: Forgejo/Gitea builds html_url from its external ROOT_URL,
         # so the user-facing base URL can be derived even without a web_url setting.


### PR DESCRIPTION
Fixes #2612

## Problem

`GiteaProvider` derives both its **API endpoint** and every **user-facing link** from the single `gitea.url` setting. On self-hosted Gitea/Forgejo deployments where the API is reached via an internal address (Docker service name, cluster DNS) but users browse a different external address, every link PR-Agent publishes points at the internal address and is unclickable:

- `get_line_link()` built code links from the API base URL
- `get_pr_url()` returned the raw (possibly API-form) webhook URL

## Fix

Mirrors the separation `GithubProvider` already has (`base_url` vs `base_url_html`), following the approach suggested in the issue:

- New `base_url_html` attribute, resolved by `_resolve_base_url_html()`:
  1. the new optional `gitea.web_url` setting (also documented in `configuration.toml` and the Gitea installation guide, env var `GITEA__WEB_URL`)
  2. otherwise derived from `pr.html_url`, which Gitea/Forgejo builds from its own external `ROOT_URL` (zero-config for correctly configured instances)
  3. otherwise falls back to `gitea.url`, so existing single-URL deployments are unaffected
- `get_line_link()` now builds links from `base_url_html`; `base_url` stays in use for the API host, `get_git_repo_url()` and clone URL preparation (those should stay internal)
- `get_pr_url()` returns `pr.html_url` when available, falling back to the raw PR URL otherwise

## Tests

Added 7 unit tests to `tests/unittest/test_gitea_provider.py` covering: `web_url` precedence, derivation from `pr.html_url` (the reverse-proxy scenario from the issue), fallback to `base_url` for the issue flow and for missing/foreign `html_url`, all three `get_line_link()` variants, and both `get_pr_url()` paths.

```
PYTHONPATH=. pytest tests/unittest/test_gitea_provider.py -q   # 32 passed
PYTHONPATH=. pytest tests/unittest -q                          # 1734 passed, 1 skipped, 1 xfailed
```

Ruff (repo config) reports only pre-existing findings in untouched regions of the file; all lines this PR touches are clean.