### PR TITLE
fix(review): apply the security label using the same predicate as the review body (#2605)

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -648,6 +648,8 @@ class PRReviewer:
                         estimated_effort_number = max(1, min(5, int(estimated_effort_number)))
                         review_labels.append(f'Review effort {estimated_effort_number}/5')
                 if get_settings().pr_reviewer.enable_review_labels_security and get_settings().pr_reviewer.require_security_review:
+                    if 'security_concerns' not in data['review']:
+                        get_logger().warning("Missing security_concerns in review data")
                     if not is_value_no(data['review'].get('security_concerns')):
                         review_labels.append('Possible security concern')
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -28,6 +28,7 @@ from pr_agent.algo.utils import (
     add_pr_review_identity,
     convert_to_markdown_v2,
     github_action_output,
+    is_value_no,
     load_yaml,
     show_relevant_configurations,
     show_run_details,
@@ -647,9 +648,7 @@ class PRReviewer:
                         estimated_effort_number = max(1, min(5, int(estimated_effort_number)))
                         review_labels.append(f'Review effort {estimated_effort_number}/5')
                 if get_settings().pr_reviewer.enable_review_labels_security and get_settings().pr_reviewer.require_security_review:
-                    security_concerns = data['review']['security_concerns']  # yes, because ...
-                    security_concerns_bool = 'yes' in security_concerns.lower() or 'true' in security_concerns.lower()
-                    if security_concerns_bool:
+                    if not is_value_no(data['review'].get('security_concerns')):
                         review_labels.append('Possible security concern')
 
                 current_labels = self.git_provider.get_pr_labels(update=True)

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -9,7 +9,8 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
 )
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
+from pr_agent.algo.utils import (PRReviewHeader, PRReviewIdentity,
+                                 is_value_no)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -892,7 +893,8 @@ def test_can_run_incremental_review_skips_auto_mode_without_new_commit():
     assert reviewer._can_run_incremental_review() is False
 
 
-def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
+@pytest.fixture
+def review_label_settings():
     settings = get_settings()
     original = {
         "publish_output": settings.config.publish_output,
@@ -906,30 +908,59 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
     settings.pr_reviewer.require_security_review = True
     settings.pr_reviewer.enable_review_labels_effort = True
     settings.pr_reviewer.enable_review_labels_security = True
+    yield
+    settings.config.publish_output = original["publish_output"]
+    settings.pr_reviewer.require_estimate_effort_to_review = original["require_estimate_effort_to_review"]
+    settings.pr_reviewer.require_security_review = original["require_security_review"]
+    settings.pr_reviewer.enable_review_labels_effort = original["enable_review_labels_effort"]
+    settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
+
+
+def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels(review_label_settings):
     git_provider = MagicMock()
     git_provider.get_pr_labels.return_value = ["Review effort 1/5", "Possible security concern", "keep-me"]
     reviewer = _make_reviewer(git_provider)
     data = {
         "review": {
             "estimated_effort_to_review_[1-5]": "3, moderate",
-            "security_concerns": "yes",
+            "security_concerns": "SQL injection: the order id is concatenated into the query\n",
         }
     }
 
-    try:
-        reviewer.set_review_labels(data)
+    reviewer.set_review_labels(data)
 
-        git_provider.publish_labels.assert_called_once_with([
-            "Review effort 3/5",
-            "Possible security concern",
-            "keep-me",
-        ])
-    finally:
-        settings.config.publish_output = original["publish_output"]
-        settings.pr_reviewer.require_estimate_effort_to_review = original["require_estimate_effort_to_review"]
-        settings.pr_reviewer.require_security_review = original["require_security_review"]
-        settings.pr_reviewer.enable_review_labels_effort = original["enable_review_labels_effort"]
-        settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
+    git_provider.publish_labels.assert_called_once_with([
+        "Review effort 3/5",
+        "Possible security concern",
+        "keep-me",
+    ])
+
+
+@pytest.mark.parametrize(
+    "security_concerns, expect_label",
+    [
+        ("SQL injection: the order id is concatenated into the query\n", True),
+        ("Sensitive information exposure: the API key is written to the log\n", True),
+        ("No\n", False),
+        ("no", False),
+        ("  No  \n", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_set_review_labels_security_label_matches_the_rendered_review_body(
+    review_label_settings, security_concerns, expect_label
+):
+    git_provider = MagicMock()
+    git_provider.get_pr_labels.return_value = []
+    reviewer = _make_reviewer(git_provider)
+    data = {"review": {"estimated_effort_to_review_[1-5]": "2", "security_concerns": security_concerns}}
+
+    reviewer.set_review_labels(data)
+
+    published = git_provider.publish_labels.call_args[0][0]
+    assert ("Possible security concern" in published) is expect_label
+    assert is_value_no(security_concerns) is not expect_label
 
 
 def test_get_user_answers_collects_question_and_answer_from_issue_comments():

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -9,8 +9,7 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
 )
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.algo.utils import (PRReviewHeader, PRReviewIdentity,
-                                 is_value_no)
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, convert_to_markdown_v2
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -946,6 +945,8 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels(re
         ("  No  \n", False),
         ("", False),
         (None, False),
+        # A punctuated negative is not a recognised "no", so it labels and renders as a concern.
+        ("No.", True),
     ],
 )
 def test_set_review_labels_security_label_matches_the_rendered_review_body(
@@ -960,7 +961,9 @@ def test_set_review_labels_security_label_matches_the_rendered_review_body(
 
     published = git_provider.publish_labels.call_args[0][0]
     assert ("Possible security concern" in published) is expect_label
-    assert is_value_no(security_concerns) is not expect_label
+
+    body = convert_to_markdown_v2(data)
+    assert ("<strong>Security concerns</strong>" in body) is expect_label
 
 
 def test_get_user_answers_collects_question_and_answer_from_issue_comments():


### PR DESCRIPTION
Fixes #2605.

The prompt asks for `No` or an answer starting with a header such as `SQL injection: ...`, but the label check tested for `yes`/`true`, so `Possible security concern` was never applied. The decision now goes through `is_value_no`, which `convert_to_markdown_v2` already uses for the same field a few lines earlier, so the label and the rendered review body cannot disagree. The test asserts that equivalence directly by rendering the body.

Notes for reviewers:

This label has effectively been dormant since `e589dcb4` (2024-03) and will start appearing on stock configuration, since `require_security_review` and `enable_review_labels_security` both default to true.

The existing test asserted through `"yes"`, which the current prompt cannot produce and which `is_value_no` also rejects, so it passed before and after the fix. It is corrected here rather than supplemented.

`is_value_no` matches only the exact tokens `no`, `none` and `false`, so a punctuated negative such as `No.` now labels the PR. That is deliberate rather than overlooked: the rendered body already treats `No.` as a concern today, so the label now agrees with the body instead of contradicting it, and there is a test case pinning it. Tightening the tokens would change review output for the seven fields that share the helper, which belongs in its own PR. The same applies to the English-only assumption, which affects anyone setting `response_language`. Happy to follow up on either.
