### PR TITLE
fix: drop deletion-only hunk when a later hunk has additions

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -246,9 +246,12 @@ def omit_deletion_hunks(patch_lines) -> str:
         if line.startswith('@@'):
             match = RE_HUNK_HEADER.match(line)
             if match:
-                # finish previous hunk
-                if inside_hunk and add_hunk:
-                    added_patched.extend(temp_hunk)
+                # finish previous hunk: keep it only if it had additions,
+                # otherwise drop it entirely (a deletion-only hunk must not
+                # leak into the next hunk's output)
+                if inside_hunk:
+                    if add_hunk:
+                        added_patched.extend(temp_hunk)
                     temp_hunk = []
                     add_hunk = False
                 temp_hunk.append(line)

--- a/tests/unittest/test_delete_hunks.py
+++ b/tests/unittest/test_delete_hunks.py
@@ -82,3 +82,16 @@ class TestOmitDeletionHunks:
         patch_lines = ['@@ -1,1 +1,0 @@\n', '-deleted line\n']
         expected_output = ''
         assert omit_deletion_hunks(patch_lines) == expected_output
+
+    # Tests that a deletion-only hunk followed by a hunk with additions is
+    # dropped entirely and does not leak into the later hunk's output.
+    def test_deletion_only_hunk_before_added_hunk_is_omitted(self):
+        patch_lines = [
+            "@@ -1,1 +1,0 @@\n",
+            "-deleted line\n",
+            "@@ -10,0 +10,1 @@\n",
+            "+added line\n",
+        ]
+        assert omit_deletion_hunks(patch_lines) == (
+            "@@ -10,0 +10,1 @@\n\n+added line\n"
+        )


### PR DESCRIPTION
## Description

Fixes #2608. In `omit_deletion_hunks`, the pending hunk was only reset when it was flushed, which happens only when it contains additions. A deletion-only hunk immediately followed by a hunk with additions therefore kept its header and body lines in the buffer and leaked them into the output, corrupting the patch that pr-agent analyzes.

The fix resets the pending hunk on every new hunk header, keeping it only when it had additions.

## Verification

- The repro from the issue is included as `test_deletion_only_hunk_before_added_hunk_is_omitted`. It fails on the original code and passes with the fix.
- Full `tests/unittest/test_delete_hunks.py` suite: 7/7 pass.

Confirmed by maintainer on the issue thread. Thanks @IsmaelMartinez for the review guidance.