### PR TITLE
fix(polling): give each polled comment its own settings scope (#2623)

### DIFF
--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -3,6 +3,7 @@ import copy
 import multiprocessing
 import traceback
 from collections import deque
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 import aiohttp
@@ -87,22 +88,33 @@ def _polling_request_settings():
     return settings
 
 
+@contextmanager
+def _polling_settings_scope():
+    """request_cycle_context with a guaranteed reset: its bare yield skips the
+    ContextVar reset when an exception crosses the with-body, so enter and exit
+    are driven explicitly and the reset runs on any exit, BaseException included.
+    """
+    cm = request_cycle_context({"settings": _polling_request_settings()})
+    cm.__enter__()
+    try:
+        yield
+    finally:
+        cm.__exit__(None, None, None)
+
+
 def process_comment_sync(pr_url, rest_of_comment, comment_id):
-    # The except stays inside the scope: request_cycle_context has no try/finally
-    # around its yield, so an exception crossing the with-body would skip the
-    # ContextVar reset and pin this comment's settings on the surrounding context.
-    with request_cycle_context({"settings": _polling_request_settings()}):
-        try:
+    try:
+        with _polling_settings_scope():
             # Run the async handle_request in a separate function
             git_provider = get_git_provider()(pr_url=pr_url)
             run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
-        except Exception as e:
-            get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
+    except Exception as e:
+        get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
 
 async def process_comment(pr_url, rest_of_comment, comment_id):
-    with request_cycle_context({"settings": _polling_request_settings()}):
-        try:
+    try:
+        with _polling_settings_scope():
             git_provider = get_git_provider()(pr_url=pr_url)
             git_provider.set_pr(pr_url)
             agent = PRAgent()
@@ -111,9 +123,9 @@ async def process_comment(pr_url, rest_of_comment, comment_id):
                 rest_of_comment,
                 notify=lambda: git_provider.add_eyes_reaction(comment_id)
             )
-            get_logger().info(f"Finished processing comment for PR: {pr_url}")
-        except Exception as e:
-            get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
+        get_logger().info(f"Finished processing comment for PR: {pr_url}")
+    except Exception as e:
+        get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
 async def is_valid_notification(notification, headers, handled_ids, session, user_id):
     try:

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import multiprocessing
 import traceback
 from collections import deque
@@ -6,6 +7,7 @@ from datetime import datetime, timezone
 
 import aiohttp
 import requests
+from starlette_context import request_cycle_context
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.ai_handlers.litellm_helpers import (
@@ -13,7 +15,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     drain_litellm_callbacks,
     litellm_callbacks_registered,
 )
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 
@@ -71,25 +73,41 @@ def run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
     return asyncio.run(_handle_request_and_drain(pr_url, rest_of_comment, comment_id, git_provider))
 
 
+def _polling_request_settings():
+    """A per-comment settings scope, like the webhook servers' per-request clone.
+
+    Also carries the polling-mode overrides: applying them here instead of in
+    ``polling_loop`` makes them reach the task regardless of the multiprocessing
+    start method (fork children inherit the parent's globals, spawn/forkserver
+    children do not - and forkserver is the Linux default from Python 3.14).
+    """
+    settings = copy.deepcopy(global_settings)
+    settings.set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
+    settings.set("pr_description.publish_description_as_comment", True)
+    return settings
+
+
 def process_comment_sync(pr_url, rest_of_comment, comment_id):
     try:
         # Run the async handle_request in a separate function
-        git_provider = get_git_provider()(pr_url=pr_url)
-        success = run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
+        with request_cycle_context({"settings": _polling_request_settings()}):
+            git_provider = get_git_provider()(pr_url=pr_url)
+            success = run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
     except Exception as e:
         get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
 
 async def process_comment(pr_url, rest_of_comment, comment_id):
     try:
-        git_provider = get_git_provider()(pr_url=pr_url)
-        git_provider.set_pr(pr_url)
-        agent = PRAgent()
-        success = await agent.handle_request(
-            pr_url,
-            rest_of_comment,
-            notify=lambda: git_provider.add_eyes_reaction(comment_id)
-        )
+        with request_cycle_context({"settings": _polling_request_settings()}):
+            git_provider = get_git_provider()(pr_url=pr_url)
+            git_provider.set_pr(pr_url)
+            agent = PRAgent()
+            success = await agent.handle_request(
+                pr_url,
+                rest_of_comment,
+                notify=lambda: git_provider.add_eyes_reaction(comment_id)
+            )
         get_logger().info(f"Finished processing comment for PR: {pr_url}")
     except Exception as e:
         get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
@@ -190,8 +208,6 @@ async def polling_loop():
     last_modified = [None]
     git_provider = get_git_provider()()
     user_id = git_provider.get_user_id()
-    get_settings().set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
-    get_settings().set("pr_description.publish_description_as_comment", True)
 
     try:
         deployment_type = get_settings().github.deployment_type

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -95,7 +95,7 @@ def process_comment_sync(pr_url, rest_of_comment, comment_id):
         try:
             # Run the async handle_request in a separate function
             git_provider = get_git_provider()(pr_url=pr_url)
-            success = run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
+            run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
         except Exception as e:
             get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
@@ -106,7 +106,7 @@ async def process_comment(pr_url, rest_of_comment, comment_id):
             git_provider = get_git_provider()(pr_url=pr_url)
             git_provider.set_pr(pr_url)
             agent = PRAgent()
-            success = await agent.handle_request(
+            await agent.handle_request(
                 pr_url,
                 rest_of_comment,
                 notify=lambda: git_provider.add_eyes_reaction(comment_id)

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -88,18 +88,21 @@ def _polling_request_settings():
 
 
 def process_comment_sync(pr_url, rest_of_comment, comment_id):
-    try:
-        # Run the async handle_request in a separate function
-        with request_cycle_context({"settings": _polling_request_settings()}):
+    # The except stays inside the scope: request_cycle_context has no try/finally
+    # around its yield, so an exception crossing the with-body would skip the
+    # ContextVar reset and pin this comment's settings on the surrounding context.
+    with request_cycle_context({"settings": _polling_request_settings()}):
+        try:
+            # Run the async handle_request in a separate function
             git_provider = get_git_provider()(pr_url=pr_url)
             success = run_handle_request(pr_url, rest_of_comment, comment_id, git_provider)
-    except Exception as e:
-        get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
+        except Exception as e:
+            get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
 
 async def process_comment(pr_url, rest_of_comment, comment_id):
-    try:
-        with request_cycle_context({"settings": _polling_request_settings()}):
+    with request_cycle_context({"settings": _polling_request_settings()}):
+        try:
             git_provider = get_git_provider()(pr_url=pr_url)
             git_provider.set_pr(pr_url)
             agent = PRAgent()
@@ -108,9 +111,9 @@ async def process_comment(pr_url, rest_of_comment, comment_id):
                 rest_of_comment,
                 notify=lambda: git_provider.add_eyes_reaction(comment_id)
             )
-        get_logger().info(f"Finished processing comment for PR: {pr_url}")
-    except Exception as e:
-        get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
+            get_logger().info(f"Finished processing comment for PR: {pr_url}")
+        except Exception as e:
+            get_logger().error(f"Error processing comment: {e}", artifact={"traceback": traceback.format_exc()})
 
 async def is_valid_notification(notification, headers, handled_ids, session, user_id):
     try:

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -75,12 +75,12 @@ def run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
 
 
 def _polling_request_settings():
-    """A per-comment settings scope, like the webhook servers' per-request clone.
+    """Clone global settings with the polling-mode overrides applied.
 
-    Also carries the polling-mode overrides: applying them here instead of in
-    ``polling_loop`` makes them reach the task regardless of the multiprocessing
-    start method (fork children inherit the parent's globals, spawn/forkserver
-    children do not - and forkserver is the Linux default from Python 3.14).
+    Applying the overrides here instead of in ``polling_loop`` makes them reach
+    the task regardless of the multiprocessing start method: fork children
+    inherit the parent's globals, spawn/forkserver children do not - and
+    forkserver is the Linux default from Python 3.14.
     """
     settings = copy.deepcopy(global_settings)
     settings.set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
@@ -90,9 +90,10 @@ def _polling_request_settings():
 
 @contextmanager
 def _polling_settings_scope():
-    """request_cycle_context with a guaranteed reset: its bare yield skips the
-    ContextVar reset when an exception crosses the with-body, so enter and exit
-    are driven explicitly and the reset runs on any exit, BaseException included.
+    """request_cycle_context with a guaranteed reset: its bare yield (unfixed
+    upstream as of starlette-context 0.5.1) skips the ContextVar reset when an
+    exception crosses the with-body, so enter and exit are driven explicitly
+    and the reset runs on any exit, BaseException included.
     """
     cm = request_cycle_context({"settings": _polling_request_settings()})
     cm.__enter__()

--- a/tests/unittest/test_github_polling_settings.py
+++ b/tests/unittest/test_github_polling_settings.py
@@ -97,3 +97,15 @@ async def test_failed_comment_does_not_pin_settings_on_the_calling_context():
         await github_polling.process_comment("https://example/pr/3", "/review", 789)
 
     assert get_settings() is settings_before
+
+
+def test_cancellation_does_not_pin_settings_on_the_calling_context():
+    # BaseException is not caught by the handlers' except Exception, so it must
+    # still leave the scope through _polling_settings_scope's finally.
+    settings_before = get_settings()
+
+    with patch.object(github_polling, "get_git_provider", side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            github_polling.process_comment_sync("https://example/pr/4", "/review", 999)
+
+    assert get_settings() is settings_before

--- a/tests/unittest/test_github_polling_settings.py
+++ b/tests/unittest/test_github_polling_settings.py
@@ -1,9 +1,23 @@
+import copy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.servers import github_polling
+
+
+@pytest.fixture(autouse=True)
+def fresh_global_settings():
+    """Restore global_settings afterwards so a failing isolation test cannot
+    pollute the rest of the suite with the very leak it is asserting against."""
+    snapshot = copy.deepcopy(global_settings.as_dict())
+    yield
+    for section in set(global_settings.as_dict().keys()) - set(snapshot.keys()):
+        global_settings.unset(section)
+    for section, contents in snapshot.items():
+        global_settings.unset(section)
+        global_settings.set(section, copy.deepcopy(contents), merge=False)
 
 
 def test_process_comment_sync_scopes_settings_per_comment():

--- a/tests/unittest/test_github_polling_settings.py
+++ b/tests/unittest/test_github_polling_settings.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.servers import github_polling
+
+
+def test_process_comment_sync_scopes_settings_per_comment():
+    captured = {}
+    publish_progress_before = global_settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS")
+    describe_as_comment_before = global_settings.get("pr_description.publish_description_as_comment")
+
+    def fake_run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
+        settings = get_settings()
+        captured["settings"] = settings
+        captured["publish_progress"] = settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS")
+        captured["describe_as_comment"] = settings.get("pr_description.publish_description_as_comment")
+        # Simulate what apply_repo_settings does mid-run: mutate the active settings.
+        settings.set("config.leaky_test_key", "from-another-pr")
+        return True
+
+    with (
+        patch.object(github_polling, "get_git_provider", return_value=MagicMock()),
+        patch.object(github_polling, "run_handle_request", side_effect=fake_run_handle_request) as run_mock,
+    ):
+        github_polling.process_comment_sync("https://example/pr/1", "/review", 123)
+
+    run_mock.assert_called_once()
+    assert captured["settings"] is not global_settings
+    assert captured["publish_progress"] is False
+    assert captured["describe_as_comment"] is True
+    assert global_settings.get("config.leaky_test_key", None) is None
+    assert global_settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS") == publish_progress_before
+    assert global_settings.get("pr_description.publish_description_as_comment") == describe_as_comment_before
+
+
+@pytest.mark.asyncio
+async def test_process_comment_scopes_settings_per_comment():
+    captured = {}
+
+    async def fake_handle_request(pr_url, request, notify=None):
+        settings = get_settings()
+        captured["settings"] = settings
+        captured["publish_progress"] = settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS")
+        settings.set("config.leaky_test_key_async", "from-another-pr")
+        return True
+
+    agent = MagicMock()
+    agent.handle_request = AsyncMock(side_effect=fake_handle_request)
+
+    with (
+        patch.object(github_polling, "get_git_provider", return_value=MagicMock()),
+        patch.object(github_polling, "PRAgent", return_value=agent),
+    ):
+        await github_polling.process_comment("https://example/pr/2", "/describe", 456)
+
+    agent.handle_request.assert_awaited_once()
+    assert captured["settings"] is not global_settings
+    assert captured["publish_progress"] is False
+    assert global_settings.get("config.leaky_test_key_async", None) is None
+
+
+def test_consecutive_comments_do_not_share_state():
+    seen = []
+
+    def fake_run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
+        settings = get_settings()
+        seen.append(settings.get("related_tickets", None))
+        settings.set("related_tickets", [{"ticket_id": 1, "pr": pr_url}])
+        return True
+
+    with (
+        patch.object(github_polling, "get_git_provider", return_value=MagicMock()),
+        patch.object(github_polling, "run_handle_request", side_effect=fake_run_handle_request),
+    ):
+        github_polling.process_comment_sync("https://example/pr/1", "/review", 1)
+        github_polling.process_comment_sync("https://example/pr/2", "/review", 2)
+
+    assert seen == [None, None]
+    assert global_settings.get("related_tickets", None) is None

--- a/tests/unittest/test_github_polling_settings.py
+++ b/tests/unittest/test_github_polling_settings.py
@@ -11,7 +11,9 @@ def test_process_comment_sync_scopes_settings_per_comment():
     publish_progress_before = global_settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS")
     describe_as_comment_before = global_settings.get("pr_description.publish_description_as_comment")
 
-    def fake_run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
+    # Patch one level below run_handle_request so the real asyncio.run path
+    # executes and the test pins that the contextvar survives it.
+    async def fake_async_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
         settings = get_settings()
         captured["settings"] = settings
         captured["publish_progress"] = settings.get("CONFIG.PUBLISH_OUTPUT_PROGRESS")
@@ -22,11 +24,11 @@ def test_process_comment_sync_scopes_settings_per_comment():
 
     with (
         patch.object(github_polling, "get_git_provider", return_value=MagicMock()),
-        patch.object(github_polling, "run_handle_request", side_effect=fake_run_handle_request) as run_mock,
+        patch.object(github_polling, "async_handle_request", side_effect=fake_async_handle_request),
+        patch.object(github_polling, "litellm_callbacks_registered", return_value=False),
     ):
         github_polling.process_comment_sync("https://example/pr/1", "/review", 123)
 
-    run_mock.assert_called_once()
     assert captured["settings"] is not global_settings
     assert captured["publish_progress"] is False
     assert captured["describe_as_comment"] is True
@@ -62,9 +64,10 @@ async def test_process_comment_scopes_settings_per_comment():
 
 
 def test_consecutive_comments_do_not_share_state():
+    tickets_before = global_settings.get("related_tickets", None)
     seen = []
 
-    def fake_run_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
+    async def fake_async_handle_request(pr_url, rest_of_comment, comment_id, git_provider):
         settings = get_settings()
         seen.append(settings.get("related_tickets", None))
         settings.set("related_tickets", [{"ticket_id": 1, "pr": pr_url}])
@@ -72,10 +75,25 @@ def test_consecutive_comments_do_not_share_state():
 
     with (
         patch.object(github_polling, "get_git_provider", return_value=MagicMock()),
-        patch.object(github_polling, "run_handle_request", side_effect=fake_run_handle_request),
+        patch.object(github_polling, "async_handle_request", side_effect=fake_async_handle_request),
+        patch.object(github_polling, "litellm_callbacks_registered", return_value=False),
     ):
         github_polling.process_comment_sync("https://example/pr/1", "/review", 1)
         github_polling.process_comment_sync("https://example/pr/2", "/review", 2)
 
-    assert seen == [None, None]
-    assert global_settings.get("related_tickets", None) is None
+    # Neither comment saw the other's tickets, and the base settings kept their prior value.
+    assert seen == [tickets_before, tickets_before]
+    assert global_settings.get("related_tickets", None) == tickets_before
+
+
+@pytest.mark.asyncio
+async def test_failed_comment_does_not_pin_settings_on_the_calling_context():
+    # request_cycle_context has no try/finally around its yield, so an exception
+    # crossing the with-body would skip the ContextVar reset and leave this
+    # comment's settings active for everything that runs later in the task.
+    settings_before = get_settings()
+
+    with patch.object(github_polling, "get_git_provider", side_effect=ValueError("bad PR url")):
+        await github_polling.process_comment("https://example/pr/3", "/review", 789)
+
+    assert get_settings() is settings_before


### PR DESCRIPTION
Fixes #2623.

Wraps both polled-comment entry points in `request_cycle_context` with a deepcopy of `global_settings`, matching the per-request clone every webhook entrypoint already has, and applies the polling-mode overrides to that copy instead of mutating the process globals in `polling_loop`.

One correction to the issue as filed, which I verified while implementing: the loop dispatches each comment into a throwaway `multiprocessing.Process`, so under the fork start method the cross-PR leak does not manifest today — isolation was implicit in the process boundary. It is still worth making explicit: spawn/forkserver children (forkserver is the Linux default from Python 3.14) silently lose the two polling overrides set in `polling_loop`, and the in-process `process_comment` path shares `global_settings` across PRs outright. The new `test_consecutive_comments_do_not_share_state` fails on main for that path.
