### PR TITLE
fix(improve): require improved_code to be complete, without ellipsis (#2086)

### DIFF
--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -164,6 +164,7 @@ The PR Diff:
 
 Example output:
 ```yaml
+# '...' is placeholder text - replace it with actual content
 code_suggestions:
 - relevant_file: |
     src/file1.py
@@ -180,7 +181,6 @@ code_suggestions:
   label: |
     ...
 ```
-(replace '...' with actual content)
 {%- endif %}
 
 

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -108,7 +108,7 @@ class CodeSuggestion(BaseModel):
     language: str = Field(description="Programming language used by the relevant file")
     existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Don't present here actual code snippets, just the suggestion. Be short and concise")
-    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion.")
+    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Must be a complete, ready-to-apply replacement for 'existing_code': never shorten it with ellipsis (...) or use placeholders for omitted code.")
     one_sentence_summary: str = Field(description="A concise, single-sentence overview (up to 6 words) of the suggested improvement. Focus on the 'what'. Be general, and avoid method or variable names.")
 {%- if not focus_only_on_problems %}
     label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")
@@ -140,6 +140,7 @@ code_suggestions:
   label: |
     ...
 ```
+(replace '...' with actual content)
 
 Each YAML output MUST be after a newline, indented, with block scalar indicator ('|').
 """

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -124,6 +124,7 @@ class PRCodeSuggestions(BaseModel):
 
 Example output:
 ```yaml
+# '...' is placeholder text - replace it with actual content
 code_suggestions:
 - relevant_file: |
     src/file1.py
@@ -140,7 +141,6 @@ code_suggestions:
   label: |
     ...
 ```
-(replace '...' with actual content)
 
 Each YAML output MUST be after a newline, indented, with block scalar indicator ('|').
 """

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -113,6 +113,7 @@ class PRCodeSuggestions(BaseModel):
 
 Example output:
 ```yaml
+# '...' is placeholder text - replace it with actual content
 code_suggestions:
 - relevant_file: |
     src/file1.py
@@ -129,7 +130,6 @@ code_suggestions:
   label: |
     ...
 ```
-(replace '...' with actual content)
 
 Each YAML output MUST be after a newline, indented, with block scalar indicator ('|').
 """

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -153,6 +153,7 @@ The PR Diff:
 
 Example output:
 ```yaml
+# '...' is placeholder text - replace it with actual content
 code_suggestions:
 - relevant_file: |
     src/file1.py
@@ -169,7 +170,6 @@ code_suggestions:
   label: |
     ...
 ```
-(replace '...' with actual content)
 {%- endif %}
 
 

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -97,7 +97,7 @@ class CodeSuggestion(BaseModel):
     language: str = Field(description="Programming language used by the relevant file")
     existing_code: str = Field(description="A short code snippet, from the final state of the PR diff, that the suggestion will address. Select only the specific span of code that will be modified - without surrounding unchanged code. Preserve all indentation, newlines, and original formatting. Show the code snippet without the '+'/'-'/' ' prefixes. When providing suggestions for long code sections, shorten the presented code with ellipsis (...) for brevity where possible.")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Use 2-3 short sentences.")
-    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion.")
+    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Must be a complete, ready-to-apply replacement for 'existing_code': never shorten it with ellipsis (...) or use placeholders for omitted code.")
     one_sentence_summary: str = Field(description="A single-sentence overview (up to 6 words) of the suggestion. Focus on the 'what'. Be general, and avoid mentioning method or variable names.")
 {%- if not focus_only_on_problems %}
     label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")
@@ -129,6 +129,7 @@ code_suggestions:
   label: |
     ...
 ```
+(replace '...' with actual content)
 
 Each YAML output MUST be after a newline, indented, with block scalar indicator ('|').
 """


### PR DESCRIPTION
The existing_code brevity instruction leaks `...` into `improved_code`, producing committable suggestions that can't be applied (#2086). This requires `improved_code` to be a complete replacement in both prompt variants and marks the example placeholders as meta in the system prompt, as sketched by @yefuyou in the issue thread. Fixes #2086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)