### PR TITLE
fix(ask): stop discarding GitLab answers that mention quick actions (#2302)

### DIFF
--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -9,7 +9,7 @@ from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import ModelType
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import get_git_provider, GitLabProvider
+from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
@@ -117,22 +117,12 @@ class PRQuestions:
                 model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
         return response
 
-    def gitlab_protections(self, model_answer: str) -> str:
-        github_quick_actions_MR = ["/approve", "/close", "/merge", "/reopen", "/unapprove", "/title", "/assign",
-                                "/copy_metadata", "/target_branch"]
-        if any(action in model_answer for action in github_quick_actions_MR):
-            str_err = "Model answer contains GitHub quick actions, which are not supported in GitLab"
-            get_logger().error(str_err)
-            return str_err
-        return model_answer
-
     def _prepare_pr_answer(self) -> str:
         model_answer = self.prediction.strip()
-        # sanitize the answer so that no line will start with "/"
+        # sanitize the answer so that no line will start with "/", which would
+        # trigger quick actions on providers that support them (e.g. GitLab)
         model_answer_sanitized = model_answer.replace("\n/", "\n /")
         model_answer_sanitized = model_answer_sanitized.replace("\r/", "\r /")
-        if isinstance(self.git_provider, GitLabProvider):
-            model_answer_sanitized = self.gitlab_protections(model_answer_sanitized)
         if model_answer_sanitized.startswith("/"):
             model_answer_sanitized = " " + model_answer_sanitized
         if model_answer_sanitized != model_answer:

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -150,26 +150,35 @@ class TestPreparePrAnswer:
         assert "\r /close" in out
         assert "\r/close" not in out
 
-    def test_non_gitlab_provider_does_not_apply_gitlab_protections(self):
-        # Use a non-GitLab provider; a model answer that *does* contain a
-        # quick-action substring like "/merge" must still come through as a
-        # (sanitized) answer, NOT be replaced with the GitLab error string.
+    @pytest.mark.parametrize(
+        "quick_action",
+        ["/approve", "/close", "/merge", "/reopen", "/unapprove",
+         "/title", "/assign", "/copy_metadata", "/target_branch"],
+    )
+    def test_mid_line_quick_action_mention_survives_on_gitlab(self, quick_action):
+        # Regression pin for #2302: prose that merely *mentions* a quick action
+        # (e.g. an MR template documenting pr-agent usage) must be published
+        # verbatim, not replaced with an error. Quick actions only execute at
+        # the start of a line, and line starts are already space-prefixed.
+        gitlab_provider = GitLabProvider.__new__(GitLabProvider)
+        prediction = f"Comment {quick_action} on the MR to trigger the flow."
         pr = _make_pr_questions(
-            question_str="q", prediction="/merge would be premature", git_provider=MagicMock()
+            question_str="q", prediction=prediction, git_provider=gitlab_provider
         )
         out = pr._prepare_pr_answer()
+        assert prediction in out
         assert "Model answer contains GitHub quick actions" not in out
-        assert "would be premature" in out
 
-    def test_gitlab_provider_blocks_quick_actions(self):
+    def test_line_leading_quick_action_is_neutralized_on_gitlab(self):
         gitlab_provider = GitLabProvider.__new__(GitLabProvider)
         pr = _make_pr_questions(
             question_str="q",
-            prediction="/merge this please",
+            prediction="To finish:\n/merge this please",
             git_provider=gitlab_provider,
         )
         out = pr._prepare_pr_answer()
-        assert "Model answer contains GitHub quick actions" in out
+        assert "\n /merge this please" in out
+        assert "\n/merge" not in out
 
     def test_gitlab_provider_passes_through_safe_text(self):
         gitlab_provider = GitLabProvider.__new__(GitLabProvider)
@@ -181,27 +190,6 @@ class TestPreparePrAnswer:
         out = pr._prepare_pr_answer()
         assert "this change looks correct" in out
         assert "Model answer contains GitHub quick actions" not in out
-
-
-# ---------------------------------------------------------------------------
-# PRQuestions.gitlab_protections
-# ---------------------------------------------------------------------------
-
-class TestGitlabProtections:
-    @pytest.mark.parametrize(
-        "quick_action",
-        ["/approve", "/close", "/merge", "/reopen", "/unapprove",
-         "/title", "/assign", "/copy_metadata", "/target_branch"],
-    )
-    def test_detects_each_quick_action(self, quick_action):
-        pr = _make_pr_questions()
-        result = pr.gitlab_protections(f"prefix {quick_action} suffix")
-        assert "GitHub quick actions" in result
-
-    def test_passthrough_for_safe_text(self):
-        pr = _make_pr_questions()
-        safe = "everything is fine here"
-        assert pr.gitlab_protections(safe) == safe
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`gitlab_protections` is a bare substring test that replaces the whole /ask answer with an error when it merely mentions `/merge`, `/close`, etc. (#2302). It also postdates the generic line-start sanitization (`16dc29a2`, Dec 2024) that already space-prefixes every slash-leading line before the guard runs — and since GitLab quick actions only execute at line start, the guard could never catch a real one, only false positives. Remove it and pin the sanitization contract with tests. Fixes #2302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)