### PR TITLE
fix(ask): sanitize the echoed question against quick-action execution (#2629)

### DIFF
--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -15,6 +15,7 @@ from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.log import get_logger
+from pr_agent.tools.pr_questions import _sanitize_slash_commands
 
 
 class PR_LineQuestions:
@@ -108,10 +109,7 @@ class PR_LineQuestions:
                 should_resolve = True
                 model_answer = answer_stripped[:-len("[THREAD_RESOLVED]")].rstrip()
 
-            # sanitize the answer so that no line will start with "/"
-            model_answer_sanitized = model_answer.strip().replace("\n/", "\n /")
-            if model_answer_sanitized.startswith("/"):
-                model_answer_sanitized = " " + model_answer_sanitized
+            model_answer_sanitized = _sanitize_slash_commands(model_answer.strip())
 
             get_logger().info('Preparing answer...')
             if comment_id:

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -15,6 +15,14 @@ from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
 
 
+def _sanitize_slash_commands(text: str) -> str:
+    # make sure no line starts with "/", so the published comment cannot trigger quick actions
+    sanitized = text.replace("\n/", "\n /").replace("\r/", "\r /")
+    if sanitized.startswith("/"):
+        sanitized = " " + sanitized
+    return sanitized
+
+
 class PRQuestions:
     def __init__(self, pr_url: str, args=None, ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler):
         question_str = self.parse_args(args)
@@ -119,18 +127,13 @@ class PRQuestions:
 
     def _prepare_pr_answer(self) -> str:
         model_answer = self.prediction.strip()
-        # sanitize the answer so that no line will start with "/", which would
-        # trigger quick actions on providers that support them (e.g. GitLab)
-        model_answer_sanitized = model_answer.replace("\n/", "\n /")
-        model_answer_sanitized = model_answer_sanitized.replace("\r/", "\r /")
-        if model_answer_sanitized.startswith("/"):
-            model_answer_sanitized = " " + model_answer_sanitized
+        model_answer_sanitized = _sanitize_slash_commands(model_answer)
         if model_answer_sanitized != model_answer:
             get_logger().debug("Sanitized model answer",
                                artifact={"model_answer": model_answer, "sanitized_answer": model_answer_sanitized})
         answer_header = format_pr_questions_header(
             escape_markdown=self.git_provider.is_supported("markdown_backslash_escapes")
         )
-        answer_str = f"{answer_header}\n{self.question_str}\n\n"
+        answer_str = f"{answer_header}\n{_sanitize_slash_commands(self.question_str)}\n\n"
         answer_str += f"### **Answer:**\n{model_answer_sanitized}\n\n"
         return answer_str

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -17,7 +17,7 @@ from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.codecommit_provider import CodeCommitProvider
 from pr_agent.git_providers.gerrit_provider import GerritProvider, adopt_to_gerrit_message
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
-from pr_agent.tools.pr_questions import PRQuestions
+from pr_agent.tools.pr_questions import PRQuestions, _sanitize_slash_commands
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
 
 
@@ -320,6 +320,58 @@ class TestPreparePrAnswer:
         out = pr._prepare_pr_answer()
         assert "this change looks correct" in out
         assert "Model answer contains GitHub quick actions" not in out
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_slash_commands and the question echo
+# ---------------------------------------------------------------------------
+
+class TestSanitizeSlashCommands:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("/merge this now", " /merge this now"),
+            ("please\n/close this", "please\n /close this"),
+            ("please\r/close this", "please\r /close this"),
+            ("what does /merge do here?", "what does /merge do here?"),
+            ("", ""),
+        ],
+    )
+    def test_no_line_starts_with_slash(self, text, expected):
+        assert _sanitize_slash_commands(text) == expected
+
+
+class TestQuestionEchoSanitization:
+    def test_question_with_leading_slash_is_space_prefixed(self):
+        pr = _make_pr_questions(
+            question_str="/merge this now", prediction="no", git_provider=MagicMock()
+        )
+        out = pr._prepare_pr_answer()
+        assert "\n /merge this now" in out
+        assert "\n/merge" not in out
+
+    def test_question_with_newline_slash_is_space_prefixed(self):
+        pr = _make_pr_questions(
+            question_str="why?\n/merge now", prediction="no", git_provider=MagicMock()
+        )
+        out = pr._prepare_pr_answer()
+        assert "\n /merge now" in out
+        assert "\n/merge" not in out
+
+    def test_question_with_carriage_return_slash_is_neutralized(self):
+        pr = _make_pr_questions(
+            question_str="why?\r/close", prediction="no", git_provider=MagicMock()
+        )
+        out = pr._prepare_pr_answer()
+        assert "\r /close" in out
+        assert "\r/close" not in out
+
+    def test_mid_line_slash_mention_in_question_survives(self):
+        pr = _make_pr_questions(
+            question_str="what does /merge do here?", prediction="no", git_provider=MagicMock()
+        )
+        out = pr._prepare_pr_answer()
+        assert "what does /merge do here?" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The /ask tool sanitized the model answer against line-leading slash commands but echoed the user's raw question into the same bot comment, so GitLab quick actions in the question ran under the bot's account. This extracts the rewrites (including the `\r/` case GitLab normalizes to line start) into `_sanitize_slash_commands`, applies it to both the echoed question and the answer, and reuses it in `pr_line_questions.py` where the `\r/` rewrite was missing. Fixes #2629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)