### PR TITLE
chore(deps): Upgrade LiteLLM to the latest stable v1.96.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.4
+aiohttp==3.14.3
 anthropic>=0.69.0
 #anthropic[vertex]==0.47.1
 atlassian-python-api==3.41.4
@@ -16,7 +16,7 @@ google-cloud-storage==2.10.0; python_version < "3.13"
 google-cloud-storage==3.12.0; python_version >= "3.13"
 protobuf==6.33.6  # grpcio-status 1.80.0 forces >=6.31.1,<7; pinned to lock the resolved transitive version
 Jinja2==3.1.6
-litellm==1.95.0
+litellm==1.96.2
 loguru==0.7.2
 msrest==0.7.1
 openai>=1.55.3
@@ -38,9 +38,9 @@ langfuse==3.14.5
 gunicorn==23.0.0
 pytest-cov==7.0.0
 pydantic==2.13.3
-# litellm 1.95.0 imports pydantic-settings unconditionally (litellm/integrations/otel/model/config.py) but declares it
-# only under its optional 'proxy' extra; without it the 'langfuse_otel' callback silently fails to load and no LLM
-# call is traced. Version matches litellm's own constraint (>=2.14.1,<3.0).
+# litellm 1.96.2 declares pydantic-settings as a base dependency and imports it unconditionally from
+# litellm/integrations/otel/model/config.py. Keep the exact pin to lock the resolved transitive version.
+# Version matches litellm's own constraint (>=2.14.1,<3.0); the existing observability guard covers the callback import.
 pydantic-settings==2.14.2
 html2text==2024.2.26
 giteapy==1.0.8

--- a/tests/unittest/test_mosaico_observability_deps.py
+++ b/tests/unittest/test_mosaico_observability_deps.py
@@ -3,10 +3,10 @@
 pr_agent/mosaico/env_bridge.py registers 'langfuse_otel' as the Langfuse callback
 (the legacy 'langfuse' callback raises a ``sdk_integration`` TypeError against
 langfuse 3.x). litellm imports pydantic-settings unconditionally from
-``litellm/integrations/otel/model/config.py`` but declares it only under its optional
-'proxy' extra, so an environment built from requirements.txt without that pin makes
-litellm's callback factory return None -- silently, because the factory swallows the
-ImportError -- and not a single LLM call is traced.
+``litellm/integrations/otel/model/config.py`` and declares it as a base dependency.
+If it is missing from the environment, litellm's callback factory returns None --
+silently, because the factory swallows the ImportError -- and not a single LLM call
+is traced.
 
 These tests assert the environment, not pr-agent logic, hence a file of their own
 rather than an addition to test_mosaico_env_bridge.py. They are meaningful in CI:
@@ -19,14 +19,13 @@ import importlib
 import pytest
 
 CALLBACK_NAME = "langfuse_otel"
-# Imported at module scope by litellm/integrations/otel/model/config.py, declared only under
-# litellm's 'proxy' extra, so it must be pinned explicitly in pr-agent's requirements.txt.
-UNDECLARED_LITELLM_DEP = "pydantic_settings"
+# Imported at module scope by litellm/integrations/otel/model/config.py and declared in
+# litellm's base dependencies, so it must remain available in pr-agent's environment.
+LITELLM_OTEL_DEP = "pydantic_settings"
 
 _REMEDY = (
-    f"'{UNDECLARED_LITELLM_DEP}' must be pinned in requirements.txt: litellm imports it "
-    f"unconditionally from litellm/integrations/otel/model/config.py but declares it only under "
-    f"its optional 'proxy' extra."
+    f"'{LITELLM_OTEL_DEP}' must be installed: litellm imports it unconditionally from "
+    f"litellm/integrations/otel/model/config.py and declares it in its base dependencies."
 )
 
 
@@ -58,7 +57,7 @@ def restore_in_memory_loggers():
 
 class TestLangfuseOtelCallbackDeps:
     def test_pydantic_settings_is_installed(self):
-        err = _import_error(UNDECLARED_LITELLM_DEP)
+        err = _import_error(LITELLM_OTEL_DEP)
         assert err is None, f"{_REMEDY} Import failed with: {err!r}"
 
     def test_litellm_otel_config_imports(self):


### PR DESCRIPTION
The reviewed releases include proxy request-handling and runtime dependency updates, with fixes across streaming, routing, observability, authorization, and metadata handling. Scoped breaking changes affect proxy, MCP, and mock-testing paths; none affect PR-Agent's LiteLLM SDK call path.

Upgrade aiohttp from 3.13.4 to 3.14.3 to satisfy LiteLLM's new minimum while avoiding GHSA-cq5v-8q36-5273 in 3.14.2. LiteLLM now declares pydantic-settings as a base dependency, so update the existing observability guard and its documentation while retaining the project's exact 2.14.2 pin for deterministic installs.

Stable release lines reviewed:
- v1.95.1
- v1.96.0
- v1.96.2

Stable release references:
- https://pypi.org/project/litellm/1.95.1/
- https://pypi.org/project/litellm/1.96.0/
- https://pypi.org/project/litellm/1.96.2/

Additional dependency references:
- https://pypi.org/project/aiohttp/3.14.3/
- https://github.com/advisories/GHSA-cq5v-8q36-5273