### PR TITLE
fix(azure): anchor inline comments to diff paths

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -71,6 +71,7 @@ class AzureDevopsProvider(GitProvider):
 
         self.azure_devops_client, self.azure_devops_board_client = self._get_azure_devops_client()
         self.diff_files = None
+        self._diff_path_map = None
         self.workspace_slug = None
         self.repo_slug = None
         self.repo = None
@@ -84,19 +85,83 @@ class AzureDevopsProvider(GitProvider):
         if pr_url:
             self.set_pr(pr_url)
 
+    def _resolve_diff_file_path(self, relevant_file: str) -> Optional[str]:
+        if not isinstance(relevant_file, str) or not relevant_file.strip():
+            return None
+        relevant_file = relevant_file.strip().strip("`").strip()
+        if not relevant_file:
+            return None
+        path_map = getattr(self, "_diff_path_map", None)
+        if path_map is None or getattr(self, "diff_files", None) is None:
+            diff_paths = [f.filename for f in (self.get_diff_files() or []) if f.filename]
+            path_map = {path: path for path in diff_paths}
+            for path in diff_paths:
+                path_map.setdefault(path.lstrip("/"), path)
+            if getattr(self, "diff_files", None) is not None:
+                self._diff_path_map = path_map
+        return path_map.get(relevant_file) or path_map.get(relevant_file.lstrip("/"))
+
+    @staticmethod
+    def _fallback_suggestion_section(suggestion: dict, reason: str) -> str:
+        relevant_file = str(suggestion["relevant_file"]).strip().strip("`").strip().replace("`", "")
+        location = (f"`{relevant_file}` "
+                    f"(lines {suggestion['relevant_lines_start']}-{suggestion['relevant_lines_end']})")
+        return f"{location} - {reason}\n\n{suggestion['body']}"
+
+    def _publish_fallback_suggestions(self, suggestions: list[tuple[dict, str]]) -> int:
+        sections = []
+        for suggestion, reason in suggestions:
+            try:
+                sections.append(self._fallback_suggestion_section(suggestion, reason))
+            except (KeyError, TypeError) as e:
+                get_logger().warning(f"Could not format Azure code suggestion fallback, error: {e}")
+        if not sections:
+            return 0
+        try:
+            self.publish_comment("\n\n---\n\n".join(sections))
+        except Exception as e:
+            get_logger().exception(f"Azure failed to publish code suggestion fallback, error: {e}")
+            published = 0
+            for suggestion, reason in suggestions:
+                try:
+                    self.publish_comment(self._fallback_suggestion_section(suggestion, reason))
+                except Exception as fallback_error:
+                    get_logger().exception(
+                        f"Azure failed to publish code suggestion fallback, error: {fallback_error}")
+                else:
+                    published += 1
+            return published
+        return len(sections)
+
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         """
         Publishes code suggestions as comments on the PR.
         """
-        post_parameters_list = []
+        publishable_count = 0
+        published_count = 0
+        fallback_suggestions = []
         status = get_settings().azure_devops.get("default_comment_status", "closed")
         for suggestion in code_suggestions:
-            body = suggestion['body']
-            relevant_file = suggestion['relevant_file']
-            relevant_lines_start = suggestion['relevant_lines_start']
-            relevant_lines_end = suggestion['relevant_lines_end']
+            try:
+                body = suggestion["body"]
+                relevant_file = suggestion["relevant_file"]
+                relevant_lines_start = suggestion["relevant_lines_start"]
+                relevant_lines_end = suggestion["relevant_lines_end"]
+            except (KeyError, TypeError) as e:
+                get_logger().warning(f"Could not parse Azure code suggestion, error: {e}")
+                continue
 
-            if not relevant_lines_start or relevant_lines_start == -1:
+            if (not isinstance(body, str) or not isinstance(relevant_file, str)
+                    or not isinstance(relevant_lines_start, int) or isinstance(relevant_lines_start, bool)
+                    or not isinstance(relevant_lines_end, int) or isinstance(relevant_lines_end, bool)):
+                get_logger().warning("Could not parse Azure code suggestion, invalid value types")
+                continue
+
+            if not relevant_file.strip().strip("`").strip():
+                get_logger().warning("Could not parse Azure code suggestion, relevant_file is empty")
+                continue
+
+            if relevant_lines_start < 1:
                 get_logger().warning(
                     f"Failed to publish code suggestion, relevant_lines_start is {relevant_lines_start}")
                 continue
@@ -107,8 +172,16 @@ class AzureDevopsProvider(GitProvider):
                                        f"relevant_lines_start is {relevant_lines_start}")
                 continue
 
+            publishable_count += 1
+            resolved_file = self._resolve_diff_file_path(relevant_file)
+            if not resolved_file:
+                get_logger().warning(f"Could not match '{relevant_file}' to a file in the PR diff, "
+                                     f"publishing the suggestion as a PR-level comment")
+                fallback_suggestions.append((suggestion, "could not be anchored to a file in the PR diff"))
+                continue
+
             thread_context = CommentThreadContext(
-                file_path=relevant_file,
+                file_path=resolved_file,
                 right_file_start=CommentPosition(offset=1, line=relevant_lines_start),
                 right_file_end=CommentPosition(offset=1, line=relevant_lines_end))
             comment = Comment(content=body, comment_type=1)
@@ -121,8 +194,13 @@ class AzureDevopsProvider(GitProvider):
                     pull_request_id=self.pr_num
                 )
             except Exception as e:
-                get_logger().error(f"Azure failed to publish code suggestion, error: {e}", suggestion=suggestion)
-        return True
+                get_logger().exception(f"Azure failed to publish code suggestion, error: {e}", suggestion=suggestion)
+                fallback_suggestions.append((suggestion, "could not be published as an inline comment"))
+            else:
+                published_count += 1
+        if fallback_suggestions:
+            published_count += self._publish_fallback_suggestions(fallback_suggestions)
+        return published_count > 0 or publishable_count == 0
 
     def reply_to_comment_from_comment_id(self, comment_id: int, body: str, is_temporary: bool = False) -> Comment:
         # comment_id is actually thread_id
@@ -184,6 +262,8 @@ class AzureDevopsProvider(GitProvider):
         return True
 
     def set_pr(self, pr_url: str):
+        self.diff_files = None
+        self._diff_path_map = None
         self.pr_url = pr_url
         self.workspace_slug, self.repo_slug, self.pr_num = self._parse_pr_url(pr_url)
         self.pr = self._get_pr()
@@ -197,6 +277,7 @@ class AzureDevopsProvider(GitProvider):
             # provider instance, so incremental filtering/rebuild is recomputed rather than
             # returning the full-PR diff.
             self.diff_files = None
+            self._diff_path_map = None
             self.unreviewed_files_map = {}
             self._get_incremental_commits()
 
@@ -407,6 +488,7 @@ class AzureDevopsProvider(GitProvider):
 
             if self.diff_files is not None:
                 return self.diff_files
+            self._diff_path_map = None
 
             if self.pr.last_merge_commit is None or self.pr.last_merge_target_commit is None:
                 get_logger().info(
@@ -674,8 +756,11 @@ class AzureDevopsProvider(GitProvider):
 
     def create_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str,
                               absolute_position: int = None):
+        clean_relevant_file = relevant_file.strip().strip("`").strip() if isinstance(relevant_file, str) else ""
+        resolved_file = self._resolve_diff_file_path(clean_relevant_file)
+        lookup_file = resolved_file or clean_relevant_file
         position, absolute_position = find_line_number_of_relevant_line_in_file(self.get_diff_files(),
-                                                                                relevant_file.strip('`'),
+                                                                                lookup_file,
                                                                                 relevant_line_in_file,
                                                                                 absolute_position)
         if position == -1:
@@ -684,28 +769,47 @@ class AzureDevopsProvider(GitProvider):
             subject_type = "FILE"
         else:
             subject_type = "LINE"
-        path = relevant_file.strip()
-        return dict(body=body, path=path, position=position, absolute_position=absolute_position) if subject_type == "LINE" else {}
+        return dict(
+            body=body,
+            path=resolved_file,
+            relevant_file=clean_relevant_file,
+            position=position,
+            absolute_position=absolute_position,
+            subject_type=subject_type,
+        )
 
     def publish_inline_comments(self, comments: list[dict], disable_fallback: bool = False):
             overall_success = True
             for comment in comments:
+                if not comment:
+                    continue
                 try:
-                    self.publish_comment(comment["body"],
-                                        thread_context={
-                                            "filePath": comment["path"],
-                                            "rightFileStart": {
-                                                "line": comment["absolute_position"],
-                                                "offset": comment["position"],
-                                            },
-                                            "rightFileEnd": {
-                                                "line": comment["absolute_position"],
-                                                "offset": comment["position"],
-                                            },
-                                        })
+                    comment_body = comment["body"]
+                    relevant_file = comment.get("relevant_file") or "unknown file"
+                    thread_context = None
+                    if comment.get("path"):
+                        relevant_file = comment["path"]
+                        thread_context = {"filePath": relevant_file}
+                        if comment.get("subject_type", "LINE") == "LINE":
+                            thread_context["rightFileStart"] = {
+                                "line": comment["absolute_position"],
+                                "offset": comment["position"],
+                            }
+                            thread_context["rightFileEnd"] = {
+                                "line": comment["absolute_position"],
+                                "offset": comment["position"],
+                            }
+                        body = comment_body
+                    else:
+                        relevant_file = relevant_file.replace("`", "")
+                        get_logger().warning(f"Could not match '{relevant_file}' to a file in the PR diff, "
+                                             f"publishing the comment as a PR-level comment")
+                        body = (f"`{relevant_file}` - could not be anchored to a file in the PR diff\n\n"
+                                f"{comment_body}")
+                    self.publish_comment(body, thread_context=thread_context)
                     if get_settings().config.verbosity_level >= 2:
                         get_logger().info(
-                            f"Published code suggestion on {self.pr_num} at {comment['path']}"
+                            f"Published code suggestion on {self.pr_num} at {relevant_file}"
                         )
                 except Exception as e:
                     if get_settings().config.verbosity_level >= 2:

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock
 
+import pytest
+
+from pr_agent.algo.types import FilePatchInfo
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 
 
@@ -49,3 +52,328 @@ class TestAzureDevopsProviderRepoContext:
         provider.azure_devops_client.get_item.side_effect = Exception("not found")
 
         assert provider.get_repo_file_content("MISSING.md") == ""
+
+
+def _provider_with_diff(*filenames):
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.repo_slug = "my-repo"
+    provider.workspace_slug = "my-project"
+    provider.pr_num = 1
+    provider.temp_comments = []
+    provider.azure_devops_client = MagicMock()
+    provider.diff_files = [
+        FilePatchInfo(base_file="", head_file="", patch="", filename=filename) for filename in filenames
+    ]
+    return provider
+
+
+def _created_threads(provider):
+    return [kwargs["comment_thread"] for _, kwargs in provider.azure_devops_client.create_thread.call_args_list]
+
+
+def _suggestion(relevant_file):
+    return {
+        "body": "```suggestion\nfixed\n```",
+        "relevant_file": relevant_file,
+        "relevant_lines_start": 10,
+        "relevant_lines_end": 12,
+    }
+
+
+class TestAzureDevopsProviderSuggestionAnchoring:
+    def test_suggestion_without_leading_slash_is_published_with_the_diff_path(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        assert provider.publish_code_suggestions([_suggestion("src/Api/Controllers/SomeController.cs")]) is True
+
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+        assert threads[0].thread_context.right_file_start.line == 10
+        assert threads[0].thread_context.right_file_end.line == 12
+
+    def test_suggestion_with_matching_path_is_published_unchanged(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/SomeController.cs")])
+
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+
+    def test_suggestion_with_extra_leading_slash_is_published_with_the_diff_path(self):
+        provider = _provider_with_diff("src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/SomeController.cs")])
+
+        assert _created_threads(provider)[0].thread_context.file_path == "src/Api/Controllers/SomeController.cs"
+
+    def test_suggestion_with_padded_backticks_is_published_with_the_diff_path(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([_suggestion("` src/Api/Controllers/SomeController.cs `")])
+
+        assert _created_threads(provider)[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+
+    def test_unmatched_suggestion_becomes_a_pr_level_comment_instead_of_an_orphaned_thread(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/Removed.cs")])
+
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context is None
+        body = threads[0].comments[0].content
+        assert "/src/Api/Controllers/Removed.cs" in body
+        assert "fixed" in body
+
+    def test_unmatched_suggestions_are_published_in_one_comment(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/First.cs"),
+            _suggestion("/src/Api/Controllers/Second.cs"),
+        ])
+
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context is None
+        body = threads[0].comments[0].content
+        assert "/src/Api/Controllers/First.cs" in body
+        assert "/src/Api/Controllers/Second.cs" in body
+
+    def test_diff_path_index_is_reused_for_a_batch(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.get_diff_files = MagicMock(return_value=provider.diff_files)
+
+        provider.publish_code_suggestions([
+            _suggestion("src/Api/Controllers/SomeController.cs"),
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+        ])
+
+        provider.get_diff_files.assert_called_once_with()
+
+    def test_transient_diff_failure_does_not_cache_an_empty_path_index(self):
+        provider = _provider_with_diff()
+        provider.diff_files = None
+        diff_file = FilePatchInfo(
+            base_file="",
+            head_file="",
+            patch="",
+            filename="/src/Api/Controllers/SomeController.cs",
+        )
+        responses = iter([None, [diff_file]])
+
+        def load_diff_files():
+            provider.diff_files = next(responses)
+            return provider.diff_files or []
+
+        provider.get_diff_files = MagicMock(side_effect=load_diff_files)
+
+        assert provider._resolve_diff_file_path("src/Api/Controllers/SomeController.cs") is None
+        assert provider._resolve_diff_file_path("src/Api/Controllers/SomeController.cs") == diff_file.filename
+        assert provider.get_diff_files.call_count == 2
+
+    def test_incremental_mode_invalidates_the_diff_path_index(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider._diff_path_map = {"stale.cs": "/stale.cs"}
+        provider._get_incremental_commits = MagicMock()
+        incremental = MagicMock()
+        incremental.is_incremental = True
+
+        provider.get_incremental_commits(incremental)
+
+        assert provider.diff_files is None
+        assert provider._diff_path_map is None
+
+    def test_set_pr_invalidates_the_diff_path_index(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider._diff_path_map = {"stale.cs": "/stale.cs"}
+        provider._parse_pr_url = MagicMock(return_value=("project", "repo", 2))
+        provider._get_pr = MagicMock(return_value=MagicMock())
+
+        provider.set_pr("https://dev.azure.com/example/project/_git/repo/pullrequest/2")
+
+        assert provider.diff_files is None
+        assert provider._diff_path_map is None
+
+    def test_unmatched_suggestion_path_does_not_break_markdown(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([_suggestion("` /src/Api/Controllers/Removed.cs `")])
+
+        body = _created_threads(provider)[-1].comments[0].content
+        assert body.startswith("`/src/Api/Controllers/Removed.cs` (lines 10-12)")
+
+    def test_aggregate_fallback_retries_suggestions_individually(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.azure_devops_client.create_thread.side_effect = [RuntimeError("request failed"),
+                                                                  MagicMock(), MagicMock()]
+
+        result = provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/First.cs"),
+            _suggestion("/src/Api/Controllers/Second.cs"),
+        ])
+
+        assert result is True
+        assert provider.azure_devops_client.create_thread.call_count == 3
+
+    def test_unanchored_publish_failure_is_reported(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.azure_devops_client.create_thread.side_effect = RuntimeError("request failed")
+
+        assert provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/Removed.cs")]) is False
+
+    def test_anchored_publish_failure_is_reported(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.azure_devops_client.create_thread.side_effect = RuntimeError("request failed")
+
+        assert provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/SomeController.cs")]) is False
+
+    def test_anchored_publish_failure_uses_the_publish_failure_reason(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.azure_devops_client.create_thread.side_effect = [RuntimeError("request failed"), MagicMock()]
+
+        provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/SomeController.cs")])
+
+        fallback_body = _created_threads(provider)[-1].comments[0].content
+        assert "could not be published as an inline comment" in fallback_body
+
+    def test_malformed_suggestion_does_not_stop_the_batch(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([
+            {"body": "missing location"},
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+        ])
+
+        assert len(_created_threads(provider)) == 1
+
+    @pytest.mark.parametrize("overrides", [
+        {"relevant_file": 123},
+        {"relevant_file": " "},
+        {"relevant_file": "``"},
+        {"body": None},
+        {"relevant_lines_start": "10"},
+        {"relevant_lines_start": True},
+        {"relevant_lines_start": -2},
+        {"relevant_lines_end": None},
+    ])
+    def test_invalid_values_do_not_stop_the_batch(self, overrides):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        malformed = _suggestion("/src/Api/Controllers/SomeController.cs")
+        malformed.update(overrides)
+
+        result = provider.publish_code_suggestions([
+            malformed,
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+        ])
+
+        assert result is True
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+
+    def test_diff_path_resolver_rejects_non_string_paths(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        assert provider._resolve_diff_file_path(123) is None
+
+    def test_invalid_range_does_not_retry_successful_suggestions(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        invalid = _suggestion("/src/Api/Controllers/SomeController.cs")
+        invalid["relevant_lines_start"] = -1
+
+        result = provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+            invalid,
+        ])
+
+        assert result is True
+        assert len(_created_threads(provider)) == 1
+
+    def test_reversed_range_does_not_retry_successful_suggestions(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        invalid = _suggestion("/src/Api/Controllers/SomeController.cs")
+        invalid["relevant_lines_start"] = 12
+        invalid["relevant_lines_end"] = 10
+
+        result = provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+            invalid,
+        ])
+
+        assert result is True
+        assert len(_created_threads(provider)) == 1
+
+    def test_partial_publish_failure_does_not_retry_successful_suggestions(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.azure_devops_client.create_thread.side_effect = [MagicMock(), RuntimeError("request failed"),
+                                                                  RuntimeError("request failed"),
+                                                                  RuntimeError("request failed")]
+
+        result = provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/SomeController.cs"),
+            _suggestion("src/Api/Controllers/SomeController.cs"),
+        ])
+
+        assert result is True
+
+    def test_unmatched_suggestion_does_not_stop_the_remaining_suggestions(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_code_suggestions([
+            _suggestion("/src/Api/Controllers/Removed.cs"),
+            _suggestion("src/Api/Controllers/SomeController.cs"),
+        ])
+
+        anchored = [t for t in _created_threads(provider) if t.thread_context is not None]
+        assert len(anchored) == 1
+        assert anchored[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+
+
+class TestAzureDevopsProviderCreateInlineComment:
+    def test_resolved_line_comment_uses_the_diff_path(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+        provider.diff_files[0].patch = "@@ -1,3 +1,4 @@\n context\n+    var x = 1;\n"
+        provider.diff_files[0].head_file = " context\n    var x = 1;\n"
+
+        comment = provider.create_inline_comment("body", "src/Api/Controllers/SomeController.cs", "    var x = 1;")
+
+        assert comment["path"] == "/src/Api/Controllers/SomeController.cs"
+        assert comment["subject_type"] == "LINE"
+
+    def test_unresolved_line_returns_a_file_level_comment_instead_of_an_empty_dict(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        comment = provider.create_inline_comment("body", "src/Api/Controllers/SomeController.cs", "no such line")
+
+        assert comment
+        assert comment["subject_type"] == "FILE"
+        assert comment["path"] == "/src/Api/Controllers/SomeController.cs"
+
+    def test_file_level_comment_is_published_without_a_line_anchor(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_inline_comment("body", "src/Api/Controllers/SomeController.cs", "no such line")
+
+        thread_context = _created_threads(provider)[0].thread_context
+        assert thread_context == {"filePath": "/src/Api/Controllers/SomeController.cs"}
+
+    def test_comment_on_a_file_outside_the_diff_becomes_a_pr_level_comment(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_inline_comment("body", "src/Api/Controllers/Removed.cs", "no such line")
+
+        thread = _created_threads(provider)[0]
+        assert thread.thread_context is None
+        assert "src/Api/Controllers/Removed.cs" in thread.comments[0].content
+        assert "body" in thread.comments[0].content
+
+    def test_pr_level_fallback_removes_backticks_from_the_display_path(self):
+        provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
+
+        provider.publish_inline_comment("body", "src/Api/Controllers`Removed.cs", "no such line")
+
+        body = _created_threads(provider)[0].comments[0].content
+        assert body.startswith("`src/Api/ControllersRemoved.cs`")


### PR DESCRIPTION
## Summary

Keeps Azure DevOps inline comments attached when a suggestion path differs only by its leading slash or Markdown formatting.

## Scope

Azure DevOps only.

The provider builds one canonical path index from the pull request diff and reuses it for every suggestion. The index is invalidated when the provider changes pull requests, enters incremental mode, or refreshes diff data, and transient fetch failures remain retryable. If Azure rejects an anchored suggestion, the comment falls back to a pull-request-level comment instead of disappearing. Inline review findings opt out of that fallback so failed findings remain in the review summary. Fallback messages distinguish path mismatches from publish failures and sanitize display paths. Suggestions with missing keys, invalid value types, empty paths, or invalid line ranges are skipped individually without stopping later valid suggestions. Publication tracking prevents callers from duplicating successful comments.

## Validation

- 90 focused Azure provider and reviewer tests pass.
- 1,905 unit tests pass, with 1 skipped and 1 expected failure.
- Ruff passes on the focused test files.
- `git diff --check` passes.

Closes #2642.
