### PR TITLE
fix(suggestions): only offer applicable changes

### DIFF
--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -29,11 +29,13 @@ To edit [configurations](#configuration-options) related to the `improve` tool, 
 /improve --pr_code_suggestions.some_config1=... --pr_code_suggestions.some_config2=...
 ```
 
-For example, you can choose to present all the suggestions as committable code comments, by running the following command:
+For example, you can present suggestions with verified replacement ranges as committable code comments by running:
 
 ```toml
 /improve --pr_code_suggestions.commitable_code_suggestions=true
 ```
+
+Suggestions whose replacement ranges cannot be verified remain regular comments without an apply action.
 
 ![improve](https://codium.ai/images/pr_agent/improve.png){width=512}
 

--- a/pr_agent/algo/types.py
+++ b/pr_agent/algo/types.py
@@ -24,3 +24,4 @@ class FilePatchInfo:
     num_minus_lines: int = -1
     language: Optional[str] = None
     ai_file_summary: str = None
+    head_file_is_complete: bool = True

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -79,7 +79,7 @@ class GiteaProvider(GitProvider):
         self.sha = None
         self.base_sha = ""
         self.base_ref = ""
-        self.diff_files = []
+        self.diff_files = None
         self.incremental = IncrementalPR(False)
         self.comments_list = []
         self.unreviewed_files_map = dict()

--- a/pr_agent/mosaico/diff_provider.py
+++ b/pr_agent/mosaico/diff_provider.py
@@ -100,6 +100,7 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
             filename=filename,
             edit_type=edit_type,
             old_filename=old_filename,
+            head_file_is_complete=False,
         ))
     return files
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -748,7 +748,7 @@ class PRCodeSuggestions:
         diff_file = self._get_diff_file(relevant_file)
         if diff_file is None:
             return False, "the file content is unavailable", False
-        if diff_file.head_file:
+        if diff_file.head_file and getattr(diff_file, "head_file_is_complete", True):
             file_lines = diff_file.head_file.splitlines()
             if relevant_lines_end > len(file_lines):
                 return False, "the anchored range is outside the file", False
@@ -761,8 +761,8 @@ class PRCodeSuggestions:
 
         if not existing_code:
             return False, "the existing code is unavailable", True
-        anchored_lines = [line.strip() for line in anchored_lines]
-        existing_lines = [line.strip() for line in existing_code.splitlines()]
+        anchored_lines = [line.rstrip() for line in textwrap.dedent("\n".join(anchored_lines)).split("\n")]
+        existing_lines = [line.rstrip() for line in textwrap.dedent(existing_code).splitlines()]
         if existing_lines != anchored_lines:
             return False, "the existing code does not match the anchored range", True
         return True, "", True

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -13,23 +13,26 @@ from jinja2 import Environment, StrictUndefined
 from pr_agent.algo import MAX_TOKENS
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
-from pr_agent.algo.git_patch_processing import decouple_and_convert_to_hunks_with_lines_numbers
+from pr_agent.algo.git_patch_processing import \
+    decouple_and_convert_to_hunks_with_lines_numbers
 from pr_agent.algo.pr_processing import (_get_all_models,
                                          add_ai_metadata_to_diff_files,
                                          get_pr_diff, get_pr_multi_diffs,
                                          retry_with_fallback_models)
+from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.run_details import init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
-from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
-from pr_agent.algo.utils import (ModelType, load_yaml, replace_code_tags,
-                                 show_relevant_configurations, show_run_details,
-                                 get_max_tokens, clip_tokens, get_model)
+from pr_agent.algo.utils import (ModelType, clip_tokens, get_max_tokens,
+                                 get_model, load_yaml, replace_code_tags,
+                                 show_relevant_configurations,
+                                 show_run_details)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
                                     GitLabProvider, get_git_provider,
                                     get_git_provider_with_context)
-from pr_agent.git_providers.git_provider import GitProvider, IncrementalPR, get_main_pr_language
+from pr_agent.git_providers.git_provider import (GitProvider, IncrementalPR,
+                                                 get_main_pr_language)
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.pr_description import insert_br_after_x_chars
@@ -660,6 +663,9 @@ class PRCodeSuggestions:
                 relevant_lines_end = int(d['relevant_lines_end'])
                 content = d['suggestion_content'].rstrip()
                 new_code_snippet = (d.get("improved_code") or "").rstrip()
+                existing_code = d.get("existing_code")
+                if not isinstance(existing_code, str):
+                    raise TypeError("existing_code must be a string")
                 label = d['label'].strip()
             except (AttributeError, KeyError, TypeError, ValueError) as e:
                 get_logger().warning(f"Could not parse suggestion: {d}, error: {e}")
@@ -667,7 +673,7 @@ class PRCodeSuggestions:
 
             is_applicable, fallback_reason, has_valid_anchor = self._validate_suggestion(
                 relevant_file, relevant_lines_start, relevant_lines_end,
-                d.get("existing_code") if new_code_snippet else None)
+                existing_code if new_code_snippet else None)
             if new_code_snippet and has_valid_anchor:
                 new_code_snippet = self.dedent_code(relevant_file, relevant_lines_start, new_code_snippet)
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -6,7 +6,7 @@ import textwrap
 import traceback
 from datetime import datetime
 from functools import partial
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from jinja2 import Environment, StrictUndefined
 
@@ -298,10 +298,10 @@ class PRCodeSuggestions:
         try:
             for suggestion in data['code_suggestions']:
                 if int(suggestion.get('score', 0)) >= int(
-                        get_settings().pr_code_suggestions.dual_publishing_score_threshold) \
-                        and suggestion.get('improved_code'):
-                    data_above_threshold['code_suggestions'].append(suggestion)
-                    if not data_above_threshold['code_suggestions'][-1]['existing_code']:
+                        get_settings().pr_code_suggestions.dual_publishing_score_threshold):
+                    data_above_threshold["code_suggestions"].append(suggestion)
+                    if suggestion.get("improved_code") and not data_above_threshold["code_suggestions"][-1][
+                            "existing_code"]:
                         get_logger().info(f'Identical existing and improved code for dual publishing found')
                         data_above_threshold['code_suggestions'][-1]['existing_code'] = suggestion[
                             'improved_code']
@@ -641,6 +641,7 @@ class PRCodeSuggestions:
 
     async def push_inline_code_suggestions(self, data):
         code_suggestions = []
+        fallback_comments = []
 
         if not data['code_suggestions']:
             get_logger().info('No suggestions found to improve this PR.')
@@ -658,33 +659,124 @@ class PRCodeSuggestions:
                 relevant_lines_start = int(d['relevant_lines_start'])  # absolute position
                 relevant_lines_end = int(d['relevant_lines_end'])
                 content = d['suggestion_content'].rstrip()
-                new_code_snippet = d['improved_code'].rstrip()
+                new_code_snippet = (d.get("improved_code") or "").rstrip()
                 label = d['label'].strip()
+            except (AttributeError, KeyError, TypeError, ValueError) as e:
+                get_logger().warning(f"Could not parse suggestion: {d}, error: {e}")
+                continue
 
+            is_applicable, fallback_reason, has_valid_anchor = self._validate_suggestion(
+                relevant_file, relevant_lines_start, relevant_lines_end,
+                d.get("existing_code") if new_code_snippet else None)
+            if new_code_snippet and has_valid_anchor:
+                new_code_snippet = self.dedent_code(relevant_file, relevant_lines_start, new_code_snippet)
+
+            score = d.get("score")
+            header = f"**Suggestion:** {content} [{label}, importance: {score}]" if score \
+                else f"**Suggestion:** {content} [{label}]"
+            if new_code_snippet and is_applicable:
+                body = f"{header}\n```suggestion\n" + new_code_snippet + "\n```"
+            else:
+                body = header
                 if new_code_snippet:
-                    new_code_snippet = self.dedent_code(relevant_file, relevant_lines_start, new_code_snippet)
+                    body += (f"\n\nProposed code (not offered as a committable change because {fallback_reason}):\n"
+                             f"```\n{new_code_snippet}\n```")
 
-                if d.get('score'):
-                    body = f"**Suggestion:** {content} [{label}, importance: {d.get('score')}]\n```suggestion\n" + new_code_snippet + "\n```"
-                else:
-                    body = f"**Suggestion:** {content} [{label}]\n```suggestion\n" + new_code_snippet + "\n```"
+            if not has_valid_anchor:
+                fallback_comments.append(f"{body}\n\nLocation: `{relevant_file}:"
+                                         f"{relevant_lines_start}-{relevant_lines_end}`")
+            else:
                 code_suggestions.append({'body': body, 'relevant_file': relevant_file,
                                          'relevant_lines_start': relevant_lines_start,
                                          'relevant_lines_end': relevant_lines_end,
                                          'original_suggestion': d})
-            except Exception:
-                get_logger().info(f"Could not parse suggestion: {d}")
 
-        is_successful = self.git_provider.publish_code_suggestions(code_suggestions)
-        if not is_successful:
-            get_logger().info("Failed to publish code suggestions, trying to publish each suggestion separately")
-            for code_suggestion in code_suggestions:
-                self.git_provider.publish_code_suggestions([code_suggestion])
+        if code_suggestions:
+            is_successful = self.git_provider.publish_code_suggestions(code_suggestions)
+            if not is_successful:
+                get_logger().info("Failed to publish code suggestions, trying to publish each suggestion separately")
+                for code_suggestion in code_suggestions:
+                    self.git_provider.publish_code_suggestions([code_suggestion])
+        if fallback_comments:
+            self.git_provider.publish_comment("\n\n---\n\n".join(fallback_comments))
+
+    def _get_diff_file(self, relevant_file):
+        diff_files = getattr(self.git_provider, "diff_files", None)
+        if diff_files is None:
+            diff_files = self.git_provider.get_diff_files()
+        for file in diff_files or []:
+            if file.filename and file.filename.strip() == relevant_file:
+                return file
+        return None
+
+    @staticmethod
+    def _get_patch_range_lines(patch, relevant_lines_start, relevant_lines_end) -> Optional[List[str]]:
+        target_lines = {}
+        target_line = None
+        target_remaining = 0
+        for line in (patch or "").splitlines():
+            hunk_match = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line)
+            if hunk_match:
+                target_line = int(hunk_match.group(1))
+                target_remaining = int(hunk_match.group(2) or 1)
+                continue
+            if target_line is None or target_remaining == 0 or line.startswith(("-", "\\")):
+                continue
+            if line.startswith((" ", "+")):
+                if relevant_lines_start <= target_line <= relevant_lines_end:
+                    target_lines[target_line] = line[1:]
+                target_line += 1
+                target_remaining -= 1
+
+        if all(line_number in target_lines
+               for line_number in range(relevant_lines_start, relevant_lines_end + 1)):
+            return [target_lines[line_number]
+                    for line_number in range(relevant_lines_start, relevant_lines_end + 1)]
+        return None
+
+    def _validate_suggestion(self, relevant_file, relevant_lines_start, relevant_lines_end,
+                             existing_code) -> tuple[bool, str, bool]:
+        if relevant_lines_start < 1 or relevant_lines_end < relevant_lines_start:
+            return False, "the anchored range is outside the file", False
+
+        diff_file = self._get_diff_file(relevant_file)
+        if diff_file is None:
+            return False, "the file content is unavailable", False
+        if diff_file.head_file:
+            file_lines = diff_file.head_file.splitlines()
+            if relevant_lines_end > len(file_lines):
+                return False, "the anchored range is outside the file", False
+            anchored_lines = file_lines[relevant_lines_start - 1:relevant_lines_end]
+        else:
+            anchored_lines = self._get_patch_range_lines(
+                diff_file.patch, relevant_lines_start, relevant_lines_end)
+            if anchored_lines is None:
+                return False, "the file content is unavailable", False
+
+        if not existing_code:
+            return False, "the existing code is unavailable", True
+        anchored_lines = [line.strip() for line in anchored_lines]
+        existing_lines = [line.strip() for line in existing_code.splitlines()]
+        if existing_lines != anchored_lines:
+            return False, "the existing code does not match the anchored range", True
+        return True, "", True
+
+    def _suggestion_applyability(self, relevant_file, relevant_lines_start, relevant_lines_end,
+                                 existing_code) -> tuple[bool, str]:
+        is_applicable, fallback_reason, _ = self._validate_suggestion(
+            relevant_file, relevant_lines_start, relevant_lines_end, existing_code)
+        return is_applicable, fallback_reason
+
+    def is_applicable_suggestion(self, relevant_file, relevant_lines_start, relevant_lines_end,
+                                 existing_code) -> bool:
+        return self._suggestion_applyability(relevant_file, relevant_lines_start,
+                                             relevant_lines_end, existing_code)[0]
 
     def dedent_code(self, relevant_file, relevant_lines_start, new_code_snippet):
         try:  # dedent code snippet
-            self.diff_files = self.git_provider.diff_files if self.git_provider.diff_files \
-                else self.git_provider.get_diff_files()
+            self.diff_files = getattr(self.git_provider, "diff_files", None)
+            if self.diff_files is None:
+                self.diff_files = self.git_provider.get_diff_files()
             original_initial_line = None
             for file in self.diff_files:
                 if file.filename.strip() == relevant_file:
@@ -701,11 +793,16 @@ class PRCodeSuggestions:
                         else:
                             original_initial_line = file_lines[relevant_lines_start - 1]
                     else:
-                        get_logger().warning("Could not dedent code snippet, because head_file is missing",
-                                             artifact={'filename': file.filename,
-                                                       'relevant_lines_start': relevant_lines_start,
-                                                       'new_code_snippet': new_code_snippet})
-                        return new_code_snippet
+                        patch_lines = self._get_patch_range_lines(
+                            file.patch, relevant_lines_start, relevant_lines_start)
+                        if patch_lines is None:
+                            get_logger().warning(
+                                "Could not dedent code snippet, because file content is unavailable",
+                                artifact={'filename': file.filename,
+                                          'relevant_lines_start': relevant_lines_start,
+                                          'new_code_snippet': new_code_snippet})
+                            return new_code_snippet
+                        original_initial_line = patch_lines[0]
                     break
             if original_initial_line:
                 suggested_initial_line = new_code_snippet.splitlines()[0]

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -8,6 +8,17 @@ from pr_agent.git_providers.gitea_provider import GiteaProvider
 
 
 class TestGiteaProvider:
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_diff_cache_starts_unloaded(self, mock_get_settings, _):
+        mock_get_settings.return_value.get.side_effect = lambda key, default=None: {
+            "GITEA.PERSONAL_ACCESS_TOKEN": "token",
+        }.get(key, default)
+
+        provider = GiteaProvider("https://gitea.example.com/repository")
+
+        assert provider.diff_files is None
+
     @patch('pr_agent.git_providers.gitea_provider.get_settings')
     @patch('pr_agent.git_providers.gitea_provider.giteapy.ApiClient')
     def test_gitea_provider_auth_header(self, mock_api_client_cls, mock_get_settings):

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -53,6 +53,7 @@ class TestParseUnifiedDiff:
         # head has the new line, base has the old
         assert "x = 2" in existing.head_file
         assert "x = 1" in existing.base_file
+        assert existing.head_file_is_complete is False
         # context lines preserved in both
         assert "import os" in existing.head_file
         assert "import os" in existing.base_file

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -442,6 +442,23 @@ async def test_malformed_suggestion_does_not_stop_later_suggestions():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("existing_code", [123, ["old()"], {"code": "old()"}])
+@pytest.mark.parametrize("improved_code", ["new()", ""])
+async def test_non_string_existing_code_does_not_stop_later_suggestions(existing_code, improved_code):
+    git_provider = _provider_with_file("old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(existing_code=existing_code, improved_code=improved_code, score=8),
+        _valid_suggestion(score=8),
+    ]})
+
+    published = git_provider.publish_code_suggestions.call_args.args[0]
+    assert len(published) == 1
+    assert published[0]["original_suggestion"]["existing_code"] == "old()"
+
+
+@pytest.mark.asyncio
 async def test_advice_only_suggestion_is_published_instead_of_being_dropped():
     git_provider = _provider_with_file("def f():\n    return old()\n")
     tool = _make_tool(git_provider)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -573,6 +573,29 @@ def test_is_applicable_suggestion_preserves_blank_line_positions():
     assert tool.is_applicable_suggestion("app.py", 1, 3, "first()\n\nsecond()") is True
 
 
+def test_is_applicable_suggestion_preserves_relative_indentation():
+    git_provider = _provider_with_file("if ready:\n    run()\n")
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 1, 2, "    if ready:\n        run()") is True
+    assert tool.is_applicable_suggestion("app.py", 1, 2, "if ready:\nrun()") is False
+
+
+def test_is_applicable_suggestion_uses_absolute_patch_lines_for_partial_head_content():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="first()\nlater()\n",
+        head_file="first()\nlater()\n",
+        patch=("@@ -10 +10 @@\n-old_first()\n+first()\n"
+               "@@ -100 +100 @@\n-old_later()\n+later()\n"),
+        filename="app.py",
+        head_file_is_complete=False,
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 100, 100, "later()") is True
+
+
 def test_persistent_update_survives_progress_cleanup_failure():
     """A failing progress-note cleanup must not abort the persistent update:
     if the cleanup error propagated, the caller would fall back to publishing

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -129,6 +129,19 @@ def test_dedent_code_matches_target_file_indentation():
     assert tool.dedent_code("app.py", 2, "return new()") == "    return new()"
 
 
+def test_dedent_code_uses_patch_when_file_content_is_unavailable():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="",
+        patch="@@ -1,2 +1,2 @@\n def f():\n-    return older()\n+    return old()\n",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.dedent_code("app.py", 2, "return new()") == "    return new()"
+
+
 @pytest.mark.asyncio
 async def test_push_inline_code_suggestions_falls_back_to_individual_publish_calls():
     git_provider = MagicMock()
@@ -152,6 +165,8 @@ async def test_push_inline_code_suggestions_falls_back_to_individual_publish_cal
         _valid_suggestion(
             relevant_lines_start=2,
             relevant_lines_end=2,
+            existing_code="return old()",
+            improved_code="return new()",
             score=8,
         ),
         _valid_suggestion(
@@ -176,7 +191,7 @@ async def test_push_inline_code_suggestions_falls_back_to_individual_publish_cal
     assert first_retry[0]["relevant_file"] == "app.py"
     assert first_retry[0]["relevant_lines_start"] == 2
     assert first_retry[0]["relevant_lines_end"] == 2
-    assert "```suggestion\n    new()" in first_retry[0]["body"]
+    assert "```suggestion\n    return new()" in first_retry[0]["body"]
     assert second_retry[0]["relevant_file"] == "worker.py"
     assert second_retry[0]["relevant_lines_start"] == 2
     assert second_retry[0]["relevant_lines_end"] == 2
@@ -206,6 +221,104 @@ async def test_publish_no_suggestions_removes_the_progress_comment_when_quiet(pu
 
     git_provider.remove_comment.assert_called_once_with(tool.progress_response)
     git_provider.edit_comment.assert_not_called()
+    git_provider.publish_comment.assert_not_called()
+
+
+def _provider_with_file(head_file, filename="app.py"):
+    git_provider = MagicMock()
+    git_provider.diff_files = [
+        FilePatchInfo(base_file="", head_file=head_file, patch="", filename=filename)
+    ]
+    git_provider.publish_code_suggestions.return_value = True
+    return git_provider
+
+
+def _published_suggestion(git_provider):
+    published = git_provider.publish_code_suggestions.call_args_list[0].args[0]
+    assert len(published) == 1
+    return published[0]
+
+
+@pytest.mark.asyncio
+async def test_suggestion_covering_the_anchored_range_is_published_as_committable():
+    git_provider = _provider_with_file("def f():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old()",
+            improved_code="return new()",
+            score=8,
+        )
+    ]})
+
+    assert "```suggestion\n    return new()\n```" in _published_suggestion(git_provider)["body"]
+
+
+@pytest.mark.asyncio
+async def test_suggestion_rewriting_more_lines_than_it_replaces_is_published_as_a_plain_comment():
+    git_provider = _provider_with_file("def f():\n    return old(\n        arg)\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old(\n    arg)",
+            improved_code="return new(arg)",
+            score=8,
+        )
+    ]})
+
+    body = _published_suggestion(git_provider)["body"]
+    assert "```suggestion" not in body
+    assert "return new(arg)" in body
+
+
+@pytest.mark.asyncio
+async def test_suggestion_anchored_outside_the_file_is_published_as_a_plain_comment():
+    git_provider = _provider_with_file("def f():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(relevant_lines_start=40, relevant_lines_end=41, score=8)
+    ]})
+
+    git_provider.publish_code_suggestions.assert_not_called()
+    body = git_provider.publish_comment.call_args.args[0]
+    assert "```suggestion" not in body
+    assert "`app.py:40-41`" in body
+    assert "because the anchored range is outside the file" in body
+
+
+@pytest.mark.asyncio
+async def test_suggestion_with_reversed_range_is_published_as_a_pr_comment():
+    git_provider = _provider_with_file("def f():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(relevant_lines_start=2, relevant_lines_end=1, score=8)
+    ]})
+
+    git_provider.publish_code_suggestions.assert_not_called()
+    body = git_provider.publish_comment.call_args.args[0]
+    assert "`app.py:2-1`" in body
+    assert "because the anchored range is outside the file" in body
+
+
+@pytest.mark.asyncio
+async def test_provider_diff_failure_is_not_treated_as_a_malformed_suggestion():
+    git_provider = MagicMock()
+    git_provider.diff_files = None
+    git_provider.get_diff_files.side_effect = RuntimeError("provider failed")
+    tool = _make_tool(git_provider)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await tool.push_inline_code_suggestions({"code_suggestions": [_valid_suggestion(score=8)]})
+
+    git_provider.publish_code_suggestions.assert_not_called()
     git_provider.publish_comment.assert_not_called()
 
 
@@ -311,6 +424,136 @@ def test_supports_incremental_kind_defaults_to_false_on_base_provider():
     # The base-class default must be "no support" so tools fall back to a full run
     # on providers that never implemented kind-aware incremental anchoring.
     assert GitProvider.supports_incremental_kind(MagicMock(), "suggestions") is False
+
+
+@pytest.mark.asyncio
+async def test_malformed_suggestion_does_not_stop_later_suggestions():
+    git_provider = _provider_with_file("old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(relevant_file=123, score=8),
+        _valid_suggestion(score=8),
+    ]})
+
+    published = git_provider.publish_code_suggestions.call_args.args[0]
+    assert len(published) == 1
+    assert published[0]["relevant_file"] == "app.py"
+
+
+@pytest.mark.asyncio
+async def test_advice_only_suggestion_is_published_instead_of_being_dropped():
+    git_provider = _provider_with_file("def f():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(relevant_lines_start=2, relevant_lines_end=2, improved_code="", score=8)
+    ]})
+
+    body = _published_suggestion(git_provider)["body"]
+    assert "```suggestion" not in body
+    assert "Use the shared helper." in body
+
+
+@pytest.mark.asyncio
+async def test_advice_only_suggestion_with_unverified_anchor_is_published_as_a_pr_comment():
+    git_provider = MagicMock()
+    git_provider.diff_files = None
+    git_provider.get_diff_files.return_value = []
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(improved_code="", score=8)
+    ]})
+
+    git_provider.get_diff_files.assert_called_once_with()
+    git_provider.publish_code_suggestions.assert_not_called()
+    assert "Use the shared helper." in git_provider.publish_comment.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_dual_publishing_keeps_suggestions_without_replacement_code():
+    settings = get_settings()
+    original_threshold = settings.get("pr_code_suggestions.dual_publishing_score_threshold")
+    settings.set("pr_code_suggestions.dual_publishing_score_threshold", 5)
+    git_provider = _provider_with_file("def f():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    try:
+        await tool.dual_publishing({"code_suggestions": [
+            _valid_suggestion(relevant_lines_start=2, relevant_lines_end=2, improved_code="", score=8)
+        ]})
+
+        assert "Use the shared helper." in _published_suggestion(git_provider)["body"]
+    finally:
+        settings.set("pr_code_suggestions.dual_publishing_score_threshold", original_threshold)
+
+
+def test_is_applicable_suggestion_rejects_a_range_in_an_empty_file():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(base_file="", head_file="", patch="", filename="app.py")]
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 1, 1, "old()") is False
+
+
+def test_is_applicable_suggestion_rejects_when_existing_code_does_not_cover_the_anchor():
+    git_provider = _provider_with_file("def f():\n    first()\n    second()\n")
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 2, 3, "first()") is False
+
+
+def test_is_applicable_suggestion_rejects_when_file_content_is_unavailable():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(base_file="", head_file=None, patch="", filename="app.py")]
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 1, 1, "old()") is False
+    assert tool._suggestion_applyability("app.py", 1, 1, "old()")[1] == "the file content is unavailable"
+
+
+def test_is_applicable_suggestion_uses_patch_when_file_content_is_unavailable():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="",
+        patch="@@ -1,2 +1,2 @@\n def f():\n-    return older()\n+    return old()\n",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 2, 2, "return old()") is True
+
+
+def test_is_applicable_suggestion_rejects_a_range_missing_from_the_patch():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="",
+        patch="@@ -1 +1 @@\n-old()\n+new()\n",
+        filename="app.py",
+    )]
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 2, 2, "other()") is False
+
+
+def test_get_diff_file_does_not_refetch_an_empty_cache():
+    git_provider = MagicMock()
+    git_provider.diff_files = []
+    tool = _make_tool(git_provider)
+
+    assert tool._get_diff_file("app.py") is None
+    git_provider.get_diff_files.assert_not_called()
+
+
+def test_is_applicable_suggestion_preserves_blank_line_positions():
+    git_provider = _provider_with_file("first()\n\nsecond()\n")
+    tool = _make_tool(git_provider)
+
+    assert tool.is_applicable_suggestion("app.py", 1, 3, "first()\nsecond()") is False
+    assert tool.is_applicable_suggestion("app.py", 1, 3, "first()\n\nsecond()") is True
 
 
 def test_persistent_update_survives_progress_cleanup_failure():


### PR DESCRIPTION
## Summary

Only exposes an Apply change action when the proposed replacement matches the exact lines it would replace.

## Scope

All providers.

The validation preserves blank-line positions and rejects reversed or out-of-range anchors, missing file content, unavailable existing code, source mismatches, and malformed non-string source values. Invalid suggestions are skipped without stopping later valid suggestions. When a provider omits full file content, changed lines are verified against the unified diff. Suggestions with valid anchors remain inline, while suggestions whose anchors cannot be verified are published as regular PR comments. Provider failures remain visible, and a loaded empty diff cache is reused without another provider request.

## Validation

- 86 focused suggestion and provider tests pass.
- 2,048 unit tests pass, with 1 skipped and 1 expected failure.
- Configured import ordering and changed-line length checks pass.
- `git diff --check` passes.

Related to #2110.
