### PR TITLE
feat(azure): publish review findings inline

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -78,6 +78,10 @@ extra_instructions = "..."
         <td><b>num_max_findings</b></td>
         <td>Number of maximum returned findings. Default is 3.</td>
       </tr>
+      <tr>
+        <td><b>inline_key_issues</b></td>
+        <td>Azure DevOps only. If set to true, each key issue is published as an inline thread. A finding leaves the review summary when a matching thread exists or Azure accepts the new thread. Findings that cannot be anchored or published stay in the summary. Default is false.</td>
+      </tr>
     </table>
 
 ???+ example "Enable\\disable specific sub-sections"

--- a/pr_agent/algo/inline_comment_dedup.py
+++ b/pr_agent/algo/inline_comment_dedup.py
@@ -37,6 +37,8 @@ from typing import Iterator, Optional
 
 BODY_MARKER_RE = re.compile(r"<!-- pr-agent-dedup: ([a-f0-9]{12}) -->")
 CODE_MARKER_RE = re.compile(r"<!-- pr-agent-dedup-code: ([a-f0-9]{12}) -->")
+KEY_ISSUE_LOCATION_MARKER_RE = re.compile(r"<!-- pr-agent-key-issue-location: ([a-f0-9]{12}) -->")
+_MARKER_RES = (BODY_MARKER_RE, CODE_MARKER_RE, KEY_ISSUE_LOCATION_MARKER_RE)
 
 _LEAD_RE = re.compile(r"^\*\*Suggestion:\*\*\s*", re.IGNORECASE)
 _TAG_RE = re.compile(r"\[[^\]]+?,\s*importance:\s*\d+\]", re.IGNORECASE)
@@ -66,6 +68,16 @@ def body_fingerprint(relevant_file: str, target_line_no, body: str) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
 
 
+def key_issue_fingerprint(relevant_file: str, body: str) -> str:
+    key = f"{relevant_file}|{body}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+
+
+def key_issue_location_fingerprint(fingerprint: str, start_line: int, end_line: int) -> str:
+    key = f"{fingerprint}|{start_line}|{end_line}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+
+
 def code_fingerprint(relevant_file: str, target_line_no, body: str) -> Optional[str]:
     m = _CODE_BLOCK_RE.search(_strip_markers(body))
     if not m:
@@ -86,15 +98,26 @@ def build_markers(body_fp: str, code_fp: Optional[str]) -> str:
     return "\n".join(markers)
 
 
+def _append_markers(body: str, markers: str, max_chars: Optional[int]) -> str:
+    suffix = f"\n\n{markers}"
+    if max_chars and len(body) + len(suffix) > max_chars:
+        body = body[: max(0, max_chars - len(suffix))]
+    return f"{body}{suffix}"
+
+
 def body_with_markers(body: str, body_fp: str, code_fp: "Optional[str]",
                       max_chars: "Optional[int]" = None) -> str:
     """Append the dedup marker(s) to a comment body. If max_chars is given and
     body + markers would exceed it, the body is clipped (never the markers) so
     the fingerprint marker always survives for the next run's scan."""
-    suffix = f"\n\n{build_markers(body_fp, code_fp)}"
-    if max_chars and len(body) + len(suffix) > max_chars:
-        body = body[: max(0, max_chars - len(suffix))]
-    return f"{body}{suffix}"
+    return _append_markers(body, build_markers(body_fp, code_fp), max_chars)
+
+
+def key_issue_body_with_markers(body: str, body_fp: str, location_fp: str,
+                                max_chars: Optional[int] = None) -> str:
+    markers = (f"{build_markers(body_fp, None)}\n"
+               f"<!-- pr-agent-key-issue-location: {location_fp} -->")
+    return _append_markers(body, markers, max_chars)
 
 
 def inline_comment_line(comment: dict):
@@ -127,10 +150,17 @@ def iter_existing_inline_comment_bodies(git_provider) -> Iterator[str]:
         # are seen on later runs.
         for note in git_provider.mr.notes.list(get_all=True):
             yield getattr(note, "body", "") or ""
+    elif provider_name == "AzureDevopsProvider":
+        yield from git_provider.get_inline_comment_bodies()
     else:
         raise NotImplementedError(
             f"inline-comment dedup not implemented for {provider_name}"
         )
+
+
+def can_verify_inline_comment_publication(git_provider) -> bool:
+    return (callable(getattr(git_provider, "get_inline_comment_bodies", None)) and
+            callable(getattr(git_provider, "get_recent_inline_comment_bodies", None)))
 
 
 class InlineCommentStore:
@@ -146,16 +176,16 @@ class InlineCommentStore:
         self._git_provider = git_provider
         self._keys: set = set()
         self._loaded = False
+        self._load_failed = False
 
     def load(self) -> set:
         if self._loaded:
             return self._keys
         try:
             for body in iter_existing_inline_comment_bodies(self._git_provider):
-                for marker_re in (BODY_MARKER_RE, CODE_MARKER_RE):
-                    for match in marker_re.finditer(body or ""):
-                        self._keys.add(match.group(1))
+                self.add_body(body)
         except Exception as e:
+            self._load_failed = True
             from pr_agent.log import get_logger
             get_logger().info(
                 f"Persistent inline comments: could not load existing comments, "
@@ -163,6 +193,10 @@ class InlineCommentStore:
             )
         self._loaded = True
         return self._keys
+
+    @property
+    def load_failed(self) -> bool:
+        return self._load_failed
 
     def seen(self, fingerprint: Optional[str]) -> bool:
         if fingerprint is None:
@@ -172,6 +206,11 @@ class InlineCommentStore:
     def add(self, fingerprint: Optional[str]) -> None:
         if fingerprint is not None:
             self._keys.add(fingerprint)
+
+    def add_body(self, body: str) -> None:
+        for marker_re in _MARKER_RES:
+            for match in marker_re.finditer(body or ""):
+                self._keys.add(match.group(1))
 
 
 def get_inline_comment_store(git_provider) -> InlineCommentStore:

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -81,6 +81,8 @@ class AzureDevopsProvider(GitProvider):
         self.unreviewed_files_map = {}
         self.pr_commits = None
         self.previous_review = None
+        self._published_inline_comment_bodies = []
+        self._inline_comment_store = None
         if pr_url:
             self.set_pr(pr_url)
 
@@ -122,6 +124,13 @@ class AzureDevopsProvider(GitProvider):
                 )
             except Exception as e:
                 get_logger().error(f"Azure failed to publish code suggestion, error: {e}", suggestion=suggestion)
+            else:
+                recent_bodies = getattr(self, "_published_inline_comment_bodies", None)
+                if recent_bodies is None:
+                    recent_bodies = []
+                    self._published_inline_comment_bodies = recent_bodies
+                if body not in recent_bodies:
+                    recent_bodies.append(body)
         return True
 
     def reply_to_comment_from_comment_id(self, comment_id: int, body: str, is_temporary: bool = False) -> Comment:
@@ -184,6 +193,8 @@ class AzureDevopsProvider(GitProvider):
         return True
 
     def set_pr(self, pr_url: str):
+        self._published_inline_comment_bodies = []
+        self._inline_comment_store = None
         self.pr_url = pr_url
         self.workspace_slug, self.repo_slug, self.pr_num = self._parse_pr_url(pr_url)
         self.pr = self._get_pr()
@@ -754,6 +765,31 @@ class AzureDevopsProvider(GitProvider):
 
     def get_user_id(self):
         return 0
+
+    def get_inline_comment_bodies(self) -> list[str]:
+        threads = self.azure_devops_client.get_threads(
+            repository_id=self.repo_slug,
+            pull_request_id=self.pr_num,
+            project=self.workspace_slug,
+        )
+        bodies = list(getattr(self, "_published_inline_comment_bodies", []))
+        for thread in threads or []:
+            context = getattr(thread, "thread_context", None)
+            if isinstance(context, dict):
+                is_line_comment = context.get("filePath") and context.get("rightFileStart")
+            else:
+                is_line_comment = (getattr(context, "file_path", None) and
+                                   getattr(context, "right_file_start", None))
+            if not is_line_comment:
+                continue
+            for comment in getattr(thread, "comments", None) or []:
+                content = comment.get("content") if isinstance(comment, dict) else getattr(comment, "content", None)
+                if content and content not in bodies:
+                    bodies.append(content)
+        return bodies
+
+    def get_recent_inline_comment_bodies(self) -> list[str]:
+        return list(getattr(self, "_published_inline_comment_bodies", []))
 
     def get_issue_comments(self) -> list[Comment]:
         threads = self.azure_devops_client.get_threads(repository_id=self.repo_slug, pull_request_id=self.pr_num, project=self.workspace_slug)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -107,6 +107,7 @@ require_ticket_analysis_review=true
 # general options
 publish_output_no_suggestions=true # Set to "false" if you only need the reviewer's remarks (not labels, not "security audit", etc.) and want to avoid noisy "No major issues detected" comments.
 persistent_comment=true
+inline_key_issues=false
 extra_instructions = ""
 num_max_findings = 3
 final_update_message = true

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -1,33 +1,44 @@
 import copy
 import datetime
+import re
 from functools import partial
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from jinja2 import Environment, StrictUndefined
 
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
-from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
-                                         get_pr_diff,
-                                         retry_with_fallback_models)
+from pr_agent.algo.inline_comment_dedup import (
+    InlineCommentStore,
+    can_verify_inline_comment_publication,
+    get_inline_comment_store,
+    key_issue_body_with_markers,
+    key_issue_fingerprint,
+    key_issue_location_fingerprint,
+)
+from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.run_details import init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
-from pr_agent.algo.utils import (ModelType, PRReviewHeader,
-                                 convert_to_markdown_v2, github_action_output,
-                                 load_yaml, show_relevant_configurations,
-                                 show_run_details)
+from pr_agent.algo.utils import (
+    ModelType,
+    PRReviewHeader,
+    convert_to_markdown_v2,
+    github_action_output,
+    load_yaml,
+    show_relevant_configurations,
+    show_run_details,
+)
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import (get_git_provider_with_context)
-from pr_agent.git_providers.git_provider import (IncrementalPR,
-                                                 get_main_pr_language)
+from pr_agent.git_providers import get_git_provider_with_context
+from pr_agent.git_providers.git_provider import IncrementalPR, get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
-from pr_agent.tools.ticket_pr_compliance_check import (
-    extract_and_cache_pr_tickets)
+from pr_agent.tools.ticket_pr_compliance_check import extract_and_cache_pr_tickets
 
 MAX_REVIEW_COVERAGE_FILES = 50
+_SUGGESTION_FENCE_RE = re.compile(r"```[ \t]*suggestion\b", re.IGNORECASE)
 
 
 class PRReviewer:
@@ -274,6 +285,9 @@ class PRReviewer:
             key_issues_to_review = data['review'].pop('key_issues_to_review')
             data['review']['key_issues_to_review'] = key_issues_to_review
 
+        if get_settings().config.publish_output and get_settings().pr_reviewer.get('inline_key_issues', False):
+            data = self._publish_key_issues_as_inline_comments(data)
+
         incremental_review_markdown_text = None
         # Add incremental review section
         if self.incremental.is_incremental:
@@ -319,6 +333,149 @@ class PRReviewer:
             markdown_text = ""
 
         return markdown_text
+
+    def _build_key_issue_comment(self, issue, diff_files: dict) -> Optional[dict]:
+        if not isinstance(issue, dict):
+            return None
+        relevant_file = (issue.get("relevant_file") or "").strip()
+        issue_content = _SUGGESTION_FENCE_RE.sub("```text", (issue.get("issue_content") or "").strip())
+        issue_header = (issue.get("issue_header") or "").strip()
+        if issue_header.lower() == "possible bug":
+            issue_header = "Possible Issue"
+        try:
+            start_line = int(str(issue.get("start_line", 0)).strip())
+            end_line = int(str(issue.get("end_line", 0)).strip())
+        except ValueError:
+            start_line, end_line = 0, 0
+
+        if not relevant_file or not issue_content or start_line < 1 or end_line < start_line:
+            get_logger().warning("Review finding has no usable location, keeping it in the summary",
+                                 artifact={"relevant_file": relevant_file, "start_line": start_line,
+                                           "end_line": end_line})
+            return None
+
+        file = diff_files.get(relevant_file) or diff_files.get(relevant_file.lstrip("/"))
+        if file is None:
+            get_logger().warning("Review finding points at a file that is not in the diff, "
+                                 "keeping it in the summary", artifact={"relevant_file": relevant_file})
+            return None
+        if not file.head_file or end_line > len(file.head_file.splitlines()):
+            get_logger().warning("Review finding points past the end of the file, keeping it in the summary",
+                                 artifact={"relevant_file": relevant_file, "start_line": start_line,
+                                           "end_line": end_line})
+            return None
+
+        relevant_file = file.filename.strip()
+        body = f"**{issue_header}**\n\n{issue_content}" if issue_header else issue_content
+        return {"body": body,
+                "relevant_file": relevant_file,
+                "relevant_lines_start": start_line,
+                "relevant_lines_end": end_line}
+
+    def _can_verify_inline_key_issue_publication(self) -> bool:
+        return can_verify_inline_comment_publication(self.git_provider)
+
+    def _published_inline_key_issue_fingerprints(self, store: InlineCommentStore,
+                                                 fingerprints: set[str]) -> set[str]:
+        try:
+            for body in self.git_provider.get_recent_inline_comment_bodies():
+                store.add_body(body)
+        except Exception as e:
+            get_logger().warning(
+                f"Inline key-issue publishing cannot verify new Azure DevOps threads, error: {e}; "
+                "keeping findings in the review summary")
+            return set()
+        return {fingerprint for fingerprint in fingerprints if store.seen(fingerprint)}
+
+    def _publish_key_issues_as_inline_comments(self, data: dict) -> dict:
+        issues = (data.get("review") or {}).get("key_issues_to_review")
+        if not isinstance(issues, list) or not issues:
+            return data
+        if not self._can_verify_inline_key_issue_publication():
+            get_logger().info("Inline key-issue publishing is not verifiable for this provider; "
+                              "keeping findings in the review summary")
+            return data
+
+        diff_files = {}
+        for file in self.git_provider.get_diff_files() or []:
+            if not file.filename:
+                continue
+            path = file.filename.strip()
+            diff_files[path] = file
+            diff_files.setdefault(path.lstrip("/"), file)
+        store = get_inline_comment_store(self.git_provider)
+        store.load()
+        if store.load_failed:
+            get_logger().warning("Inline key-issue publishing cannot verify existing Azure DevOps threads; "
+                                 "keeping findings in the review summary")
+            return data
+        remaining_issues = []
+        candidate_comments = {}
+        candidate_issues = {}
+        candidate_fingerprints = {}
+        published = 0
+        for issue in issues:
+            try:
+                comment = self._build_key_issue_comment(issue, diff_files)
+                if comment is None:
+                    remaining_issues.append(issue)
+                    continue
+                fingerprint = key_issue_fingerprint(comment["relevant_file"], comment["body"])
+                if store.seen(fingerprint):
+                    published += 1
+                    continue
+                location_fingerprint = key_issue_location_fingerprint(
+                    fingerprint, comment["relevant_lines_start"], comment["relevant_lines_end"])
+                if location_fingerprint in candidate_comments:
+                    candidate_issues[location_fingerprint].append(issue)
+                    continue
+                comment["body"] = key_issue_body_with_markers(
+                    comment["body"], fingerprint, location_fingerprint,
+                    getattr(self.git_provider, "max_comment_chars", None))
+                candidate_comments[location_fingerprint] = comment
+                candidate_issues[location_fingerprint] = [issue]
+                candidate_fingerprints[location_fingerprint] = fingerprint
+            except Exception as e:
+                get_logger().warning(f"Failed to prepare a review finding for inline publication, error: {e}",
+                                     artifact={"issue": issue})
+                remaining_issues.append(issue)
+
+        if candidate_comments:
+            try:
+                self.git_provider.publish_code_suggestions(list(candidate_comments.values()))
+            except Exception as e:
+                locations = [{"relevant_file": comment["relevant_file"],
+                              "start_line": comment["relevant_lines_start"],
+                              "end_line": comment["relevant_lines_end"]}
+                             for comment in candidate_comments.values()]
+                get_logger().warning(
+                    f"Failed to publish review findings as Azure DevOps threads, error: {e}",
+                    artifact={"locations": locations})
+            verified_locations = self._published_inline_key_issue_fingerprints(store, set(candidate_comments))
+            for location_fingerprint, comment in candidate_comments.items():
+                issues_for_location = candidate_issues[location_fingerprint]
+                if location_fingerprint in verified_locations:
+                    store.add(candidate_fingerprints[location_fingerprint])
+                    store.add(location_fingerprint)
+                    published += len(issues_for_location)
+                    continue
+                get_logger().warning("Failed to publish a review finding as an Azure DevOps inline comment, "
+                                     "keeping it in the summary",
+                                     artifact={"relevant_file": comment["relevant_file"],
+                                               "start_line": comment["relevant_lines_start"],
+                                               "end_line": comment["relevant_lines_end"]})
+                remaining_issues.extend(issues_for_location)
+
+        if not published:
+            return data
+        get_logger().info(f"Published {published} review finding(s) as inline comments")
+
+        data = copy.deepcopy(data)
+        if remaining_issues:
+            data["review"]["key_issues_to_review"] = remaining_issues
+        else:
+            data["review"].pop("key_issues_to_review", None)
+        return data
 
     def _get_user_answers(self) -> Tuple[str, str]:
         """

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
@@ -49,3 +50,77 @@ class TestAzureDevopsProviderRepoContext:
         provider.azure_devops_client.get_item.side_effect = Exception("not found")
 
         assert provider.get_repo_file_content("MISSING.md") == ""
+
+
+class TestAzureDevopsProviderInlineComments:
+    @staticmethod
+    def _provider(threads):
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr_num = 42
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_threads.return_value = threads
+        return provider
+
+    def test_get_inline_comment_bodies_only_returns_line_threads(self):
+        line_thread = SimpleNamespace(
+            thread_context=SimpleNamespace(file_path="/app.py", right_file_start=SimpleNamespace(line=3)),
+            comments=[SimpleNamespace(content="line finding")],
+        )
+        file_thread = SimpleNamespace(
+            thread_context=SimpleNamespace(file_path="/app.py", right_file_start=None),
+            comments=[SimpleNamespace(content="file finding")],
+        )
+        pr_thread = SimpleNamespace(
+            thread_context=None,
+            comments=[SimpleNamespace(content="PR finding")],
+        )
+        provider = self._provider([line_thread, file_thread, pr_thread])
+
+        assert provider.get_inline_comment_bodies() == ["line finding"]
+        provider.azure_devops_client.get_threads.assert_called_once_with(
+            repository_id="my-repo",
+            pull_request_id=42,
+            project="my-project",
+        )
+
+    def test_get_inline_comment_bodies_supports_serialized_context(self):
+        thread = SimpleNamespace(
+            thread_context={"filePath": "/app.py", "rightFileStart": {"line": 3, "offset": 1}},
+            comments=[SimpleNamespace(content="line finding"), SimpleNamespace(content="")],
+        )
+
+        assert self._provider([thread]).get_inline_comment_bodies() == ["line finding"]
+
+    def test_get_inline_comment_bodies_includes_recent_successful_posts(self):
+        provider = self._provider([])
+        provider.publish_code_suggestions([{
+            "body": "line finding",
+            "relevant_file": "/app.py",
+            "relevant_lines_start": 3,
+            "relevant_lines_end": 3,
+        }])
+
+        assert provider.get_inline_comment_bodies() == ["line finding"]
+
+    def test_set_pr_clears_inline_comment_state(self):
+        provider = self._provider([])
+        provider._published_inline_comment_bodies = ["old finding"]
+        provider._inline_comment_store = MagicMock()
+        provider._parse_pr_url = MagicMock(return_value=("new-project", "new-repo", 43))
+        provider._get_pr = MagicMock(return_value=MagicMock())
+
+        provider.set_pr("https://dev.azure.com/example/new-project/_git/new-repo/pullrequest/43")
+
+        assert provider._published_inline_comment_bodies == []
+        assert provider._inline_comment_store is None
+
+    def test_recent_inline_comment_bodies_returns_a_copy(self):
+        provider = self._provider([])
+        provider._published_inline_comment_bodies = ["line finding"]
+
+        bodies = provider.get_recent_inline_comment_bodies()
+        bodies.append("other finding")
+
+        assert provider.get_recent_inline_comment_bodies() == ["line finding"]

--- a/tests/unittest/test_inline_comment_dedup.py
+++ b/tests/unittest/test_inline_comment_dedup.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from pr_agent.algo import inline_comment_dedup as d
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
@@ -28,6 +29,33 @@ def test_body_fingerprint_strips_lead_and_tag():
 def test_body_fingerprint_varies_by_file_and_line():
     assert d.body_fingerprint("f.py", 10, "x") != d.body_fingerprint("g.py", 10, "x")
     assert d.body_fingerprint("f.py", 10, "x") != d.body_fingerprint("f.py", 11, "x")
+
+
+def test_key_issue_fingerprint_uses_path_and_full_body():
+    prefix = "x" * 100
+
+    assert d.key_issue_fingerprint("f.py", f"{prefix}a") != d.key_issue_fingerprint("f.py", f"{prefix}b")
+    assert d.key_issue_fingerprint("f.py", prefix) != d.key_issue_fingerprint("g.py", prefix)
+
+
+def test_key_issue_location_fingerprint_uses_the_full_range():
+    fingerprint = d.key_issue_fingerprint("f.py", "finding")
+
+    assert d.key_issue_location_fingerprint(fingerprint, 1, 2) != d.key_issue_location_fingerprint(
+        fingerprint, 1, 3)
+
+
+def test_key_issue_markers_survive_clipping_and_load_into_the_store():
+    body_fingerprint = d.key_issue_fingerprint("f.py", "x" * 300)
+    location_fingerprint = d.key_issue_location_fingerprint(body_fingerprint, 1, 2)
+    body = d.key_issue_body_with_markers("x" * 300, body_fingerprint, location_fingerprint, 200)
+    store = d.InlineCommentStore(_gh_provider([]))
+
+    store.add_body(body)
+
+    assert len(body) == 200
+    assert store.seen(body_fingerprint)
+    assert store.seen(location_fingerprint)
 
 
 def test_code_fingerprint_none_without_block():
@@ -89,7 +117,8 @@ def test_store_load_failure_degrades_to_empty():
     prov = _gh_provider([])
     prov.pr.get_comments.side_effect = RuntimeError("api down")
     store = d.InlineCommentStore(prov)
-    assert store.load() == set()  # must not raise
+    assert store.load() == set()
+    assert store.load_failed is True
 
 
 def test_iter_unsupported_provider_raises():
@@ -97,9 +126,30 @@ def test_iter_unsupported_provider_raises():
         pass
     try:
         list(d.iter_existing_inline_comment_bodies(FooProvider()))
-        assert False, "expected NotImplementedError"
+        raise AssertionError("expected NotImplementedError")
     except NotImplementedError:
         pass
+
+
+def _azure_provider(existing_threads=None):
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_threads.return_value = existing_threads or []
+    provider.repo_slug = "repo"
+    provider.workspace_slug = "project"
+    provider.pr_num = 1
+    return provider
+
+
+def test_inline_publication_verification_is_limited_to_azure_devops():
+    assert d.can_verify_inline_comment_publication(_azure_provider()) is True
+    assert d.can_verify_inline_comment_publication(_gh_provider([])) is False
+    assert d.can_verify_inline_comment_publication(_gl_provider([])) is False
+
+    class FooProvider:
+        pass
+
+    assert d.can_verify_inline_comment_publication(FooProvider()) is False
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -3,7 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pr_agent.algo.inline_comment_dedup import (
+    body_with_markers,
+    get_inline_comment_store,
+    key_issue_fingerprint,
+)
+from pr_agent.algo.types import FilePatchInfo
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
@@ -170,6 +177,331 @@ def test_prepare_pr_review_reports_number_of_files_beyond_coverage_limit():
 
     assert "... and 3 more" in review
     assert "- `file_50.py`" not in review
+
+
+def _key_issue(**overrides):
+    issue = {
+        "relevant_file": "app.py",
+        "issue_header": "Possible Issue",
+        "issue_content": "The new branch never releases the lock.",
+        "start_line": 2,
+        "end_line": 3,
+    }
+    issue.update(overrides)
+    return issue
+
+
+def _reviewer_with_findings(*issues, head_file="one\ntwo\nthree\nfour\n"):
+    git_provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    git_provider.azure_devops_client = MagicMock()
+    git_provider.azure_devops_client.get_threads.return_value = []
+    git_provider.repo_slug = "repo"
+    git_provider.workspace_slug = "project"
+    git_provider.pr_num = 1
+    git_provider.get_diff_files = MagicMock()
+    git_provider.get_diff_files.return_value = [
+        FilePatchInfo(base_file="", head_file=head_file, patch="", filename="app.py")
+    ]
+    git_provider.publish_code_suggestions = MagicMock(return_value=True)
+    git_provider.max_comment_chars = None
+    git_provider._inline_comment_store = None
+    reviewer = _make_reviewer(git_provider)
+    reviewer._published_inline_key_issue_fingerprints = MagicMock(
+        side_effect=lambda _store, fingerprints: fingerprints
+    )
+    return reviewer, {"review": {"key_issues_to_review": list(issues)}}
+
+
+def _published_comment(git_provider):
+    published = git_provider.publish_code_suggestions.call_args_list[0].args[0]
+    assert len(published) == 1
+    return published[0]
+
+
+def test_key_issues_are_published_on_their_lines_and_leave_the_summary():
+    reviewer, data = _reviewer_with_findings(_key_issue())
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    comment = _published_comment(reviewer.git_provider)
+    assert comment["relevant_file"] == "app.py"
+    assert comment["relevant_lines_start"] == 2
+    assert comment["relevant_lines_end"] == 3
+    assert "The new branch never releases the lock." in comment["body"]
+    assert "```suggestion" not in comment["body"]
+    assert "key_issues_to_review" not in result["review"]
+    assert len(data["review"]["key_issues_to_review"]) == 1
+
+
+def test_prepare_pr_review_does_not_publish_key_issues_inline_by_default():
+    reviewer = _make_prediction_reviewer()
+
+    review = _render_review(reviewer, [])
+
+    assert review == "original review"
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+
+
+def test_prepare_pr_review_publishes_key_issues_inline_when_enabled():
+    reviewer = _make_prediction_reviewer()
+    settings = get_settings()
+    original_inline_key_issues = settings.pr_reviewer.get("inline_key_issues", False)
+    reviewer._publish_key_issues_as_inline_comments = MagicMock(return_value={"review": {}})
+
+    try:
+        settings.pr_reviewer.inline_key_issues = True
+        _render_review(reviewer, [])
+    finally:
+        settings.pr_reviewer.inline_key_issues = original_inline_key_issues
+
+    reviewer._publish_key_issues_as_inline_comments.assert_called_once()
+
+
+@pytest.mark.parametrize("issue", [
+    _key_issue(relevant_file="not_in_the_diff.py"),
+    _key_issue(start_line=0, end_line=0),
+    _key_issue(start_line=3, end_line=2),
+    _key_issue(start_line=40, end_line=41),
+    _key_issue(issue_content=""),
+])
+def test_unanchorable_key_issue_stays_in_the_summary(issue):
+    reviewer, data = _reviewer_with_findings(issue)
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert result["review"]["key_issues_to_review"] == [issue]
+
+
+def test_key_issue_that_fails_to_publish_stays_in_the_summary():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    reviewer.git_provider.publish_code_suggestions.return_value = False
+    reviewer._published_inline_key_issue_fingerprints.side_effect = None
+    reviewer._published_inline_key_issue_fingerprints.return_value = set()
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert result["review"]["key_issues_to_review"] == [issue]
+
+
+def test_key_issue_that_cannot_be_verified_stays_in_the_summary():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    reviewer._published_inline_key_issue_fingerprints.side_effect = None
+    reviewer._published_inline_key_issue_fingerprints.return_value = set()
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert result["review"]["key_issues_to_review"] == [issue]
+
+
+def test_key_issue_without_file_content_stays_in_the_summary():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue, head_file="")
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert result["review"]["key_issues_to_review"] == [issue]
+
+
+def test_key_issue_is_not_published_when_the_provider_cannot_verify_it():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    reviewer._can_verify_inline_key_issue_publication = MagicMock(return_value=False)
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert result is data
+
+
+def test_same_key_issue_on_different_lines_is_published_at_each_location():
+    first = _key_issue(start_line=1, end_line=1)
+    second = _key_issue(start_line=3, end_line=3)
+    reviewer, data = _reviewer_with_findings(first, second)
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert reviewer.git_provider.publish_code_suggestions.call_count == 1
+    assert len(reviewer.git_provider.publish_code_suggestions.call_args.args[0]) == 2
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_duplicate_key_issue_is_published_once():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue, issue.copy())
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert len(reviewer.git_provider.publish_code_suggestions.call_args.args[0]) == 1
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_key_issues_that_diverge_after_eighty_characters_are_both_published():
+    prefix = "x" * 100
+    first = _key_issue(issue_content=f"{prefix}a")
+    second = _key_issue(issue_content=f"{prefix}b")
+    reviewer, data = _reviewer_with_findings(first, second)
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert len(reviewer.git_provider.publish_code_suggestions.call_args.args[0]) == 2
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_unverified_duplicate_key_issue_stays_in_the_summary():
+    issue = _key_issue()
+    duplicate = issue.copy()
+    reviewer, data = _reviewer_with_findings(issue, duplicate)
+    reviewer._published_inline_key_issue_fingerprints.side_effect = None
+    reviewer._published_inline_key_issue_fingerprints.return_value = set()
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert result is data
+    assert result["review"]["key_issues_to_review"] == [issue, duplicate]
+
+
+def test_batch_publish_failure_keeps_unverified_findings_in_the_summary():
+    failing = _key_issue(issue_content="This one raises.")
+    working = _key_issue(issue_content="This one publishes.", start_line=1, end_line=1)
+    reviewer, data = _reviewer_with_findings(failing, working)
+    reviewer.git_provider.publish_code_suggestions.side_effect = RuntimeError("API rejected the comments")
+    reviewer._published_inline_key_issue_fingerprints.side_effect = None
+    reviewer._published_inline_key_issue_fingerprints.return_value = set()
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert reviewer.git_provider.publish_code_suggestions.call_count == 1
+    assert result["review"]["key_issues_to_review"] == [failing, working]
+
+
+def test_existing_comment_load_failure_skips_inline_publishing():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    reviewer.git_provider.azure_devops_client.get_threads.side_effect = RuntimeError("request failed")
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert result is data
+
+
+def test_publish_without_a_success_record_keeps_findings_in_the_summary():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    reviewer.git_provider.azure_devops_client.get_threads.return_value = []
+    reviewer._published_inline_key_issue_fingerprints = (
+        PRReviewer._published_inline_key_issue_fingerprints.__get__(reviewer)
+    )
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert result["review"]["key_issues_to_review"] == [issue]
+
+
+def test_existing_azure_thread_removes_finding_from_summary():
+    reviewer, data = _reviewer_with_findings(_key_issue())
+    body = "**Possible Issue**\n\nThe new branch never releases the lock."
+    fingerprint = key_issue_fingerprint("app.py", body)
+    reviewer.git_provider.azure_devops_client.get_threads.return_value = [
+        SimpleNamespace(
+            thread_context=SimpleNamespace(
+                file_path="app.py",
+                right_file_start=SimpleNamespace(line=2),
+            ),
+            comments=[SimpleNamespace(content=body_with_markers(body, fingerprint, None))],
+        )
+    ]
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_recent_azure_post_is_verified_before_thread_listing_catches_up():
+    reviewer, data = _reviewer_with_findings(_key_issue())
+    reviewer.git_provider.publish_code_suggestions = (
+        AzureDevopsProvider.publish_code_suggestions.__get__(reviewer.git_provider)
+    )
+    reviewer._published_inline_key_issue_fingerprints = (
+        PRReviewer._published_inline_key_issue_fingerprints.__get__(reviewer)
+    )
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert reviewer.git_provider.azure_devops_client.create_thread.call_count == 1
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_recent_azure_post_does_not_reload_threads_for_verification():
+    reviewer, data = _reviewer_with_findings(_key_issue())
+    reviewer.git_provider.publish_code_suggestions = (
+        AzureDevopsProvider.publish_code_suggestions.__get__(reviewer.git_provider)
+    )
+    reviewer._published_inline_key_issue_fingerprints = (
+        PRReviewer._published_inline_key_issue_fingerprints.__get__(reviewer)
+    )
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert reviewer.git_provider.azure_devops_client.get_threads.call_count == 1
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_same_finding_at_failed_location_stays_in_the_summary():
+    published = _key_issue(start_line=1, end_line=1)
+    failed = _key_issue(start_line=3, end_line=3)
+    reviewer, data = _reviewer_with_findings(published, failed)
+    reviewer.git_provider.publish_code_suggestions = (
+        AzureDevopsProvider.publish_code_suggestions.__get__(reviewer.git_provider)
+    )
+    reviewer.git_provider.azure_devops_client.create_thread.side_effect = [MagicMock(), RuntimeError("failed")]
+    reviewer._published_inline_key_issue_fingerprints = (
+        PRReviewer._published_inline_key_issue_fingerprints.__get__(reviewer)
+    )
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert reviewer.git_provider.azure_devops_client.create_thread.call_count == 2
+    assert result["review"]["key_issues_to_review"] == [failed]
+
+
+def test_key_issue_already_anchored_on_the_pr_is_not_published_again():
+    issue = _key_issue()
+    reviewer, data = _reviewer_with_findings(issue)
+    store = get_inline_comment_store(reviewer.git_provider)
+    store.add(key_issue_fingerprint(
+        "app.py", "**Possible Issue**\n\nThe new branch never releases the lock."
+    ))
+
+    result = reviewer._publish_key_issues_as_inline_comments(data)
+
+    reviewer.git_provider.publish_code_suggestions.assert_not_called()
+    assert "key_issues_to_review" not in result["review"]
+
+
+def test_key_issue_path_without_leading_slash_uses_azure_diff_path():
+    reviewer, data = _reviewer_with_findings(_key_issue())
+    reviewer.git_provider.get_diff_files.return_value[0].filename = "/app.py"
+
+    reviewer._publish_key_issues_as_inline_comments(data)
+
+    assert _published_comment(reviewer.git_provider)["relevant_file"] == "/app.py"
+
+
+def test_key_issue_suggestion_fence_is_published_as_plain_code():
+    issue = _key_issue(issue_content="Use this code:\n```suggestion\nlock.release()\n```")
+    reviewer, data = _reviewer_with_findings(issue)
+
+    reviewer._publish_key_issues_as_inline_comments(data)
+
+    body = _published_comment(reviewer.git_provider)["body"]
+    assert "```suggestion" not in body
+    assert "```text" in body
 
 
 def test_should_publish_review_no_suggestions_respects_config():


### PR DESCRIPTION
## Summary

Adds opt-in Azure DevOps support for publishing `/review` findings as inline threads beside the affected code.

## Scope

Azure DevOps only. The `[pr_reviewer] inline_key_issues` setting is off by default.

When enabled, the reviewer:

- validates each file and right-side line range before publishing;
- converts any `suggestion` fence to plain code;
- confirms current-run posts from successful Azure thread creation without a second thread listing;
- clears cached publication state when the provider changes pull requests;
- keeps failed or unanchorable findings in the summary;
- continues after per-finding failures;
- publishes identical findings at each distinct current-run range while collapsing exact duplicates;
- deduplicates by canonical path and full body across runs by reading Azure's complete PR thread list once per review run;
- preserves the caller data.

GitHub and GitLab behavior is unchanged.

## Validation

- 100 focused unit tests pass for reviewer, Azure provider, deduplication, and Markdown behavior.
- 1,783 unit tests pass, with 1 skipped and 1 expected failure.
- Ruff passes on the added helper and test coverage.
- `git diff --check` passes.

Closes #2650.
