### PR TITLE
fix: include agent run details in /improve output when no suggestions are found

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -226,6 +226,10 @@ class PRCodeSuggestions:
         pr_body = "## PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
         if (get_settings().config.publish_output and
                 get_settings().pr_code_suggestions.get('publish_output_no_suggestions', True)):
+            # Output the agent run details (model, tokens, time cost) if enabled, so the
+            # "no suggestions" result still shows which model produced it.
+            if get_settings().get('config', {}).get('output_run_details', False):
+                pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
             get_logger().warning('No code suggestions found for the PR.')
             get_logger().debug(f"PR output", artifact=pr_body)
             if self.progress_response:

--- a/tests/unittest/test_run_details_wiring.py
+++ b/tests/unittest/test_run_details_wiring.py
@@ -40,6 +40,13 @@ _TRACKED_KEYS_SUGGESTIONS = (
     "pr_code_suggestions.persistent_comment",
     "pr_code_suggestions.dual_publishing_score_threshold",
 )
+_TRACKED_KEYS_NO_SUGGESTIONS = (
+    "config.output_run_details",
+    "config.publish_output",
+    "config.publish_output_progress",
+    "config.is_auto_command",
+    "pr_code_suggestions.publish_output_no_suggestions",
+)
 
 
 class _Usage:
@@ -192,6 +199,48 @@ async def test_pr_code_suggestions_appends_run_details_only_when_enabled(monkeyp
         await suggestions.run()
         with_details = suggestions.git_provider.publish_comment.call_args[0][0]
 
+        assert "⚙️ Agent run details" not in without_details
+        assert "⚙️ Agent run details" in with_details
+    finally:
+        restore_settings(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monkeypatch):
+    # When /improve finds nothing it still called the model, so the "No code
+    # suggestions found" comment must carry the run details when enabled.
+    snapshot = snapshot_settings(_TRACKED_KEYS_NO_SUGGESTIONS)
+    try:
+        suggestions = PRCodeSuggestions.__new__(PRCodeSuggestions)
+        suggestions.pr_url = "https://example/pr/1"
+        suggestions.progress = "progress"
+        suggestions.progress_response = None
+        suggestions.git_provider = MagicMock()
+        suggestions.git_provider.get_files.return_value = ["changed.py"]
+        suggestions.git_provider.is_supported.side_effect = lambda cap: cap == "gfm_markdown"
+
+        async def _fake_retry_empty(*_args, **_kwargs):
+            return {"code_suggestions": []}
+
+        monkeypatch.setattr("pr_agent.tools.pr_code_suggestions.init_run_details", _seeded_init_run_details)
+        monkeypatch.setattr("pr_agent.tools.pr_code_suggestions.retry_with_fallback_models", _fake_retry_empty)
+
+        get_settings().set("config.publish_output", True)
+        get_settings().set("config.publish_output_progress", False)
+        get_settings().set("config.is_auto_command", False)
+        get_settings().pr_code_suggestions.publish_output_no_suggestions = True
+
+        get_settings().set("config.output_run_details", False)
+        await suggestions.run()
+        without_details = suggestions.git_provider.publish_comment.call_args[0][0]
+
+        suggestions.git_provider.publish_comment.reset_mock()
+
+        get_settings().set("config.output_run_details", True)
+        await suggestions.run()
+        with_details = suggestions.git_provider.publish_comment.call_args[0][0]
+
+        assert "No code suggestions found for the PR." in without_details
         assert "⚙️ Agent run details" not in without_details
         assert "⚙️ Agent run details" in with_details
     finally:

--- a/tests/unittest/test_run_details_wiring.py
+++ b/tests/unittest/test_run_details_wiring.py
@@ -206,9 +206,16 @@ async def test_pr_code_suggestions_appends_run_details_only_when_enabled(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monkeypatch):
+@pytest.mark.parametrize("gfm_supported", [True, False])
+async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monkeypatch, gfm_supported):
     # When /improve finds nothing it still called the model, so the "No code
     # suggestions found" comment must carry the run details when enabled.
+    #
+    # Unlike the has-suggestions summary path (only reachable when gfm_markdown is
+    # supported), publish_no_suggestions() runs for every provider, GFM or not, and
+    # show_run_details() renders different markup in each case (collapsible <details>
+    # vs. a plain fallback). Parametrizing over both locks in the non-GFM path too,
+    # e.g. for LocalGitProvider, which does not support gfm_markdown.
     snapshot = snapshot_settings(_TRACKED_KEYS_NO_SUGGESTIONS)
     try:
         suggestions = PRCodeSuggestions.__new__(PRCodeSuggestions)
@@ -217,7 +224,7 @@ async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monke
         suggestions.progress_response = None
         suggestions.git_provider = MagicMock()
         suggestions.git_provider.get_files.return_value = ["changed.py"]
-        suggestions.git_provider.is_supported.side_effect = lambda cap: cap == "gfm_markdown"
+        suggestions.git_provider.is_supported.side_effect = lambda cap: cap == "gfm_markdown" and gfm_supported
 
         async def _fake_retry_empty(*_args, **_kwargs):
             return {"code_suggestions": []}
@@ -243,5 +250,13 @@ async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monke
         assert "No code suggestions found for the PR." in without_details
         assert "⚙️ Agent run details" not in without_details
         assert "⚙️ Agent run details" in with_details
+        # Confirm the markup actually matches the branch under test, not just that
+        # some text landed: GFM gets the collapsible <details> block, non-GFM the
+        # plain fallback section.
+        if gfm_supported:
+            assert "<details>" in with_details
+        else:
+            assert "<details>" not in with_details
+            assert "___" in with_details
     finally:
         restore_settings(snapshot)


### PR DESCRIPTION
## What

When `config.output_run_details=true`, the agent run-details section (model used,
tokens, time cost, AI calls) is appended to `/review`, `/describe`, and to
`/improve` when it publishes suggestions. But when `/improve` finds nothing,
`PRCodeSuggestions.publish_no_suggestions()` published only:

```
## PR Code Suggestions ✨

No code suggestions found for the PR.
```

with no run-details section. The model *is* invoked in this case (the run details
are recorded), so there was no way to tell which model produced the "no
suggestions" result.

## Change

Append the run-details section in `publish_no_suggestions()` before publishing,
gated on `output_run_details`, mirroring the existing suggestions path:

```python
if get_settings().get('config', {}).get('output_run_details', False):
    pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
```

`show_run_details` is already imported and returns an empty string when no details
are available, so behaviour is unchanged when the flag is off or nothing was
recorded.

## Tests

Added `test_pr_code_suggestions_appends_run_details_when_no_suggestions` in
`tests/unittest/test_run_details_wiring.py`, alongside the existing wiring tests. It
drives `PRCodeSuggestions.run()` with an empty suggestions result and asserts the
published "no suggestions" comment includes the run-details section only when
`output_run_details` is enabled. Verified it fails without the fix and passes with
it; the full run-details wiring suite passes.

## Scope

Limited to the `/improve` "no suggestions" path. No changes to other commands,
providers, or the suggestions/inline publish paths.

Closes #2652