### PR TITLE
fix: render tickets requiring only human verification

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -383,7 +383,7 @@ def ticket_markdown_logic(emoji, markdown_text, value, gfm_supported) -> str:
                 requires_further_human_verification = ticket_analysis.get('requires_further_human_verification',
                                                                           '').strip()
 
-                if not fully_compliant_str and not not_compliant_str:
+                if not fully_compliant_str and not not_compliant_str and not requires_further_human_verification:
                     get_logger().debug(f"Ticket compliance has no requirements",
                                        artifact={'ticket_url': ticket_url})
                     continue
@@ -399,6 +399,8 @@ def ticket_markdown_logic(emoji, markdown_text, value, gfm_supported) -> str:
                             ticket_compliance_level = 'PR Code Verified'
                 elif not_compliant_str:
                     ticket_compliance_level = 'Not compliant'
+                elif requires_further_human_verification:
+                    ticket_compliance_level = 'PR Code Verified'
 
                 # Store the compliance level for aggregation
                 if ticket_compliance_level:

--- a/tests/unittest/test_markdown_ticket_output_core.py
+++ b/tests/unittest/test_markdown_ticket_output_core.py
@@ -30,6 +30,7 @@ from pr_agent.algo.utils import (
     process_can_be_split,
     ticket_markdown_logic,
 )
+from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_description import insert_br_after_x_chars
 from pr_agent.tools.ticket_pr_compliance_check import (
     extract_ticket_links_from_pr_description,
@@ -381,9 +382,31 @@ class TestTicketMarkdownLogic:
         # All tickets verified ⇒ green check.
         assert "Ticket compliance analysis ✅" in out
 
+    @pytest.mark.parametrize("gfm_supported", [True, False])
+    def test_human_verification_only_ticket_is_rendered(self, gfm_supported):
+        tickets = [
+            self._ticket(
+                requires_further_human_verification="- verify UI behavior\n",
+            )
+        ]
+
+        out = ticket_markdown_logic("🎫", "", tickets, gfm_supported)
+
+        assert "[42](https://example.com/ticket/42)" in out, (
+            "human-verification-only ticket should be rendered"
+        )
+        assert "[42](https://example.com/ticket/42) - PR Code Verified" in out
+        assert "Requires further human verification:" in out
+        assert "- verify UI behavior" in out
+        assert "Ticket compliance analysis ✅" in out
+        compliance_level = get_settings().get(
+            "config.extra_statistics.compliance_level"
+        )
+        assert compliance_level == "PR Code Verified"
+
     def test_ticket_with_no_requirements_renders_header_only(self):
-        # Tickets that have neither compliant nor non-compliant requirements
-        # are skipped in the per-ticket loop, but the gfm branch still
+        # Tickets with no classified requirements are skipped in the
+        # per-ticket loop, but the gfm branch still
         # emits an (empty-body) header row. This documents that current
         # behavior — no compliance level or per-ticket detail is shown.
         tickets = [self._ticket()]


### PR DESCRIPTION
## Summary

Fixes #2639.

Ticket compliance entries were skipped when both code-review classifications were empty, even if `requires_further_human_verification` contained requirements. Treat human-verification-only entries as valid `PR Code Verified` results so their ticket link and verification details contribute to both per-ticket and aggregate compliance output. Entirely empty entries remain skipped.

## Testing

- RED: the new GFM and non-GFM regression cases fail on unmodified `main` because the ticket link is absent
- GREEN: the focused regression cases pass
- GREEN: `tests/unittest/test_markdown_ticket_output_core.py` and `tests/unittest/test_convert_to_markdown.py` pass (90 passed, 1 xfailed)
- GREEN: the full unit suite passes (1729 passed, 1 skipped, 1 xfailed)