### PR TITLE
docs: pin current GitHub install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,12 @@ jobs:
 #### 2. CLI Usage (Local Development)
 
 Run PR-Agent locally on your repository:
+
+PyPI publishing is temporarily behind: `pip install pr-agent` currently installs `0.39.0`.
+Until publishing resumes, install the current release (`v0.42.0`) reproducibly from its GitHub tag:
+
 ```bash
-pip install pr-agent
+pip install "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@v0.42.0"
 export OPENAI_KEY=your_key_here
 pr-agent --pr_url https://github.com/owner/repo/pull/123 review
 ```

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -94,8 +94,11 @@ Same goes for other providers, make sure to check the [documentation](../usage-g
 
 Install the package:
 
+PyPI publishing is temporarily behind: `pip install pr-agent` currently installs `0.39.0`.
+Until publishing resumes, install the current release (`v0.42.0`) reproducibly from its GitHub tag:
+
 ```bash
-pip install pr-agent
+pip install "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@v0.42.0"
 ```
 
 Then run the relevant tool with the script below.


### PR DESCRIPTION
## Summary

- explain that the current PyPI package still resolves to 0.39.0
- provide a reproducible install command pinned to the latest v0.42.0 GitHub release
- keep the README and local installation guide aligned

Closes #2627

## Validation

- git diff --check
- docs-only change; no runtime tests needed