### PR TITLE
feat(webhooks): add feedback_on_draft_pr to run auto commands on draft PRs

### DIFF
--- a/docs/docs/faq/index.md
+++ b/docs/docs/faq/index.md
@@ -58,7 +58,7 @@ ___
 ??? note "Q: Can PR-Agent review draft/offline PRs?"
     #### Answer:<span style="display:none;">6</span>
 
-    Yes. While PR-Agent won't automatically review draft PRs, you can still get feedback by manually requesting it through [online commenting](../usage-guide/automations_and_usage.md#online-usage).
+    Yes. Draft PRs are not reviewed automatically by default, but you can enable it with the `feedback_on_draft_pr` parameter. You can also get feedback on any draft by manually requesting it through [online commenting](../usage-guide/automations_and_usage.md#online-usage).
 
     For active PRs, you can customize the automatic feedback settings [here](../usage-guide/automations_and_usage.md#pr-agent-automatic-feedback) to match your team's workflow.
 ___

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -115,7 +115,7 @@ This means that when a new PR is opened/reopened or marked as ready for review, 
 
 By default, draft PRs are not considered for automatic tools, but you can change this by setting the `feedback_on_draft_pr` parameter to `true` in the configuration file.
 When enabled, marking the PR as ready does not run `pr_commands` a second time.
-Because this setting can be overridden per repository, draft PR events still fetch the repository configuration before being skipped.
+Because this setting can be overridden per repository, draft PR events, including each `synchronize` event caused by a push, still fetch the repository configuration before being skipped.
 
 ```toml
 [github_app]

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -115,6 +115,7 @@ This means that when a new PR is opened/reopened or marked as ready for review, 
 
 By default, draft PRs are not considered for automatic tools, but you can change this by setting the `feedback_on_draft_pr` parameter to `true` in the configuration file.
 When enabled, marking the PR as ready does not run `pr_commands` a second time.
+Because this setting can be overridden per repository, draft PR events still fetch the repository configuration before being skipped.
 
 ```toml
 [github_app]
@@ -267,6 +268,7 @@ pr_commands = [
 
 Draft MRs are skipped by default. Set `feedback_on_draft_pr = true` under `[gitlab]` to enable automatic feedback.
 When enabled, marking the MR as ready does not run `pr_commands` a second time.
+Because this setting can be overridden per repository, draft MR events still fetch the repository configuration before being skipped.
 For environment-based deployments, set `GITLAB__FEEDBACK_ON_DRAFT_PR=true`.
 
 the GitLab webhook can also respond to new code that is pushed to an open MR.

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -114,6 +114,7 @@ This means that when a new PR is opened/reopened or marked as ready for review, 
 **Draft PRs:** 
 
 By default, draft PRs are not considered for automatic tools, but you can change this by setting the `feedback_on_draft_pr` parameter to `true` in the configuration file.
+When enabled, marking the PR as ready does not run `pr_commands` a second time.
 
 ```toml
 [github_app]
@@ -265,6 +266,8 @@ pr_commands = [
 ```
 
 Draft MRs are skipped by default. Set `feedback_on_draft_pr = true` under `[gitlab]` to enable automatic feedback.
+When enabled, marking the MR as ready does not run `pr_commands` a second time.
+For environment-based deployments, set `GITLAB__FEEDBACK_ON_DRAFT_PR=true`.
 
 the GitLab webhook can also respond to new code that is pushed to an open MR.
 The configuration toggle `handle_push_trigger` can be used to enable this feature.

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -264,6 +264,8 @@ pr_commands = [
 ]
 ```
 
+Draft MRs are skipped by default. Set `feedback_on_draft_pr = true` under `[gitlab]` to enable automatic feedback.
+
 the GitLab webhook can also respond to new code that is pushed to an open MR.
 The configuration toggle `handle_push_trigger` can be used to enable this feature.
 The configuration parameter `push_commands` defines the list of tools that will be **run automatically** when new code is pushed to the MR.

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -394,7 +394,6 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict) -> Tup
 
 async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body: dict, api_url: str,
                                         log_context: dict):
-    apply_repo_settings(api_url)
     feedback_on_draft = get_settings().github_app.feedback_on_draft_pr
     is_draft = body.get("pull_request", {}).get("draft", True)
     if is_draft and not feedback_on_draft:

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -395,6 +395,9 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict) -> Tup
 async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body: dict, api_url: str,
                                         log_context: dict):
     feedback_on_draft = get_settings().github_app.feedback_on_draft_pr
+    if commands_conf == "pr_commands" and body.get("action") == "ready_for_review" and feedback_on_draft:
+        get_logger().info(f"Skipping draft-ready commands because draft feedback is enabled: {api_url}")
+        return
     is_draft = body.get("pull_request", {}).get("draft", True)
     if is_draft and not feedback_on_draft:
         get_logger().info(f"Skipping draft PR {api_url=}")

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -384,7 +384,7 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict) -> Tup
     if not api_url:
         return invalid_result
     log_context["api_url"] = api_url
-    if pull_request.get("draft", True) or pull_request.get("state") != "open":
+    if pull_request.get("state") != "open":
         return invalid_result
     if action in ("review_requested", "synchronize") and pull_request.get("created_at") == pull_request.get("updated_at"):
         # avoid double reviews when opening a PR for the first time
@@ -395,6 +395,11 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict) -> Tup
 async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body: dict, api_url: str,
                                         log_context: dict):
     apply_repo_settings(api_url)
+    feedback_on_draft = get_settings().github_app.feedback_on_draft_pr
+    is_draft = body.get("pull_request", {}).get("draft", True)
+    if is_draft and not feedback_on_draft:
+        get_logger().info(f"Skipping draft PR {api_url=}")
+        return
     if commands_conf == "pr_commands" and get_settings().config.disable_auto_feedback:  # auto commands for PR, and auto feedback is disabled
         get_logger().info(f"Auto feedback is disabled, skipping auto commands for PR {api_url=}")
         return

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -290,8 +290,10 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 url = object_attributes.get('url')
                 get_logger().info(f"Draft MR is ready: {url}")
 
-                # same as open MR
                 apply_repo_settings(url)
+                if get_settings().get("gitlab.feedback_on_draft_pr", False):
+                    get_logger().info(f"Skipping draft-ready commands because draft feedback is enabled: {url}")
+                    return
                 await _perform_commands_gitlab("pr_commands", PRAgent(), url, log_context, data)
 
         elif data.get('object_kind') == 'note' and data.get('event_type') == 'note': # comment on MR

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -16,11 +16,11 @@ from starlette_context.middleware import RawContextMiddleware
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.utils import update_settings_from_args
 from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import (get_secret_provider,
                                        validate_secret_provider_setting)
-from pr_agent.git_providers import get_git_provider_with_context
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -59,7 +59,6 @@ async def handle_request(api_url: str, body: str, log_context: dict, sender_id: 
 
 async def _perform_commands_gitlab(commands_conf: str, agent: PRAgent, api_url: str,
                                    log_context: dict, data: dict):
-    apply_repo_settings(api_url)
     feedback_on_draft = get_settings().get(
         "gitlab.feedback_on_draft_pr", False
     )
@@ -266,6 +265,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             if object_attributes.get('action') in ['open', 'reopen']:
                 url = object_attributes.get('url')
                 get_logger().info(f"New merge request: {url}")
+                apply_repo_settings(url)
                 await _perform_commands_gitlab("pr_commands", PRAgent(), url, log_context, data)
 
             # for push event triggered merge requests
@@ -291,6 +291,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 get_logger().info(f"Draft MR is ready: {url}")
 
                 # same as open MR
+                apply_repo_settings(url)
                 await _perform_commands_gitlab("pr_commands", PRAgent(), url, log_context, data)
 
         elif data.get('object_kind') == 'note' and data.get('event_type') == 'note': # comment on MR

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -60,6 +60,12 @@ async def handle_request(api_url: str, body: str, log_context: dict, sender_id: 
 async def _perform_commands_gitlab(commands_conf: str, agent: PRAgent, api_url: str,
                                    log_context: dict, data: dict):
     apply_repo_settings(api_url)
+    feedback_on_draft = get_settings().get(
+        "gitlab.feedback_on_draft_pr", False
+    )
+    if is_draft(data) and not feedback_on_draft:
+        get_logger().info(f"Skipping draft MR: {api_url}")
+        return
     if commands_conf == "pr_commands" and get_settings().config.disable_auto_feedback:  # auto commands for PR, and auto feedback is disabled
         get_logger().info(f"Auto feedback is disabled, skipping auto commands for PR {api_url=}", **log_context)
         return
@@ -260,20 +266,12 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             if object_attributes.get('action') in ['open', 'reopen']:
                 url = object_attributes.get('url')
                 get_logger().info(f"New merge request: {url}")
-                if is_draft(data):
-                    get_logger().info(f"Skipping draft MR: {url}")
-                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
-
                 await _perform_commands_gitlab("pr_commands", PRAgent(), url, log_context, data)
 
             # for push event triggered merge requests
             elif object_attributes.get('action') == 'update' and object_attributes.get('oldrev'):
                 url = object_attributes.get('url')
                 get_logger().info(f"New merge request: {url}")
-                if is_draft(data):
-                    get_logger().info(f"Skipping draft MR: {url}")
-                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
-
                 # Apply repo settings before checking push commands or handle_push_trigger
                 apply_repo_settings(url)
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -271,6 +271,7 @@ bot_user = "github-actions[bot]"
 override_deployment_type = true
 # settings for "pull_request" event
 handle_pr_actions = ['opened', 'reopened', 'ready_for_review']
+feedback_on_draft_pr = false
 pr_commands = [
     "/describe --pr_description.final_update_message=false",
     "/review",
@@ -291,6 +292,7 @@ push_commands = [
 [gitlab]
 url = "https://gitlab.com"
 expand_submodule_diffs = false
+feedback_on_draft_pr = false
 # Post the /review summary as a resolvable thread (discussion) instead of a plain note.
 publish_review_as_thread = false
 pr_commands = [

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -321,18 +321,6 @@ class TestCheckPullRequestEvent:
         body = {"pull_request": self._pr(state="closed")}
         assert github_app._check_pull_request_event("opened", body, {}) == ({}, "")
 
-    def test_rejects_draft_pr(self):
-        body = {"pull_request": self._pr(draft=True)}
-        assert github_app._check_pull_request_event("opened", body, {}) == ({}, "")
-
-    def test_rejects_when_draft_field_missing(self):
-        # pull_request.get("draft", True) defaults to True, so a missing draft
-        # field is treated as draft and rejected.
-        pr = self._pr()
-        pr.pop("draft")
-        body = {"pull_request": pr}
-        assert github_app._check_pull_request_event("opened", body, {}) == ({}, "")
-
     def test_rejects_synchronize_when_created_equals_updated(self):
         body = {
             "pull_request": self._pr(

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -178,14 +178,15 @@ class RecordingAgent:
     def __init__(self):
         self.commands = []
 
-    async def handle_request(self, _url, command):
+    async def handle_request(self, _url, command, notify=None):
         self.commands.append(command)
 
 
-async def _run_github_pr_commands(monkeypatch, repo_setting):
+async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", draft=True):
     settings = get_settings()
     original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.HANDLE_PR_ACTIONS", ["opened", "reopened", "ready_for_review"])
     settings.set("GITHUB_APP.PR_COMMANDS", ["/review"])
     # Prove the repo setting, not the global default, decides.
     settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", not repo_setting)
@@ -209,11 +210,11 @@ async def _run_github_pr_commands(monkeypatch, repo_setting):
     try:
         await github_app.handle_request(
             {
-                "action": "opened",
+                "action": action,
                 "pull_request": {
                     "url": "https://api.github.com/repos/org/repo/pulls/1",
                     "state": "open",
-                    "draft": True,
+                    "draft": draft,
                 },
                 "sender": {"login": "alice", "id": 1, "type": "User"},
                 "repository": {"full_name": "org/repo"},
@@ -226,24 +227,30 @@ async def _run_github_pr_commands(monkeypatch, repo_setting):
     return agent.commands, repo_settings_calls
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("feedback_on_draft_pr", "expected_commands"),
+    ("action", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
-        (False, []),
-        (True, ["/review"]),
+        ("opened", True, False, []),
+        ("opened", True, True, ["/review"]),
+        ("ready_for_review", False, False, ["/review"]),
+        ("ready_for_review", False, True, []),
     ],
 )
-async def test_github_draft_pr_feedback_follows_repo_setting(
-    monkeypatch, feedback_on_draft_pr, expected_commands
+async def test_github_automatic_feedback_follows_draft_setting(
+    monkeypatch, action, draft, feedback_on_draft_pr, expected_commands
 ):
-    commands, repo_settings_calls = await _run_github_pr_commands(monkeypatch, feedback_on_draft_pr)
+    commands, repo_settings_calls = await _run_github_pr_commands(
+        monkeypatch, feedback_on_draft_pr, action, draft
+    )
 
     assert commands == expected_commands
     assert repo_settings_calls == 1
 
 
-def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, action="open"):
+def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="open"):
     settings = get_settings()
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
     settings.set("GITLAB.PR_COMMANDS", ["/review"])
     settings.set("GITLAB.PUSH_COMMANDS", ["/review"])
     settings.set("GITLAB.HANDLE_PUSH_TRIGGER", True)
@@ -267,46 +274,93 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, action="op
         module, "get_fork_safe_secret_provider", lambda: secret_provider
     )
     object_attributes = {
-        "action": action,
+        "action": "update" if event == "draft_ready" else event,
         "draft": draft,
         "url": "https://gitlab.com/org/repo/-/merge_requests/1",
     }
-    if action == "update":
+    if event == "update":
         object_attributes["oldrev"] = "previous-revision"
     data = _gitlab_payload(**object_attributes)
     data["object_kind"] = "merge_request"
-    with TestClient(module.app) as client:
-        response = client.post(
-            "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
-        )
+    if event == "draft_ready":
+        data["changes"] = {"draft": {"previous": True, "current": False}}
+    try:
+        with TestClient(module.app) as client:
+            response = client.post(
+                "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
+            )
+    finally:
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
 
     assert response.status_code == 200
     return agent.commands, repo_settings_calls
 
 
 @pytest.mark.parametrize(
-    ("action", "draft", "feedback_on_draft_pr", "expected_commands"),
+    ("event", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
         ("open", True, False, []),
         ("open", True, True, ["/review"]),
         ("open", False, False, ["/review"]),
+        ("reopen", True, False, []),
+        ("reopen", True, True, ["/review"]),
         ("update", True, False, []),
+        ("update", True, True, ["/review"]),
+        ("draft_ready", False, False, ["/review"]),
+        ("draft_ready", False, True, []),
     ],
 )
 def test_gitlab_automatic_feedback_follows_draft_setting(
     gitlab_webhook_module,
     monkeypatch,
-    action,
+    event,
     draft,
     feedback_on_draft_pr,
     expected_commands,
 ):
     commands, repo_settings_calls = _run_gitlab_pr_commands(
-        gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr, action
+        gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr, event
     )
 
     assert commands == expected_commands
     assert repo_settings_calls == 1
+
+
+def test_gitlab_manual_feedback_on_draft_is_unaffected(gitlab_webhook_module, monkeypatch):
+    settings = get_settings()
+    settings.set("GITLAB.FEEDBACK_ON_DRAFT_PR", False)
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(gitlab_webhook_module, "PRAgent", lambda: agent)
+    monkeypatch.setattr(
+        gitlab_webhook_module,
+        "get_fork_safe_secret_provider",
+        lambda: SimpleNamespace(get_secret=lambda _: '{"gitlab_token": "token"}'),
+    )
+    monkeypatch.setattr(
+        gitlab_webhook_module,
+        "get_git_provider_with_context",
+        lambda **_: SimpleNamespace(add_eyes_reaction=lambda *_: None),
+    )
+    data = _gitlab_payload(note="/review", id=1)
+    data.update(
+        {
+            "object_kind": "note",
+            "event_type": "note",
+            "merge_request": {
+                "draft": True,
+                "url": "https://gitlab.com/org/repo/-/merge_requests/1",
+            },
+        }
+    )
+
+    with TestClient(gitlab_webhook_module.app) as client:
+        response = client.post(
+            "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
+        )
+
+    assert response.status_code == 200
+    assert agent.commands == ["/review"]
 
 
 def test_gitlab_handle_ask_line_converts_new_line_diff_note_to_right_side_command(gitlab_webhook_module):

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -5,10 +5,9 @@ from types import SimpleNamespace
 import pytest
 from starlette.testclient import TestClient
 
-import pr_agent.servers.bitbucket_server_webhook as bitbucket_server_webhook
 from pr_agent.config_loader import get_settings
 from pr_agent.identity_providers.identity_provider import Eligibility
-from pr_agent.servers import github_app
+from pr_agent.servers import bitbucket_server_webhook, github_app
 
 
 @pytest.fixture
@@ -191,7 +190,11 @@ async def _run_github_pr_commands(monkeypatch, repo_setting):
     # Prove the repo setting, not the global default, decides.
     settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", not repo_setting)
 
+    repo_settings_calls = 0
+
     def apply_repo_settings(_):
+        nonlocal repo_settings_calls
+        repo_settings_calls += 1
         get_settings().set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", repo_setting)
 
     agent = RecordingAgent()
@@ -220,7 +223,7 @@ async def _run_github_pr_commands(monkeypatch, repo_setting):
     finally:
         settings.set("GITHUB_APP", original_github_app)
         settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
-    return agent.commands
+    return agent.commands, repo_settings_calls
 
 
 @pytest.mark.parametrize(
@@ -233,18 +236,25 @@ async def _run_github_pr_commands(monkeypatch, repo_setting):
 async def test_github_draft_pr_feedback_follows_repo_setting(
     monkeypatch, feedback_on_draft_pr, expected_commands
 ):
-    commands = await _run_github_pr_commands(monkeypatch, feedback_on_draft_pr)
+    commands, repo_settings_calls = await _run_github_pr_commands(monkeypatch, feedback_on_draft_pr)
 
     assert commands == expected_commands
+    assert repo_settings_calls == 1
 
 
-def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting):
+def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, action="open"):
     settings = get_settings()
     settings.set("GITLAB.PR_COMMANDS", ["/review"])
+    settings.set("GITLAB.PUSH_COMMANDS", ["/review"])
+    settings.set("GITLAB.HANDLE_PUSH_TRIGGER", True)
     # Prove repo settings are applied before draft filtering.
     settings.set("GITLAB.FEEDBACK_ON_DRAFT_PR", not repo_setting)
 
+    repo_settings_calls = 0
+
     def apply_repo_settings(_):
+        nonlocal repo_settings_calls
+        repo_settings_calls += 1
         get_settings().set("GITLAB.FEEDBACK_ON_DRAFT_PR", repo_setting)
 
     agent = RecordingAgent()
@@ -256,11 +266,14 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting):
     monkeypatch.setattr(
         module, "get_fork_safe_secret_provider", lambda: secret_provider
     )
-    data = _gitlab_payload(
-        action="open",
-        draft=draft,
-        url="https://gitlab.com/org/repo/-/merge_requests/1",
-    )
+    object_attributes = {
+        "action": action,
+        "draft": draft,
+        "url": "https://gitlab.com/org/repo/-/merge_requests/1",
+    }
+    if action == "update":
+        object_attributes["oldrev"] = "previous-revision"
+    data = _gitlab_payload(**object_attributes)
     data["object_kind"] = "merge_request"
     with TestClient(module.app) as client:
         response = client.post(
@@ -268,29 +281,32 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting):
         )
 
     assert response.status_code == 200
-    return agent.commands
+    return agent.commands, repo_settings_calls
 
 
 @pytest.mark.parametrize(
-    ("draft", "feedback_on_draft_pr", "expected_commands"),
+    ("action", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
-        (True, False, []),
-        (True, True, ["/review"]),
-        (False, False, ["/review"]),
+        ("open", True, False, []),
+        ("open", True, True, ["/review"]),
+        ("open", False, False, ["/review"]),
+        ("update", True, False, []),
     ],
 )
 def test_gitlab_automatic_feedback_follows_draft_setting(
     gitlab_webhook_module,
     monkeypatch,
+    action,
     draft,
     feedback_on_draft_pr,
     expected_commands,
 ):
-    commands = _run_gitlab_pr_commands(
-        gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr
+    commands, repo_settings_calls = _run_gitlab_pr_commands(
+        gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr, action
     )
 
     assert commands == expected_commands
+    assert repo_settings_calls == 1
 
 
 def test_gitlab_handle_ask_line_converts_new_line_diff_note_to_right_side_command(gitlab_webhook_module):

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -1,10 +1,14 @@
 import copy
 import importlib
+from types import SimpleNamespace
 
 import pytest
+from starlette.testclient import TestClient
 
 import pr_agent.servers.bitbucket_server_webhook as bitbucket_server_webhook
 from pr_agent.config_loader import get_settings
+from pr_agent.identity_providers.identity_provider import Eligibility
+from pr_agent.servers import github_app
 
 
 @pytest.fixture
@@ -169,6 +173,124 @@ def test_gitlab_is_draft_ready_accepts_string_booleans(gitlab_webhook_module):
     }
 
     assert gitlab_webhook_module.is_draft_ready(data) is True
+
+
+class RecordingAgent:
+    def __init__(self):
+        self.commands = []
+
+    async def handle_request(self, _url, command):
+        self.commands.append(command)
+
+
+async def _run_github_pr_commands(monkeypatch, repo_setting):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.PR_COMMANDS", ["/review"])
+    # Prove the repo setting, not the global default, decides.
+    settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", not repo_setting)
+
+    def apply_repo_settings(_):
+        get_settings().set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", repo_setting)
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", apply_repo_settings)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+    identity_provider = SimpleNamespace(
+        verify_eligibility=lambda *args, **kwargs: Eligibility.ELIGIBLE
+    )
+    monkeypatch.setattr(
+        github_app, "get_identity_provider", lambda: identity_provider
+    )
+    try:
+        await github_app.handle_request(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": True,
+                },
+                "sender": {"login": "alice", "id": 1, "type": "User"},
+                "repository": {"full_name": "org/repo"},
+            },
+            "pull_request",
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+    return agent.commands
+
+
+@pytest.mark.parametrize(
+    ("feedback_on_draft_pr", "expected_commands"),
+    [
+        (False, []),
+        (True, ["/review"]),
+    ],
+)
+async def test_github_draft_pr_feedback_follows_repo_setting(
+    monkeypatch, feedback_on_draft_pr, expected_commands
+):
+    commands = await _run_github_pr_commands(monkeypatch, feedback_on_draft_pr)
+
+    assert commands == expected_commands
+
+
+def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting):
+    settings = get_settings()
+    settings.set("GITLAB.PR_COMMANDS", ["/review"])
+    # Prove repo settings are applied before draft filtering.
+    settings.set("GITLAB.FEEDBACK_ON_DRAFT_PR", not repo_setting)
+
+    def apply_repo_settings(_):
+        get_settings().set("GITLAB.FEEDBACK_ON_DRAFT_PR", repo_setting)
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(module, "apply_repo_settings", apply_repo_settings)
+    monkeypatch.setattr(module, "PRAgent", lambda: agent)
+    secret_provider = SimpleNamespace(
+        get_secret=lambda _: '{"gitlab_token": "token"}'
+    )
+    monkeypatch.setattr(
+        module, "get_fork_safe_secret_provider", lambda: secret_provider
+    )
+    data = _gitlab_payload(
+        action="open",
+        draft=draft,
+        url="https://gitlab.com/org/repo/-/merge_requests/1",
+    )
+    data["object_kind"] = "merge_request"
+    with TestClient(module.app) as client:
+        response = client.post(
+            "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
+        )
+
+    assert response.status_code == 200
+    return agent.commands
+
+
+@pytest.mark.parametrize(
+    ("draft", "feedback_on_draft_pr", "expected_commands"),
+    [
+        (True, False, []),
+        (True, True, ["/review"]),
+        (False, False, ["/review"]),
+    ],
+)
+def test_gitlab_automatic_feedback_follows_draft_setting(
+    gitlab_webhook_module,
+    monkeypatch,
+    draft,
+    feedback_on_draft_pr,
+    expected_commands,
+):
+    commands = _run_gitlab_pr_commands(
+        gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr
+    )
+
+    assert commands == expected_commands
 
 
 def test_gitlab_handle_ask_line_converts_new_line_diff_note_to_right_side_command(gitlab_webhook_module):

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -183,6 +183,7 @@ class RecordingAgent:
 
 
 async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", draft=True):
+    # draft=None omits the field from the payload.
     settings = get_settings()
     original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
@@ -214,7 +215,7 @@ async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", dr
                 "pull_request": {
                     "url": "https://api.github.com/repos/org/repo/pulls/1",
                     "state": "open",
-                    "draft": draft,
+                    **({} if draft is None else {"draft": draft}),
                 },
                 "sender": {"login": "alice", "id": 1, "type": "User"},
                 "repository": {"full_name": "org/repo"},
@@ -232,6 +233,8 @@ async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", dr
     ("action", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
         ("opened", True, False, []),
+        # A missing draft field defaults to draft and is rejected.
+        ("opened", None, False, []),
         ("opened", True, True, ["/review"]),
         ("ready_for_review", False, False, ["/review"]),
         ("ready_for_review", False, True, []),


### PR DESCRIPTION
github_app.feedback_on_draft_pr has been documented since 625085a0 but was never implemented here: _check_pull_request_event rejected every draft PR outright. Implement it, and add the same setting for gitlab.

Closes #2658 