### PR TITLE
fix(improve): route self-reflection through the reasoning fallback chain (#2660)

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -23,7 +23,7 @@ from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, load_yaml, replace_code_tags,
                                  show_relevant_configurations, show_run_details,
-                                 get_max_tokens, clip_tokens, get_model)
+                                 get_max_tokens, clip_tokens)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
                                     GitLabProvider, get_git_provider,
@@ -422,15 +422,7 @@ class PRCodeSuggestions:
         data = self._prepare_pr_code_suggestions(response)
 
         # self-reflect on suggestions (mandatory, since line numbers are generated now here)
-        model_reflect_with_reasoning = get_model('model_reasoning')
-        fallbacks = get_settings().config.fallback_models
-        if model_reflect_with_reasoning == get_settings().config.model and model != get_settings().config.model and fallbacks and model == \
-                fallbacks[0]:
-            # we are using a fallback model (should not happen on regular conditions)
-            get_logger().warning(f"Using the same model for self-reflection as the one used for suggestions")
-            model_reflect_with_reasoning = model
-        response_reflect = await self.self_reflect_on_suggestions(data["code_suggestions"],
-                                                                  patches_diff, model=model_reflect_with_reasoning)
+        response_reflect = await self._self_reflect_with_fallback(data["code_suggestions"], patches_diff)
         if response_reflect:
             await self.analyze_self_reflection_response(data, response_reflect)
         else:
@@ -440,6 +432,25 @@ class PRCodeSuggestions:
                 suggestion["score_why"] = ""
 
         return data
+
+    async def _self_reflect_with_fallback(self, suggestion_list: List, patches_diff: str) -> str:
+        # self_reflect_on_suggestions swallows its errors and returns "", so treat an empty
+        # response as a failure to let retry_with_fallback_models move to the next model.
+        if not suggestion_list:
+            return ""
+
+        async def reflect(reflection_model: str) -> str:
+            response = await self.self_reflect_on_suggestions(suggestion_list, patches_diff,
+                                                              model=reflection_model)
+            if not response:
+                raise ValueError(f"Empty self-reflection response from {reflection_model}")
+            return response
+
+        try:
+            return await retry_with_fallback_models(reflect, model_type=ModelType.REASONING)
+        except Exception as e:
+            get_logger().warning("Self-reflection failed on all models", artifact={"error": e})
+            return ""
 
     async def analyze_self_reflection_response(self, data, response_reflect):
         response_reflect_yaml = load_yaml(response_reflect)

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -14,7 +14,8 @@ from pr_agent.algo import MAX_TOKENS
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.git_patch_processing import decouple_and_convert_to_hunks_with_lines_numbers
-from pr_agent.algo.pr_processing import (add_ai_metadata_to_diff_files,
+from pr_agent.algo.pr_processing import (_get_all_models,
+                                         add_ai_metadata_to_diff_files,
                                          get_pr_diff, get_pr_multi_diffs,
                                          retry_with_fallback_models)
 from pr_agent.algo.run_details import init_run_details
@@ -23,7 +24,7 @@ from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (ModelType, load_yaml, replace_code_tags,
                                  show_relevant_configurations, show_run_details,
-                                 get_max_tokens, clip_tokens)
+                                 get_max_tokens, clip_tokens, get_model)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
                                     GitLabProvider, get_git_provider,
@@ -422,7 +423,7 @@ class PRCodeSuggestions:
         data = self._prepare_pr_code_suggestions(response)
 
         # self-reflect on suggestions (mandatory, since line numbers are generated now here)
-        response_reflect = await self._self_reflect_with_fallback(data["code_suggestions"], patches_diff)
+        response_reflect = await self._self_reflect_with_fallback(data["code_suggestions"], patches_diff, model)
         if response_reflect:
             await self.analyze_self_reflection_response(data, response_reflect)
         else:
@@ -433,24 +434,31 @@ class PRCodeSuggestions:
 
         return data
 
-    async def _self_reflect_with_fallback(self, suggestion_list: List, patches_diff: str) -> str:
-        # self_reflect_on_suggestions swallows its errors and returns "", so treat an empty
-        # response as a failure to let retry_with_fallback_models move to the next model.
+    async def _self_reflect_with_fallback(self, suggestion_list: List, patches_diff: str, model: str) -> str:
+        """Reflect over the reasoning models, returning the first non-empty response.
+
+        self_reflect_on_suggestions swallows its errors and returns "", so an empty response is
+        treated as a failure. This walks the chain itself rather than nesting
+        retry_with_fallback_models, which sets the global openai.deployment_id without restoring
+        it - nested, that would leak the reflection's deployment into the rest of the run and race
+        the other chunk calls, since parallel_calls is on by default.
+        """
         if not suggestion_list:
             return ""
 
-        async def reflect(reflection_model: str) -> str:
+        models = _get_all_models(ModelType.REASONING)
+        if get_model('model_reasoning') == get_settings().config.model and model in models:
+            # No dedicated reasoning model, so this is the regular chain and the outer fallback
+            # loop has already burned everything before the model it settled on.
+            models = models[models.index(model):]
+
+        for reflection_model in models:
             response = await self.self_reflect_on_suggestions(suggestion_list, patches_diff,
                                                               model=reflection_model)
-            if not response:
-                raise ValueError(f"Empty self-reflection response from {reflection_model}")
-            return response
-
-        try:
-            return await retry_with_fallback_models(reflect, model_type=ModelType.REASONING)
-        except Exception as e:
-            get_logger().warning("Self-reflection failed on all models", artifact={"error": e})
-            return ""
+            if response:
+                return response
+            get_logger().warning(f"Empty self-reflection response from {reflection_model}")
+        return ""
 
     async def analyze_self_reflection_response(self, data, response_reflect):
         response_reflect_yaml = load_yaml(response_reflect)

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -451,6 +451,11 @@ class PRCodeSuggestions:
             # No dedicated reasoning model, so this is the regular chain and the outer fallback
             # loop has already burned everything before the model it settled on.
             models = models[models.index(model):]
+        if get_settings().get("openai.fallback_deployments", []):
+            # Each model is pinned to its own deployment, and openai.deployment_id is global to a
+            # run whose chunk calls are already in flight concurrently. Retrying another model here
+            # would route it to the deployment this one is pinned to, so stop at the first.
+            models = models[:1]
 
         for reflection_model in models:
             response = await self.self_reflect_on_suggestions(suggestion_list, patches_diff,

--- a/tests/unittest/test_self_reflect_fallback.py
+++ b/tests/unittest/test_self_reflect_fallback.py
@@ -1,6 +1,6 @@
 """
-Tests that self-reflection uses the reasoning-model fallback chain: a model that
-returns nothing advances to the next model instead of degrading to score 7.
+Tests that self-reflection walks the reasoning-model chain: a model that returns
+nothing advances to the next one instead of degrading every suggestion to score 7.
 """
 from unittest.mock import AsyncMock, patch
 
@@ -12,31 +12,45 @@ from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 class _Settings:
     """Minimal settings object exposing only what the reflection path reads."""
 
-    class config:
-        model = "primary-model"
-        model_reasoning = "reasoning-model"
-        fallback_models = ["fallback-model"]
+    def __init__(self, model_reasoning="reasoning-model"):
+        self._model_reasoning = model_reasoning
+        self.set_calls = []
+
+        class config:
+            model = "primary-model"
+            fallback_models = ["fallback-model"]
+
+        config.model_reasoning = model_reasoning
+        self.config = config
 
     def get(self, key, default=None):
         return {
             "config.model_weak": None,
-            "config.model_reasoning": "reasoning-model",
+            "config.model_reasoning": self._model_reasoning,
             "openai.deployment_id": None,
             "openai.fallback_deployments": [],
         }.get(key, default)
 
     def set(self, key, value):
-        pass
+        self.set_calls.append((key, value))
 
 
-@pytest.fixture
-def settings(monkeypatch):
-    stub = _Settings()
+def _install(monkeypatch, stub):
     for module in ("pr_agent.tools.pr_code_suggestions",
                    "pr_agent.algo.pr_processing",
                    "pr_agent.algo.utils"):
         monkeypatch.setattr(f"{module}.get_settings", lambda: stub)
     return stub
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    return _install(monkeypatch, _Settings())
+
+
+@pytest.fixture
+def settings_no_reasoning_model(monkeypatch):
+    return _install(monkeypatch, _Settings(model_reasoning=None))
 
 
 def _tool():
@@ -51,7 +65,8 @@ class TestSelfReflectFallback:
         with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
                           new_callable=AsyncMock) as reflect:
             reflect.side_effect = ["", "reflection from fallback"]
-            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "primary-model")
 
         assert result == "reflection from fallback"
         assert [call.kwargs["model"] for call in reflect.call_args_list] == [
@@ -63,7 +78,8 @@ class TestSelfReflectFallback:
         with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
                           new_callable=AsyncMock) as reflect:
             reflect.return_value = "reflection"
-            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "primary-model")
 
         assert result == "reflection"
         reflect.assert_awaited_once()
@@ -75,7 +91,8 @@ class TestSelfReflectFallback:
         with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
                           new_callable=AsyncMock) as reflect:
             reflect.return_value = ""
-            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "primary-model")
 
         assert result == ""
         assert reflect.await_count == 2
@@ -85,7 +102,37 @@ class TestSelfReflectFallback:
         tool = _tool()
         with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
                           new_callable=AsyncMock) as reflect:
-            result = await tool._self_reflect_with_fallback([], "diff")
+            result = await tool._self_reflect_with_fallback([], "diff", "primary-model")
 
         assert result == ""
         reflect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_models_already_burned_by_the_outer_loop_are_skipped(
+            self, settings_no_reasoning_model):
+        # With no dedicated reasoning model the reasoning chain is the regular chain. If the
+        # outer fallback loop already failed over to "fallback-model", reflection must not
+        # start again on the dead "primary-model".
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.return_value = "reflection"
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "fallback-model")
+
+        assert result == "reflection"
+        reflect.assert_awaited_once()
+        assert reflect.call_args.kwargs["model"] == "fallback-model"
+
+    @pytest.mark.asyncio
+    async def test_reflection_does_not_mutate_the_global_deployment_id(self, settings):
+        # retry_with_fallback_models sets openai.deployment_id without restoring it. Reflection
+        # runs inside a chunk call, so mutating it here would leak into the run's remaining
+        # chunks and race them (parallel_calls is on by default).
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.side_effect = ["", "reflection from fallback"]
+            await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff", "primary-model")
+
+        assert not [key for key, _ in settings.set_calls if key == "openai.deployment_id"]

--- a/tests/unittest/test_self_reflect_fallback.py
+++ b/tests/unittest/test_self_reflect_fallback.py
@@ -12,8 +12,9 @@ from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 class _Settings:
     """Minimal settings object exposing only what the reflection path reads."""
 
-    def __init__(self, model_reasoning="reasoning-model"):
+    def __init__(self, model_reasoning="reasoning-model", fallback_deployments=()):
         self._model_reasoning = model_reasoning
+        self._fallback_deployments = fallback_deployments
         self.set_calls = []
 
         class config:
@@ -28,7 +29,7 @@ class _Settings:
             "config.model_weak": None,
             "config.model_reasoning": self._model_reasoning,
             "openai.deployment_id": None,
-            "openai.fallback_deployments": [],
+            "openai.fallback_deployments": self._fallback_deployments,
         }.get(key, default)
 
     def set(self, key, value):
@@ -51,6 +52,11 @@ def settings(monkeypatch):
 @pytest.fixture
 def settings_no_reasoning_model(monkeypatch):
     return _install(monkeypatch, _Settings(model_reasoning=None))
+
+
+@pytest.fixture
+def settings_pinned_deployments(monkeypatch):
+    return _install(monkeypatch, _Settings(fallback_deployments=["fallback-deployment"]))
 
 
 def _tool():
@@ -123,6 +129,22 @@ class TestSelfReflectFallback:
         assert result == "reflection"
         reflect.assert_awaited_once()
         assert reflect.call_args.kwargs["model"] == "fallback-model"
+
+    @pytest.mark.asyncio
+    async def test_pinned_deployments_do_not_retry_other_models(self, settings_pinned_deployments):
+        # With fallback_deployments configured each model lives on its own deployment, and
+        # openai.deployment_id is global. Retrying the next model here would send it to the
+        # current model's deployment, so reflection stops after one attempt.
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.return_value = ""
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "primary-model")
+
+        assert result == ""
+        reflect.assert_awaited_once()
+        assert reflect.call_args.kwargs["model"] == "reasoning-model"
 
     @pytest.mark.asyncio
     async def test_reflection_does_not_mutate_the_global_deployment_id(self, settings):

--- a/tests/unittest/test_self_reflect_fallback.py
+++ b/tests/unittest/test_self_reflect_fallback.py
@@ -1,0 +1,91 @@
+"""
+Tests that self-reflection uses the reasoning-model fallback chain: a model that
+returns nothing advances to the next model instead of degrading to score 7.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+
+
+class _Settings:
+    """Minimal settings object exposing only what the reflection path reads."""
+
+    class config:
+        model = "primary-model"
+        model_reasoning = "reasoning-model"
+        fallback_models = ["fallback-model"]
+
+    def get(self, key, default=None):
+        return {
+            "config.model_weak": None,
+            "config.model_reasoning": "reasoning-model",
+            "openai.deployment_id": None,
+            "openai.fallback_deployments": [],
+        }.get(key, default)
+
+    def set(self, key, value):
+        pass
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    stub = _Settings()
+    for module in ("pr_agent.tools.pr_code_suggestions",
+                   "pr_agent.algo.pr_processing",
+                   "pr_agent.algo.utils"):
+        monkeypatch.setattr(f"{module}.get_settings", lambda: stub)
+    return stub
+
+
+def _tool():
+    return PRCodeSuggestions.__new__(PRCodeSuggestions)
+
+
+class TestSelfReflectFallback:
+
+    @pytest.mark.asyncio
+    async def test_empty_response_advances_to_next_model(self, settings):
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.side_effect = ["", "reflection from fallback"]
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+
+        assert result == "reflection from fallback"
+        assert [call.kwargs["model"] for call in reflect.call_args_list] == [
+            "reasoning-model", "fallback-model"]
+
+    @pytest.mark.asyncio
+    async def test_reasoning_model_is_tried_first(self, settings):
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.return_value = "reflection"
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+
+        assert result == "reflection"
+        reflect.assert_awaited_once()
+        assert reflect.call_args.kwargs["model"] == "reasoning-model"
+
+    @pytest.mark.asyncio
+    async def test_all_models_failing_degrades_quietly(self, settings):
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.return_value = ""
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff")
+
+        assert result == ""
+        assert reflect.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_suggestions_skips_all_model_calls(self, settings):
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            result = await tool._self_reflect_with_fallback([], "diff")
+
+        assert result == ""
+        reflect.assert_not_awaited()


### PR DESCRIPTION
Routes `/improve`'s self-reflection call through `retry_with_fallback_models(..., ModelType.REASONING)`, so a transient failure advances to the next model instead of stamping a fabricated `score = 7` and empty `score_why` onto every suggestion in the run. The quiet degrade is kept, but only once every model is exhausted.

Fixes #2660
