### PR TITLE
enable bedrock access through private VPC endpoint

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -345,6 +345,13 @@ When the GitHub Actions runner is on AWS infrastructure (EC2, ECS, EKS), use the
 
 The IAM role must have `bedrock:InvokeModel` on the target model ARN. See [Bedrock model configuration](../usage-guide/changing_a_model.md#amazon-bedrock) for the full IAM policy example and supported models.
 
+To route calls through a VPC interface endpoint, add `AWS_BEDROCK_RUNTIME_ENDPOINT` alongside the credentials above:
+
+```yaml
+      env:
+        AWS_BEDROCK_RUNTIME_ENDPOINT: "https://bedrock-runtime.us-east-1.amazonaws.com"
+```
+
 #### Advanced Configuration Options
 
 ##### Custom Review Instructions

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -325,6 +325,15 @@ model_id = "your-custom-inference-profile-id"
 
 The `model_id` parameter will be passed to all Bedrock completion calls, allowing you to use custom inference profiles for better cost allocation and reporting.
 
+#### Using a Custom VPC Endpoint (PrivateLink)
+
+To route Bedrock traffic through a VPC interface endpoint instead of the public `bedrock-runtime` endpoint, set `AWS_BEDROCK_RUNTIME_ENDPOINT` either as an environment variable or in `[aws]`:
+
+```toml
+[aws]
+AWS_BEDROCK_RUNTIME_ENDPOINT="https://bedrock-runtime.us-east-1.amazonaws.com"
+```
+
 See [litellm](https://docs.litellm.ai/docs/providers/bedrock#usage) documentation for more information about the environment variables required for Amazon Bedrock.
 
 ### DeepSeek

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -69,6 +69,10 @@ class LiteLLMAIHandler(BaseAiHandler):
             # provider env vars (OPENROUTER_API_KEY, AZURE_API_KEY, ...) in LiteLLM's
             # resolution chain, so a placeholder there silently shadows them.
             litellm.openai_key = DUMMY_LITELLM_API_KEY
+        # Custom Bedrock endpoint (e.g. a VPC endpoint interface endpoint); litellm reads this
+        # directly from the environment regardless of the credentials model below
+        if not os.environ.get("AWS_BEDROCK_RUNTIME_ENDPOINT") and get_settings().get("aws.AWS_BEDROCK_RUNTIME_ENDPOINT"):
+            os.environ["AWS_BEDROCK_RUNTIME_ENDPOINT"] = get_settings().aws.AWS_BEDROCK_RUNTIME_ENDPOINT
         if os.environ.get("AWS_USE_IMDS", "").strip().lower() in ("1", "true", "yes"):
             import boto3
             import botocore.exceptions

--- a/tests/unittest/test_litellm_imds.py
+++ b/tests/unittest/test_litellm_imds.py
@@ -119,6 +119,29 @@ def default_settings(monkeypatch):
 
 class TestImdsInit:
 
+    def test_bedrock_runtime_endpoint_from_settings(self, monkeypatch):
+        """aws.AWS_BEDROCK_RUNTIME_ENDPOINT in settings is exported to the environment for litellm."""
+        endpoint = "https://vpce-0c618f5a6c9f4912f-jsh4i6at.bedrock-runtime.eu-central-1.vpce.amazonaws.com"
+        settings = _base_settings(extra_get=lambda key: {"aws.AWS_BEDROCK_RUNTIME_ENDPOINT": endpoint}.get(key))
+        settings.aws = type("AWS", (), {"AWS_BEDROCK_RUNTIME_ENDPOINT": endpoint})()
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings)
+
+        LiteLLMAIHandler()
+
+        assert os.environ["AWS_BEDROCK_RUNTIME_ENDPOINT"] == endpoint
+
+    def test_bedrock_runtime_endpoint_env_var_not_overridden(self, monkeypatch):
+        """An already-exported AWS_BEDROCK_RUNTIME_ENDPOINT wins over the settings value."""
+        monkeypatch.setenv("AWS_BEDROCK_RUNTIME_ENDPOINT", "https://env-configured.example.com")
+        settings_endpoint = "https://settings-configured.example.com"
+        settings = _base_settings(extra_get=lambda key: {"aws.AWS_BEDROCK_RUNTIME_ENDPOINT": settings_endpoint}.get(key))
+        settings.aws = type("AWS", (), {"AWS_BEDROCK_RUNTIME_ENDPOINT": settings_endpoint})()
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings)
+
+        LiteLLMAIHandler()
+
+        assert os.environ["AWS_BEDROCK_RUNTIME_ENDPOINT"] == "https://env-configured.example.com"
+      
     def test_imds_creds_written_to_env(self, monkeypatch):
         """When AWS_USE_IMDS=true, boto3 creds are placed in os.environ."""
         monkeypatch.setenv("AWS_USE_IMDS", "true")

--- a/tests/unittest/test_litellm_imds.py
+++ b/tests/unittest/test_litellm_imds.py
@@ -103,7 +103,8 @@ def _frozen_creds(
 def clean_aws_env(monkeypatch):
     """Ensure AWS env vars don't bleed between tests."""
     for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-                "AWS_SESSION_TOKEN", "AWS_REGION_NAME", "AWS_USE_IMDS"):
+                "AWS_SESSION_TOKEN", "AWS_REGION_NAME", "AWS_USE_IMDS",
+                "AWS_BEDROCK_RUNTIME_ENDPOINT"):
         monkeypatch.delenv(var, raising=False)
 
 


### PR DESCRIPTION
Right now it is not possible to use Bedrock models through private VPC endpoints. 