### PR TITLE
docs: document local git provider workflow

### DIFF
--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -1,5 +1,7 @@
 To run PR-Agent locally, you first need to acquire two keys:
 
+Local execution has two distinct cases: use the hosted-provider examples below for an existing PR/MR URL, or use the [Local Git Provider guide](../usage-guide/local_git_provider.md) for branch comparisons without a hosted PR/MR.
+
 1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.6 and gpt-5.6-terra (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
 2. A personal access token from your Git platform (GitHub, GitLab, BitBucket, Gitea) with repo scope. GitHub token, for example, can be issued from [here](https://github.com/settings/tokens){:target="_blank"}
 

--- a/docs/docs/usage-guide/local_git_provider.md
+++ b/docs/docs/usage-guide/local_git_provider.md
@@ -1,0 +1,88 @@
+# Local Git Provider
+
+Use the `local` Git provider to run PR-Agent from a local Git checkout when there is no hosted GitHub, GitLab, or Bitbucket pull/merge request. It treats the local branch comparison as a pull-request-like change and writes the result to files in the checkout.
+
+This page covers branch-to-branch local review. To run PR-Agent locally against an existing hosted PR/MR, follow [Run from source](../installation/locally.md#run-from-source) and configure that hosted provider instead.
+
+## When to use it
+
+Use the Local Git Provider for:
+
+- local experimentation
+- workflows without a hosted PR/MR
+- CI jobs that operate directly on a local Git checkout
+
+## How it works
+
+- The current `HEAD` is the proposed change.
+- PR-Agent computes the diff between the current `HEAD` and the merge base of `HEAD` and the supplied local target branch.
+
+The shared CLI keeps the `--pr_url` option name for compatibility with the other providers. With `git_provider=local`, pass a local target branch name such as `main`, not a hosted PR/MR URL.
+
+## Prerequisites
+
+Before running a command:
+
+- Run it from inside the Git repository that contains the proposed change.
+- Keep the working tree clean. Check it with `git status --short`; the command compares committed `HEAD` content.
+- Make sure the target branch exists locally, for example with `git branch --list main`.
+- Configure the LLM provider required by your setup. A hosted Git provider token is not required for this mode.
+
+## Basic usage
+
+The CLI command names are `review`, `describe`, and `improve`; they correspond to the `/review`, `/describe`, and `/improve` tools.
+
+Run `/review` against a local `main` branch:
+
+```bash
+cd /path/to/repository
+CONFIG__GIT_PROVIDER=local \
+python -m pr_agent.cli --pr_url main review
+```
+
+Run `/describe`:
+
+```bash
+CONFIG__GIT_PROVIDER=local \
+python -m pr_agent.cli --pr_url main describe
+```
+
+Run `/improve`:
+
+```bash
+CONFIG__GIT_PROVIDER=local \
+python -m pr_agent.cli --pr_url main improve
+```
+
+Replace `main` with the local branch to use as the target.
+
+## Output files
+
+By default, the commands write files in the repository root:
+
+- The `/review` command writes `review.md`.
+- The `/describe` command writes `description.md`.
+- The `/improve` command writes `improve.md`.
+
+The local provider writes these files instead of publishing the result to a hosted pull/merge request.
+
+## Custom output paths
+
+Set paths in the configuration used by the run, for example in the repository root `.pr_agent.toml`:
+
+```toml
+[local]
+review_path = "artifacts/review.md"
+description_path = "artifacts/description.md"
+improve_path = "artifacts/improve.md"
+```
+
+When using relative custom paths, run PR-Agent from the repository root as shown above.
+
+Create any parent directories for custom paths before running the command.
+
+## Limitations
+
+The Local Git Provider cannot publish to a hosted platform: it does not publish hosted PR comments, apply labels, add reactions, or publish inline comments.
+
+PR-Agent still requires a configured LLM provider, which may require network access.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
     - Changing a Model: 'usage-guide/changing_a_model.md'
     - Additional Configurations: 'usage-guide/additional_configurations.md'
     - Plain-Diff Mode: 'usage-guide/plain_diff_mode.md'
+    - Local Git Provider: 'usage-guide/local_git_provider.md'
     - Frequently Asked Questions: 'faq/index.md'
   - Tools:
      - 'tools/index.md'


### PR DESCRIPTION
## Summary

- add a Usage Guide for running PR-Agent against a local Git branch with `git_provider=local`
- document the local target-branch behavior of `--pr_url`, prerequisites, output files, and custom output paths
- distinguish LocalGitProvider usage from running PR-Agent locally against a hosted PR/MR

## Validation

- `git diff --check`
- `pytest -q tests/unittest/test_local_git_provider.py` — 6 passed
- `mkdocs build -f docs/mkdocs.yml` — passed

Closes #2664