### PR TITLE
docs: remove wiki configuration file, which this repo does not implement

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -28,7 +28,7 @@ If you want to edit [configurations](#configuration-options), add the relevant o
 
 ### Automatic triggering
 
-To run the `describe` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#wiki-configuration-file):
+To run the `describe` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#local-configuration-file):
 
 ```
 [github_app]

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -39,7 +39,7 @@ For example, you can choose to present all the suggestions as committable code c
 
 ### Automatic triggering
 
-To run the `improve` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#wiki-configuration-file):
+To run the `improve` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#local-configuration-file):
 
 ```toml
 [github_app]

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -32,7 +32,7 @@ If you want to edit [configurations](#configuration-options), add the relevant o
 
 ### Automatic triggering
 
-To run the `review` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#wiki-configuration-file):
+To run the `review` automatically when a PR is opened, define in a [configuration file](../usage-guide/configuration_options.md#local-configuration-file):
 
 ```
 [github_app]

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -122,7 +122,7 @@ feedback_on_draft_pr = true
 
 **Changing default tool parameters:**
 
-You can override the default tool parameters by using one the three options for a [configuration file](./configuration_options.md): **wiki**, **local**, or **global**.
+You can override the default tool parameters by using one the three options for a [configuration file](./configuration_options.md): **local**, **global**, or **external URL**.
 For example, if your configuration file contains:
 
 ```toml

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -1,12 +1,11 @@
 The different tools and sub-tools used by PR-Agent are adjustable via a Git configuration file.
-There are four main ways to set persistent configurations:
+There are three main ways to set persistent configurations:
 
-1. [Wiki](./configuration_options.md#wiki-configuration-file) configuration page
-2. [Local](./configuration_options.md#local-configuration-file) configuration file
-3. [Global](./configuration_options.md#global-configuration-file) configuration file
-4. [External configuration URL](./configuration_options.md#external-configuration-url) (CLI flag)
+1. [Local](./configuration_options.md#local-configuration-file) configuration file
+2. [Global](./configuration_options.md#global-configuration-file) configuration file
+3. [External configuration URL](./configuration_options.md#external-configuration-url) (CLI flag)
 
-In terms of precedence, wiki configurations will override local configurations, local configurations will override global configurations, and global configurations will override an external configuration URL.
+In terms of precedence, local configurations will override global configurations, and global configurations will override an external configuration URL.
 
 
 For a list of all possible configurations, see the [configuration options](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) page.
@@ -18,25 +17,6 @@ In addition to general configuration options, each tool has its own configuratio
     If you set `config.output_relevant_configurations` to True, each tool will also output in a collapsible section its relevant configurations. This can be useful for debugging, or getting to know the configurations better.
 
 
-
-## Wiki configuration file
-
-`Platforms supported: GitHub, GitLab, Bitbucket`
-
-With PR-Agent, you can set configurations by creating a page called `.pr_agent.toml` in the [wiki](https://github.com/the-pr-agent/pr-agent/wiki/pr_agent.toml) of the repo.
-The advantage of this method is that it allows to set configurations without needing to commit new content to the repo - just edit the wiki page and **save**.
-
-![wiki_configuration](https://codium.ai/images/pr_agent/wiki_configuration.png){width=512}
-
-Click [here](https://codium.ai/images/pr_agent/wiki_configuration_pr_agent.mp4) to see a short instructional video. We recommend surrounding the configuration content with triple-quotes (or \`\`\`toml), to allow better presentation when displayed in the wiki as markdown.
-An example content:
-
-```toml
-[pr_description]
-generate_ai_title=true
-```
-
-PR-Agent will know to remove the surrounding quotes when reading the configuration content.
 
 ## Local configuration file
 
@@ -192,8 +172,7 @@ built-in defaults
   < --extra_config_url
     < global pr-agent-settings
       < local .pr_agent.toml (repo default branch)
-        < wiki .pr_agent.toml
-          < environment variables (PR_AGENT__SECTION__KEY)
+        < environment variables (PR_AGENT__SECTION__KEY)
 ```
 
 This means an external URL acts as an organization-wide *default* that any team can still override with their own `pr-agent-settings` or repo-local `.pr_agent.toml`.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -19,7 +19,6 @@ use_extra_bad_extensions=false
 # Log
 log_level="DEBUG"
 # Configurations
-use_wiki_settings_file=true
 use_repo_settings_file=true
 use_global_settings_file=true
 extra_config_url="" # optional URL or path to an additional .pr_agent.toml merged before the repo-local config; also settable via --extra_config_url or PR_AGENT_EXTRA_CONFIG_URL. See docs/docs/usage-guide/configuration_options.md#external-configuration-url.


### PR DESCRIPTION
The docs list a wiki `.pr_agent.toml` as the highest-precedence configuration source on GitHub, GitLab and Bitbucket, but no Python code in this repo reads or writes a wiki for any provider, and `use_wiki_settings_file` shipped defaulting to `true` while being read by nothing. Removes the wiki section, the four deep links to it, its place in the precedence chain, and the dead config key. Same treatment as #2615.

Fixes #2119.

> [!NOTE]
> If the hosted product reads `config.use_wiki_settings_file`, drop that one hunk and I will keep this docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
