### PR TITLE
feat: wire model backend to Atlara router

### DIFF
--- a/docs/ATLARA_DEPLOYMENT.md
+++ b/docs/ATLARA_DEPLOYMENT.md
@@ -1,0 +1,55 @@
+# Atlara deployment notes
+
+This fork of [PR-Agent](https://github.com/The-PR-Agent/pr-agent) is Atlara's free AI
+code review GitHub App. It is a thin layer on top of upstream PR-Agent: the diff
+parsing, GitHub App auth, and suggestion-posting logic are untouched — the only
+integration point is the model backend, which is pointed at Atlara's router
+instead of a direct OpenAI/Anthropic key.
+
+## How the backend is wired
+
+PR-Agent's `LiteLLMAIHandler` already has a first-class path for OpenAI-compatible
+custom endpoints (the same path used for self-hosted vLLM/LM Studio deployments):
+setting `[openai].api_base` routes every chat-completion call through that base URL
+instead of `api.openai.com`, using the model id in `[config].model`.
+
+`pr_agent/settings/atlara.toml` sets:
+- `openai.api_base = "https://cloud.atlara.ai/v1"` — Atlara's router
+- `config.model = "openai/<catalogue-model-id>"` — a model from Atlara's live
+  `model_catalogue`, not a guess. **This still needs to be filled in** with a
+  confirmed coding-capable, cost-appropriate catalogue id before this ships.
+
+The API key is deliberately **not** in that file. Dynaconf's env loader overlays
+env vars onto the nested toml keys as `SECTION__SETTING`, so the deploy environment
+sets:
+
+```
+OPENAI__KEY=<atlara-issued API key for the atlara-review service account>
+```
+
+That key should belong to a dedicated Atlara org/service account so free-tier
+review spend is trackable and capped separately from any other traffic, per the
+credit-metering plan (see the growth-strategy memo this fork implements).
+
+## Still to build (not in this change)
+
+This commit only wires the model backend. Still open, per the plan:
+
+1. **Credit-aware routing.** Free reviews should debit a bounded per-org credit
+   grant through the same `recordUsage`/`debitCredits` path the router already
+   uses for other inference, not call the router unmetered. This needs either a
+   dedicated Atlara API key per installing org (simplest, reuses existing
+   per-org billing) or a new PR-Agent-side usage hook — needs a decision before
+   this goes further than a single shared key.
+2. **CTA injection.** The three passive footer variants and the "out of
+   credits" fork-in-the-road comment are not implemented. They belong in the
+   comment-formatting layer (`pr_agent/tools/pr_reviewer.py` and
+   `pr_agent/tools/pr_code_suggestions.py` are the likely insertion points —
+   not yet investigated in depth).
+3. **GitHub App registration + webhook deployment.** `github.deployment_type =
+   "app"` plus `app_id`/`private_key`/`webhook_secret` in secrets are already
+   supported by upstream PR-Agent; a real Atlara GitHub App still needs to be
+   registered and those secrets provisioned.
+4. **Where this runs.** Per the plan, this should be its own small stateless
+   service, not folded into `neuralgrid-router-go` or `neuralgrid-web`. Hosting
+   (same prod VM vs. separate) not yet decided.

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -37,6 +37,7 @@ global_settings = Dynaconf(
         "settings/pr_help_prompts.toml",
         "settings/pr_help_docs_prompts.toml",
         "settings/pr_help_docs_headings_prompts.toml",
+        "settings/atlara.toml",
         "settings/.secrets.toml",
         "settings_prod/.secrets.toml",
     ]],

--- a/pr_agent/settings/atlara.toml
+++ b/pr_agent/settings/atlara.toml
@@ -1,0 +1,21 @@
+# Atlara-specific defaults for the atlara-review deployment.
+#
+# This file wires PR-Agent's OpenAI-compatible backend at Atlara's router
+# instead of a direct OpenAI/Anthropic key, so reviews run through Atlara's
+# model catalogue and credit-metered billing (see docs/ATLARA_DEPLOYMENT.md).
+#
+# Secrets (OPENAI__KEY) are never set here - they're injected at deploy time
+# via env vars, which dynaconf's env loader overlays on top of this file.
+
+[config]
+# TODO(atlara): confirm the exact catalogue id to default to before launch -
+# pick a coding-capable model from the live model_catalogue, not a guess.
+# The "openai/" prefix is litellm's convention for routing through an
+# OpenAI-compatible custom endpoint (this repo already uses it for
+# vLLM/LM Studio-style self-hosting - see litellm_ai_handler.py).
+model = "openai/REPLACE_WITH_CATALOGUE_MODEL_ID"
+fallback_models = []
+
+[openai]
+api_base = "https://cloud.atlara.ai/v1"
+# key is supplied via the OPENAI__KEY env var at deploy time.


### PR DESCRIPTION
## Summary
First step of the free-review growth-funnel plan: point PR-Agent's existing OpenAI-compatible custom-endpoint path at Atlara's router (`cloud.atlara.ai/v1`) instead of a direct OpenAI/Anthropic key, via `pr_agent/settings/atlara.toml`. No secrets committed — the API key comes from `OPENAI__KEY` at deploy time.

Draft because several things still need a decision before this is mergeable/deployable, tracked in `docs/ATLARA_DEPLOYMENT.md`:
- [ ] Fill in a real catalogue model id (currently a placeholder)
- [ ] Decide how free-tier credit metering plugs in (dedicated per-org API key vs. new usage hook)
- [ ] CTA-footer injection (not started)
- [ ] Register the actual Atlara GitHub App + provision webhook/private-key secrets

## Test plan
- [x] Verified `pr_agent/config_loader.py` loads `atlara.toml` and resolves `openai.api_base`/`config.model` correctly (local dynaconf sanity check)
- [ ] End-to-end review against a real PR once an API key + catalogue model id are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)