### PR TITLE
fix(deps): pin langfuse to 2.59.7 to match litellm constraint and prevent sdk_integration TypeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,9 @@ unidiff==0.7.5
 uvicorn==0.22.0
 tenacity==8.2.3
 a2a-sdk[http-server]==1.0.3
-langfuse==3.14.5
+# litellm 1.96.2 requires langfuse v2 (<3.0) for the native 'langfuse' callback to avoid TypeError with sdk_integration.
+# Version matches litellm's own constraint in pyproject.toml (>=2.59.7,<3.0).
+langfuse==2.59.7
 gunicorn==23.0.0
 pytest-cov==7.0.0
 pydantic==2.13.3


### PR DESCRIPTION
### Summary
Pins `langfuse==2.59.7` in `requirements.txt` to align with LiteLLM's internal dependency constraint (`langfuse>=2.59.7,<3.0`).

### Problem
When `langfuse` was pinned to `3.14.5`, attempting to use LiteLLM's native callback (`LITELLM.SUCCESS_CALLBACK=["langfuse"]`) triggers a fatal runtime error:
```text
TypeError: Langfuse.__init__() got an unexpected keyword argument 'sdk_integration'
```
This occurs because Langfuse Python SDK v3 removed the `sdk_integration` constructor argument, while LiteLLM's `LangFuseLogger` (`litellm/integrations/langfuse.py`) passes `sdk_integration="litellm"` when initializing the Langfuse client.

### Upstream Alignment with LiteLLM's Build Strategy
LiteLLM's own repository (`BerriAI/litellm`) explicitly pins `langfuse>=2.59.7,<3.0` in their `pyproject.toml` (specifically under the `proxy-runtime` extra used to build official Docker images like `ghcr.io/berriai/litellm:main-latest`, as well as `langfuse==2.59.7` in `dev`).

Pinning `langfuse==2.59.7` here brings PR-Agent into 100% consistency with LiteLLM's official build configuration.

### Solution
- Pin `langfuse==2.59.7` in `requirements.txt` with explanatory comments matching `pydantic-settings`.
- Ensures out-of-the-box Langfuse logging without `sdk_integration` crashes.