### PR TITLE
fix: break the circular import between pr_agent.log and custom_merge_loader

### DIFF
--- a/pr_agent/custom_merge_loader.py
+++ b/pr_agent/custom_merge_loader.py
@@ -3,10 +3,13 @@ import tomllib #tomllib should be used instead of Py toml for Python 3.11+
 
 from jinja2.exceptions import SecurityError
 
-from pr_agent.log import get_logger
-
 # Prevent out-of-memory exceptions by limiting settings files to 100 MB (sufficient for up to ~1M lines).
 MAX_TOML_SIZE_IN_BYTES = 100 * 1024 * 1024
+
+
+def get_logger():
+    from pr_agent.log import get_logger as _get_logger
+    return _get_logger()
 
 
 def load(obj, env=None, silent=True, key=None, filename=None):


### PR DESCRIPTION
Closes #2694.

## Description

`ImportError: cannot import name 'get_logger' from partially initialized module 'pr_agent.log'`.

### Root cause

`pr_agent/log/__init__.py:10` imports `pr_agent.config_loader` at module scope. `pr_agent/config_loader.py:91` calls `load_file(pyproject_path)` at import time, which makes Dynaconf import the configured loader `pr_agent.custom_merge_loader`, which imports `pr_agent.log` — still only partially initialised.

### The fix

Resolve `get_logger` lazily inside `custom_merge_loader` instead of at module import time.

## Behaviour change

| | |
|---|---|
| **Before** | `cd <repo with pyproject.toml> && python -c 'from pr_agent.log import get_logger'` → ImportError |
| **After** | imports cleanly from any directory, in any order |

The shipped entrypoints were never affected (they import other modules first); this removes the trap for embedding code, plugins and ad-hoc scripts.

## Files changed

```
pr_agent/custom_merge_loader.py | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

## Testing

- `pytest tests/unittest` — **1748 passed, 1 skipped, 1 xfailed** (unchanged from `main`)
- CI pipeline reproduced locally exactly as `.github/workflows/build-and-test.yaml` runs it:
  ```
  docker build -f docker/Dockerfile --target test .
  docker run --rm <image> pytest -v tests/unittest
  ```
  → **1748 passed, 1 skipped, 1 xfailed** on `python:3.12.13-slim`
- Targeted regression check for this defect: reproduced on `main`, no longer reproducible on this branch
- `ruff` — no new findings vs `main`; `isort` — clean

## Risk / compatibility

Only the import timing of the logger changes; logging behaviour is identical.

## Checklist

- [x] Focused on a single fix
- [x] Existing tests pass
- [x] No new dependencies
- [x] No user-facing configuration changes
- [ ] Reviewed by a maintainer
