### PR TITLE
fix: allow importing get_logger as the first pr_agent import

### DIFF
--- a/pr_agent/log/__init__.py
+++ b/pr_agent/log/__init__.py
@@ -7,8 +7,6 @@ from enum import Enum
 
 from loguru import logger
 
-from pr_agent.config_loader import get_settings
-
 
 class LoggingFormat(str, Enum):
     CONSOLE = "CONSOLE"
@@ -45,6 +43,11 @@ def setup_logger(level: str = "INFO", fmt: LoggingFormat = LoggingFormat.CONSOLE
     elif fmt == LoggingFormat.CONSOLE: # does not print the 'extra' fields
         logger.remove(None)
         logger.add(sys.stdout, level=level, colorize=True, filter=inv_analytics_filter)
+
+    # Imported lazily so `from pr_agent.log import get_logger` does not pull
+    # in config_loader while this package is still initializing. config_loader
+    # loads settings via custom_merge_loader, which itself imports get_logger.
+    from pr_agent.config_loader import get_settings
 
     log_folder = get_settings().get("CONFIG.ANALYTICS_FOLDER", "")
     if log_folder:

--- a/tests/unittest/test_log_import.py
+++ b/tests/unittest/test_log_import.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+
+_IMPORT_GET_LOGGER_FIRST = """
+from pr_agent.log import get_logger
+
+assert get_logger() is not None
+"""
+
+
+class TestLogImport:
+    """Regression for importing pr_agent.log before any other pr_agent module (issue #2694)."""
+
+    def test_get_logger_as_first_pr_agent_import(self):
+        """`from pr_agent.log import get_logger` must succeed even when it is
+        the first pr_agent import. A cwd with pyproject.toml used to trip a
+        circular import through config_loader -> custom_merge_loader.
+        Runs in a subprocess so a failed partial import cannot poison this process."""
+        result = subprocess.run(
+            [sys.executable, "-c", _IMPORT_GET_LOGGER_FIRST],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, (
+            f"from pr_agent.log import get_logger failed as the first import:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Problem

```
python -c "from pr_agent.log import get_logger"
```

fails with `ImportError: cannot import name 'get_logger' from partially initialized module 'pr_agent.log'` whenever this is the first `pr_agent` import (and the cwd has a `pyproject.toml` / `.git`, which is the normal case).

Cycle:

1. `pr_agent/log/__init__.py` imported `get_settings` at module scope.
2. `config_loader` constructs Dynaconf, which loads `pr_agent.custom_merge_loader`.
3. `custom_merge_loader` does `from pr_agent.log import get_logger` while `pr_agent.log` is still initializing.

Importing `config_loader` first hid the bug, because then `log` finished loading as a side effect.

Fixes #2694.

## Change

Import `get_settings` inside `setup_logger` only. `get_logger()` itself does not need settings.

## Test

`tests/unittest/test_log_import.py` runs `from pr_agent.log import get_logger` in a subprocess so a failed partial import cannot poison the suite (same pattern as `test_github_provider_import.py`).

```
PYTHONPATH=. python -m pytest tests/unittest/test_log_import.py -q
# 1 passed
```
