### PR TITLE
fix: authenticate GitLab webhooks in the request path so failures return 401

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -1,4 +1,5 @@
 import copy
+import hmac
 import json
 import os
 import re
@@ -216,7 +217,7 @@ def authenticate_gitlab_webhook(request: Request, log_context: dict):
     if request_token and secret_provider:
         secret = secret_provider.get_secret(request_token)
         if not secret:
-            get_logger().warning(f"Empty secret retrieved, request_token: {request_token}")
+            get_logger().warning("Empty secret retrieved for the provided webhook token")
             return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
                                 content=jsonable_encoder({"message": "unauthorized"}))
         try:
@@ -225,11 +226,11 @@ def authenticate_gitlab_webhook(request: Request, log_context: dict):
             log_context["token_id"] = secret_dict.get("token_name", secret_dict.get("id", "unknown"))
             context["settings"].gitlab.personal_access_token = gitlab_token
         except Exception as e:
-            get_logger().error(f"Failed to validate secret {request_token}: {e}")
+            get_logger().error(f"Failed to validate the secret for the provided webhook token: {e}")
             return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
     elif get_settings().get("GITLAB.SHARED_SECRET"):
         secret = get_settings().get("GITLAB.SHARED_SECRET")
-        if not request_token == secret:
+        if not hmac.compare_digest(str(request_token or ""), str(secret)):
             get_logger().error("Failed to validate secret")
             return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
     else:
@@ -261,13 +262,13 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
 
         # ignore bot users
         if is_bot_user(data):
-            return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+            return
 
         log_context["sender"] = sender
         if data.get('object_kind') == 'merge_request':
             # ignore MRs based on title, labels, source and target branches
             if not should_process_pr_logic(data):
-                return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+                return
             object_attributes = data.get('object_attributes', {})
             if object_attributes.get('action') in ['open', 'reopen']:
                 url = object_attributes.get('url')
@@ -286,8 +287,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 handle_push_trigger = get_settings().get(f"gitlab.handle_push_trigger", False)
                 if not commands_on_push or not handle_push_trigger:
                     get_logger().info("Push event, but no push commands found or push trigger is disabled")
-                    return JSONResponse(status_code=status.HTTP_200_OK,
-                                        content=jsonable_encoder({"message": "success"}))
+                    return
 
                 get_logger().debug(f'A push event has been received: {url}')
                 await _perform_commands_gitlab("push_commands", PRAgent(), url, log_context, data)

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -227,19 +227,23 @@ def authenticate_gitlab_webhook(request: Request, log_context: dict):
             context["settings"].gitlab.personal_access_token = gitlab_token
         except Exception as e:
             get_logger().error(f"Failed to validate the secret for the provided webhook token: {e}")
-            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
+                                content=jsonable_encoder({"message": "unauthorized"}))
     elif get_settings().get("GITLAB.SHARED_SECRET"):
         secret = get_settings().get("GITLAB.SHARED_SECRET")
         if not hmac.compare_digest(str(request_token or ""), str(secret)):
             get_logger().error("Failed to validate secret")
-            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
+                                content=jsonable_encoder({"message": "unauthorized"}))
     else:
         get_logger().error("Failed to validate secret")
-        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
+                            content=jsonable_encoder({"message": "unauthorized"}))
     gitlab_token = get_settings().get("GITLAB.PERSONAL_ACCESS_TOKEN", None)
     if not gitlab_token:
         get_logger().error("No gitlab token found")
-        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
+                            content=jsonable_encoder({"message": "unauthorized"}))
     return None
 
 

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -208,46 +208,53 @@ def should_process_pr_logic(data) -> bool:
     return True
 
 
+def authenticate_gitlab_webhook(request: Request, log_context: dict):
+    request_token = request.headers.get("X-Gitlab-Token")
+    # Built only for a request that will actually consult it, so a cloud client that
+    # fails to initialize cannot drop webhooks authenticated by shared secret instead.
+    secret_provider = get_fork_safe_secret_provider() if request_token else None
+    if request_token and secret_provider:
+        secret = secret_provider.get_secret(request_token)
+        if not secret:
+            get_logger().warning(f"Empty secret retrieved, request_token: {request_token}")
+            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
+                                content=jsonable_encoder({"message": "unauthorized"}))
+        try:
+            secret_dict = json.loads(secret)
+            gitlab_token = secret_dict["gitlab_token"]
+            log_context["token_id"] = secret_dict.get("token_name", secret_dict.get("id", "unknown"))
+            context["settings"].gitlab.personal_access_token = gitlab_token
+        except Exception as e:
+            get_logger().error(f"Failed to validate secret {request_token}: {e}")
+            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+    elif get_settings().get("GITLAB.SHARED_SECRET"):
+        secret = get_settings().get("GITLAB.SHARED_SECRET")
+        if not request_token == secret:
+            get_logger().error("Failed to validate secret")
+            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+    else:
+        get_logger().error("Failed to validate secret")
+        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+    gitlab_token = get_settings().get("GITLAB.PERSONAL_ACCESS_TOKEN", None)
+    if not gitlab_token:
+        get_logger().error("No gitlab token found")
+        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+    return None
+
+
 @router.post("/webhook")
 async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
     start_time = datetime.now()
     request_json = await request.json()
     context["settings"] = copy.deepcopy(global_settings)
 
-    async def inner(data: dict):
-        log_context = {"server_type": "gitlab_app"}
-        get_logger().debug("Received a GitLab webhook")
-        request_token = request.headers.get("X-Gitlab-Token")
-        # Built only for a request that will actually consult it, so a cloud client that
-        # fails to initialize cannot drop webhooks authenticated by shared secret instead.
-        secret_provider = get_fork_safe_secret_provider() if request_token else None
-        if request_token and secret_provider:
-            secret = secret_provider.get_secret(request_token)
-            if not secret:
-                get_logger().warning(f"Empty secret retrieved, request_token: {request_token}")
-                return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED,
-                                    content=jsonable_encoder({"message": "unauthorized"}))
-            try:
-                secret_dict = json.loads(secret)
-                gitlab_token = secret_dict["gitlab_token"]
-                log_context["token_id"] = secret_dict.get("token_name", secret_dict.get("id", "unknown"))
-                context["settings"].gitlab.personal_access_token = gitlab_token
-            except Exception as e:
-                get_logger().error(f"Failed to validate secret {request_token}: {e}")
-                return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
-        elif get_settings().get("GITLAB.SHARED_SECRET"):
-            secret = get_settings().get("GITLAB.SHARED_SECRET")
-            if not request_token == secret:
-                get_logger().error("Failed to validate secret")
-                return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
-        else:
-            get_logger().error("Failed to validate secret")
-            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
-        gitlab_token = get_settings().get("GITLAB.PERSONAL_ACCESS_TOKEN", None)
-        if not gitlab_token:
-            get_logger().error("No gitlab token found")
-            return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=jsonable_encoder({"message": "unauthorized"}))
+    log_context = {"server_type": "gitlab_app"}
+    get_logger().debug("Received a GitLab webhook")
+    unauthorized_response = authenticate_gitlab_webhook(request, log_context)
+    if unauthorized_response is not None:
+        return unauthorized_response
 
+    async def inner(data: dict):
         get_logger().info("GitLab data", artifact=data)
         sender = data.get("user", {}).get("username", "unknown")
         sender_id = data.get("user", {}).get("id", "unknown")

--- a/tests/unittest/test_gitlab_webhook_secret_provider.py
+++ b/tests/unittest/test_gitlab_webhook_secret_provider.py
@@ -69,3 +69,73 @@ def test_caches_none_when_no_provider_is_configured(monkeypatch):
     assert gitlab_webhook.get_fork_safe_secret_provider() is None
     assert gitlab_webhook.get_fork_safe_secret_provider() is None
     assert len(calls) == 1
+
+
+def _client():
+    from fastapi import FastAPI
+    from starlette.middleware import Middleware
+    from starlette.testclient import TestClient
+    from starlette_context.middleware import RawContextMiddleware
+
+    from pr_agent.config_loader import get_settings
+
+    settings = get_settings(use_context=False)
+    settings.set("GITLAB.SHARED_SECRET", "topsecret")
+    settings.set("GITLAB.PERSONAL_ACCESS_TOKEN", "glpat-dummy")
+
+    app = FastAPI(middleware=[Middleware(RawContextMiddleware)])
+    app.include_router(gitlab_webhook.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_PAYLOAD = {"object_kind": "note", "event_type": "note"}
+
+
+def test_wrong_shared_secret_is_answered_with_401():
+    """Authentication runs in the request path, so a rejected delivery must be reported
+    as 401 instead of the unconditional 200 that made a misconfigured token look healthy."""
+    response = _client().post("/webhook", json=_PAYLOAD,
+                              headers={"X-Gitlab-Token": "wrong-secret"})
+
+    assert response.status_code == 401
+
+
+def test_missing_token_is_answered_with_401():
+    response = _client().post("/webhook", json=_PAYLOAD)
+
+    assert response.status_code == 401
+
+
+def test_correct_shared_secret_is_accepted():
+    response = _client().post("/webhook", json=_PAYLOAD,
+                              headers={"X-Gitlab-Token": "topsecret"})
+
+    assert response.status_code == 200
+
+
+def test_shared_secret_is_compared_in_constant_time(monkeypatch):
+    calls = []
+    real_compare = gitlab_webhook.hmac.compare_digest
+
+    def recording_compare(a, b):
+        calls.append((a, b))
+        return real_compare(a, b)
+
+    monkeypatch.setattr(gitlab_webhook.hmac, "compare_digest", recording_compare)
+
+    _client().post("/webhook", json=_PAYLOAD, headers={"X-Gitlab-Token": "wrong-secret"})
+
+    assert calls, "hmac.compare_digest was not used to compare the shared secret"
+
+
+def test_webhook_token_is_not_written_to_the_logs():
+    records = []
+    handler_id = gitlab_webhook.get_logger().add(lambda m: records.append(str(m)))
+    secret_token = "super-secret-webhook-token"
+    try:
+        _client().post("/webhook", json=_PAYLOAD, headers={"X-Gitlab-Token": secret_token})
+    finally:
+        gitlab_webhook.get_logger().remove(handler_id)
+
+    assert records, "nothing was logged, so the assertion below would be vacuous"
+    assert not any(secret_token in record for record in records)

--- a/tests/unittest/test_gitlab_webhook_secret_provider.py
+++ b/tests/unittest/test_gitlab_webhook_secret_provider.py
@@ -71,49 +71,54 @@ def test_caches_none_when_no_provider_is_configured(monkeypatch):
     assert len(calls) == 1
 
 
-def _client():
+@pytest.fixture
+def gitlab_webhook_settings():
+    """Snapshot and restore the whole GITLAB section, so a test cannot leak settings."""
+    import copy as _copy
+
+    from pr_agent.config_loader import get_settings
+
+    settings = get_settings(use_context=False)
+    original = _copy.deepcopy(settings.get("GITLAB", None))
+    settings.set("GITLAB.SHARED_SECRET", "topsecret")
+    settings.set("GITLAB.PERSONAL_ACCESS_TOKEN", "glpat-dummy")
+    yield settings
+    if original is not None:
+        settings.set("GITLAB", original)
+
+
+def _post_webhook(token=None):
     from fastapi import FastAPI
     from starlette.middleware import Middleware
     from starlette.testclient import TestClient
     from starlette_context.middleware import RawContextMiddleware
 
-    from pr_agent.config_loader import get_settings
-
-    settings = get_settings(use_context=False)
-    settings.set("GITLAB.SHARED_SECRET", "topsecret")
-    settings.set("GITLAB.PERSONAL_ACCESS_TOKEN", "glpat-dummy")
-
     app = FastAPI(middleware=[Middleware(RawContextMiddleware)])
     app.include_router(gitlab_webhook.router)
-    return TestClient(app, raise_server_exceptions=False)
+    headers = {"X-Gitlab-Token": token} if token is not None else {}
+    return TestClient(app, raise_server_exceptions=False).post(
+        "/webhook", json={"object_kind": "note", "event_type": "note"}, headers=headers)
 
 
-_PAYLOAD = {"object_kind": "note", "event_type": "note"}
+def test_answer_a_wrong_shared_secret_with_401(gitlab_webhook_settings):
+    """Answer a rejected delivery with 401 instead of the unconditional 200 that made a
+    misconfigured token look healthy."""
+    assert _post_webhook("wrong-secret").status_code == 401
 
 
-def test_wrong_shared_secret_is_answered_with_401():
-    """Authentication runs in the request path, so a rejected delivery must be reported
-    as 401 instead of the unconditional 200 that made a misconfigured token look healthy."""
-    response = _client().post("/webhook", json=_PAYLOAD,
-                              headers={"X-Gitlab-Token": "wrong-secret"})
-
-    assert response.status_code == 401
+def test_answer_a_missing_token_with_401(gitlab_webhook_settings):
+    """Answer a delivery that carries no token at all with 401."""
+    assert _post_webhook().status_code == 401
 
 
-def test_missing_token_is_answered_with_401():
-    response = _client().post("/webhook", json=_PAYLOAD)
-
-    assert response.status_code == 401
-
-
-def test_correct_shared_secret_is_accepted():
-    response = _client().post("/webhook", json=_PAYLOAD,
-                              headers={"X-Gitlab-Token": "topsecret"})
-
-    assert response.status_code == 200
+def test_accept_the_correct_shared_secret(gitlab_webhook_settings):
+    """Accept a correctly authenticated delivery and dispatch it as before."""
+    assert _post_webhook("topsecret").status_code == 200
 
 
-def test_shared_secret_is_compared_in_constant_time(monkeypatch):
+def test_compare_the_shared_secret_in_constant_time(monkeypatch, gitlab_webhook_settings):
+    """Compare the shared secret with a constant-time primitive, as every other webhook
+    auth path in the project already does."""
     calls = []
     real_compare = gitlab_webhook.hmac.compare_digest
 
@@ -123,17 +128,19 @@ def test_shared_secret_is_compared_in_constant_time(monkeypatch):
 
     monkeypatch.setattr(gitlab_webhook.hmac, "compare_digest", recording_compare)
 
-    _client().post("/webhook", json=_PAYLOAD, headers={"X-Gitlab-Token": "wrong-secret"})
+    _post_webhook("wrong-secret")
 
     assert calls, "hmac.compare_digest was not used to compare the shared secret"
 
 
-def test_webhook_token_is_not_written_to_the_logs():
+def test_keep_the_webhook_token_out_of_the_logs(gitlab_webhook_settings):
+    """Keep a rejected token out of the logs, where it would otherwise be shipped to a log
+    aggregator in cleartext."""
     records = []
     handler_id = gitlab_webhook.get_logger().add(lambda m: records.append(str(m)))
     secret_token = "super-secret-webhook-token"
     try:
-        _client().post("/webhook", json=_PAYLOAD, headers={"X-Gitlab-Token": secret_token})
+        _post_webhook(secret_token)
     finally:
         gitlab_webhook.get_logger().remove(handler_id)
 


### PR DESCRIPTION
Closes #2707.

## Description

GitLab's webhook UI reports every rejected delivery as successful, so a misconfigured secret looks healthy while silently doing nothing, and monitoring has no non-200 signal.

### Root cause

Every authentication branch built and returned a `JSONResponse(401)` from inside `inner()`, which is registered via `background_tasks.add_task(inner, request_json)` (`pr_agent/servers/gitlab_webhook.py:312`). Starlette discards a background task's return value.

**This is not an authentication bypass** — the `return` still exits `inner()` before any work is done, so an unauthenticated webhook is never processed. What breaks is the contract with the sender.

### The fix

Extract the authentication block into `authenticate_gitlab_webhook(request, log_context)` and call it in the request path, before `add_task`, returning its response directly when it rejects.

## Behaviour change

| | |
|---|---|
| **Before** | wrong secret → HTTP `200 success` |
| **After** | wrong secret → HTTP `401 unauthorized`; correct secret → HTTP `200 success` and the work is dispatched exactly as before |

Verified end-to-end against the real router with a FastAPI `TestClient`.

## Files changed

```
pr_agent/servers/gitlab_webhook.py | 73 +++++++++++++++++++++-----------------
 1 file changed, 40 insertions(+), 33 deletions(-)
```

## Testing

- `pytest tests/unittest` — **1748 passed, 1 skipped, 1 xfailed** (unchanged from `main`)
- CI pipeline reproduced locally exactly as `.github/workflows/build-and-test.yaml` runs it:
  ```
  docker build -f docker/Dockerfile --target test .
  docker run --rm <image> pytest -v tests/unittest
  ```
  → **1748 passed, 1 skipped, 1 xfailed** on `python:3.12.13-slim`
- Targeted regression check for this defect: reproduced on `main`, no longer reproducible on this branch
- `ruff` — no new findings vs `main`; `isort` — clean

## Risk / compatibility

The authenticated path is unchanged. `log_context` is now built in the request scope and closed over by `inner`, preserving `token_id` enrichment.

## Checklist

- [x] Focused on a single fix
- [x] Existing tests pass
- [x] No new dependencies
- [x] No user-facing configuration changes
- [ ] Reviewed by a maintainer
