### PR TITLE
fix(observability): support langfuse_otel in litellm handler and add opentelemetry dependencies

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -148,11 +148,20 @@ class LiteLLMAIHandler(BaseAiHandler):
         if get_settings().get("LITELLM.DROP_PARAMS", None):
             litellm.drop_params = get_settings().litellm.drop_params
         if get_settings().get("LITELLM.SUCCESS_CALLBACK", None):
-            litellm.success_callback = get_settings().litellm.success_callback
+            success_cb = get_settings().litellm.success_callback
+            if isinstance(success_cb, list):
+                success_cb = ["langfuse_otel" if c == "langfuse" else c for c in success_cb]
+            litellm.success_callback = success_cb
         if get_settings().get("LITELLM.FAILURE_CALLBACK", None):
-            litellm.failure_callback = get_settings().litellm.failure_callback
+            failure_cb = get_settings().litellm.failure_callback
+            if isinstance(failure_cb, list):
+                failure_cb = ["langfuse_otel" if c == "langfuse" else c for c in failure_cb]
+            litellm.failure_callback = failure_cb
         if get_settings().get("LITELLM.SERVICE_CALLBACK", None):
-            litellm.service_callback = get_settings().litellm.service_callback
+            service_cb = get_settings().litellm.service_callback
+            if isinstance(service_cb, list):
+                service_cb = ["langfuse_otel" if c == "langfuse" else c for c in service_cb]
+            litellm.service_callback = service_cb
         if get_settings().get("OPENAI.ORG", None):
             litellm.organization = get_settings().openai.org
         if get_settings().get("OPENAI.API_TYPE", None):
@@ -426,7 +435,7 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         metadata = dict()
         callbacks = litellm.success_callback + litellm.failure_callback + litellm.service_callback
-        if "langfuse" in callbacks:
+        if "langfuse" in callbacks or "langfuse_otel" in callbacks:
             metadata.update({
                 "trace_name": command,
                 "tags": [git_provider, command, f'version:{get_version()}'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,9 @@ uvicorn==0.22.0
 tenacity==8.2.3
 a2a-sdk[http-server]==1.0.3
 langfuse==3.14.5
+opentelemetry-api==1.28.0
+opentelemetry-sdk==1.28.0
+opentelemetry-exporter-otlp==1.28.0
 gunicorn==23.0.0
 pytest-cov==7.0.0
 pydantic==2.13.3


### PR DESCRIPTION
### Summary
Enables seamless Langfuse v3 tracing via OpenTelemetry (`langfuse_otel`) across PR-Agent by adding required OpenTelemetry dependencies and supporting `langfuse_otel` metadata in `LiteLLMAIHandler`.

### Motivation & Problem
1. **Langfuse v3 SDK Compatibility:** PR-Agent uses `langfuse==3.14.5` (required by MOSAICO's direct tracing APIs such as `get_client`, `propagate_attributes`, and `start_as_current_observation`).
2. **`sdk_integration` Crash:** In Langfuse v3, the legacy callback `["langfuse"]` in LiteLLM raises `TypeError: Langfuse.__init__() got an unexpected keyword argument 'sdk_integration'`.
3. **Missing OTel Dependencies & Metadata:** When using `langfuse_otel`, LiteLLM requires OpenTelemetry packages (`opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp`), and `LiteLLMAIHandler` previously only injected PR metadata (`trace_name`, `tags`, `trace_metadata`) when `"langfuse"` was in callbacks, omitting `"langfuse_otel"`.

### Solution
- **Dependencies:** Added `opentelemetry-api==1.28.0`, `opentelemetry-sdk==1.28.0`, and `opentelemetry-exporter-otlp==1.28.0` to `requirements.txt`.
- **LiteLLMAIHandler Callback Normalization:** Automatically map legacy `"langfuse"` callback entries to `"langfuse_otel"` during handler initialization, ensuring backwards compatibility for users configuring `LITELLM.SUCCESS_CALLBACK: ["langfuse"]`.
- **Metadata Injection:** Updated `add_litellm_callbacks` to inject trace metadata (`command`, `pr_url`, `tags`) for `"langfuse_otel"` callbacks.