### PR TITLE
fix: update stale unreviewed_files_set references to unreviewed_files_map in tests

### DIFF
--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -217,7 +217,7 @@ def _make_provider_for_diff(files):
     p.diff_files = None
     p.git_files = None
     p.incremental = SimpleNamespace(is_incremental=False)
-    p.unreviewed_files_set = {}
+    p.unreviewed_files_map = {}
     # pr.base/head shas drive repo.compare which we stub out below.
     p.pr = SimpleNamespace(
         base=SimpleNamespace(sha="base-sha"),

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -159,7 +159,7 @@ def mosaico_input():
 # ---------------------------------------------------------------------------
 
 _INCREMENTAL_ONLY_METHODS = (
-    "get_incremental_commits", "unreviewed_files_set", "previous_review", "auto_approve",
+    "get_incremental_commits", "unreviewed_files_map", "previous_review", "auto_approve",
 )
 
 


### PR DESCRIPTION
## Description

Fix two stale test-only references left after the incremental review attribute was renamed from `unreviewed_files_set` to `unreviewed_files_map` (in #2381).

- `tests/unittest/test_mosaico_provider.py`: update `_INCREMENTAL_ONLY_METHODS` tuple entry.
- `tests/unittest/test_github_provider_urls_and_diffs.py`: update the fake provider attribute assignment.

## Type of change

- [x] Bug fix (non-breaking change)

## Verification

Ran the two affected test files:

```
$ python3 -m pytest tests/unittest/test_github_provider_urls_and_diffs.py tests/unittest/test_mosaico_provider.py -q
41 passed in 2.88s
```

Closes #2710