### PR TITLE
tests: use unreviewed_files_map in incremental test refs

### DIFF
--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -217,7 +217,7 @@ def _make_provider_for_diff(files):
     p.diff_files = None
     p.git_files = None
     p.incremental = SimpleNamespace(is_incremental=False)
-    p.unreviewed_files_set = {}
+    p.unreviewed_files_map = {}
     # pr.base/head shas drive repo.compare which we stub out below.
     p.pr = SimpleNamespace(
         base=SimpleNamespace(sha="base-sha"),

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -159,7 +159,7 @@ def mosaico_input():
 # ---------------------------------------------------------------------------
 
 _INCREMENTAL_ONLY_METHODS = (
-    "get_incremental_commits", "unreviewed_files_set", "previous_review", "auto_approve",
+    "get_incremental_commits", "unreviewed_files_map", "previous_review", "auto_approve",
 )
 
 


### PR DESCRIPTION
Fixes #2710.

Two test-only references to `unreviewed_files_set` survived the rename in a7f152ec (#2381). Renamed both to `unreviewed_files_map`.

The one that mattered is `_INCREMENTAL_ONLY_METHODS` in `tests/unittest/test_mosaico_provider.py` — `_SpyProvider` was trapping an attribute name production no longer uses, so the `incremental == []` assertions at :294 and :303 would not have caught the mosaico diff path reading `unreviewed_files_map`. The line in `test_github_provider_urls_and_diffs.py` is dead setup either way (`is_incremental` is False in those tests), but leaving the old name in the tree is what the issue flags as misleading.

`pytest tests/unittest`: 1748 passed, 1 skipped, 1 xfailed — same as main.