### PR TITLE
test: fix stale unreviewed_files_set references to unreviewed_files_map

### DIFF
--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -217,7 +217,7 @@ def _make_provider_for_diff(files):
     p.diff_files = None
     p.git_files = None
     p.incremental = SimpleNamespace(is_incremental=False)
-    p.unreviewed_files_set = {}
+    p.unreviewed_files_map = {}
     # pr.base/head shas drive repo.compare which we stub out below.
     p.pr = SimpleNamespace(
         base=SimpleNamespace(sha="base-sha"),

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -159,7 +159,7 @@ def mosaico_input():
 # ---------------------------------------------------------------------------
 
 _INCREMENTAL_ONLY_METHODS = (
-    "get_incremental_commits", "unreviewed_files_set", "previous_review", "auto_approve",
+    "get_incremental_commits", "unreviewed_files_map", "previous_review", "auto_approve",
 )
 
 


### PR DESCRIPTION
## What
Fixes stale references to `unreviewed_files_set` in two test files — the
attribute was renamed to `unreviewed_files_map` in production code but two
tests still watched/set the old name.

## Why
Closes #2710. In `test_mosaico_provider.py`, the `_SpyProvider` was watching
`unreviewed_files_set`, an attribute production code no longer uses — meaning
the assertion couldn't actually catch a real regression.

## Testing
Ran both affected test files locally: 41 passed, no failures.