### PR TITLE
test: rename stale unreviewed_files_set refs to unreviewed_files_map

### DIFF
--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -217,7 +217,7 @@ def _make_provider_for_diff(files):
     p.diff_files = None
     p.git_files = None
     p.incremental = SimpleNamespace(is_incremental=False)
-    p.unreviewed_files_set = {}
+    p.unreviewed_files_map = {}
     # pr.base/head shas drive repo.compare which we stub out below.
     p.pr = SimpleNamespace(
         base=SimpleNamespace(sha="base-sha"),

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -159,7 +159,7 @@ def mosaico_input():
 # ---------------------------------------------------------------------------
 
 _INCREMENTAL_ONLY_METHODS = (
-    "get_incremental_commits", "unreviewed_files_set", "previous_review", "auto_approve",
+    "get_incremental_commits", "unreviewed_files_map", "previous_review", "auto_approve",
 )
 
 


### PR DESCRIPTION
## What

Closes #2710.

`#2381` (commit a7f152ec) renamed the incremental attribute from `unreviewed_files_set` to `unreviewed_files_map` across the Azure DevOps, Gitea and GitHub providers, and the gate in `pr_agent/tools/pr_reviewer.py`. Two test-only references to the old name were left behind. No production code on `main` uses the old name, so nothing is broken at runtime — but the stale names weaken the tests.

## Why it is worth fixing

**`tests/unittest/test_mosaico_provider.py:161-163`** — `_INCREMENTAL_ONLY_METHODS` lists the attribute names `_SpyProvider` traps, so the tests at `:294` and `:303` can assert `incremental == []` and prove the mosaico diff path never touches incremental state. Because the tuple still named `unreviewed_files_set`, the spy was watching a name production no longer uses: if that path ever did read `unreviewed_files_map`, the assertion would not catch it. The guarantee was weaker than it read.

**`tests/unittest/test_github_provider_urls_and_diffs.py:220`** — `_make_provider_for_diff` set `p.unreviewed_files_set = {}`. `GithubProvider.get_diff_files` reads `self.unreviewed_files_map` behind an `is_incremental` check that is `False` in those tests, so the line was dead setup. Still worth removing: leaving the old name in the tree makes it look current (part of why #2389 carried the old name through a merge and only noticed when the shared skip path stopped firing).

## The change

Two lines, `unreviewed_files_set` → `unreviewed_files_map` in both places.

## Verification

Full unittest suite, unchanged from `main`:

```
1748 passed, 1 skipped, 1 xfailed in 18.29s
```

No production code touched.