### PR TITLE
fix: rename stale unreviewed_files_set references in tests

### DIFF
--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -217,7 +217,7 @@ def _make_provider_for_diff(files):
     p.diff_files = None
     p.git_files = None
     p.incremental = SimpleNamespace(is_incremental=False)
-    p.unreviewed_files_set = {}
+    p.unreviewed_files_map = {}
     # pr.base/head shas drive repo.compare which we stub out below.
     p.pr = SimpleNamespace(
         base=SimpleNamespace(sha="base-sha"),

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -159,7 +159,7 @@ def mosaico_input():
 # ---------------------------------------------------------------------------
 
 _INCREMENTAL_ONLY_METHODS = (
-    "get_incremental_commits", "unreviewed_files_set", "previous_review", "auto_approve",
+    "get_incremental_commits", "unreviewed_files_map", "previous_review", "auto_approve",
 )
 
 


### PR DESCRIPTION
## What

Two test files still referenced `unreviewed_files_set` after the incremental rename in #2381 moved production code to `unreviewed_files_map`. This updates both, production code is untouched.

## Why

The mosaico spy defines `_INCREMENTAL_ONLY_METHODS` as the attribute names it traps, and the tests assert `incremental == []` to prove the diff path never touches incremental state. With the old name still in the tuple, the spy was watching a name production no longer uses, so that guarantee was weaker than it reads.

The github provider helper set a now-dead attribute during setup. It was harmless, but leaving the old name in the tree makes it look current, which is exactly how #2389 carried the stale name through a merge.

## Change

Two lines:

- `tests/unittest/test_mosaico_provider.py:162`: `unreviewed_files_set` to `unreviewed_files_map` in the spy tuple
- `tests/unittest/test_github_provider_urls_and_diffs.py:220`: same rename in `_make_provider_for_diff`

## Verification

Ran the full unit suite on a clean checkout: 1800 passed, 1 skipped, 1 xfailed, no failures.

Also confirmed the spy actually bites under the new name. A minimal probe showed the old tuple does not trap access to `unreviewed_files_map` and the new one does.

Fixes #2710