### PR TITLE
fix(gitea): parse PR and issue URLs by shape rather than fixed offset

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -221,45 +221,55 @@ class GiteaProvider(GitProvider):
         except Exception as e:
             self.logger.error(f"Error getting diff content: {str(e)}")
 
+    # Locate the resource by shape rather than by a fixed offset. The same
+    # resource is addressed by several paths and only the tail is invariant:
+    #
+    #   /{owner}/{repo}/{marker}/{number}                  web
+    #   /api/v1/repos/{owner}/{repo}/{marker}/{number}     api
+    #   /{sub}/{owner}/{repo}/{marker}/{number}            instance under a subpath
+    #   /{owner}/{repo}/{marker}/{number}/files            a tab on the web view
+    #
+    # Fixed offsets cannot span those, which is why stripping a known prefix
+    # breaks whenever the prefix changes.
+    @staticmethod
+    def _parse_resource_url(url: str, marker: str, kind: str) -> Tuple[str, str, int]:
+        path_parts = [part for part in urlparse(url).path.split("/") if part]
+
+        # Accept a segment as the marker only when a number follows it and an
+        # owner and repository precede it. Skip an occurrence whose successor is
+        # not a number, so a repository named "pulls" or "issues" resolves to
+        # the marker beside the number rather than to its own name.
+        candidates = []
+        for i in range(2, len(path_parts) - 1):
+            if path_parts[i] != marker:
+                continue
+            try:
+                candidates.append((i, int(path_parts[i + 1])))
+            except ValueError:
+                continue
+
+        # Refuse to guess when a path holds more than one candidate. Picking one
+        # would silently resolve to a different owner and repository, and those
+        # values go straight into API requests.
+        if len(candidates) > 1:
+            raise ValueError(f"The provided URL contains more than one Gitea {kind} path")
+
+        if candidates:
+            i, number = candidates[0]
+            return path_parts[i - 2], path_parts[i - 1], number
+
+        # Separate "number is unusable" from "not a resource URL": the two have
+        # different causes and different fixes.
+        if any(part == marker and i >= 2 and i + 1 < len(path_parts)
+               for i, part in enumerate(path_parts)):
+            raise ValueError(f"Unable to convert {kind} number to integer")
+        raise ValueError(f"The provided URL does not appear to be a Gitea {kind} URL")
+
     def _parse_pr_url(self, pr_url: str) -> Tuple[str, str, int]:
-        parsed_url = urlparse(pr_url)
-
-        if parsed_url.path.startswith('/api/v1'):
-            parsed_url = urlparse(pr_url.replace("/api/v1", ""))
-
-        path_parts = parsed_url.path.strip('/').split('/')
-        if len(path_parts) < 4 or path_parts[2] != 'pulls':
-            raise ValueError("The provided URL does not appear to be a Gitea PR URL")
-
-        try:
-            pr_number = int(path_parts[3])
-        except ValueError as e:
-            raise ValueError("Unable to convert PR number to integer") from e
-
-        owner = path_parts[0]
-        repo = path_parts[1]
-
-        return owner, repo, pr_number
+        return self._parse_resource_url(pr_url, "pulls", "PR")
 
     def _parse_issue_url(self, issue_url: str) -> Tuple[str, str, int]:
-        parsed_url = urlparse(issue_url)
-
-        if parsed_url.path.startswith('/api/v1'):
-            parsed_url = urlparse(issue_url.replace("/api/v1", ""))
-
-        path_parts = parsed_url.path.strip('/').split('/')
-        if len(path_parts) < 4 or path_parts[2] != 'issues':
-            raise ValueError("The provided URL does not appear to be a Gitea issue URL")
-
-        try:
-            issue_number = int(path_parts[3])
-        except ValueError as e:
-            raise ValueError("Unable to convert issue number to integer") from e
-
-        owner = path_parts[0]
-        repo = path_parts[1]
-
-        return owner, repo, issue_number
+        return self._parse_resource_url(issue_url, "issues", "issue")
 
     def __set_repo_and_owner_from_pr(self):
         """Extract owner and repo from the PR URL"""

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -634,9 +634,9 @@ class TestGiteaProviderUserFacingLinks:
     ``__init__`` performs network calls, so instances are built with ``__new__``
     and only the attributes under test are wired up. ``base_url`` below stands
     in for an internal address (e.g. a Docker service name) that users cannot
-    browse. ``pr_url`` uses the user-facing form throughout: ``_parse_pr_url``
-    rejects the API form, so a constructed provider could never carry it, and
-    Gitea sets ``url``/``html_url`` on the PR payload to the user-facing page.
+    browse. ``pr_url`` uses the user-facing form throughout, matching the
+    payload's ``html_url``. The payload's ``url`` carries the API form, which
+    the parser also accepts.
     """
 
     @staticmethod
@@ -760,3 +760,77 @@ class TestGiteaProviderUserFacingLinks:
         provider.base_url_html = provider._resolve_base_url_html()
 
         assert provider.get_pr_url() == "http://forgejo:3000/owner/repo/pulls/4"
+
+
+class TestGiteaProviderUrlParsing:
+    """Exercise URL parsing without a client by building the provider via __new__."""
+
+    @staticmethod
+    def _provider():
+        return GiteaProvider.__new__(GiteaProvider)
+
+    def test_parse_pr_url_accepts_web_and_api_forms(self):
+        # Webhook payloads carry the api form; --pr_url arguments carry the web form.
+        provider = self._provider()
+        assert provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/1") == ("owner", "repo", 1)
+        assert provider._parse_pr_url(
+            "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1") == ("owner", "repo", 1)
+
+    def test_parse_pr_url_accepts_subpath_installs(self):
+        # Prefix the path the way an instance hosted under a subpath does.
+        provider = self._provider()
+        assert provider._parse_pr_url("https://example.com/git/owner/repo/pulls/42") == ("owner", "repo", 42)
+        assert provider._parse_pr_url(
+            "https://example.com/git/api/v1/repos/owner/repo/pulls/42") == ("owner", "repo", 42)
+
+    def test_parse_pr_url_ignores_trailing_segments(self):
+        provider = self._provider()
+        assert provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/7/files") == ("owner", "repo", 7)
+        assert provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/7?x=1") == ("owner", "repo", 7)
+
+    def test_parse_pr_url_keeps_api_sub_resources_on_their_parent_pr(self):
+        # Address a review or a comment without retargeting the PR itself.
+        provider = self._provider()
+        url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/7/reviews/12"
+        assert provider._parse_pr_url(url) == ("owner", "repo", 7)
+
+    def test_parse_pr_url_handles_repo_named_pulls(self):
+        # Resolve to the marker beside the number, not to the repository name.
+        provider = self._provider()
+        assert provider._parse_pr_url("https://gitea.example.com/owner/pulls/pulls/3") == ("owner", "pulls", 3)
+
+    def test_parse_pr_url_skips_a_marker_that_is_not_followed_by_a_number(self):
+        # Treat a non-numeric successor as proof this occurrence is not the marker.
+        provider = self._provider()
+        url = "https://gitea.example.com/owner/repo/pulls/5/files/pulls/x"
+        assert provider._parse_pr_url(url) == ("owner", "repo", 5)
+
+    def test_parse_pr_url_rejects_an_ambiguous_path(self):
+        # Fail loudly rather than resolve to an owner and repo the URL never named.
+        provider = self._provider()
+        with pytest.raises(ValueError, match="more than one Gitea PR path"):
+            provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/7/files/pulls/8")
+
+    def test_parse_pr_url_rejects_non_pr_urls(self):
+        provider = self._provider()
+        with pytest.raises(ValueError, match="does not appear to be a Gitea PR URL"):
+            provider._parse_pr_url("https://gitea.example.com/owner/repo/issues/1")
+        with pytest.raises(ValueError, match="does not appear to be a Gitea PR URL"):
+            provider._parse_pr_url("https://gitea.example.com/owner/repo")
+        with pytest.raises(ValueError, match="Unable to convert PR number to integer"):
+            provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/abc")
+
+    def test_parse_issue_url_accepts_web_and_api_forms(self):
+        provider = self._provider()
+        assert provider._parse_issue_url("https://gitea.example.com/owner/repo/issues/5") == ("owner", "repo", 5)
+        assert provider._parse_issue_url(
+            "https://gitea.example.com/api/v1/repos/owner/repo/issues/5") == ("owner", "repo", 5)
+
+    def test_parse_issue_url_rejects_ambiguous_and_non_issue_urls(self):
+        provider = self._provider()
+        with pytest.raises(ValueError, match="does not appear to be a Gitea issue URL"):
+            provider._parse_issue_url("https://gitea.example.com/owner/repo/pulls/1")
+        with pytest.raises(ValueError, match="Unable to convert issue number to integer"):
+            provider._parse_issue_url("https://gitea.example.com/owner/repo/issues/abc")
+        with pytest.raises(ValueError, match="more than one Gitea issue path"):
+            provider._parse_issue_url("https://gitea.example.com/owner/repo/issues/4/x/issues/9")


### PR DESCRIPTION
## Description

`_parse_pr_url` and `_parse_issue_url` strip a leading `/api/v1` and then read the owner, repo and number from path positions 0, 1 and 3. That requires the `pulls`/`issues` marker to sit at index 2, and two common URL shapes do not satisfy it:

- **API URLs**, which is what the webhook path uses. `gitea_app.handle_comment_event` reads `pull_request.url` straight off the payload, and on Forgejo that field is the API URL: `/api/v1/repos/{owner}/{repo}/pulls/{n}`. Stripping `/api/v1` leaves `/repos/{owner}/{repo}/pulls/{n}`, where index 2 holds the repository name, so every call raises `The provided URL does not appear to be a Gitea PR URL`.
- **Instances served under a subpath** (`https://example.com/git/{owner}/{repo}/pulls/{n}`), where the prefix shifts every index. These fail in the web and API forms alike.

Under the `gitea_app` server the failure is invisible from the outside. `handle_gitea_webhooks` queues `handle_request` as a background task and returns `{}` before the parse runs, so the forge records a successful delivery — 2xx, green in the hook history — while no review is ever posted. The only trace is a traceback in the container log.

`_parse_issue_url` carries the same bug, so `/ask` on an issue fails the same way.

The fix locates the marker segment that directly precedes the number and reads the owner and repo back from there, rather than assuming a fixed offset. Three properties fall out of that:

- An occurrence whose successor is not a number is skipped, so a repository literally named `pulls` or `issues` resolves to the marker beside the number rather than to its own name.
- API sub-resources (`/pulls/7/reviews/12`, `/pulls/7/comments/3`) still resolve to their parent PR.
- A path holding more than one candidate is refused rather than resolved. Picking one would hand a wrong owner and repository straight to the API.

Both parsers share one helper. The existing error messages are byte-identical, including the distinction between "number is unusable" and "not a resource URL".

## Type of change

- [x] Bug fix (non-breaking change)

## Verification

```
$ PYTHONPATH=. python -m pytest tests/unittest/test_gitea_provider.py -q
46 passed in 0.75s

$ PYTHONPATH=. python -m pytest tests/unittest -q
1946 passed, 1 skipped, 1 xfailed in 20.83s
```

Against `main` with only the tests applied, 3 of the 10 new cases fail — the API form, the subpath form, and the issue API form. The rest pass either way, pinning the shapes that already worked.

The new parser was also compared against the old one over every generated 2-to-4 segment path combination (22,619 URLs) to confirm the change is additive: no URL that `main` parses successfully is parsed differently here.

`ruff check` and `flake8` on both touched files report exactly the same violations as `main` (9 pre-existing, none introduced).

One test-only follow-on: `TestGiteaProviderUserFacingLinks` (added in #2617) had a docstring stating that `_parse_pr_url` rejects the API form. That is no longer true, so the sentence is reworded to say what the payload actually carries — `html_url` is the user-facing page and `url` is the API form, which is what `gitea_app.py:92` reads as `api_url`. The tests themselves are unchanged and still pass.
