### PR TITLE
fix(azure): span complete suggestion lines

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -103,6 +103,17 @@ class AzureDevopsProvider(GitProvider):
                 self._diff_path_map = path_map
         return path_map.get(relevant_file) or path_map.get(relevant_file.lstrip("/"))
 
+    def _get_suggestion_end_offset(self, relevant_file: str, relevant_lines_end: int) -> Optional[int]:
+        for file in self.diff_files or []:
+            if file.filename != relevant_file or not isinstance(file.head_file, str):
+                continue
+            lines = file.head_file.splitlines()
+            if relevant_lines_end > len(lines):
+                return None
+            line = lines[relevant_lines_end - 1]
+            return len(line.encode("utf-16-le")) // 2 + 1
+        return None
+
     @staticmethod
     def _fallback_suggestion_section(suggestion: dict, reason: str) -> str:
         relevant_file = str(suggestion["relevant_file"]).strip().strip("`").strip().replace("`", "")
@@ -186,10 +197,25 @@ class AzureDevopsProvider(GitProvider):
                     get_logger().warning(f"Could not match '{relevant_file}' to a file in the PR diff")
                 continue
 
+            end_offset = 1
+            if "```suggestion" in body:
+                end_offset = self._get_suggestion_end_offset(resolved_file, relevant_lines_end)
+                if end_offset is None:
+                    if fallback_to_pr_comment:
+                        get_logger().warning(
+                            f"Could not resolve the full suggestion range in '{resolved_file}', "
+                            f"publishing the suggestion as a PR-level comment")
+                        fallback_suggestions.append(
+                            (suggestion, "could not resolve the complete line range in the PR diff"))
+                    else:
+                        get_logger().warning(
+                            f"Could not resolve the full suggestion range in '{resolved_file}'")
+                    continue
+
             thread_context = CommentThreadContext(
                 file_path=resolved_file,
                 right_file_start=CommentPosition(offset=1, line=relevant_lines_start),
-                right_file_end=CommentPosition(offset=1, line=relevant_lines_end))
+                right_file_end=CommentPosition(offset=end_offset, line=relevant_lines_end))
             comment = Comment(content=body, comment_type=1)
             thread = CommentThread(comments=[comment], thread_context=thread_context, status=status)
             try:

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -63,7 +63,13 @@ def _provider_with_diff(*filenames):
     provider.temp_comments = []
     provider.azure_devops_client = MagicMock()
     provider.diff_files = [
-        FilePatchInfo(base_file="", head_file="", patch="", filename=filename) for filename in filenames
+        FilePatchInfo(
+            base_file="",
+            head_file="\n".join(f"line {line}" for line in range(1, 13)),
+            patch="",
+            filename=filename,
+        )
+        for filename in filenames
     ]
     return provider
 
@@ -90,8 +96,81 @@ class TestAzureDevopsProviderSuggestionAnchoring:
         threads = _created_threads(provider)
         assert len(threads) == 1
         assert threads[0].thread_context.file_path == "/src/Api/Controllers/SomeController.cs"
+        assert threads[0].comments[0].content == _suggestion("/src/Api/Controllers/SomeController.cs")["body"]
         assert threads[0].thread_context.right_file_start.line == 10
         assert threads[0].thread_context.right_file_end.line == 12
+
+    def test_suggestion_span_covers_the_complete_final_line(self):
+        provider = _provider_with_diff("/src/app.py")
+        provider.diff_files[0].head_file = "\n".join([
+            *(f"line {line}" for line in range(1, 10)),
+            "    if ready:",
+            "        run()",
+            "    }",
+        ])
+
+        provider.publish_code_suggestions([_suggestion("/src/app.py")])
+
+        context = _created_threads(provider)[0].thread_context
+        assert context.right_file_start.offset == 1
+        assert context.right_file_end.offset == 6
+
+    def test_suggestion_end_offset_uses_utf16_code_units(self):
+        provider = _provider_with_diff("/src/app.py")
+        provider.diff_files[0].head_file = "\n".join([
+            *(f"line {line}" for line in range(1, 12)),
+            "return '😀'",
+        ])
+
+        provider.publish_code_suggestions([_suggestion("/src/app.py")])
+
+        context = _created_threads(provider)[0].thread_context
+        assert context.right_file_end.offset == 12
+
+    def test_suggestion_with_unavailable_final_line_becomes_a_pr_level_comment(self):
+        provider = _provider_with_diff("/src/app.py")
+        provider.diff_files[0].head_file = "line 1"
+
+        provider.publish_code_suggestions([_suggestion("/src/app.py")])
+
+        threads = _created_threads(provider)
+        assert len(threads) == 1
+        assert threads[0].thread_context is None
+        assert "could not resolve the complete line range" in threads[0].comments[0].content
+
+    def test_unavailable_final_line_does_not_stop_the_batch(self):
+        provider = _provider_with_diff("/src/short.py", "/src/complete.py")
+        provider.diff_files[0].head_file = "line 1"
+
+        provider.publish_code_suggestions([
+            _suggestion("/src/short.py"),
+            _suggestion("/src/complete.py"),
+        ])
+
+        threads = _created_threads(provider)
+        anchored = [thread for thread in threads if thread.thread_context is not None]
+        assert len(anchored) == 1
+        assert anchored[0].thread_context.file_path == "/src/complete.py"
+
+    def test_unavailable_final_line_respects_disabled_fallback(self):
+        provider = _provider_with_diff("/src/app.py")
+        provider.diff_files[0].head_file = "line 1"
+        suggestion = _suggestion("/src/app.py")
+        suggestion["fallback_to_pr_comment"] = False
+
+        assert provider.publish_code_suggestions([suggestion]) is False
+        provider.azure_devops_client.create_thread.assert_not_called()
+
+    def test_regular_inline_finding_keeps_its_existing_character_anchor(self):
+        provider = _provider_with_diff("/src/app.py")
+        finding = _suggestion("/src/app.py")
+        finding["body"] = "Review finding"
+
+        provider.publish_code_suggestions([finding])
+
+        context = _created_threads(provider)[0].thread_context
+        assert context.right_file_start.offset == 1
+        assert context.right_file_end.offset == 1
 
     def test_suggestion_with_matching_path_is_published_unchanged(self):
         provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")


### PR DESCRIPTION
## Summary

Fix Azure DevOps code suggestions that leave content from the final selected line behind after clicking **Apply Change**.

## What went wrong

Azure DevOps identifies a suggestion range using line and character offsets. PR-Agent correctly selected the start and end lines, but always used character offset `1` for the final line.

That ended the replacement range at the beginning of the final line instead of after its contents.

For example, suppose the existing code is:

```javascript
if (isReady) {
    processItem();
}
```

And PR-Agent suggests:

```javascript
if (isReady || canRetry) {
    processItem();
}
```

Because the closing brace on the final selected line was outside the replacement range, applying the suggestion could produce:

```javascript
if (isReady || canRetry) {
    processItem();
}   }
```

The suggestion preview could therefore show duplicated braces or other original content left on the same line.

## How this fixes it

For committable Azure DevOps suggestions, PR-Agent now:

1. Reads the final selected line from the pull request's updated file.
2. Calculates the character position immediately after its last character.
3. Uses that position as the suggestion range's end offset.

Azure DevOps counts character positions using UTF-16 code units, so the calculation also handles Unicode characters correctly.

Regular inline review comments keep their existing single-character anchor. If PR-Agent cannot verify the complete source range, it safely publishes the suggestion as a PR-level comment instead of creating a broken Apply Change action.

## Result

Applying the example suggestion now produces exactly:

```javascript
if (isReady || canRetry) {
    processItem();
}
```

No original characters, braces, or other final-line content remain appended.

## Validation

- 49 Azure DevOps provider tests pass.
- Full unit suite: 1,942 passed, 1 skipped, 1 expected failure.
- Live Azure DevOps Apply Change and Undo test confirms the complete range is replaced without leftover content.
- All GitHub CI and CodeQL checks pass.
- Qodo reports no active bugs or rule violations.

Closes #2110.
