### PR TITLE
feat(review): preserve findings across review reruns

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -6,6 +6,7 @@
 [pr_reviewer]
 enable_review_labels_effort = true
 enable_auto_approval = true
+persistent_finding_state = true
 
 [github_app]
 pr_commands = [

--- a/docs/docs/installation/azure.md
+++ b/docs/docs/installation/azure.md
@@ -115,7 +115,7 @@ thread, and uses the existing thread discussion as context. Generic phrases such
 response.
 
 For the first mention before PR-Agent has posted on the pull request, or when its Azure DevOps identity changes,
-configure the identity ID, display name, or unique name. A list can be used during an identity transition:
+configure a stable identity (GUID/ID, unique name, or descriptor). A list can be used during an identity transition:
 
 ```toml
 [azure_devops_server]

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -74,6 +74,11 @@ for the authoritative default values.
         </td>
       </tr>
       <tr>
+        <td><b>persistent_finding_state</b></td>
+        <td>If set to true, PR-Agent persists structured review finding state across complete review runs, so findings can be resolved and reopened. Incremental and partial reviews do not resolve absent findings. Default is true.</td>
+
+      </tr>
+      <tr>
       <td><b>final_update_message</b></td>
       <td>When set to true, updating a persistent review comment during online commenting will automatically add a short comment with a link to the updated review in the pull request.</td>
       </tr>

--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -1,4 +1,4 @@
-"""Persistent state helpers for cross-run review findings."""
+"""Persist review finding state across runs."""
 
 from __future__ import annotations
 
@@ -173,7 +173,10 @@ def _retained_findings(
         ),
         reverse=True,
     )
-    return sorted(active + resolved[:max(0, max_resolved_findings)], key=lambda finding: finding["finding_id"])
+    return sorted(
+        active + resolved[:max(0, max_resolved_findings)],
+        key=lambda finding: finding["finding_id"],
+    )
 
 
 def reconcile_review_findings(

--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -1,0 +1,296 @@
+"""Persistent state helpers for cross-run review findings."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+from pr_agent.algo.inline_comment_dedup import key_issue_fingerprint
+
+STATE_SCHEMA_VERSION = 1
+DEFAULT_MAX_RESOLVED_FINDINGS = 20
+_STATE_MARKER_RE = re.compile(
+    r"<!-- pr-agent-review-state:v(?P<version>\d+)\n(?P<payload>.*?)\n-->",
+    re.DOTALL,
+)
+_STATE_MARKER_NAMESPACE = "<!-- pr-agent-review-state"
+_WHITESPACE_RE = re.compile(r"\s+")
+_VALID_STATES = {"ACTIVE", "RESOLVED"}
+
+
+@dataclass(frozen=True)
+class ParsedReviewState:
+    state: dict[str, Any] | None
+    present: bool
+    valid: bool
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    state: dict[str, Any]
+    changed: bool
+    resolved_ids: tuple[str, ...]
+    reopened_ids: tuple[str, ...]
+
+
+def _timestamp(value: str | None) -> str:
+    if value:
+        return value
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _as_line(value: Any) -> int | None:
+    try:
+        line = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return line if line > 0 else None
+
+
+def normalize_finding(finding: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return the stable, display-oriented fields needed for reconciliation."""
+    if not isinstance(finding, Mapping):
+        return None
+
+    path = str(finding.get("path") or finding.get("relevant_file") or "").strip()
+    path = path.strip().strip(chr(96)).lstrip("/")
+    body = str(
+        finding.get("body")
+        or finding.get("issue_content")
+        or finding.get("description")
+        or ""
+    ).strip()
+    if not path or not body:
+        return None
+
+    body = _WHITESPACE_RE.sub(" ", body)
+    finding_id = key_issue_fingerprint(path, body.lower())
+    start = _as_line(
+        finding.get("line_start")
+        or finding.get("relevant_lines_start")
+        or finding.get("start_line")
+    )
+    end = _as_line(
+        finding.get("line_end")
+        or finding.get("relevant_lines_end")
+        or finding.get("end_line")
+    )
+    if start is not None and end is None:
+        end = start
+    if start is not None and end is not None and end < start:
+        end = start
+
+    normalized = {
+        "finding_id": finding_id,
+        "state": "ACTIVE",
+        "body": body,
+        "path": path,
+    }
+    if start is not None:
+        normalized["line_start"] = start
+    if end is not None:
+        normalized["line_end"] = end
+    return normalized
+
+
+def normalize_findings(findings: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize and de-duplicate current structured findings deterministically."""
+    by_id: dict[str, dict[str, Any]] = {}
+    for finding in findings or []:
+        normalized = normalize_finding(finding)
+        if normalized is not None:
+            by_id.setdefault(normalized["finding_id"], normalized)
+    return [by_id[finding_id] for finding_id in sorted(by_id)]
+
+
+def _is_valid_state(state: Any) -> bool:
+    if not isinstance(state, dict):
+        return False
+    if state.get("schema_version") != STATE_SCHEMA_VERSION:
+        return False
+    if not isinstance(state.get("findings"), list) or not isinstance(state.get("last_run"), dict):
+        return False
+    finding_ids = set()
+    for finding in state["findings"]:
+        if not isinstance(finding, dict):
+            return False
+        if finding.get("state") not in _VALID_STATES:
+            return False
+        finding_id = finding.get("finding_id")
+        if not isinstance(finding_id, str) or not finding_id or finding_id in finding_ids:
+            return False
+        finding_ids.add(finding_id)
+        reopened_count = finding.get("reopened_count", 0)
+        if type(reopened_count) is not int or reopened_count < 0:
+            return False
+        if not finding.get("path") or not finding.get("body"):
+            return False
+    return True
+
+
+def parse_review_state(comment_body: str) -> ParsedReviewState:
+    """Parse the versioned state marker, treating malformed state as unsafe."""
+    body = comment_body or ""
+    namespace_count = body.count(_STATE_MARKER_NAMESPACE)
+    matches = list(_STATE_MARKER_RE.finditer(body))
+    if namespace_count == 0:
+        return ParsedReviewState(None, present=False, valid=True)
+    if namespace_count != 1 or len(matches) != 1:
+        return ParsedReviewState(None, present=True, valid=False)
+    match = matches[0]
+    try:
+        version = int(match.group("version"))
+        state = json.loads(match.group("payload"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return ParsedReviewState(None, present=True, valid=False)
+    if version != STATE_SCHEMA_VERSION or not _is_valid_state(state):
+        return ParsedReviewState(None, present=True, valid=False)
+    return ParsedReviewState(state, present=True, valid=True)
+
+
+def serialize_review_state(state: Mapping[str, Any]) -> str:
+    """Serialize state deterministically so repeated updates are diffable."""
+    if not _is_valid_state(state):
+        raise ValueError("Invalid review finding state")
+    payload = json.dumps(state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return f"<!-- pr-agent-review-state:v{STATE_SCHEMA_VERSION}\n{payload}\n-->"
+
+
+def _retained_findings(
+    findings: Iterable[dict[str, Any]],
+    max_resolved_findings: int,
+) -> list[dict[str, Any]]:
+    active = [finding for finding in findings if finding["state"] == "ACTIVE"]
+    resolved = [finding for finding in findings if finding["state"] == "RESOLVED"]
+    resolved.sort(
+        key=lambda finding: (
+            str(finding.get("resolved_at") or ""),
+            str(finding["finding_id"]),
+        ),
+        reverse=True,
+    )
+    return sorted(active + resolved[:max(0, max_resolved_findings)], key=lambda finding: finding["finding_id"])
+
+
+def reconcile_review_findings(
+    previous_state: Mapping[str, Any] | None,
+    current_findings: Iterable[Mapping[str, Any]],
+    *,
+    allow_resolution: bool,
+    excluded_files: Iterable[str] | None = None,
+    head_sha: str = "",
+    run_id: str = "",
+    timestamp: str | None = None,
+    max_resolved_findings: int = DEFAULT_MAX_RESOLVED_FINDINGS,
+) -> ReconciliationResult:
+    """Reconcile current structured findings against the previous state.
+
+    Resolution is deliberately controlled by the caller. The caller must only
+    pass allow_resolution=True for a successful, complete full review.
+    """
+    now = _timestamp(timestamp)
+    current = normalize_findings(current_findings)
+    previous_findings = list((previous_state or {}).get("findings", []))
+    previous_by_id = {finding["finding_id"]: finding for finding in previous_findings}
+    current_by_id = {finding["finding_id"]: finding for finding in current}
+    reconciled: dict[str, dict[str, Any]] = {}
+    resolved_ids: list[str] = []
+    reopened_ids: list[str] = []
+    changed = previous_state is None and bool(current)
+
+    for finding_id, current_finding in current_by_id.items():
+        previous = previous_by_id.get(finding_id)
+        if previous is None:
+            record = dict(current_finding)
+            record.update(first_seen=now, last_seen=now)
+            changed = True
+        else:
+            record = copy.deepcopy(previous)
+            old_state = record.get("state")
+            record.update(current_finding)
+            record["state"] = "ACTIVE"
+            record["last_seen"] = now
+            if old_state == "RESOLVED":
+                record["reopened_at"] = now
+                record["reopened_count"] = int(record.get("reopened_count", 0)) + 1
+                reopened_ids.append(finding_id)
+            if record != previous:
+                changed = True
+        if head_sha:
+            record["last_seen_head_sha"] = head_sha
+        reconciled[finding_id] = record
+
+    for finding_id, previous in previous_by_id.items():
+        if finding_id in current_by_id:
+            continue
+        record = copy.deepcopy(previous)
+        if record.get("state") == "ACTIVE" and allow_resolution:
+            record["state"] = "RESOLVED"
+            record["resolved_at"] = now
+            if head_sha:
+                record["resolved_head_sha"] = head_sha
+            if run_id:
+                record["resolution_run_id"] = run_id
+            resolved_ids.append(finding_id)
+            changed = True
+        reconciled[finding_id] = record
+
+    excluded = sorted({str(path) for path in (excluded_files or []) if path})
+    state = {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "findings": _retained_findings(reconciled.values(), max_resolved_findings),
+        "last_run": {
+            "complete": bool(allow_resolution),
+            "excluded_files": excluded,
+            "head_sha": head_sha,
+            "kind": "full" if allow_resolution else "partial",
+            "run_id": run_id,
+        },
+    }
+    if previous_state is not None and state["findings"] != previous_state.get("findings", []):
+        changed = True
+    return ReconciliationResult(
+        state=state,
+        changed=changed,
+        resolved_ids=tuple(sorted(resolved_ids)),
+        reopened_ids=tuple(sorted(reopened_ids)),
+    )
+
+
+def _render_resolved_section(state: Mapping[str, Any]) -> str:
+    resolved = [finding for finding in state.get("findings", []) if finding.get("state") == "RESOLVED"]
+    if not resolved:
+        return ""
+    resolved.sort(
+        key=lambda finding: (
+            str(finding.get("resolved_at") or ""),
+            str(finding.get("finding_id") or ""),
+        ),
+        reverse=True,
+    )
+    lines = [
+        "<details>",
+        "<summary>✅ Resolved findings</summary>",
+        "",
+    ]
+    for finding in resolved:
+        location = finding["path"]
+        if finding.get("line_start"):
+            location += f":{finding['line_start']}"
+            if finding.get("line_end") and finding["line_end"] != finding["line_start"]:
+                location += f"-{finding['line_end']}"
+        lines.extend([f"### {location}", "", finding["body"], ""])
+    lines.extend(["</details>", ""])
+    return "\n".join(lines).rstrip()
+
+
+def append_review_state(review_body: str, state: Mapping[str, Any]) -> str:
+    """Append the human-readable resolved section and hidden state marker."""
+    body = _STATE_MARKER_RE.sub("", review_body or "").rstrip()
+    sections = [section for section in (body, _render_resolved_section(state)) if section]
+    sections.append(serialize_review_state(state))
+    return "\n\n".join(sections).rstrip() + "\n"

--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -194,12 +194,27 @@ def reconcile_review_findings(
 ) -> ReconciliationResult:
     """Reconcile current structured findings against the previous state.
 
-    Resolution is deliberately controlled by the caller. The caller must only
-    pass allow_resolution=True for a successful, complete full review.
+    Resolution is deliberately conservative. The caller must only pass
+    allow_resolution=True for a successful, complete full review, and the
+    previous and current reviewed HEADs must both be known and different.
     """
     now = _timestamp(timestamp)
     current = normalize_findings(current_findings)
     previous_findings = list((previous_state or {}).get("findings", []))
+    previous_last_run = (previous_state or {}).get("last_run", {})
+    previous_head_sha = (
+        previous_last_run.get("head_sha", "")
+        if isinstance(previous_last_run, Mapping)
+        else ""
+    )
+    resolution_allowed = (
+        allow_resolution
+        and isinstance(previous_head_sha, str)
+        and bool(previous_head_sha.strip())
+        and isinstance(head_sha, str)
+        and bool(head_sha.strip())
+        and previous_head_sha != head_sha
+    )
     previous_by_id = {finding["finding_id"]: finding for finding in previous_findings}
     current_by_id = {finding["finding_id"]: finding for finding in current}
     reconciled: dict[str, dict[str, Any]] = {}
@@ -233,7 +248,7 @@ def reconcile_review_findings(
         if finding_id in current_by_id:
             continue
         record = copy.deepcopy(previous)
-        if record.get("state") == "ACTIVE" and allow_resolution:
+        if record.get("state") == "ACTIVE" and resolution_allowed:
             record["state"] = "RESOLVED"
             record["resolved_at"] = now
             if head_sha:

--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -291,9 +291,35 @@ def _render_resolved_section(state: Mapping[str, Any]) -> str:
     return "\n".join(lines).rstrip()
 
 
-def append_review_state(review_body: str, state: Mapping[str, Any]) -> str:
-    """Append the human-readable resolved section and hidden state marker."""
+def append_review_state(
+    review_body: str,
+    state: Mapping[str, Any],
+    max_chars: int | None = None,
+) -> str:
+    """Append the resolved section and hidden marker within an optional limit.
+
+    The optional limit is reserved for the complete hidden marker.
+    """
     body = _STATE_MARKER_RE.sub("", review_body or "").rstrip()
-    sections = [section for section in (body, _render_resolved_section(state)) if section]
-    sections.append(serialize_review_state(state))
+    human_body = "\n\n".join(
+        section
+        for section in (body, _render_resolved_section(state))
+        if section
+    )
+    marker = serialize_review_state(state)
+    if max_chars is not None:
+        if not isinstance(max_chars, int) or max_chars < len(marker) + 1:
+            raise ValueError(
+                "Comment limit is too small for the persistent "
+                "review state marker"
+            )
+        human_budget = max_chars - len(marker) - 3
+        if len(human_body) > human_budget:
+            if human_budget <= 0:
+                human_body = ""
+            elif human_budget < 3:
+                human_body = human_body[:human_budget]
+            else:
+                human_body = human_body[: human_budget - 3] + "..."
+    sections = [section for section in (human_body, marker) if section]
     return "\n\n".join(sections).rstrip() + "\n"

--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -136,10 +136,12 @@ def parse_review_state(comment_body: str) -> ParsedReviewState:
     """Parse the versioned state marker, treating malformed state as unsafe."""
     body = comment_body or ""
     namespace_count = body.count(_STATE_MARKER_NAMESPACE)
-    matches = list(_STATE_MARKER_RE.finditer(body))
     if namespace_count == 0:
         return ParsedReviewState(None, present=False, valid=True)
-    if namespace_count != 1 or len(matches) != 1:
+    if namespace_count != 1:
+        return ParsedReviewState(None, present=True, valid=False)
+    matches = list(_STATE_MARKER_RE.finditer(body))
+    if len(matches) != 1:
         return ParsedReviewState(None, present=True, valid=False)
     match = matches[0]
     try:
@@ -300,7 +302,16 @@ def append_review_state(
 
     The optional limit is reserved for the complete hidden marker.
     """
-    body = _STATE_MARKER_RE.sub("", review_body or "").rstrip()
+    raw_body = review_body or ""
+    namespace_count = raw_body.count(_STATE_MARKER_NAMESPACE)
+    if namespace_count == 1:
+        body = _STATE_MARKER_RE.sub("", raw_body).rstrip()
+        if _STATE_MARKER_NAMESPACE in body:
+            body = body.split(_STATE_MARKER_NAMESPACE, 1)[0].rstrip()
+    elif namespace_count > 1:
+        body = raw_body.split(_STATE_MARKER_NAMESPACE, 1)[0].rstrip()
+    else:
+        body = raw_body.rstrip()
     human_body = "\n\n".join(
         section
         for section in (body, _render_resolved_section(state))

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -968,20 +968,41 @@ class AzureDevopsProvider(GitProvider):
             if isinstance(value, str) and value.strip()
         }
 
+    @staticmethod
+    def _is_stable_agent_identity(identity: str) -> bool:
+        return (
+            "@" in identity
+            or bool(re.fullmatch(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                identity,
+                re.IGNORECASE,
+            ))
+            or identity.startswith(("aad.", "acs.", "app.", "msa.", "svc.", "vss."))
+        )
+
+    def _configured_stable_agent_identities(self) -> set[str]:
+        return {
+            identity
+            for identity in self._configured_agent_identities()
+            if self._is_stable_agent_identity(identity)
+        }
+
     def supports_review_finding_state(self) -> bool:
-        return bool(self._configured_agent_identities())
+        return bool(self._configured_stable_agent_identities())
 
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
         identities = self._configured_agent_identities()
         if not identities:
             raise RuntimeError("Azure DevOps agent identity is not configured")
+        stable_identities = self._configured_stable_agent_identities()
+        if not stable_identities:
+            return False
         author = self._value(comment, "author") or self._value(comment, "user")
         if author is None:
             raise RuntimeError("Azure DevOps comment author cannot be verified")
         values = []
         for attribute, serialized_attribute in (
             ("id", None),
-            ("display_name", "displayName"),
             ("unique_name", "uniqueName"),
         ):
             value = self._value(author, attribute, serialized_attribute)
@@ -989,7 +1010,7 @@ class AzureDevopsProvider(GitProvider):
                 values.append(str(value).strip().casefold())
         if not values:
             raise RuntimeError("Azure DevOps comment author cannot be verified")
-        return any(value in identities for value in values)
+        return any(value in stable_identities for value in values)
 
     def publish_description(self, pr_title: str, pr_body: str):
         if len(pr_body) > MAX_PR_DESCRIPTION_AZURE_LENGTH:

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -954,6 +954,43 @@ class AzureDevopsProvider(GitProvider):
     def supports_review_comment_identity(self) -> bool:
         return True
 
+    def _configured_agent_identities(self) -> set[str]:
+        configured = get_settings().get("azure_devops_server.agent_identity", "")
+        if isinstance(configured, str):
+            values = (configured,)
+        elif isinstance(configured, (list, tuple, set)):
+            values = configured
+        else:
+            values = ()
+        return {
+            value.strip().casefold()
+            for value in values
+            if isinstance(value, str) and value.strip()
+        }
+
+    def supports_review_finding_state(self) -> bool:
+        return bool(self._configured_agent_identities())
+
+    def is_comment_authored_by_pr_agent(self, comment) -> bool:
+        identities = self._configured_agent_identities()
+        if not identities:
+            raise RuntimeError("Azure DevOps agent identity is not configured")
+        author = self._value(comment, "author") or self._value(comment, "user")
+        if author is None:
+            raise RuntimeError("Azure DevOps comment author cannot be verified")
+        values = []
+        for attribute, serialized_attribute in (
+            ("id", None),
+            ("display_name", "displayName"),
+            ("unique_name", "uniqueName"),
+        ):
+            value = self._value(author, attribute, serialized_attribute)
+            if value is not None:
+                values.append(str(value).strip().casefold())
+        if not values:
+            raise RuntimeError("Azure DevOps comment author cannot be verified")
+        return any(value in identities for value in values)
+
     def publish_description(self, pr_title: str, pr_body: str):
         if len(pr_body) > MAX_PR_DESCRIPTION_AZURE_LENGTH:
 
@@ -1294,6 +1331,7 @@ class AzureDevopsProvider(GitProvider):
             comments.append(SimpleNamespace(
                 id=self._value(comment, "id"),
                 body=content,
+                author=author,
                 user=SimpleNamespace(login=author_name),
             ))
         return comments
@@ -1366,6 +1404,9 @@ class AzureDevopsProvider(GitProvider):
                     comment.thread_id = thread.id
                     comment_list.append(comment)
         return comment_list
+
+    def get_issue_comments_newest_first(self):
+        return list(self.get_issue_comments())
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         return None

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1004,6 +1004,7 @@ class AzureDevopsProvider(GitProvider):
         for attribute, serialized_attribute in (
             ("id", None),
             ("unique_name", "uniqueName"),
+            ("descriptor", "descriptor"),
         ):
             value = self._value(author, attribute, serialized_attribute)
             if value is not None:
@@ -1308,6 +1309,41 @@ class AzureDevopsProvider(GitProvider):
             return value.get(serialized_attribute or attribute)
         return getattr(value, attribute, None)
 
+    @staticmethod
+    def _stable_id_sort_key(value):
+        if value is None:
+            return (0, "")
+        text = str(value).strip()
+        if not text:
+            return (0, "")
+        try:
+            return (2, int(text))
+        except (TypeError, ValueError):
+            return (1, text.casefold())
+
+    @classmethod
+    def _comment_latest_timestamp(cls, comment):
+        timestamps = []
+        for attribute, serialized_attribute in (
+            ("published_date", "publishedDate"),
+            ("last_updated_date", "lastUpdatedDate"),
+        ):
+            value = cls._value(comment, attribute, serialized_attribute)
+            if isinstance(value, str):
+                value = value.strip()
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                try:
+                    value = _dt.datetime.fromisoformat(value)
+                except ValueError:
+                    continue
+            if isinstance(value, _dt.datetime):
+                value = _to_naive_utc(value)
+                if value is not None:
+                    timestamps.append(value)
+        return max(timestamps, default=_dt.datetime.min)
+
+
     def _get_threads(self):
         threads = getattr(self, "_threads_cache", None)
         if threads is None:
@@ -1418,12 +1454,28 @@ class AzureDevopsProvider(GitProvider):
 
     def get_issue_comments(self) -> list[Comment]:
         comment_list = []
-        for thread in reversed(self._get_threads()):
-            for comment in thread.comments:
-                if comment.content and comment not in comment_list:
-                    comment.body = comment.content
-                    comment.thread_id = thread.id
-                    comment_list.append(comment)
+        for thread in self._get_threads():
+            thread_id = self._value(thread, "id")
+            for comment in self._value(thread, "comments") or []:
+                content = self._value(comment, "content")
+                if not content or comment in comment_list:
+                    continue
+                if isinstance(comment, dict):
+                    comment["body"] = content
+                    comment["thread_id"] = thread_id
+                else:
+                    comment.body = content
+                    comment.thread_id = thread_id
+                comment_list.append(comment)
+
+        comment_list.sort(
+            key=lambda comment: (
+                self._comment_latest_timestamp(comment),
+                self._stable_id_sort_key(self._value(comment, "id")),
+                self._stable_id_sort_key(self._value(comment, "thread_id")),
+            ),
+            reverse=True,
+        )
         return comment_list
 
     def get_issue_comments_newest_first(self):

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -458,6 +458,7 @@ class BitbucketProvider(GitProvider):
             comment.update(body)
         except Exception as e:
             get_logger().exception(f"Failed to update comment, error: {e}")
+            raise
 
     def remove_initial_comment(self):
         try:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -458,7 +458,7 @@ class BitbucketProvider(GitProvider):
             comment.update(body)
         except Exception as e:
             get_logger().exception(f"Failed to update comment, error: {e}")
-            raise
+            return False
 
     def remove_initial_comment(self):
         try:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -518,68 +518,10 @@ class GitProvider(ABC):
                         get_logger().warning(f"Failed to reopen review thread: {e}")
                 if final_update_message:
                     try:
-                        return self.publish_comment(
-                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                    except Exception:
-                        get_logger().opt(exception=True).warning(
-                            "Failed to publish persistent review update message; review was already updated")
-                        return comment
-                return comment
-        except Exception as e:
-            get_logger().exception(f"Failed to update persistent review, error: {e}")
-            if not fallback_on_error:
-                return None
-        return self.publish_comment(pr_comment, **({'as_thread': True} if as_thread else {}))
 
-        try:
-            pr_comment = add_pr_review_identity(pr_comment, identity_marker)
-            prev_comments = list(self.get_issue_comments())
-            identifiers = (
-                [identity_marker, legacy_initial_header]
-                if identity_marker
-                else [initial_header]
-            )
-            comment_to_update = next(
-                (
-                    comment
-                    for identifier in identifiers
-                    if identifier
-                    for comment in prev_comments
-                    if comment_matches_identity(comment.body, identifier)
-                    and not comment_carries_other_identity(comment.body, identity_marker)
-                ),
-                None,
-            )
-            if comment_to_update is not None:
-                comment = comment_to_update
-                latest_commit_url = self.get_latest_commit_url()
-                comment_url = self.get_comment_url(comment)
-                if update_header:
-                    update_message = f"#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
-                    update_anchor = identity_marker or initial_header
-                    updated_anchor = f"{update_anchor}\n\n{update_message}"
-                    pr_comment_updated = pr_comment.replace(update_anchor, updated_anchor, 1)
-                else:
-                    pr_comment_updated = pr_comment
-                get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                # response = self.mr.notes.update(comment.id, {'body': pr_comment_updated})
-                if self.edit_comment(comment, pr_comment_updated) is False:
-                    raise RuntimeError("Failed to update persistent comment")
-                if as_thread:
-                    try:
-                        # Reopen the thread if it was resolved, so the developer revisits the updated review.
-                        self.unresolve_comment_thread(comment)
-                    except Exception as e:
-                        # The review was already updated in place; a reopen failure must not reach the
-                        # outer except, whose fallback publish would duplicate the review.
-                        get_logger().warning(f"Failed to reopen review thread: {e}")
-                if final_update_message:
-                    try:
                         return self.publish_comment(
                             f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
                     except Exception:
-                        # The review was already updated in place; a notification failure must not reach
-                        # the outer except, whose fallback publish would duplicate the review.
                         get_logger().opt(exception=True).warning(
                             "Failed to publish persistent review update message; review was already updated")
                         return comment

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -547,9 +547,15 @@ class GitProvider(ABC):
                         get_logger().warning(f"Failed to reopen review thread: {e}")
                 if final_update_message:
                     try:
-
-                        return self.publish_comment(
+                        status_comment = self.publish_comment(
                             f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                        if status_comment is None or status_comment is False:
+                            get_logger().warning(
+                                "Persistent review update message was not published; "
+                                "review was already updated"
+                            )
+                            return comment
+                        return status_comment
                     except Exception:
                         get_logger().opt(exception=True).warning(
                             "Failed to publish persistent review update message; review was already updated")

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -436,6 +436,14 @@ class GitProvider(ABC):
     def supports_review_comment_identity(self) -> bool:
         return False
 
+    def supports_review_finding_state(self) -> bool:
+        """Return whether this provider can verify PR-Agent-authored review comments."""
+        return False
+
+    def is_comment_authored_by_pr_agent(self, comment) -> bool:
+        """Return whether a provider comment was authored by this PR-Agent identity."""
+        return False
+
     def unresolve_comment_thread(self, comment):  # noqa: B027 - intentional no-op
         pass
 
@@ -466,6 +474,32 @@ class GitProvider(ABC):
             return comment.get("body", "")
         return getattr(comment, "body", "")
 
+    def get_issue_comments_newest_first(self):
+        """Return issue comments newest first; providers override known API ordering."""
+        return list(reversed(list(self.get_issue_comments())))
+
+    def _iter_persistent_comments(
+        self,
+        identifiers,
+        *,
+        identity_marker: str | None = None,
+        require_agent_authorship: bool = False,
+    ):
+        """Yield matching comments in identity-priority and newest-first order."""
+        comments = self.get_issue_comments_newest_first()
+        for identifier in identifiers:
+            if not identifier:
+                continue
+            for comment in comments:
+                body = GitProvider._get_comment_body(comment)
+                if not comment_matches_identity(body, identifier):
+                    continue
+                if comment_carries_other_identity(body, identity_marker):
+                    continue
+                if require_agent_authorship and not self.is_comment_authored_by_pr_agent(comment):
+                    continue
+                yield comment, body
+
     def publish_persistent_comment_full(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,
@@ -474,29 +508,24 @@ class GitProvider(ABC):
                                    as_thread: bool = False,
                                    identity_marker: str | None = None,
                                    legacy_initial_header: str | None = None,
+                                   require_agent_authorship: bool = False,
                                    fallback_on_error: bool = True):
         try:
             pr_comment = add_pr_review_identity(pr_comment, identity_marker)
-            prev_comments = list(self.get_issue_comments())
             identifiers = (
                 [identity_marker, legacy_initial_header]
                 if identity_marker
                 else [initial_header]
             )
             comment_to_update = None
-            for identifier in identifiers:
-                if not identifier:
-                    continue
-                for comment in reversed(prev_comments):
-                    body = GitProvider._get_comment_body(comment)
-                    if (
-                        comment_matches_identity(body, identifier)
-                        and not comment_carries_other_identity(body, identity_marker)
-                    ):
-                        comment_to_update = comment
-                        break
-                if comment_to_update is not None:
-                    break
+            for comment, _body in GitProvider._iter_persistent_comments(
+                self,
+                identifiers,
+                identity_marker=identity_marker,
+                require_agent_authorship=require_agent_authorship,
+            ):
+                comment_to_update = comment
+                break
             if comment_to_update is not None:
                 comment = comment_to_update
                 latest_commit_url = self.get_latest_commit_url()

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -459,6 +459,13 @@ class GitProvider(ABC):
                                    legacy_initial_header: str | None = None):
         return self.publish_comment(pr_comment, **({'as_thread': True} if as_thread else {}))
 
+    @staticmethod
+    def _get_comment_body(comment) -> str:
+        """Return a comment body for object- and mapping-shaped provider payloads."""
+        if isinstance(comment, dict):
+            return comment.get("body", "")
+        return getattr(comment, "body", "")
+
     def publish_persistent_comment_full(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,
@@ -466,7 +473,64 @@ class GitProvider(ABC):
                                    final_update_message=True,
                                    as_thread: bool = False,
                                    identity_marker: str | None = None,
-                                   legacy_initial_header: str | None = None):
+                                   legacy_initial_header: str | None = None,
+                                   fallback_on_error: bool = True):
+        try:
+            pr_comment = add_pr_review_identity(pr_comment, identity_marker)
+            prev_comments = list(self.get_issue_comments())
+            identifiers = (
+                [identity_marker, legacy_initial_header]
+                if identity_marker
+                else [initial_header]
+            )
+            comment_to_update = None
+            for identifier in identifiers:
+                if not identifier:
+                    continue
+                for comment in reversed(prev_comments):
+                    body = GitProvider._get_comment_body(comment)
+                    if (
+                        comment_matches_identity(body, identifier)
+                        and not comment_carries_other_identity(body, identity_marker)
+                    ):
+                        comment_to_update = comment
+                        break
+                if comment_to_update is not None:
+                    break
+            if comment_to_update is not None:
+                comment = comment_to_update
+                latest_commit_url = self.get_latest_commit_url()
+                comment_url = self.get_comment_url(comment)
+                if update_header:
+                    update_message = f"#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
+                    update_anchor = identity_marker or initial_header
+                    updated_anchor = f"{update_anchor}\n\n{update_message}"
+                    pr_comment_updated = pr_comment.replace(update_anchor, updated_anchor, 1)
+                else:
+                    pr_comment_updated = pr_comment
+                get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
+                if self.edit_comment(comment, pr_comment_updated) is False:
+                    raise RuntimeError("Failed to update persistent comment")
+                if as_thread:
+                    try:
+                        self.unresolve_comment_thread(comment)
+                    except Exception as e:
+                        get_logger().warning(f"Failed to reopen review thread: {e}")
+                if final_update_message:
+                    try:
+                        return self.publish_comment(
+                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                    except Exception:
+                        get_logger().opt(exception=True).warning(
+                            "Failed to publish persistent review update message; review was already updated")
+                        return comment
+                return comment
+        except Exception as e:
+            get_logger().exception(f"Failed to update persistent review, error: {e}")
+            if not fallback_on_error:
+                return None
+        return self.publish_comment(pr_comment, **({'as_thread': True} if as_thread else {}))
+
         try:
             pr_comment = add_pr_review_identity(pr_comment, identity_marker)
             prev_comments = list(self.get_issue_comments())
@@ -522,7 +586,8 @@ class GitProvider(ABC):
                 return comment
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")
-            pass
+            if not fallback_on_error:
+                return None
         return self.publish_comment(pr_comment, **({'as_thread': True} if as_thread else {}))
 
     @abstractmethod

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -673,7 +673,7 @@ class GiteaProvider(GitProvider):
             repo=self.repo,
             index=index
         )
-        if comments is None:
+        if not isinstance(comments, list):
             self.logger.error("Failed to get comments")
             raise RuntimeError("Failed to get comments")
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -320,12 +320,14 @@ class GiteaProvider(GitProvider):
                                    identity_marker: str | None = None,
                                    legacy_initial_header: str | None = None):
         # Keep the legacy updater path until Gitea normalizes its dictionary-shaped comment payloads.
-        self.publish_persistent_comment_full(
+        return self.publish_persistent_comment_full(
             pr_comment,
             initial_header,
             update_header,
             name,
             final_update_message,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
         )
 
     def publish_comment(self, comment: str,is_temporary: bool = False) -> None:

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -308,7 +308,9 @@ class GiteaProvider(GitProvider):
         return self.last_commit.html_url if self.last_commit else ""
 
     def get_comment_url(self, comment) -> str:
-        return comment.html_url
+        if isinstance(comment, dict):
+            return comment.get("html_url") or comment.get("url") or ""
+        return getattr(comment, "html_url", "") or getattr(comment, "url", "")
 
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
@@ -366,11 +368,15 @@ class GiteaProvider(GitProvider):
 
     def edit_comment(self, comment, body : str):
         body = self.limit_output_characters(body, self.max_comment_chars)
+        if isinstance(comment, dict):
+            comment_id = comment.get("comment_id") or comment.get("id")
+        else:
+            comment_id = getattr(comment, "id", None)
         try:
             self.repo_api.edit_comment(
                 owner=self.owner,
                 repo=self.repo,
-                comment_id=comment.get("comment_id") if isinstance(comment, dict) else comment.id,
+                comment_id=comment_id,
                 comment=body
             )
         except ApiException as e:

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -381,10 +381,10 @@ class GiteaProvider(GitProvider):
             )
         except ApiException as e:
             self.logger.error(f"Error editing comment: {e}")
-            raise
+            return False
         except Exception as e:
             self.logger.error(f"Unexpected error: {e}")
-            raise
+            return False
 
 
     def publish_inline_comment(self,body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -381,10 +381,10 @@ class GiteaProvider(GitProvider):
             )
         except ApiException as e:
             self.logger.error(f"Error editing comment: {e}")
-            return None
+            raise
         except Exception as e:
             self.logger.error(f"Unexpected error: {e}")
-            return None
+            raise
 
 
     def publish_inline_comment(self,body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
@@ -673,9 +673,9 @@ class GiteaProvider(GitProvider):
             repo=self.repo,
             index=index
         )
-        if not comments:
+        if comments is None:
             self.logger.error("Failed to get comments")
-            return []
+            raise RuntimeError("Failed to get comments")
 
         return comments
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -948,6 +948,7 @@ class GithubProvider(GitProvider):
                     artifact={"error": e})
             else:
                 get_logger().exception("Failed to edit github comment", artifact={"error": e})
+            raise
 
     def edit_comment_from_comment_id(self, comment_id: int, body: str):
         try:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -432,13 +432,29 @@ class GithubProvider(GitProvider):
     def supports_review_comment_identity(self) -> bool:
         return True
 
+    def _configured_app_bot_login(self) -> str:
+        app_name = get_settings().get("GITHUB.APP_NAME", "")
+        if not isinstance(app_name, str) or not app_name.strip():
+            return ""
+        app_name = app_name.strip()
+        if not app_name.casefold().endswith("[bot]"):
+            app_name = f"{app_name}[bot]"
+        return app_name
+
     def supports_review_finding_state(self) -> bool:
         deployment_type = getattr(self, "deployment_type", None)
         if deployment_type is None:
             deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
-        # Both deployment modes expose the authenticated account through the
-        # provider API; an unsupported mode cannot safely verify comment ownership.
-        return deployment_type in {"user", "app"}
+        # User deployments resolve the authenticated account through the API;
+        # app deployments use a cached or configured bot login.
+        if deployment_type == "user":
+            return True
+        if deployment_type == "app":
+            return bool(
+                getattr(self, "github_user_id", None)
+                or self._configured_app_bot_login()
+            )
+        return False
 
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
         if isinstance(comment, dict):
@@ -460,12 +476,13 @@ class GithubProvider(GitProvider):
 
         agent_login = getattr(self, "github_user_id", None)
         if not agent_login:
-            try:
-                # This resolves the authenticated user for both PAT and App
-                # deployments, including the App's [bot] login.
-                agent_login = self.get_user_id()
-            except Exception as error:
-                raise RuntimeError("GitHub user identity cannot be verified") from error
+            if deployment_type == "app":
+                agent_login = self._configured_app_bot_login()
+            else:
+                try:
+                    agent_login = self.get_user_id()
+                except Exception as error:
+                    raise RuntimeError("GitHub user identity cannot be verified") from error
         if not isinstance(agent_login, str) or not agent_login.strip():
             raise RuntimeError("GitHub user identity cannot be verified")
         return login.casefold() == agent_login.casefold()

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -432,6 +432,44 @@ class GithubProvider(GitProvider):
     def supports_review_comment_identity(self) -> bool:
         return True
 
+    def supports_review_finding_state(self) -> bool:
+        deployment_type = getattr(self, "deployment_type", None)
+        if deployment_type is None:
+            deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
+        # Both deployment modes expose the authenticated account through the
+        # provider API; an unsupported mode cannot safely verify comment ownership.
+        return deployment_type in {"user", "app"}
+
+    def is_comment_authored_by_pr_agent(self, comment) -> bool:
+        if isinstance(comment, dict):
+            author = comment.get("user") or comment.get("author")
+        else:
+            author = getattr(comment, "user", None) or getattr(comment, "author", None)
+        if isinstance(author, dict):
+            login = author.get("login")
+        else:
+            login = getattr(author, "login", None)
+        if not isinstance(login, str) or not login.strip():
+            raise RuntimeError("GitHub comment author cannot be verified")
+
+        deployment_type = getattr(self, "deployment_type", None)
+        if deployment_type is None:
+            deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
+        if deployment_type not in {"user", "app"}:
+            raise RuntimeError("Unsupported GitHub deployment identity")
+
+        agent_login = getattr(self, "github_user_id", None)
+        if not agent_login:
+            try:
+                # This resolves the authenticated user for both PAT and App
+                # deployments, including the App's [bot] login.
+                agent_login = self.get_user_id()
+            except Exception as error:
+                raise RuntimeError("GitHub user identity cannot be verified") from error
+        if not isinstance(agent_login, str) or not agent_login.strip():
+            raise RuntimeError("GitHub user identity cannot be verified")
+        return login.casefold() == agent_login.casefold()
+
     def _publish_check_run(self, text: str, name: str) -> bool:
         if not getattr(self, 'last_commit_id', None):
             get_logger().error("Cannot publish check run without a commit SHA")
@@ -948,7 +986,10 @@ class GithubProvider(GitProvider):
                     artifact={"error": e})
             else:
                 get_logger().exception("Failed to edit github comment", artifact={"error": e})
-            raise
+            return False
+        except Exception as e:
+            get_logger().exception("Failed to edit github comment", artifact={"error": e})
+            return False
 
     def edit_comment_from_comment_id(self, comment_id: int, body: str):
         try:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -432,28 +432,17 @@ class GithubProvider(GitProvider):
     def supports_review_comment_identity(self) -> bool:
         return True
 
-    def _configured_app_bot_login(self) -> str:
-        app_name = get_settings().get("GITHUB.APP_NAME", "")
-        if not isinstance(app_name, str) or not app_name.strip():
-            return ""
-        app_name = app_name.strip()
-        if not app_name.casefold().endswith("[bot]"):
-            app_name = f"{app_name}[bot]"
-        return app_name
-
     def supports_review_finding_state(self) -> bool:
         deployment_type = getattr(self, "deployment_type", None)
         if deployment_type is None:
             deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
-        # User deployments resolve the authenticated account through the API;
-        # app deployments use a cached or configured bot login.
+        # User deployments resolve the authenticated account through the API.
+        # App deployments require a login grounded in a trusted provider response.
         if deployment_type == "user":
             return True
         if deployment_type == "app":
-            return bool(
-                getattr(self, "github_user_id", None)
-                or self._configured_app_bot_login()
-            )
+            cached_login = getattr(self, "github_user_id", None)
+            return isinstance(cached_login, str) and bool(cached_login.strip())
         return False
 
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
@@ -475,14 +464,13 @@ class GithubProvider(GitProvider):
             raise RuntimeError("Unsupported GitHub deployment identity")
 
         agent_login = getattr(self, "github_user_id", None)
-        if not agent_login:
+        if not isinstance(agent_login, str) or not agent_login.strip():
             if deployment_type == "app":
-                agent_login = self._configured_app_bot_login()
-            else:
-                try:
-                    agent_login = self.get_user_id()
-                except Exception as error:
-                    raise RuntimeError("GitHub user identity cannot be verified") from error
+                raise RuntimeError("GitHub App identity cannot be verified")
+            try:
+                agent_login = self.get_user_id()
+            except Exception as error:
+                raise RuntimeError("GitHub user identity cannot be verified") from error
         if not isinstance(agent_login, str) or not agent_login.strip():
             raise RuntimeError("GitHub user identity cannot be verified")
         return login.casefold() == agent_login.casefold()

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1433,7 +1433,7 @@ class GitLabProvider(GitProvider):
         return self.mr.notes.list(get_all=True)[::-1]
 
     def get_issue_comments_newest_first(self):
-        return list(self.get_issue_comments())
+        return list(reversed(self.get_issue_comments()))
 
     def get_repo_settings(self):
         settings_files = []

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -920,6 +920,25 @@ class GitLabProvider(GitProvider):
     def supports_review_comment_identity(self) -> bool:
         return True
 
+    def supports_review_finding_state(self) -> bool:
+        return True
+
+    def is_comment_authored_by_pr_agent(self, comment) -> bool:
+        if isinstance(comment, dict):
+            author = comment.get("author") or comment.get("user")
+        else:
+            author = getattr(comment, "author", None) or getattr(comment, "user", None)
+        if isinstance(author, dict):
+            author_id = author.get("id")
+        else:
+            author_id = getattr(author, "id", None)
+        if author_id is None:
+            raise RuntimeError("GitLab comment author cannot be verified")
+        own_user_id = self._get_own_user_id()
+        if own_user_id is None:
+            raise RuntimeError("GitLab authenticated user cannot be verified")
+        return str(author_id) == str(own_user_id)
+
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,
@@ -1412,6 +1431,9 @@ class GitLabProvider(GitProvider):
 
     def get_issue_comments(self):
         return self.mr.notes.list(get_all=True)[::-1]
+
+    def get_issue_comments_newest_first(self):
+        return list(self.get_issue_comments())
 
     def get_repo_settings(self):
         settings_files = []

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -123,6 +123,8 @@ publish_output_no_suggestions=true # Set to "false" if you only need the reviewe
 persistent_comment=true
 # Visible base heading for full and incremental review comments. Identity is tracked separately.
 review_heading = "PR Reviewer Guide"
+persistent_finding_state=true # Persist review finding state across complete review runs.
+
 inline_key_issues=false
 extra_instructions = ""
 num_max_findings = 3

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -419,17 +419,27 @@ class PRCodeSuggestions:
                 pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
             get_logger().debug("PR output", artifact=pr_body)
             if self.progress_response:
-                if _edit_comment_safely(self.git_provider, self.progress_response, pr_body):
+                progress_response = self.progress_response
+                if _edit_comment_safely(self.git_provider, progress_response, pr_body):
                     if self._improve_thread_kwargs():
                         # A mere status message isn't actionable; resolve the thread instead of
                         # leaving it open for the user to close manually.
-                        self.git_provider.resolve_comment_thread(self.progress_response.id)
+                        self.git_provider.resolve_comment_thread(progress_response.id)
                 else:
-                    comment = self.git_provider.publish_comment(
-                        pr_body, **self._improve_thread_kwargs()
-                    )
-                    if comment and self._improve_thread_kwargs():
-                        self.git_provider.resolve_comment_thread(comment.id)
+                    try:
+                        comment = self.git_provider.publish_comment(
+                            pr_body, **self._improve_thread_kwargs()
+                        )
+                        if comment and self._improve_thread_kwargs():
+                            self.git_provider.resolve_comment_thread(comment.id)
+                    finally:
+                        try:
+                            self.git_provider.remove_comment(progress_response)
+                        except Exception as cleanup_error:
+                            get_logger().warning(
+                                f"Failed to remove the failed progress comment: {cleanup_error}"
+                            )
+                        self.progress_response = None
             else:
                 comment = self.git_provider.publish_comment(pr_body, **self._improve_thread_kwargs())
                 if comment and self._improve_thread_kwargs():
@@ -493,23 +503,54 @@ class PRCodeSuggestions:
                 return False
             return True
 
+        def _publish_persistent_update_failure():
+            _clean_up_progress_note()
+            failure_body = (
+                f"⚠️ Failed to update the persistent {name} comment; "
+                f"the previous {name} remain unchanged."
+            )
+            try:
+                return git_provider.publish_comment(
+                    failure_body,
+                    **({"as_thread": True} if as_thread else {}),
+                )
+            except Exception as error:
+                get_logger().exception(
+                    f"Failed to publish persistent update failure, error: {error}"
+                )
+                return None
+
+        def _update_existing_comment(comment, body: str):
+            try:
+                _edit_comment(comment, body)
+            except Exception as error:
+                get_logger().exception(
+                    f"Failed to update persistent {name} comment, error: {error}"
+                )
+                return _publish_persistent_update_failure()
+            return comment
+
         if hasattr(git_provider, '_publish_check_run') and get_settings().github.publish_as_check_run:
             if git_provider._publish_check_run(pr_comment, name):
                 return progress_response if _clean_up_progress_note() else None
 
         if _supports_code_suggestion_state(git_provider) and max_previous_comments <= 0:
-            result = git_provider.publish_persistent_comment(
+            result = GitProvider.publish_persistent_comment_full(
+                git_provider,
                 pr_comment,
                 initial_header,
                 update_header,
                 name,
                 final_update_message,
+                as_thread=as_thread,
                 identity_marker=identity_marker,
                 legacy_initial_header=legacy_initial_header,
+                fallback_on_error=False,
             )
             if result is not None:
                 _clean_up_progress_note("Code suggestions updated in the persistent thread above.")
-            return result
+                return result
+            return _publish_persistent_update_failure()
 
         def _extract_link(comment_text: str):
             match = re.search(r"<!--\s*([0-9a-fA-F]{7,40})\s*-->", comment_text)
@@ -560,7 +601,7 @@ class PRCodeSuggestions:
 
         if max_previous_comments > 0:
             try:
-                prev_comments = list(git_provider.get_issue_comments())
+                prev_comments = list(git_provider.get_issue_comments_newest_first())
                 if identity_marker:
                     comment = next(
                         (
@@ -601,7 +642,9 @@ class PRCodeSuggestions:
                                 f"{initial_header}\n\n{latest_commit_html_comment}\n\n"
                                 f"{new_suggestion_table}\n\n"
                             )
-                            _edit_comment(comment, pr_comment_updated)
+                            updated_comment = _update_existing_comment(comment, pr_comment_updated)
+                            if updated_comment is not comment:
+                                return updated_comment
                             _clean_up_progress_note()
                             return comment
                         # find http link from comment.body[:table_index]
@@ -655,7 +698,9 @@ class PRCodeSuggestions:
                         )
 
                     get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                    _edit_comment(comment, pr_comment_updated)
+                    updated_comment = _update_existing_comment(comment, pr_comment_updated)
+                    if updated_comment is not comment:
+                        return updated_comment
                     _clean_up_progress_note()
                     return comment
             except Exception as e:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -58,6 +58,18 @@ def _supports_code_suggestion_state(git_provider) -> bool:
     return callable(supports) and bool(supports())
 
 
+def _edit_comment_safely(git_provider, comment, body: str) -> bool:
+    try:
+        result = git_provider.edit_comment(comment, body)
+    except Exception as error:
+        get_logger().warning(f"Failed to edit code suggestions comment: {error}")
+        return False
+    if result is False:
+        get_logger().warning("Failed to edit code suggestions comment")
+        return False
+    return True
+
+
 class PRCodeSuggestions:
     def __init__(self, pr_url: str, cli_mode=False, args: list = None,
                  ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler):
@@ -301,7 +313,16 @@ class PRCodeSuggestions:
                             PRCodeSuggestionsIdentity.SUMMARY.value,
                         )
                         if self.progress_response:
-                            self.git_provider.edit_comment(self.progress_response, body=pr_body)
+                            if not _edit_comment_safely(self.git_provider, self.progress_response, pr_body):
+                                self.git_provider.publish_comment(
+                                    pr_body, **self._improve_thread_kwargs()
+                                )
+                                try:
+                                    self.git_provider.remove_comment(self.progress_response)
+                                except Exception as cleanup_error:
+                                    get_logger().warning(
+                                        f"Failed to remove the failed progress comment: {cleanup_error}"
+                                    )
                             self.progress_response = None
                         else:
                             self.git_provider.publish_comment(pr_body, **self._improve_thread_kwargs())
@@ -322,16 +343,11 @@ class PRCodeSuggestions:
                 return
         except asyncio.CancelledError:
             if self.progress_response is not None:
-                try:
-                    self.git_provider.edit_comment(
-                        self.progress_response,
-                        "Code suggestions generation cancelled.",
-                    )
-                except Exception as cleanup_error:
-                    get_logger().exception(
-                        f"Failed to update code suggestions progress comment after cancellation, "
-                        f"error: {cleanup_error}"
-                    )
+                _edit_comment_safely(
+                    self.git_provider,
+                    self.progress_response,
+                    "Code suggestions generation cancelled.",
+                )
                 try:
                     self.git_provider.remove_comment(self.progress_response)
                 except Exception as cleanup_error:
@@ -403,11 +419,17 @@ class PRCodeSuggestions:
                 pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
             get_logger().debug("PR output", artifact=pr_body)
             if self.progress_response:
-                self.git_provider.edit_comment(self.progress_response, body=pr_body)
-                if self._improve_thread_kwargs():
-                    # A mere status message isn't actionable; resolve the thread instead of
-                    # leaving it open for the user to close manually.
-                    self.git_provider.resolve_comment_thread(self.progress_response.id)
+                if _edit_comment_safely(self.git_provider, self.progress_response, pr_body):
+                    if self._improve_thread_kwargs():
+                        # A mere status message isn't actionable; resolve the thread instead of
+                        # leaving it open for the user to close manually.
+                        self.git_provider.resolve_comment_thread(self.progress_response.id)
+                else:
+                    comment = self.git_provider.publish_comment(
+                        pr_body, **self._improve_thread_kwargs()
+                    )
+                    if comment and self._improve_thread_kwargs():
+                        self.git_provider.resolve_comment_thread(comment.id)
             else:
                 comment = self.git_provider.publish_comment(pr_body, **self._improve_thread_kwargs())
                 if comment and self._improve_thread_kwargs():
@@ -454,22 +476,16 @@ class PRCodeSuggestions:
                                                 legacy_initial_header: str | None = None,
                                                 as_thread: bool = False):
         def _edit_comment(comment, body: str):
-            result = git_provider.edit_comment(comment, body)
-            if result is False:
+            if not _edit_comment_safely(git_provider, comment, body):
                 raise RuntimeError("Failed to edit code suggestions comment")
-            return result
+            return True
 
         def _clean_up_progress_note(
             message: str = "Code suggestions published in the persistent thread above.",
         ) -> bool:
             if not progress_response:
                 return True
-            try:
-                _edit_comment(progress_response, message)
-            except Exception as edit_error:
-                get_logger().warning(
-                    f"Failed to update progress note before cleanup: {edit_error}"
-                )
+            _edit_comment_safely(git_provider, progress_response, message)
             try:
                 git_provider.remove_comment(progress_response)
             except Exception as remove_error:
@@ -652,7 +668,7 @@ class PRCodeSuggestions:
             f"{new_suggestion_table}\n\n"
         )
         if progress_response:
-            if git_provider.edit_comment(progress_response, pr_comment) is False:
+            if not _edit_comment_safely(git_provider, progress_response, pr_comment):
                 new_comment = git_provider.publish_comment(
                     pr_comment,
                     **({"as_thread": True} if as_thread else {}),
@@ -891,7 +907,8 @@ class PRCodeSuggestions:
                                       if empty_coverage_footer else "No suggestions found to improve this PR.")
             pr_body = no_suggestions_message + empty_coverage_footer
             if self.progress_response:
-                self.git_provider.edit_comment(self.progress_response, body=pr_body)
+                if not _edit_comment_safely(self.git_provider, self.progress_response, pr_body):
+                    self.git_provider.publish_comment(pr_body)
             else:
                 self.git_provider.publish_comment(pr_body)
             return

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -17,14 +17,6 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
     key_issue_location_fingerprint,
 )
-from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
-from pr_agent.algo.repo_context import build_repo_context
-from pr_agent.algo.review_finding_state import (
-    append_review_state,
-    parse_review_state,
-    reconcile_review_findings,
-)
-<<<<<<< HEAD
 from pr_agent.algo.pr_processing import (
     add_ai_metadata_to_diff_files,
     get_pr_diff,
@@ -33,9 +25,12 @@ from pr_agent.algo.pr_processing import (
 )
 from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
+from pr_agent.algo.review_finding_state import (
+    append_review_state,
+    parse_review_state,
+    reconcile_review_findings,
+)
 from pr_agent.algo.review_merge import merge_review_chunks
-=======
->>>>>>> 2541960 (fix(review): harden persistent finding state)
 from pr_agent.algo.run_details import get_run_details, init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -17,6 +17,11 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
     key_issue_location_fingerprint,
 )
+from pr_agent.algo.review_finding_state import (
+    append_review_state,
+    parse_review_state,
+    reconcile_review_findings,
+)
 from pr_agent.algo.pr_processing import (
     add_ai_metadata_to_diff_files,
     get_pr_diff,
@@ -43,7 +48,7 @@ from pr_agent.algo.utils import (
 )
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider_with_context
-from pr_agent.git_providers.git_provider import IncrementalPR, get_main_pr_language
+from pr_agent.git_providers.git_provider import GitProvider, IncrementalPR, get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.ticket_pr_compliance_check import extract_and_cache_pr_tickets
@@ -95,6 +100,8 @@ class PRReviewer:
         self.patches_diff = None
         self.remaining_files_list = []
         self.prediction = None
+        self._review_state_result = None
+        self._review_state_blocked = False
         question_str, answer_str = self._get_user_answers()
         self.pr_description, self.pr_description_files = (
             self.git_provider.get_pr_description(split_changes_walkthrough=True))
@@ -211,7 +218,13 @@ class PRReviewer:
             pr_review = self._prepare_pr_review()
             get_logger().debug("PR output", artifact=pr_review)
 
-            should_publish = get_settings().config.publish_output and self._should_publish_review_no_suggestions(pr_review)
+            state_result = getattr(self, "_review_state_result", None)
+            state_changed = bool(state_result and state_result.changed)
+            state_blocked = getattr(self, "_review_state_blocked", False)
+            should_publish = get_settings().config.publish_output and (
+                self._should_publish_review_no_suggestions(pr_review)
+                or state_changed
+            )
             if not should_publish:
                 reason = "Review output is not published"
                 if get_settings().config.publish_output:
@@ -224,10 +237,14 @@ class PRReviewer:
             # Providers that support it (GitLab) can post the review's final comment as a resolvable thread.
             # This intent applies to the review only - never to status comments or the output of other tools.
             review_thread_kwargs = {"as_thread": True} if self.git_provider.should_publish_review_as_thread() else {}
-            if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
+            if state_blocked:
+                get_logger().warning(
+                    "Review finding state is unavailable; publishing this review without persistent state"
+                )
+                self.git_provider.publish_comment(pr_review, **review_thread_kwargs)
+            elif get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
                 final_update_message = get_settings().pr_reviewer.final_update_message
-                self.git_provider.publish_persistent_comment(
-                    pr_review,
+                persistent_args = dict(
                     initial_header=pr_review.split("\n", 1)[0],
                     update_header=True,
                     final_update_message=final_update_message,
@@ -235,6 +252,12 @@ class PRReviewer:
                     legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
                     **review_thread_kwargs,
                 )
+                if state_result is not None:
+                    persistent_args["fallback_on_error"] = False
+                    self.git_provider.publish_persistent_comment_full(pr_review, **persistent_args)
+                else:
+                    self.git_provider.publish_persistent_comment(pr_review, **persistent_args)
+
             else:
                 if self.git_provider.supports_review_comment_identity() is True:
                     identity_marker = (
@@ -261,6 +284,137 @@ class PRReviewer:
                     self.git_provider.publish_comment("Failed to review PR")
                 except Exception as e:
                     get_logger().exception(f"Failed to publish review failure result, error: {e}")
+
+    def _review_finding_state_enabled(self) -> bool:
+        settings = get_settings()
+        if not settings.config.publish_output:
+            return False
+        if not settings.pr_reviewer.get("persistent_comment", True):
+            return False
+        if not settings.pr_reviewer.get("persistent_finding_state", True):
+            return False
+        publisher = getattr(self.git_provider, "publish_persistent_comment", None)
+        if getattr(publisher, "__func__", None) is GitProvider.publish_persistent_comment:
+            # The generic implementation only creates a new comment; it cannot safely carry lifecycle state.
+            return False
+        if getattr(getattr(settings, "github", None), "publish_as_check_run", False):
+            return False
+        if getattr(getattr(self, "incremental", None), "is_incremental", False):
+            return False
+        try:
+            return bool(self.git_provider.is_supported("get_issue_comments"))
+        except Exception as e:
+            get_logger().warning(f"Review finding state is not supported by this provider, error: {e}")
+            return False
+
+    def _load_review_finding_state(self):
+        header = f"{PRReviewHeader.REGULAR.value} 🔍"
+        try:
+            for comment in self.git_provider.get_issue_comments():
+                body = getattr(comment, "body", "")
+                if not isinstance(body, str) or not body.startswith(header):
+                    continue
+                parsed = parse_review_state(body)
+                if not parsed.valid:
+                    self._review_state_blocked = True
+                    get_logger().warning(
+                        "Review finding state marker is malformed or unsupported; skipping persistent update"
+                    )
+                return parsed
+        except Exception as e:
+            self._review_state_blocked = True
+            get_logger().warning(f"Could not read persistent review state; skipping persistent update, error: {e}")
+            return None
+        return parse_review_state("")
+
+    @staticmethod
+    def _review_finding_from_issue(issue: dict) -> Optional[dict]:
+        if not isinstance(issue, dict):
+            return None
+        path = str(issue.get("relevant_file") or issue.get("path") or "").strip()
+        raw_content = issue.get("issue_content") or issue.get("body") or ""
+        content = _SUGGESTION_FENCE_RE.sub("```text", str(raw_content).strip())
+        header = str(issue.get("issue_header") or "").strip()
+        if header.lower() == "possible bug":
+            header = "Possible Issue"
+        if not path or not content:
+            return None
+
+        finding = {
+            "path": path,
+            "body": f"**{header}**\n\n{content}" if header else content,
+        }
+        try:
+            start = int(str(issue.get("start_line", 0)).strip())
+            end = int(str(issue.get("end_line", start)).strip())
+        except (TypeError, ValueError):
+            start, end = 0, 0
+        if start > 0:
+            finding["line_start"] = start
+            finding["line_end"] = max(start, end)
+        return finding
+
+    @classmethod
+    def _review_findings_from_data(cls, data: dict) -> Optional[list[dict]]:
+        review = data.get("review")
+        if not isinstance(review, dict):
+            return None
+        if "key_issues_to_review" not in review:
+            return None
+        issues = review["key_issues_to_review"]
+        if not isinstance(issues, list):
+            return None
+        findings = []
+        for issue in issues:
+            finding = cls._review_finding_from_issue(issue)
+            if finding is None:
+                return None
+            findings.append(finding)
+        return findings
+
+    def _review_head_sha(self) -> str:
+        last_commit = getattr(self.git_provider, "last_commit_id", None)
+        if isinstance(last_commit, str):
+            return last_commit
+        for attribute in ("sha", "id"):
+            value = getattr(last_commit, attribute, None)
+            if isinstance(value, str):
+                return value
+        return ""
+
+    def _review_run_id(self) -> str:
+        try:
+            value = self.git_provider.get_latest_commit_url()
+        except Exception:
+            return ""
+        return value if isinstance(value, str) else ""
+
+    def _prepare_review_finding_state(self, data: dict) -> None:
+        self._review_state_result = None
+        self._review_state_blocked = False
+        if not self._review_finding_state_enabled():
+            return
+        if not isinstance(data.get("review"), dict):
+            return
+
+        parsed = self._load_review_finding_state()
+        if self._review_state_blocked or parsed is None:
+            return
+        current_findings = self._review_findings_from_data(data)
+        if current_findings is None:
+            self._review_state_blocked = True
+            get_logger().warning("Review finding data is invalid; skipping persistent state update")
+            return
+        result = reconcile_review_findings(
+            parsed.state,
+            current_findings,
+            allow_resolution=not bool(self.remaining_files_list),
+            excluded_files=self.remaining_files_list,
+            head_sha=self._review_head_sha(),
+            run_id=self._review_run_id(),
+        )
+        if parsed.state is not None or result.changed:
+            self._review_state_result = result
 
     def _should_publish_review_no_suggestions(self, pr_review: str) -> bool:
         return get_settings().pr_reviewer.get('publish_output_no_suggestions', True) or "No major issues detected" not in pr_review
@@ -414,6 +568,7 @@ class PRReviewer:
             key_issues_to_review = data['review'].pop('key_issues_to_review')
             data['review']['key_issues_to_review'] = key_issues_to_review
 
+        self._prepare_review_finding_state(data)
         if get_settings().config.publish_output and get_settings().pr_reviewer.get('inline_key_issues', False):
             data = self._publish_key_issues_as_inline_comments(data)
 
@@ -465,11 +620,17 @@ class PRReviewer:
         if get_settings().get('config', {}).get('output_run_details', False):
             markdown_text += show_run_details(self.git_provider.is_supported("gfm_markdown"))
 
-        # Emit the review to optional external sinks (stdout/file/webhook/slack); no-op unless enabled.
-        # publish_output gates it so a dry run makes no external calls. The "no major issues"
-        # suppression deliberately does not: that only silences the PR comment.
+        if self._review_state_result is not None:
+            markdown_text = append_review_state(
+                markdown_text or "",
+                self._review_state_result.state,
+                max_chars=self._review_comment_max_chars(),
+            )
+
+        # Emit the finalized review to optional external sinks.
         if get_settings().config.publish_output:
             push_outputs("review", payload=data.get('review', {}), markdown=markdown_text)
+
 
         # Add custom labels from the review prediction (effort, security)
         self.set_review_labels(data)

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -338,23 +338,33 @@ class PRReviewer:
         header = f"{PRReviewHeader.REGULAR.value} 🔍"
         try:
             comments = list(self.git_provider.get_issue_comments())
+            invalid_marker_found = False
             for comment in reversed(comments):
-                body = getattr(comment, "body", "")
+                body = GitProvider._get_comment_body(comment)
                 if not isinstance(body, str) or not body.startswith(header):
                     continue
                 parsed = parse_review_state(body)
-                if not parsed.valid:
-                    self._review_state_blocked = True
-                    self._review_state_block_reason = _STATE_BLOCK_INVALID_MARKER
+                if parsed.valid and parsed.present:
+                    self._review_state_blocked = False
+                    self._review_state_block_reason = None
+                    return parsed
+                if not parsed.valid and parsed.present:
+                    invalid_marker_found = True
                     get_logger().warning(
-                        "Review finding state marker is malformed or unsupported; skipping persistent update"
+                        "Review finding state marker is malformed or unsupported; "
+                        "trying an older persistent review"
                     )
-                return parsed
+            if invalid_marker_found:
+                self._review_state_blocked = True
+                self._review_state_block_reason = _STATE_BLOCK_INVALID_MARKER
+                return None
         except Exception as e:
             self._review_state_blocked = True
             self._review_state_block_reason = _STATE_BLOCK_READ_ERROR
             get_logger().warning(f"Could not read persistent review state; skipping persistent update, error: {e}")
             return None
+        self._review_state_blocked = False
+        self._review_state_block_reason = None
         return parse_review_state("")
 
     @staticmethod
@@ -419,6 +429,14 @@ class PRReviewer:
             return ""
         return value if isinstance(value, str) else ""
 
+    def _review_comment_max_chars(self) -> int | None:
+        for attribute in ("max_comment_chars", "max_comment_length"):
+            value = getattr(self.git_provider, attribute, None)
+            if isinstance(value, int) and value > 0:
+                update_suffix = f"\n\n#### (Review updated until commit {self._review_run_id()})\n"
+                return value - len(update_suffix)
+        return None
+
     def _prepare_review_finding_state(self, data: dict) -> None:
         self._review_state_result = None
         self._review_state_blocked = False
@@ -432,7 +450,7 @@ class PRReviewer:
             return
 
         parsed = self._load_review_finding_state()
-        if parsed is None:
+        if parsed is None and self._review_state_block_reason != _STATE_BLOCK_INVALID_MARKER:
             return
         current_findings = self._review_findings_from_data(data)
         if current_findings is None:
@@ -441,13 +459,27 @@ class PRReviewer:
             get_logger().warning("Review finding data is invalid; skipping persistent state update")
             return
         if self._review_state_blocked:
+            if self._review_state_block_reason == _STATE_BLOCK_INVALID_MARKER:
+                self._review_state_result = reconcile_review_findings(
+                    None,
+                    current_findings,
+                    allow_resolution=False,
+                    excluded_files=self.remaining_files_list,
+                    head_sha=self._review_head_sha(),
+                    run_id=self._review_run_id(),
+                )
             return
+        try:
+            max_findings = int(get_settings().pr_reviewer.num_max_findings)
+        except (TypeError, ValueError):
+            max_findings = 0
         allow_resolution = (
             bool(self.prediction)
             and not bool(getattr(self.incremental, "is_incremental", False))
             and not bool(self.remaining_files_list)
             and parsed.valid
             and current_findings is not None
+            and len(current_findings) < max_findings
         )
         result = reconcile_review_findings(
             parsed.state,
@@ -675,9 +707,6 @@ class PRReviewer:
                 max_chars=self._review_comment_max_chars(),
             )
 
-        # Emit the finalized review to optional external sinks.
-        if get_settings().config.publish_output:
-            push_outputs("review", payload=data.get('review', {}), markdown=markdown_text)
 
 
         # Add custom labels from the review prediction (effort, security)

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -187,6 +187,7 @@ class PRReviewer:
         init_run_details()
         progress_response = None
         review_failed = False
+        persistent_write_failed = False
         try:
             if not self.git_provider.get_files():
                 get_logger().info(f"PR has no files: {self.pr_url}, skipping review")
@@ -277,13 +278,22 @@ class PRReviewer:
                     fallback_on_error=False,
                     **review_thread_kwargs,
                 )
-                self.git_provider.publish_persistent_comment_full(pr_review, **persistent_args)
+                persistent_write_failed = True
+                result = self.git_provider.publish_persistent_comment_full(
+                    pr_review, **persistent_args
+                )
+                persistent_write_failed = not self._persistent_publish_succeeded(result)
+                if persistent_write_failed:
+                    review_failed = True
             elif state_blocked:
                 get_logger().warning(
                     "Review finding state is blocked by review data or provider read failure; "
                     "publishing without changing persistent state"
                 )
-                self.git_provider.publish_comment(pr_review, **review_thread_kwargs)
+                self.git_provider.publish_comment(
+                    self._as_non_authoritative_review(pr_review),
+                    **review_thread_kwargs,
+                )
             elif get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
                 final_update_message = get_settings().pr_reviewer.final_update_message
                 persistent_args = dict(
@@ -297,9 +307,31 @@ class PRReviewer:
                 if state_result is not None:
                     persistent_args["require_agent_authorship"] = True
                     persistent_args["fallback_on_error"] = False
-                    self.git_provider.publish_persistent_comment_full(pr_review, **persistent_args)
+                    persistent_write_failed = True
+                    result = self.git_provider.publish_persistent_comment_full(
+                        pr_review, **persistent_args
+                    )
+                    persistent_write_failed = not self._persistent_publish_succeeded(result)
+                    if persistent_write_failed:
+                        review_failed = True
+                elif self._publish_review_check_run(pr_review):
+                    pass
+                elif self._review_comment_authorship_available():
+                    persistent_args["require_agent_authorship"] = True
+                    persistent_args["fallback_on_error"] = False
+                    persistent_write_failed = True
+                    result = self.git_provider.publish_persistent_comment_full(
+                        pr_review, **persistent_args
+                    )
+                    persistent_write_failed = not self._persistent_publish_succeeded(result)
+                    if persistent_write_failed:
+                        review_failed = True
                 else:
-                    self.git_provider.publish_persistent_comment(pr_review, **persistent_args)
+                    # An unverified provider identity must never update a canonical review.
+                    self.git_provider.publish_comment(
+                        self._as_non_authoritative_review(pr_review),
+                        **review_thread_kwargs,
+                    )
 
             else:
                 if self.git_provider.supports_review_comment_identity() is True:
@@ -321,8 +353,14 @@ class PRReviewer:
                     self.git_provider.remove_comment(progress_response)
                 except Exception as e:
                     get_logger().exception(f"Failed to remove review progress comment, error: {e}")
-            if (review_failed and get_settings().config.publish_output and
-                    not get_settings().config.get("is_auto_command", False)):
+            if (
+                review_failed
+                and get_settings().config.publish_output
+                and (
+                    persistent_write_failed
+                    or not get_settings().config.get("is_auto_command", False)
+                )
+            ):
                 try:
                     self.git_provider.publish_comment("Failed to review PR")
                 except Exception as e:
@@ -343,7 +381,10 @@ class PRReviewer:
         if getattr(publisher, "__func__", None) is GitProvider.publish_persistent_comment:
             # Skip generic publishers; they only create comments and cannot safely carry lifecycle state.
             return False
-        if getattr(getattr(settings, "github", None), "publish_as_check_run", False):
+        if (
+            getattr(getattr(settings, "github", None), "publish_as_check_run", False)
+            and callable(getattr(provider, "_publish_check_run", None))
+        ):
             return False
         if getattr(getattr(self, "incremental", None), "is_incremental", False):
             return False
@@ -353,6 +394,61 @@ class PRReviewer:
             return bool(provider.is_supported("get_issue_comments"))
         except Exception as e:
             get_logger().warning(f"Review finding state is not supported by this provider, error: {e}")
+            return False
+
+    @staticmethod
+    def _persistent_publish_succeeded(result) -> bool:
+        return result is not None and result is not False
+
+    @staticmethod
+    def _as_non_authoritative_review(pr_review: str) -> str:
+        identity_markers = {
+            PRReviewIdentity.REGULAR.value,
+            PRReviewIdentity.INCREMENTAL.value,
+        }
+        markerless_review = "\n".join(
+            line
+            for line in str(pr_review).splitlines()
+            if line.strip() not in identity_markers
+        ).strip()
+        return (
+            "## Standalone PR Review\n\n"
+            "_PR-Agent could not safely update the persistent review. "
+            "This standalone result will not replace the canonical review._\n\n"
+            f"{markerless_review}"
+        )
+
+    def _publish_review_check_run(self, pr_review: str) -> bool:
+        if not getattr(
+            getattr(get_settings(), "github", None),
+            "publish_as_check_run",
+            False,
+        ):
+            return False
+        publisher = getattr(self.git_provider, "_publish_check_run", None)
+        if not callable(publisher):
+            return False
+        try:
+            return publisher(pr_review, "review") is True
+        except Exception as error:
+            get_logger().warning(
+                f"Failed to publish review check run, error: {error}"
+            )
+            return False
+
+    def _review_comment_authorship_available(self) -> bool:
+        provider = getattr(self, "git_provider", None)
+        if provider is None:
+            return False
+        try:
+            return (
+                provider.supports_review_finding_state() is True
+                and provider.is_supported("get_issue_comments") is True
+            )
+        except Exception as error:
+            get_logger().warning(
+                f"Review comment authorship is not available, error: {error}"
+            )
             return False
 
     def _load_review_finding_state(self):

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -17,11 +17,14 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
     key_issue_location_fingerprint,
 )
+from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
+from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.review_finding_state import (
     append_review_state,
     parse_review_state,
     reconcile_review_findings,
 )
+<<<<<<< HEAD
 from pr_agent.algo.pr_processing import (
     add_ai_metadata_to_diff_files,
     get_pr_diff,
@@ -31,7 +34,10 @@ from pr_agent.algo.pr_processing import (
 from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.review_merge import merge_review_chunks
+=======
+>>>>>>> 2541960 (fix(review): harden persistent finding state)
 from pr_agent.algo.run_details import get_run_details, init_run_details
+
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -55,6 +61,11 @@ from pr_agent.tools.ticket_pr_compliance_check import extract_and_cache_pr_ticke
 
 MAX_REVIEW_COVERAGE_FILES = 50
 _SUGGESTION_FENCE_RE = re.compile(r"```[ \t]*suggestion\b", re.IGNORECASE)
+
+
+_STATE_BLOCK_INVALID_MARKER = "invalid_marker"
+_STATE_BLOCK_READ_ERROR = "read_error"
+_STATE_BLOCK_REVIEW_DATA = "review_data"
 
 
 class PRReviewer:
@@ -102,6 +113,7 @@ class PRReviewer:
         self.prediction = None
         self._review_state_result = None
         self._review_state_blocked = False
+        self._review_state_block_reason = None
         question_str, answer_str = self._get_user_answers()
         self.pr_description, self.pr_description_files = (
             self.git_provider.get_pr_description(split_changes_walkthrough=True))
@@ -224,6 +236,7 @@ class PRReviewer:
             should_publish = get_settings().config.publish_output and (
                 self._should_publish_review_no_suggestions(pr_review)
                 or state_changed
+                or state_blocked
             )
             if not should_publish:
                 reason = "Review output is not published"
@@ -237,9 +250,23 @@ class PRReviewer:
             # Providers that support it (GitLab) can post the review's final comment as a resolvable thread.
             # This intent applies to the review only - never to status comments or the output of other tools.
             review_thread_kwargs = {"as_thread": True} if self.git_provider.should_publish_review_as_thread() else {}
-            if state_blocked:
+            state_block_reason = getattr(self, "_review_state_block_reason", None)
+            if state_blocked and state_block_reason == _STATE_BLOCK_INVALID_MARKER:
                 get_logger().warning(
-                    "Review finding state is unavailable; publishing this review without persistent state"
+                    "Review finding state marker is invalid; replacing it with a clean persistent review"
+                )
+                persistent_args = dict(
+                    initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+                    update_header=True,
+                    final_update_message=False,
+                    fallback_on_error=False,
+                    **review_thread_kwargs,
+                )
+                self.git_provider.publish_persistent_comment_full(pr_review, **persistent_args)
+            elif state_blocked:
+                get_logger().warning(
+                    "Review finding state is blocked by review data or provider read failure; "
+                    "publishing without changing persistent state"
                 )
                 self.git_provider.publish_comment(pr_review, **review_thread_kwargs)
             elif get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
@@ -295,7 +322,7 @@ class PRReviewer:
             return False
         publisher = getattr(self.git_provider, "publish_persistent_comment", None)
         if getattr(publisher, "__func__", None) is GitProvider.publish_persistent_comment:
-            # The generic implementation only creates a new comment; it cannot safely carry lifecycle state.
+            # Skip generic publishers; they only create comments and cannot safely carry lifecycle state.
             return False
         if getattr(getattr(settings, "github", None), "publish_as_check_run", False):
             return False
@@ -310,19 +337,22 @@ class PRReviewer:
     def _load_review_finding_state(self):
         header = f"{PRReviewHeader.REGULAR.value} 🔍"
         try:
-            for comment in self.git_provider.get_issue_comments():
+            comments = list(self.git_provider.get_issue_comments())
+            for comment in reversed(comments):
                 body = getattr(comment, "body", "")
                 if not isinstance(body, str) or not body.startswith(header):
                     continue
                 parsed = parse_review_state(body)
                 if not parsed.valid:
                     self._review_state_blocked = True
+                    self._review_state_block_reason = _STATE_BLOCK_INVALID_MARKER
                     get_logger().warning(
                         "Review finding state marker is malformed or unsupported; skipping persistent update"
                     )
                 return parsed
         except Exception as e:
             self._review_state_blocked = True
+            self._review_state_block_reason = _STATE_BLOCK_READ_ERROR
             get_logger().warning(f"Could not read persistent review state; skipping persistent update, error: {e}")
             return None
         return parse_review_state("")
@@ -392,23 +422,37 @@ class PRReviewer:
     def _prepare_review_finding_state(self, data: dict) -> None:
         self._review_state_result = None
         self._review_state_blocked = False
+        self._review_state_block_reason = None
         if not self._review_finding_state_enabled():
             return
         if not isinstance(data.get("review"), dict):
+            self._review_state_blocked = True
+            self._review_state_block_reason = _STATE_BLOCK_REVIEW_DATA
+            get_logger().warning("Review data is invalid; preserving persistent finding state")
             return
 
         parsed = self._load_review_finding_state()
-        if self._review_state_blocked or parsed is None:
+        if parsed is None:
             return
         current_findings = self._review_findings_from_data(data)
         if current_findings is None:
             self._review_state_blocked = True
+            self._review_state_block_reason = _STATE_BLOCK_REVIEW_DATA
             get_logger().warning("Review finding data is invalid; skipping persistent state update")
             return
+        if self._review_state_blocked:
+            return
+        allow_resolution = (
+            bool(self.prediction)
+            and not bool(getattr(self.incremental, "is_incremental", False))
+            and not bool(self.remaining_files_list)
+            and parsed.valid
+            and current_findings is not None
+        )
         result = reconcile_review_findings(
             parsed.state,
             current_findings,
-            allow_resolution=not bool(self.remaining_files_list),
+            allow_resolution=allow_resolution,
             excluded_files=self.remaining_files_list,
             head_sha=self._review_head_sha(),
             run_id=self._review_run_id(),
@@ -541,7 +585,11 @@ class PRReviewer:
         data = self.prediction_data if self.prediction_data is not None else self._load_review_yaml(self.prediction)
         github_action_output(data, 'review')
 
-        if 'review' not in data:
+        if not isinstance(data.get('review'), dict):
+            if self._review_finding_state_enabled():
+                self._review_state_blocked = True
+                self._review_state_block_reason = _STATE_BLOCK_REVIEW_DATA
+                get_logger().warning("Review data is invalid; preserving persistent finding state")
             get_logger().exception("Failed to parse review data", artifact={"data": data})
             return ""
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -299,7 +299,9 @@ class PRReviewer:
                     legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
                     **review_thread_kwargs,
                 )
-                if state_result is not None:
+                if not self._review_finding_state_in_play():
+                    self.git_provider.publish_persistent_comment(pr_review, **persistent_args)
+                elif state_result is not None:
                     persistent_args["require_agent_authorship"] = True
                     persistent_args["fallback_on_error"] = False
                     persistent_write_failed = True
@@ -430,6 +432,19 @@ class PRReviewer:
                 f"Failed to publish review check run, error: {error}"
             )
             return False
+
+    def _review_finding_state_in_play(self) -> bool:
+        if not get_settings().pr_reviewer.get("persistent_finding_state", True):
+            return False
+        provider = getattr(self, "git_provider", None)
+        if provider is None:
+            return False
+        capability = getattr(provider, "supports_review_finding_state", None)
+        implementation = getattr(capability, "__func__", capability)
+        return (
+            callable(capability)
+            and implementation is not GitProvider.supports_review_finding_state
+        )
 
     def _review_comment_authorship_available(self) -> bool:
         provider = getattr(self, "git_provider", None)

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -292,10 +292,10 @@ class PRReviewer:
                     final_update_message=final_update_message,
                     identity_marker=PRReviewIdentity.REGULAR.value,
                     legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
-                    require_agent_authorship=True,
                     **review_thread_kwargs,
                 )
                 if state_result is not None:
+                    persistent_args["require_agent_authorship"] = True
                     persistent_args["fallback_on_error"] = False
                     self.git_provider.publish_persistent_comment_full(pr_review, **persistent_args)
                 else:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -37,7 +37,6 @@ from pr_agent.algo.review_merge import merge_review_chunks
 =======
 >>>>>>> 2541960 (fix(review): harden persistent finding state)
 from pr_agent.algo.run_details import get_run_details, init_run_details
-
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -45,7 +44,10 @@ from pr_agent.algo.utils import (
     PRReviewHeader,
     PRReviewIdentity,
     add_pr_review_identity,
+    comment_carries_other_identity,
+    comment_matches_identity,
     convert_to_markdown_v2,
+    get_pr_review_comment_identifiers,
     github_action_output,
     load_yaml,
     push_outputs,
@@ -66,6 +68,7 @@ _SUGGESTION_FENCE_RE = re.compile(r"```[ \t]*suggestion\b", re.IGNORECASE)
 _STATE_BLOCK_INVALID_MARKER = "invalid_marker"
 _STATE_BLOCK_READ_ERROR = "read_error"
 _STATE_BLOCK_REVIEW_DATA = "review_data"
+_STATE_BLOCK_SIZE = "state_size"
 
 
 class PRReviewer:
@@ -114,6 +117,8 @@ class PRReviewer:
         self._review_state_result = None
         self._review_state_blocked = False
         self._review_state_block_reason = None
+        self._review_finding_previous_state = None
+        self._review_state_preserved = False
         question_str, answer_str = self._get_user_answers()
         self.pr_description, self.pr_description_files = (
             self.git_provider.get_pr_description(split_changes_walkthrough=True))
@@ -251,14 +256,24 @@ class PRReviewer:
             # This intent applies to the review only - never to status comments or the output of other tools.
             review_thread_kwargs = {"as_thread": True} if self.git_provider.should_publish_review_as_thread() else {}
             state_block_reason = getattr(self, "_review_state_block_reason", None)
-            if state_blocked and state_block_reason == _STATE_BLOCK_INVALID_MARKER:
+            if state_blocked and (
+                state_block_reason == _STATE_BLOCK_INVALID_MARKER
+                or (
+                    state_block_reason == _STATE_BLOCK_SIZE
+                    and getattr(self, "_review_state_preserved", False)
+                )
+            ):
                 get_logger().warning(
-                    "Review finding state marker is invalid; replacing it with a clean persistent review"
+                    "Review finding state cannot be written safely; replacing the persistent review "
+                    "with a clean state marker"
                 )
                 persistent_args = dict(
                     initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
                     update_header=True,
                     final_update_message=False,
+                    identity_marker=PRReviewIdentity.REGULAR.value,
+                    legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+                    require_agent_authorship=True,
                     fallback_on_error=False,
                     **review_thread_kwargs,
                 )
@@ -277,6 +292,7 @@ class PRReviewer:
                     final_update_message=final_update_message,
                     identity_marker=PRReviewIdentity.REGULAR.value,
                     legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+                    require_agent_authorship=True,
                     **review_thread_kwargs,
                 )
                 if state_result is not None:
@@ -320,7 +336,10 @@ class PRReviewer:
             return False
         if not settings.pr_reviewer.get("persistent_finding_state", True):
             return False
-        publisher = getattr(self.git_provider, "publish_persistent_comment", None)
+        provider = getattr(self, "git_provider", None)
+        if provider is None:
+            return False
+        publisher = getattr(provider, "publish_persistent_comment", None)
         if getattr(publisher, "__func__", None) is GitProvider.publish_persistent_comment:
             # Skip generic publishers; they only create comments and cannot safely carry lifecycle state.
             return False
@@ -329,20 +348,23 @@ class PRReviewer:
         if getattr(getattr(self, "incremental", None), "is_incremental", False):
             return False
         try:
-            return bool(self.git_provider.is_supported("get_issue_comments"))
+            if provider.supports_review_finding_state() is not True:
+                return False
+            return bool(provider.is_supported("get_issue_comments"))
         except Exception as e:
             get_logger().warning(f"Review finding state is not supported by this provider, error: {e}")
             return False
 
     def _load_review_finding_state(self):
-        header = f"{PRReviewHeader.REGULAR.value} 🔍"
+        identifiers = get_pr_review_comment_identifiers(full=True, incremental=False)
         try:
-            comments = list(self.git_provider.get_issue_comments())
             invalid_marker_found = False
-            for comment in reversed(comments):
-                body = GitProvider._get_comment_body(comment)
-                if not isinstance(body, str) or not body.startswith(header):
-                    continue
+            for _comment, body in GitProvider._iter_persistent_comments(
+                self.git_provider,
+                identifiers,
+                identity_marker=PRReviewIdentity.REGULAR.value,
+                require_agent_authorship=True,
+            ):
                 parsed = parse_review_state(body)
                 if parsed.valid and parsed.present:
                     self._review_state_blocked = False
@@ -434,13 +456,19 @@ class PRReviewer:
             value = getattr(self.git_provider, attribute, None)
             if isinstance(value, int) and value > 0:
                 update_suffix = f"\n\n#### (Review updated until commit {self._review_run_id()})\n"
-                return value - len(update_suffix)
+                # The shared persistent publisher adds the full-review identity
+                # before inserting the update suffix. Reserve both pieces so a
+                # complete state marker remains inside the provider limit.
+                identity_overhead = len(PRReviewIdentity.REGULAR.value) + 2
+                return value - len(update_suffix) - identity_overhead
         return None
 
     def _prepare_review_finding_state(self, data: dict) -> None:
         self._review_state_result = None
         self._review_state_blocked = False
         self._review_state_block_reason = None
+        self._review_finding_previous_state = None
+        self._review_state_preserved = False
         if not self._review_finding_state_enabled():
             return
         if not isinstance(data.get("review"), dict):
@@ -450,6 +478,8 @@ class PRReviewer:
             return
 
         parsed = self._load_review_finding_state()
+        if parsed is not None and parsed.valid:
+            self._review_finding_previous_state = parsed.state
         if parsed is None and self._review_state_block_reason != _STATE_BLOCK_INVALID_MARKER:
             return
         current_findings = self._review_findings_from_data(data)
@@ -701,13 +731,42 @@ class PRReviewer:
             markdown_text += show_run_details(self.git_provider.is_supported("gfm_markdown"))
 
         if self._review_state_result is not None:
-            markdown_text = append_review_state(
-                markdown_text or "",
-                self._review_state_result.state,
-                max_chars=self._review_comment_max_chars(),
-            )
+            state_result = self._review_state_result
+            try:
+                markdown_text = append_review_state(
+                    markdown_text or "",
+                    state_result.state,
+                    max_chars=self._review_comment_max_chars(),
+                )
+            except ValueError as error:
+                previous_state = getattr(self, "_review_finding_previous_state", None)
+                self._review_state_result = None
+                self._review_state_blocked = True
+                self._review_state_block_reason = _STATE_BLOCK_SIZE
+                get_logger().warning(
+                    f"Persistent review state did not fit the provider comment limit; "
+                    f"publishing the review without advancing state: {error}"
+                )
+                if previous_state is not None:
+                    try:
+                        markdown_text = append_review_state(
+                            markdown_text or "",
+                            previous_state,
+                            max_chars=self._review_comment_max_chars(),
+                        )
+                    except ValueError as previous_error:
+                        get_logger().warning(
+                            f"Previous persistent review state also did not fit the provider "
+                            f"comment limit; leaving the existing state untouched: {previous_error}"
+                        )
+                    else:
+                        self._review_state_preserved = True
 
-
+        # Emit the review to optional external sinks (stdout/file/webhook/slack); no-op unless enabled.
+        # publish_output gates it so a dry run makes no external calls. The "no major issues"
+        # suppression deliberately does not: that only silences the PR comment.
+        if get_settings().config.publish_output:
+            push_outputs("review", payload=data.get('review', {}), markdown=markdown_text)
 
         # Add custom labels from the review prediction (effort, security)
         self.set_review_labels(data)

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -7,7 +7,11 @@ import pytest
 from pr_agent.algo.inline_comment_dedup import code_fingerprint
 from pr_agent.algo.types import FilePatchInfo
 from pr_agent.algo.utils import PRCodeSuggestionsIdentity
-from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+from pr_agent.git_providers.azuredevops_provider import (
+    AzureDevopsProvider,
+    Comment,
+    CommentThread,
+)
 from pr_agent.log import get_logger
 
 
@@ -1477,3 +1481,126 @@ def test_azure_lifecycle_matches_stable_identity_not_display_name(mock_get_setti
     assert provider.supports_review_finding_state() is True
     assert provider.is_comment_authored_by_pr_agent(matching_comment) is True
     assert provider.is_comment_authored_by_pr_agent(same_name_different_id) is False
+
+
+@patch("pr_agent.git_providers.azuredevops_provider.get_settings")
+def test_azure_lifecycle_matches_descriptor_identity(mock_get_settings):
+    descriptor = "aad.aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    mock_get_settings.return_value.get.side_effect = lambda key, default=None: (
+        descriptor if key == "azure_devops_server.agent_identity" else default
+    )
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    matching_comment = SimpleNamespace(
+        author=SimpleNamespace(
+            descriptor=descriptor,
+            id=None,
+            unique_name=None,
+            display_name="PR Agent",
+        )
+    )
+    same_name_different_descriptor = SimpleNamespace(
+        author=SimpleNamespace(
+            descriptor="aad.ffffffff-1111-2222-3333-444444444444",
+            id=None,
+            unique_name=None,
+            display_name="PR Agent",
+        )
+    )
+    missing_stable_identity = SimpleNamespace(
+        author=SimpleNamespace(
+            descriptor=None,
+            id=None,
+            unique_name=None,
+            display_name="PR Agent",
+        )
+    )
+
+    assert provider.supports_review_finding_state() is True
+    assert provider.is_comment_authored_by_pr_agent(matching_comment) is True
+    assert provider.is_comment_authored_by_pr_agent({
+        "author": {"descriptor": descriptor, "displayName": "PR Agent"},
+    }) is True
+    assert provider.is_comment_authored_by_pr_agent(same_name_different_descriptor) is False
+    with pytest.raises(RuntimeError, match="cannot be verified"):
+        provider.is_comment_authored_by_pr_agent(missing_stable_identity)
+
+
+def test_azure_newest_comment_order_is_chronological_across_threads():
+    from datetime import datetime, timezone
+
+    def timestamp(second):
+        return datetime(2026, 1, 1, 0, 0, second, tzinfo=timezone.utc)
+
+    def comment(comment_id, body, second):
+        return Comment(
+            id=comment_id,
+            content=body,
+            published_date=timestamp(second),
+            last_updated_date=timestamp(second),
+        )
+
+    old = comment(10, "old", 1)
+    middle = comment(20, "middle", 2)
+    tied_low = comment(30, "tied-low", 4)
+    tied_high = comment(31, "tied-high", 4)
+    newest = comment(5, "newest", 5)
+    old_thread = CommentThread(id=100, comments=[old, middle])
+    tied_thread = CommentThread(id=200, comments=[tied_low, tied_high])
+    newest_thread = CommentThread(id=300, comments=[newest])
+
+    raw_variants = [
+        [old_thread, tied_thread, newest_thread],
+        [newest_thread, tied_thread, old_thread],
+        [tied_thread, old_thread, newest_thread],
+    ]
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+
+    for raw_threads in raw_variants:
+        provider._get_threads = lambda raw_threads=raw_threads: raw_threads
+        comments = provider.get_issue_comments_newest_first()
+        assert [item.body for item in comments] == [
+            "newest",
+            "tied-high",
+            "tied-low",
+            "middle",
+            "old",
+        ]
+        assert [item.id for item in comments] == [5, 31, 30, 20, 10]
+
+
+def test_azure_raw_comment_order_uses_updates_and_thread_id_ties():
+    def raw_comment(body, published, updated):
+        return {
+            "id": 1,
+            "content": body,
+            "publishedDate": published,
+            "lastUpdatedDate": updated,
+        }
+
+    tied_time = "2026-01-01T00:00:04.000001Z"
+    older_thread = {
+        "id": 10,
+        "comments": [raw_comment("tied-older-thread", tied_time, tied_time)],
+    }
+    newer_thread = {
+        "id": 20,
+        "comments": [raw_comment("tied-newer-thread", tied_time, tied_time)],
+    }
+    edited_thread = {
+        "id": 5,
+        "comments": [raw_comment(
+            "edited-newest", "2026-01-01T00:00:01Z", "2026-01-01T00:00:05+00:00",
+        )],
+    }
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+
+    for threads in (
+        [older_thread, newer_thread, edited_thread],
+        [edited_thread, newer_thread, older_thread],
+        [newer_thread, edited_thread, older_thread],
+    ):
+        provider._get_threads = lambda threads=threads: threads
+        comments = provider.get_issue_comments_newest_first()
+        assert [comment["body"] for comment in comments] == [
+            "edited-newest", "tied-newer-thread", "tied-older-thread",
+        ]

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -1432,3 +1432,48 @@ def test_azure_comment_authorship_uses_explicit_agent_identity(mock_get_settings
     assert provider.supports_review_finding_state() is True
     assert provider.is_comment_authored_by_pr_agent(agent_comment) is True
     assert provider.is_comment_authored_by_pr_agent(human_comment) is False
+
+
+@patch("pr_agent.git_providers.azuredevops_provider.get_settings")
+def test_azure_lifecycle_does_not_trust_display_name(mock_get_settings):
+    mock_get_settings.return_value.get.side_effect = lambda key, default=None: (
+        "PR Agent" if key == "azure_devops_server.agent_identity" else default
+    )
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    comment = SimpleNamespace(
+        author=SimpleNamespace(
+            id="actual-agent-id",
+            display_name="PR Agent",
+            unique_name="different@example.com",
+        )
+    )
+
+    assert provider.supports_review_finding_state() is False
+    assert provider.is_comment_authored_by_pr_agent(comment) is False
+
+
+@patch("pr_agent.git_providers.azuredevops_provider.get_settings")
+def test_azure_lifecycle_matches_stable_identity_not_display_name(mock_get_settings):
+    agent_id = "11111111-1111-1111-1111-111111111111"
+    mock_get_settings.return_value.get.side_effect = lambda key, default=None: (
+        agent_id if key == "azure_devops_server.agent_identity" else default
+    )
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    matching_comment = SimpleNamespace(
+        author=SimpleNamespace(
+            id=agent_id,
+            display_name="PR Agent",
+            unique_name="other@example.com",
+        )
+    )
+    same_name_different_id = SimpleNamespace(
+        author=SimpleNamespace(
+            id="22222222-2222-2222-2222-222222222222",
+            display_name="PR Agent",
+            unique_name="other@example.com",
+        )
+    )
+
+    assert provider.supports_review_finding_state() is True
+    assert provider.is_comment_authored_by_pr_agent(matching_comment) is True
+    assert provider.is_comment_authored_by_pr_agent(same_name_different_id) is False

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -1387,3 +1387,48 @@ class TestAzureDevopsProviderSuggestionDiscussions:
         discussions = json.loads(provider.get_code_suggestion_thread_context())
 
         assert [reply["message"] for reply in discussions[0]["replies"]] == ["Rejected, keep as is."]
+
+
+def test_azure_issue_comments_newest_first_does_not_reverse_twice():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    threads = [
+        SimpleNamespace(
+            id=1,
+            comments=[SimpleNamespace(
+                id=11,
+                content="old comment",
+                author=SimpleNamespace(unique_name="developer@example.com"),
+            )],
+        ),
+        SimpleNamespace(
+            id=2,
+            comments=[SimpleNamespace(
+                id=22,
+                content="new comment",
+                author=SimpleNamespace(unique_name="agent@example.com"),
+            )],
+        ),
+    ]
+    provider._get_threads = MagicMock(return_value=threads)
+
+    comments = provider.get_issue_comments_newest_first()
+
+    assert [comment.body for comment in comments] == ["new comment", "old comment"]
+
+
+@patch("pr_agent.git_providers.azuredevops_provider.get_settings")
+def test_azure_comment_authorship_uses_explicit_agent_identity(mock_get_settings):
+    mock_get_settings.return_value.get.side_effect = lambda key, default=None: (
+        "agent@example.com" if key == "azure_devops_server.agent_identity" else default
+    )
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    agent_comment = SimpleNamespace(
+        author=SimpleNamespace(unique_name="agent@example.com")
+    )
+    human_comment = SimpleNamespace(
+        author=SimpleNamespace(unique_name="human@example.com")
+    )
+
+    assert provider.supports_review_finding_state() is True
+    assert provider.is_comment_authored_by_pr_agent(agent_comment) is True
+    assert provider.is_comment_authored_by_pr_agent(human_comment) is False

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -60,14 +60,13 @@ class TestBitbucketProvider:
         ):
             return provider.get_diff_files()[0]
 
-    def test_edit_comment_reraises_provider_failure(self):
+    def test_edit_comment_returns_false_on_provider_failure(self):
         provider = BitbucketProvider.__new__(BitbucketProvider)
         provider.max_comment_length = 1000
         comment = MagicMock()
         comment.update.side_effect = RuntimeError("edit failed")
 
-        with pytest.raises(RuntimeError, match="edit failed"):
-            provider.edit_comment(comment, "updated body")
+        assert provider.edit_comment(comment, "updated body") is False
 
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -60,6 +60,15 @@ class TestBitbucketProvider:
         ):
             return provider.get_diff_files()[0]
 
+    def test_edit_comment_reraises_provider_failure(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.max_comment_length = 1000
+        comment = MagicMock()
+        comment.update.side_effect = RuntimeError("edit failed")
+
+        with pytest.raises(RuntimeError, match="edit failed"):
+            provider.edit_comment(comment, "updated body")
+
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
         workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)

--- a/tests/unittest/test_code_suggestions_comment_identity.py
+++ b/tests/unittest/test_code_suggestions_comment_identity.py
@@ -156,9 +156,9 @@ def test_github_check_run_receives_configured_presentation_without_identity():
 
 def _persistent_publish(prev_comment_bodies):
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [
-        SimpleNamespace(body=body) for body in prev_comment_bodies
-    ]
+    comments = [SimpleNamespace(body=body) for body in prev_comment_bodies]
+    provider.get_issue_comments.return_value = comments
+    provider.get_issue_comments_newest_first.return_value = list(reversed(comments))
     GitProvider.publish_persistent_comment_full(
         provider,
         "## PR Code Suggestions ✨\n\n<table>new</table>",

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1066,6 +1066,44 @@ class TestGiteaProviderInlineCommentStatus:
         assert kwargs["body"]["event"] == "COMMENT"
 
 
+def test_gitea_persistent_wrapper_preserves_identity_and_result():
+    published = object()
+
+    class RecordingGiteaProvider(GiteaProvider):
+        def __init__(self):
+            self.calls = []
+
+        def publish_persistent_comment_full(
+            self, pr_comment, initial_header, update_header=True, name="review",
+            final_update_message=True, as_thread=False, identity_marker=None,
+            legacy_initial_header=None, require_agent_authorship=False,
+            fallback_on_error=True,
+        ):
+            self.calls.append((
+                pr_comment, initial_header, update_header, name,
+                final_update_message, as_thread, identity_marker,
+                legacy_initial_header, require_agent_authorship, fallback_on_error,
+            ))
+            return published
+
+    provider = RecordingGiteaProvider()
+    result = provider.publish_persistent_comment(
+        "review body",
+        "initial header",
+        update_header=False,
+        name="review",
+        final_update_message=False,
+        identity_marker="marker",
+        legacy_initial_header="legacy header",
+    )
+
+    assert result is published
+    assert provider.calls == [(
+        "review body", "initial header", False, "review", False,
+        False, "marker", "legacy header", False, True,
+    )]
+
+
 def _page(items):
     """A raw (non-preloaded) giteapy response carrying one JSON page."""
     return SimpleNamespace(data=BytesIO(json.dumps(items).encode("utf-8")))

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -47,6 +47,18 @@ def test_gitea_edit_comment_accepts_dict_ids(comment, expected_id):
     )
 
 
+def test_gitea_edit_comment_returns_false_on_failure():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.repo_api = MagicMock()
+    provider.repo_api.edit_comment.side_effect = RuntimeError("edit failed")
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.max_comment_chars = 1000
+    provider.logger = MagicMock()
+
+    assert provider.edit_comment({"id": 42}, "updated body") is False
+
+
 def test_gitea_get_issue_comments_returns_empty_list_when_no_comments():
     provider = GiteaProvider.__new__(GiteaProvider)
     provider.enabled_issue = False

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -74,6 +74,36 @@ def test_gitea_get_issue_comments_raises_when_api_returns_empty_value():
         provider.get_issue_comments()
 
 
+def test_gitea_get_issue_comments_raises_when_api_returns_error_payload():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.enabled_issue = False
+    provider.pr_number = 1
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.repo_api = MagicMock()
+    provider.repo_api.list_all_comments.return_value = {
+        "error": "unauthorized"
+    }
+    provider.logger = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Failed to get comments"):
+        provider.get_issue_comments()
+
+
+def test_gitea_get_issue_comments_returns_comment_list():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.enabled_issue = False
+    provider.pr_number = 1
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.repo_api = MagicMock()
+    comments = [{"body": "comment", "id": 1}]
+    provider.repo_api.list_all_comments.return_value = comments
+    provider.logger = MagicMock()
+
+    assert provider.get_issue_comments() == comments
+
+
 @pytest.mark.parametrize(
     ("fallback_on_error", "expected", "publishes_fallback"),
     [(True, "fallback", True), (False, None, False)],

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from giteapy.rest import ApiException
 
+from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.git_providers.gitea_provider import GiteaProvider
 
 
@@ -44,6 +45,69 @@ def test_gitea_edit_comment_accepts_dict_ids(comment, expected_id):
         comment_id=expected_id,
         comment="updated body",
     )
+
+
+def test_gitea_get_issue_comments_returns_empty_list_when_no_comments():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.enabled_issue = False
+    provider.pr_number = 1
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.repo_api = MagicMock()
+    provider.repo_api.list_all_comments.return_value = []
+    provider.logger = MagicMock()
+
+    assert provider.get_issue_comments() == []
+
+
+def test_gitea_get_issue_comments_raises_when_api_returns_empty_value():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.enabled_issue = False
+    provider.pr_number = 1
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.repo_api = MagicMock()
+    provider.repo_api.list_all_comments.return_value = None
+    provider.logger = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Failed to get comments"):
+        provider.get_issue_comments()
+
+
+@pytest.mark.parametrize(
+    ("fallback_on_error", "expected", "publishes_fallback"),
+    [(True, "fallback", True), (False, None, False)],
+)
+def test_gitea_edit_failure_respects_persistent_fallback(
+    fallback_on_error, expected, publishes_fallback
+):
+    header = "## PR Reviewer Guide 🔍"
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.repo_api = MagicMock()
+    provider.repo_api.edit_comment.side_effect = RuntimeError("edit failed")
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.max_comment_chars = 1000
+    provider.logger = MagicMock()
+    provider.get_issue_comments = MagicMock(return_value=[{"body": header, "id": 42}])
+    provider.get_latest_commit_url = MagicMock(return_value="commit-url")
+    provider.get_comment_url = MagicMock(return_value="comment-url")
+    provider.publish_comment = MagicMock(return_value="fallback")
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=fallback_on_error,
+    )
+
+    assert result == expected
+    if publishes_fallback:
+        provider.publish_comment.assert_called_once_with("new review")
+    else:
+        provider.publish_comment.assert_not_called()
 
 
 class TestGiteaProvider:

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1069,7 +1069,9 @@ class TestGiteaProviderInlineCommentStatus:
 def test_gitea_persistent_wrapper_preserves_identity_and_result():
     published = object()
 
-    class RecordingGiteaProvider(GiteaProvider):
+    class RecordingGiteaProvider:
+        publish_persistent_comment = GiteaProvider.publish_persistent_comment
+
         def __init__(self):
             self.calls = []
 

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -9,6 +9,43 @@ from giteapy.rest import ApiException
 from pr_agent.git_providers.gitea_provider import GiteaProvider
 
 
+def test_gitea_comment_url_accepts_dict_fields():
+    provider = GiteaProvider.__new__(GiteaProvider)
+
+    html_url_comment = {"html_url": "https://gitea.example/comment/1"}
+    assert provider.get_comment_url(html_url_comment) == (
+        "https://gitea.example/comment/1"
+    )
+    url_comment = {"url": "https://gitea.example/comment/2"}
+    assert provider.get_comment_url(url_comment) == (
+        "https://gitea.example/comment/2"
+    )
+
+
+@pytest.mark.parametrize(
+    ("comment", "expected_id"),
+    [
+        ({"comment_id": 7, "id": 42}, 7),
+        ({"id": 42}, 42),
+    ],
+)
+def test_gitea_edit_comment_accepts_dict_ids(comment, expected_id):
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.repo_api = MagicMock()
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.max_comment_chars = 1000
+
+    provider.edit_comment(comment, "updated body")
+
+    provider.repo_api.edit_comment.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        comment_id=expected_id,
+        comment="updated body",
+    )
+
+
 class TestGiteaProvider:
     @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
     @patch("pr_agent.git_providers.gitea_provider.get_settings")

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -625,7 +625,7 @@ class TestResolveCommentThread:
         assert result is False
 
 
-def test_app_comment_authorship_uses_configured_app_identity_without_user_endpoint(monkeypatch):
+def test_app_comment_authorship_requires_grounded_identity_without_user_endpoint(monkeypatch):
     provider = _make_provider()
     provider.deployment_type = "app"
     provider.github_user_id = ""
@@ -648,9 +648,47 @@ def test_app_comment_authorship_uses_configured_app_identity_without_user_endpoi
         user=SimpleNamespace(login="review-app-human")
     )
 
+    assert provider.supports_review_finding_state() is False
+    with pytest.raises(RuntimeError, match="identity"):
+        provider.is_comment_authored_by_pr_agent(bot_comment)
+    with pytest.raises(RuntimeError, match="identity"):
+        provider.is_comment_authored_by_pr_agent(copied_marker_comment)
+
+
+def test_app_comment_authorship_uses_published_response_identity_when_app_name_is_stale(
+    monkeypatch,
+):
+    provider = _make_provider()
+    provider.deployment_type = "app"
+    provider.github_user_id = ""
+    response = SimpleNamespace(user=SimpleNamespace(login="actual-app[bot]"))
+    provider.pr = SimpleNamespace(
+        create_issue_comment=lambda _body: response,
+    )
+    provider.issue_main = None
+    provider.github_client = SimpleNamespace(
+        get_user=lambda: pytest.fail("installation tokens must not use /user")
+    )
+    settings = SimpleNamespace(
+        get=lambda key, default=None: (
+            "stale-app" if key == "GITHUB.APP_NAME" else default
+        )
+    )
+
+    monkeypatch.setattr(gh_module, "get_settings", lambda: settings)
+
+    assert provider.publish_comment("identity bootstrap") is response
+    assert provider.github_user_id == "actual-app[bot]"
+    actual_bot_comment = SimpleNamespace(
+        user=SimpleNamespace(login="actual-app[bot]")
+    )
+    stale_bot_comment = SimpleNamespace(
+        user=SimpleNamespace(login="stale-app[bot]")
+    )
+
     assert provider.supports_review_finding_state() is True
-    assert provider.is_comment_authored_by_pr_agent(bot_comment) is True
-    assert provider.is_comment_authored_by_pr_agent(copied_marker_comment) is False
+    assert provider.is_comment_authored_by_pr_agent(actual_bot_comment) is True
+    assert provider.is_comment_authored_by_pr_agent(stale_bot_comment) is False
 
 
 def test_user_comment_authorship_resolves_authenticated_user():

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -55,13 +55,32 @@ def _make_provider(pr=None, max_chars=65000):
     return p
 
 
-def test_edit_comment_reraises_github_failure():
+def test_edit_comment_returns_false_on_github_failure():
     provider = _make_provider()
     comment = MagicMock()
     comment.edit.side_effect = gh_module.GithubException(500, "edit failed", {})
 
-    with pytest.raises(gh_module.GithubException):
-        provider.edit_comment(comment, "updated body")
+    assert provider.edit_comment(comment, "updated body") is False
+
+
+@pytest.mark.parametrize(
+    ("deployment_type", "agent_login", "comment_login", "expected"),
+    [
+        ("user", "pr-agent", "pr-agent", True),
+        ("user", "pr-agent", "human", False),
+        ("app", "review-app[bot]", "review-app[bot]", True),
+        ("app", "review-app[bot]", "review-app[bot]-human", False),
+    ],
+)
+def test_comment_authorship_uses_authenticated_github_identity(
+    deployment_type, agent_login, comment_login, expected
+):
+    provider = _make_provider()
+    provider.deployment_type = deployment_type
+    provider.github_user_id = agent_login
+    comment = SimpleNamespace(user=SimpleNamespace(login=comment_login))
+
+    assert provider.is_comment_authored_by_pr_agent(comment) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -623,3 +623,44 @@ class TestResolveCommentThread:
 
         result = p.resolve_comment_thread(123)
         assert result is False
+
+
+def test_app_comment_authorship_uses_configured_app_identity_without_user_endpoint(monkeypatch):
+    provider = _make_provider()
+    provider.deployment_type = "app"
+    provider.github_user_id = ""
+
+    def fail_get_user():
+        raise AssertionError("installation tokens must not use /user")
+
+    provider.github_client = SimpleNamespace(get_user=fail_get_user)
+    settings = SimpleNamespace(
+        get=lambda key, default=None: (
+            "review-app" if key == "GITHUB.APP_NAME" else default
+        )
+    )
+    monkeypatch.setattr(gh_module, "get_settings", lambda: settings)
+
+    bot_comment = SimpleNamespace(
+        user=SimpleNamespace(login="review-app[bot]")
+    )
+    copied_marker_comment = SimpleNamespace(
+        user=SimpleNamespace(login="review-app-human")
+    )
+
+    assert provider.supports_review_finding_state() is True
+    assert provider.is_comment_authored_by_pr_agent(bot_comment) is True
+    assert provider.is_comment_authored_by_pr_agent(copied_marker_comment) is False
+
+
+def test_user_comment_authorship_resolves_authenticated_user():
+    provider = _make_provider()
+    provider.deployment_type = "user"
+    provider.github_user_id = ""
+    provider.github_client = SimpleNamespace(
+        get_user=lambda: SimpleNamespace(raw_data={"login": "user-agent"})
+    )
+    comment = SimpleNamespace(user=SimpleNamespace(login="user-agent"))
+
+    assert provider.supports_review_finding_state() is True
+    assert provider.is_comment_authored_by_pr_agent(comment) is True

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -8,6 +8,7 @@ These tests use ``GithubProvider.__new__(GithubProvider)`` to bypass network-bou
 
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,6 +53,15 @@ def _make_provider(pr=None, max_chars=65000):
     p.diff_files = []
     p.base_url = "https://api.github.com"
     return p
+
+
+def test_edit_comment_reraises_github_failure():
+    provider = _make_provider()
+    comment = MagicMock()
+    comment.edit.side_effect = gh_module.GithubException(500, "edit failed", {})
+
+    with pytest.raises(gh_module.GithubException):
+        provider.edit_comment(comment, "updated body")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1904,6 +1904,14 @@ class TestGitLabCapabilities:
 
         assert provider.get_issue_comments() == ["oldest", "middle", "newest"]
 
+    def test_persistent_state_ownership_uses_authenticated_user_id(self):
+        provider = self._provider()
+        provider._get_own_user_id = MagicMock(return_value=42)
+
+        assert provider.supports_review_finding_state() is True
+        assert provider.is_comment_authored_by_pr_agent({"author": {"id": 42}}) is True
+        assert provider.is_comment_authored_by_pr_agent({"author": {"id": 99}}) is False
+
     @pytest.mark.parametrize("capability", [
         "create_inline_comment",
         "publish_inline_comments",

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -2031,3 +2031,11 @@ class TestGitLabProviderUrlParsing:
         provider = self._provider("https://host.local/gitlab")
         with pytest.raises(ValueError):
             provider._parse_merge_request_url("https://host.local/gitlab/shai/pr-agent")
+
+
+def test_get_issue_comments_newest_first_returns_notes_newest_first():
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.mr = MagicMock()
+    provider.mr.notes.list.return_value = ["newest", "middle", "oldest"]
+
+    assert provider.get_issue_comments_newest_first() == ["newest", "middle", "oldest"]

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -988,8 +988,9 @@ async def test_publish_no_suggestions_still_overwrites_the_progress_comment_when
 
     await tool.publish_no_suggestions()
 
-    _, kwargs = git_provider.edit_comment.call_args
-    assert "No code suggestions found for the PR." in kwargs["body"]
+    call = git_provider.edit_comment.call_args
+    edited_body = call.kwargs.get("body", call.args[1])
+    assert "No code suggestions found for the PR." in edited_body
     git_provider.remove_comment.assert_not_called()
 
 
@@ -1677,3 +1678,39 @@ def test_custom_heading_is_kept_when_a_history_section_already_exists():
     assert "Suggestions up to commit aaa1111" in updated
     assert "Suggestions up to commit 0000000" in updated
     provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.parametrize("raises", [False, True], ids=["returns-false", "raises"])
+def test_first_persistent_improve_edit_failure_publishes_visible_fallback(raises):
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = []
+    provider.get_latest_commit_url.return_value = "https://example.test/commit/deadbee"
+    progress = MagicMock()
+    fallback = MagicMock()
+    provider.publish_comment.return_value = fallback
+    if raises:
+        provider.edit_comment.side_effect = RuntimeError("edit failed")
+    else:
+        provider.edit_comment.return_value = False
+
+    header = "## PR Code Suggestions " + chr(0x2728)
+    new_comment = (
+        header + "\n\n"
+        + PRCodeSuggestionsIdentity.SUMMARY.value + "\n\n"
+        + "<!-- deadbee -->\n\n<table>new suggestions</table>\n\n"
+    )
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        header + "\n\n<table>new suggestions</table>",
+        header,
+        name="suggestions",
+        final_update_message=False,
+        progress_response=progress,
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is fallback
+    provider.edit_comment.assert_called_once_with(progress, new_comment)
+    provider.publish_comment.assert_called_once()
+    provider.remove_comment.assert_called_once_with(progress)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -1361,8 +1361,10 @@ async def test_empty_incremental_run_reconciles_existing_suggestions():
 
 def test_azure_persistent_comment_updates_without_history():
     provider = MagicMock(spec=AzureDevopsProvider)
+    provider.supports_code_suggestion_state.return_value = True
+    provider.get_issue_comments_newest_first.return_value = []
     existing = MagicMock()
-    provider.publish_persistent_comment.return_value = existing
+    provider.publish_comment.return_value = existing
 
     result = PRCodeSuggestions.publish_persistent_comment_with_history(
         provider,
@@ -1377,16 +1379,11 @@ def test_azure_persistent_comment_updates_without_history():
     )
 
     assert result is existing
-    provider.publish_persistent_comment.assert_called_once_with(
-        "## PR Code Suggestions ✨\n\nnew suggestions",
-        "## PR Code Suggestions ✨",
-        True,
-        "suggestions",
-        False,
-        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
-        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    provider.publish_comment.assert_called_once()
+    assert PRCodeSuggestionsIdentity.SUMMARY.value in (
+        provider.publish_comment.call_args.args[0]
     )
-    provider.publish_comment.assert_not_called()
+    provider.publish_persistent_comment.assert_not_called()
 
 
 def test_azure_persistent_comment_without_history_keeps_identity_marker():
@@ -1420,7 +1417,13 @@ def test_azure_persistent_comment_without_history_keeps_identity_marker():
 
 def test_failed_azure_persistent_update_keeps_progress_comment():
     provider = MagicMock(spec=AzureDevopsProvider)
-    provider.publish_persistent_comment.return_value = None
+    provider.supports_code_suggestion_state.return_value = True
+    existing = MagicMock()
+    existing.body = "## PR Code Suggestions ✨\n\nold suggestions"
+    provider.get_issue_comments_newest_first.return_value = [existing]
+    provider.edit_comment.return_value = False
+    fallback = MagicMock()
+    provider.publish_comment.return_value = fallback
     progress = MagicMock()
 
     result = PRCodeSuggestions.publish_persistent_comment_with_history(
@@ -1434,9 +1437,12 @@ def test_failed_azure_persistent_update_keeps_progress_comment():
         progress_response=progress,
     )
 
-    assert result is None
-    provider.edit_comment.assert_not_called()
-    provider.remove_comment.assert_not_called()
+    assert result is fallback
+    assert provider.edit_comment.call_count == 2
+    assert provider.edit_comment.call_args_list[0].args[0] is existing
+    assert provider.edit_comment.call_args_list[1].args[0] is progress
+    provider.publish_comment.assert_called_once()
+    provider.remove_comment.assert_called_once_with(progress)
 
 
 def test_failed_azure_history_update_publishes_current_suggestions():
@@ -1450,6 +1456,9 @@ def test_failed_azure_history_update_publishes_current_suggestions():
     progress = MagicMock()
     fallback = MagicMock()
     provider.get_issue_comments.return_value = [existing]
+    provider.get_issue_comments_newest_first.return_value = [
+        existing
+    ]
     provider.get_comment_url.return_value = "https://example.test/comment/1"
     provider.get_latest_commit_url.return_value = "https://example.test/commit/deadbee"
     provider.edit_comment.side_effect = [False, False]
@@ -1510,6 +1519,7 @@ def test_persistent_update_removes_progress_after_status_edit_failure():
     existing.body = f"{initial_header}\n<!-- aaa1111 -->\n<table>old suggestions</table>"
     provider = MagicMock()
     provider.get_issue_comments.return_value = [existing]
+    provider.get_issue_comments_newest_first.return_value = [existing]
     provider.get_comment_url.return_value = "https://example.test/comment/1"
     provider.get_latest_commit_url.return_value = "https://example.test/commit/deadbee"
     provider.edit_comment.side_effect = [None, RuntimeError("cleanup failed")]
@@ -1529,6 +1539,9 @@ def test_persistent_update_removes_progress_after_status_edit_failure():
 def _persistent_provider(existing_comments):
     provider = MagicMock()
     provider.get_issue_comments.return_value = existing_comments
+    provider.get_issue_comments_newest_first.return_value = list(
+        reversed(existing_comments)
+    )
     provider.get_comment_url.return_value = "https://example.test/comment/1"
     provider.get_latest_commit_url.return_value = "https://example.test/commit/deadbee"
     return provider
@@ -1714,3 +1727,185 @@ def test_first_persistent_improve_edit_failure_publishes_visible_fallback(raises
     provider.edit_comment.assert_called_once_with(progress, new_comment)
     provider.publish_comment.assert_called_once()
     provider.remove_comment.assert_called_once_with(progress)
+
+
+class _LifecycleSuggestionProvider:
+    def __init__(self, comments=(), edit_results=(), supports_state=False):
+        self.comments = list(comments)
+        self.edit_results = list(edit_results)
+        self._supports_state = supports_state
+        self.edits = []
+        self.published = []
+        self.removed = []
+
+    def get_issue_comments(self):
+        return list(self.comments)
+
+    def get_issue_comments_newest_first(self):
+        return list(reversed(self.get_issue_comments()))
+
+    def get_latest_commit_url(self):
+        return "https://example.test/commit/deadbee"
+
+    def get_comment_url(self, comment):
+        return f"https://example.test/comment/{comment.name}"
+
+    def edit_comment(self, comment, body):
+        self.edits.append((comment, body))
+        if self.edit_results:
+            result = self.edit_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return None
+
+    def publish_comment(self, body, **kwargs):
+        comment = SimpleNamespace(body=body, name=f"published-{len(self.published)}")
+        self.published.append((body, kwargs, comment))
+        return comment
+
+    def remove_comment(self, comment):
+        self.removed.append(comment)
+
+    def supports_code_suggestion_state(self):
+        return self._supports_state
+
+    def should_publish_improve_as_thread(self):
+        return False
+
+    def supports_code_suggestions_artifact(self):
+        return False
+
+    def is_supported(self, capability):
+        return False
+
+    def publish_persistent_comment(
+        self,
+        pr_comment,
+        initial_header,
+        update_header=True,
+        name="review",
+        final_update_message=True,
+        identity_marker=None,
+        legacy_initial_header=None,
+    ):
+        if self.comments:
+            result = self.edit_comment(self.comments[-1], pr_comment)
+            if result is False:
+                return self.publish_comment(
+                    f"{pr_comment}\n\n{identity_marker or ''}".rstrip()
+                )
+            return self.comments[-1]
+        return self.publish_comment(
+            f"{pr_comment}\n\n{identity_marker or ''}".rstrip()
+        )
+
+
+def _lifecycle_suggestion_comment(name):
+    body = (
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n"
+        f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        f"<!-- {name} -->\n\n<table>{name}</table>"
+    )
+    return SimpleNamespace(body=body, name=name)
+
+
+def test_persistent_improve_uses_newest_matching_comment():
+    old = _lifecycle_suggestion_comment("old")
+    newest = _lifecycle_suggestion_comment("newest")
+    provider = _LifecycleSuggestionProvider([old, newest])
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n<table>new suggestions</table>",
+        PRCodeSuggestionsHeader.SUMMARY.value,
+        name="suggestions",
+        final_update_message=False,
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is newest
+    assert provider.edits[0][0] is newest
+    assert provider.published == []
+
+
+def test_persistent_improve_edit_failure_does_not_publish_duplicate_summary():
+    existing = _lifecycle_suggestion_comment("existing")
+    progress = SimpleNamespace(body="Preparing suggestions...", name="progress")
+    provider = _LifecycleSuggestionProvider([existing], edit_results=[False, False])
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n<table>new suggestions</table>",
+        PRCodeSuggestionsHeader.SUMMARY.value,
+        name="suggestions",
+        progress_response=progress,
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is provider.published[0][2]
+    assert len(provider.published) == 1
+    failure_body = provider.published[0][0]
+    assert PRCodeSuggestionsIdentity.SUMMARY.value not in failure_body
+    assert "previous suggestions remain unchanged" in failure_body
+    assert provider.removed == [progress]
+
+
+@pytest.mark.asyncio
+async def test_no_suggestions_failure_removes_stale_progress_comment():
+    settings_snapshot = snapshot_settings(
+        (
+            "config.publish_output",
+            "config.publish_output_progress",
+            "pr_code_suggestions.publish_output_no_suggestions",
+        )
+    )
+    try:
+        settings = get_settings()
+        settings.config.publish_output = True
+        settings.config.publish_output_progress = True
+        settings.pr_code_suggestions.publish_output_no_suggestions = True
+
+        provider = _LifecycleSuggestionProvider(
+            edit_results=[False],
+        )
+        progress = SimpleNamespace(body="Preparing suggestions...", name="progress")
+        tool = _make_tool(provider)
+        tool.progress_response = progress
+
+        await tool.publish_no_suggestions()
+
+        assert len(provider.published) == 1
+        assert "No code suggestions found" in provider.published[0][0]
+        assert provider.removed == [progress]
+        assert tool.progress_response is None
+    finally:
+        restore_settings(settings_snapshot)
+
+
+def test_stateful_no_history_edit_failure_has_no_duplicate_authoritative_summary():
+    existing = _lifecycle_suggestion_comment("existing")
+    provider = _LifecycleSuggestionProvider(
+        [existing],
+        edit_results=[False],
+        supports_state=True,
+    )
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n<table>new suggestions</table>",
+        PRCodeSuggestionsHeader.SUMMARY.value,
+        name="suggestions",
+        final_update_message=False,
+        max_previous_comments=0,
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is provider.published[0][2]
+    assert len(provider.published) == 1
+    failure_body = provider.published[0][0]
+    assert PRCodeSuggestionsIdentity.SUMMARY.value not in failure_body
+    assert "previous suggestions remain unchanged" in failure_body

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -106,8 +106,10 @@ async def test_run_does_not_remove_final_summary_when_cancelled_during_dual_publ
             await tool.run()
 
         provider.edit_comment.assert_called_once()
-        assert provider.edit_comment.call_args.args[0] is progress_comment
-        assert "final summary" in provider.edit_comment.call_args.kwargs["body"]
+        call = provider.edit_comment.call_args
+        assert call.args[0] is progress_comment
+        edited_body = call.kwargs.get("body", call.args[1])
+        assert "final summary" in edited_body
         provider.remove_comment.assert_not_called()
         assert tool.progress_response is None
     finally:

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -998,8 +998,11 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
     progress_comment = MagicMock()
     git_provider = MagicMock()
     git_provider.should_publish_review_as_thread.return_value = thread_enabled
+    git_provider.supports_review_finding_state.return_value = True
+    git_provider.is_supported.return_value = True
     git_provider.supports_review_comment_identity.return_value = False
     git_provider.publish_comment.return_value = progress_comment
+    git_provider.publish_persistent_comment_full.return_value = object()
     reviewer = _make_reviewer(git_provider)
     reviewer.incremental = SimpleNamespace(is_incremental=False)
     reviewer.vars = {}
@@ -1034,8 +1037,11 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
         settings.pr_reviewer.persistent_comment = original["persistent_comment"]
 
     if persistent:
-        publish = git_provider.publish_persistent_comment
+        publish = git_provider.publish_persistent_comment_full
         publish.assert_called_once()
+        assert publish.call_args.kwargs["require_agent_authorship"] is True
+        assert publish.call_args.kwargs["fallback_on_error"] is False
+        git_provider.publish_persistent_comment.assert_not_called()
         assert publish.call_args.kwargs["identity_marker"] == PRReviewIdentity.REGULAR.value
         assert publish.call_args.kwargs["legacy_initial_header"] == f"{PRReviewHeader.REGULAR.value} 🔍"
     else:

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -9,9 +9,16 @@ from pr_agent.algo.review_finding_state import (
     reconcile_review_findings,
     serialize_review_state,
 )
-from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, add_pr_review_identity
+from pr_agent.algo.utils import (
+    PRReviewHeader,
+    PRReviewIdentity,
+    add_pr_review_identity,
+    comment_matches_identity,
+    get_pr_review_comment_identifiers,
+)
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
 from pr_agent.git_providers.gitea_provider import GiteaProvider
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 from pr_agent.config_loader import get_settings
@@ -750,7 +757,8 @@ async def test_non_marker_state_block_publishes_without_overwriting_state(monkey
     reviewer = _reviewer(provider)
     reviewer.vars = {}
     reviewer._prepare_prediction = AsyncMock()
-    reviewer._prepare_pr_review = MagicMock(return_value="review output")
+    review_body = f"{PRReviewHeader.REGULAR.value} {chr(0x1F50D)}\n\nreview output"
+    reviewer._prepare_pr_review = MagicMock(return_value=review_body)
     reviewer._review_state_result = None
     reviewer._review_state_blocked = True
     reviewer._review_state_block_reason = block_reason
@@ -766,7 +774,14 @@ async def test_non_marker_state_block_publishes_without_overwriting_state(monkey
 
     await reviewer.run()
 
-    provider.publish_comment.assert_any_call("review output")
+    final_body = provider.publish_comment.call_args_list[-1].args[0]
+    assert final_body.startswith("## Standalone PR Review\n")
+    assert review_body in final_body
+    assert PRReviewIdentity.REGULAR.value not in final_body
+    assert not any(
+        comment_matches_identity(final_body, identifier)
+        for identifier in get_pr_review_comment_identifiers(full=True, incremental=False)
+    )
     provider.publish_persistent_comment_full.assert_not_called()
 
 
@@ -937,17 +952,18 @@ def test_oversized_new_state_preserves_previous_valid_marker(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_legacy_review_publish_uses_provider_compatible_signature(monkeypatch):
+async def test_review_publish_uses_shared_full_signature_for_authorship(monkeypatch):
     _settings(monkeypatch)
     settings = get_settings()
     settings.config.is_auto_command = True
     settings.github.publish_as_check_run = False
 
     provider = GithubProvider.__new__(GithubProvider)
+    provider.deployment_type = "user"
     provider.get_files = lambda: ["app.py"]
     provider.should_publish_review_as_thread = lambda: False
     provider.publish_comment = MagicMock()
-    provider.publish_persistent_comment_full = MagicMock()
+    provider.publish_persistent_comment_full = MagicMock(return_value=object())
 
     reviewer = PRReviewer.__new__(PRReviewer)
     reviewer.git_provider = provider
@@ -981,9 +997,9 @@ async def test_legacy_review_publish_uses_provider_compatible_signature(monkeypa
     await reviewer.run()
 
     provider.publish_persistent_comment_full.assert_called_once()
-    assert "require_agent_authorship" not in (
-        provider.publish_persistent_comment_full.call_args.kwargs
-    )
+    kwargs = provider.publish_persistent_comment_full.call_args.kwargs
+    assert kwargs["require_agent_authorship"] is True
+    assert kwargs["fallback_on_error"] is False
     provider.publish_comment.assert_not_called()
 
 
@@ -995,15 +1011,19 @@ async def test_legacy_review_publish_uses_provider_compatible_signature(monkeypa
         AzureDevopsProvider,
         GiteaProvider,
         BitbucketProvider,
+        BitbucketServerProvider,
     ],
-    ids=["github", "gitlab", "azure", "gitea", "bitbucket"],
+    ids=["github", "gitlab", "azure", "gitea", "bitbucket", "bitbucket-server"],
 )
 def test_legacy_persistent_publish_overrides_accept_shared_arguments(provider_class):
     parameters = inspect.signature(
         provider_class.publish_persistent_comment
     ).parameters
 
+    assert "identity_marker" in parameters
+    assert "legacy_initial_header" in parameters
     assert "require_agent_authorship" not in parameters
+    assert "fallback_on_error" not in parameters
 
 
 def test_oversized_state_degradation_is_safe_on_the_next_run(monkeypatch):
@@ -1059,3 +1079,317 @@ def test_oversized_state_degradation_is_safe_on_the_next_run(monkeypatch):
     assert second_state.valid is True
     assert second_state.state["findings"][0]["state"] == "ACTIVE"
     assert second_reviewer._review_state_block_reason == "state_size"
+
+
+class _ReviewRunProvider:
+    def __init__(self, comments=None, supports_state=False, authored=False, fail_persistent=False):
+        self.comments = list(comments or [])
+        self.supports_state = supports_state
+        self.authored = authored
+        self.fail_persistent = fail_persistent
+        self.published = []
+        self.edited = []
+        self.removed = []
+        self.persistent_calls = []
+
+    def get_files(self):
+        return ["app.py"]
+
+    def should_publish_review_as_thread(self):
+        return False
+
+    def supports_review_comment_identity(self):
+        return True
+
+    def supports_review_finding_state(self):
+        return self.supports_state
+
+    def is_supported(self, capability):
+        return capability == "get_issue_comments"
+
+    def is_comment_authored_by_pr_agent(self, comment):
+        return self.authored
+
+    def get_issue_comments(self):
+        return list(self.comments)
+
+    def get_issue_comments_newest_first(self):
+        return list(reversed(self.comments))
+
+    def get_latest_commit_url(self):
+        return "https://example.test/commit/1"
+
+    def get_comment_url(self, comment):
+        return "https://example.test/comment/1"
+
+    def edit_comment(self, comment, body):
+        if self.fail_persistent:
+            return False
+        comment.body = body
+        self.edited.append((comment, body))
+        return True
+
+    def remove_comment(self, comment):
+        self.removed.append(comment)
+
+    def publish_comment(self, body, is_temporary=False, **kwargs):
+        body = str(body)
+        if (
+            self.fail_persistent
+            and not is_temporary
+            and PRReviewIdentity.REGULAR.value in body
+        ):
+            return None
+        result = SimpleNamespace(
+            id=len(self.published) + 1,
+            body=body,
+            user=SimpleNamespace(login="agent"),
+        )
+        self.published.append((body, is_temporary, kwargs))
+        return result
+
+    def publish_persistent_comment(self, pr_comment, **kwargs):
+        self.persistent_calls.append((pr_comment, kwargs))
+        return self.publish_persistent_comment_full(pr_comment, **kwargs)
+
+    def publish_persistent_comment_full(self, pr_comment, **kwargs):
+        return GitProvider.publish_persistent_comment_full(self, pr_comment, **kwargs)
+
+
+class _ReviewRunCheckProvider(_ReviewRunProvider, GithubProvider):
+    publish_persistent_comment = GithubProvider.publish_persistent_comment
+
+    def __init__(self, check_run_result, comments=None):
+        super().__init__(comments=comments, supports_state=False)
+        self.check_run_result = check_run_result
+        self.check_run_calls = []
+
+    def _publish_check_run(self, body, name):
+        self.check_run_calls.append((body, name))
+        return self.check_run_result
+
+
+def _reviewer_for_run(provider):
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.git_provider = provider
+    reviewer.pr_url = "https://example.test/pull/1"
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.remaining_files_list = []
+    reviewer.vars = {}
+    reviewer.prediction = None
+    reviewer._review_state_result = None
+    reviewer._review_state_blocked = False
+    reviewer._review_state_block_reason = None
+    reviewer._review_state_preserved = False
+    reviewer._prepare_prediction = AsyncMock()
+    review_body = f"{PRReviewHeader.REGULAR.value} {chr(0x1F50D)}\n\nreview output"
+    reviewer._prepare_pr_review = MagicMock(return_value=review_body)
+    reviewer._should_publish_review_no_suggestions = lambda _review: True
+    return reviewer
+
+
+def _patch_run_dependencies(monkeypatch, reviewer):
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets",
+        fake_extract_tickets,
+    )
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.retry_with_fallback_models",
+        fake_retry,
+    )
+
+
+def test_github_check_setting_does_not_disable_non_check_provider_lifecycle(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.github, "publish_as_check_run", True)
+    monkeypatch.setattr(
+        settings.azure_devops_server, "agent_identity",
+        "11111111-1111-1111-1111-111111111111", raising=False,
+    )
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    reviewer = _reviewer_for_run(provider)
+
+    assert reviewer._review_finding_state_enabled() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("check_run_result", [True, False])
+async def test_review_check_run_fallback_preserves_authorship_contract(
+    monkeypatch, check_run_result
+):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True, raising=False)
+    monkeypatch.setattr(settings.github, "publish_as_check_run", True)
+    forged_body = add_pr_review_identity("forged review", PRReviewIdentity.REGULAR.value)
+    forged = SimpleNamespace(body=forged_body, user=SimpleNamespace(login="human"))
+    provider = _ReviewRunCheckProvider(check_run_result, comments=[forged])
+    reviewer = _reviewer_for_run(provider)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    review_body = reviewer._prepare_pr_review.return_value
+    assert provider.check_run_calls == [(review_body, "review")]
+    assert forged.body == forged_body
+    assert provider.edited == []
+    non_temporary = [
+        body for body, is_temporary, _kwargs in provider.published if not is_temporary
+    ]
+    if check_run_result:
+        assert non_temporary == []
+    else:
+        assert len(non_temporary) == 1
+        standalone_review = non_temporary[0]
+        assert standalone_review.startswith("## Standalone PR Review\n")
+        assert review_body in standalone_review
+        assert not any(
+            comment_matches_identity(standalone_review, identifier)
+            for identifier in get_pr_review_comment_identifiers(full=True, incremental=False)
+        )
+
+
+@pytest.mark.asyncio
+async def test_review_run_does_not_edit_forged_persistent_comment_without_authorship(monkeypatch):
+    _settings(monkeypatch)
+    forged_body = add_pr_review_identity(
+        "forged review", PRReviewIdentity.REGULAR.value
+    )
+    forged = SimpleNamespace(
+        body=forged_body,
+        user=SimpleNamespace(login="human"),
+    )
+    provider = _ReviewRunProvider(
+        comments=[forged],
+        supports_state=False,
+        authored=False,
+    )
+    reviewer = _reviewer_for_run(provider)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    assert forged.body == forged_body
+    assert provider.edited == []
+    assert provider.persistent_calls == []
+    non_temporary = [
+        body for body, is_temporary, _kwargs in provider.published if not is_temporary
+    ]
+    assert len(non_temporary) == 1
+    standalone_review = non_temporary[0]
+    assert standalone_review.startswith("## Standalone PR Review\n")
+    assert reviewer._prepare_pr_review.return_value in standalone_review
+    assert PRReviewIdentity.REGULAR.value not in standalone_review
+    assert not any(
+        comment_matches_identity(standalone_review, identifier)
+        for identifier in get_pr_review_comment_identifiers(full=True, incremental=False)
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_auto_command", [False, True])
+async def test_review_run_surfaces_failed_persistent_write(monkeypatch, is_auto_command):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", is_auto_command, raising=False)
+    old_body = add_pr_review_identity(
+        "previous review", PRReviewIdentity.REGULAR.value
+    )
+    old_comment = SimpleNamespace(
+        body=old_body,
+        user=SimpleNamespace(login="agent"),
+    )
+    provider = _ReviewRunProvider(
+        comments=[old_comment],
+        supports_state=True,
+        authored=True,
+        fail_persistent=True,
+    )
+    reviewer = _reviewer_for_run(provider)
+    reviewer._review_state_result = SimpleNamespace(changed=True)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    assert old_comment.body == old_body
+    non_temporary = [
+        body for body, is_temporary, _kwargs in provider.published if not is_temporary
+    ]
+    assert non_temporary == ["Failed to review PR"]
+    assert not any(
+        comment_matches_identity(non_temporary[0], identifier)
+        for identifier in get_pr_review_comment_identifiers(full=True, incremental=False)
+    )
+
+
+def test_persistent_publish_success_rejects_none_and_false():
+    assert PRReviewer._persistent_publish_succeeded(None) is False
+    assert PRReviewer._persistent_publish_succeeded(False) is False
+    assert PRReviewer._persistent_publish_succeeded(object()) is True
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_result", [None, False])
+async def test_successful_persistence_is_not_failed_by_optional_status_result(
+    monkeypatch, status_result
+):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True, raising=False)
+    monkeypatch.setattr(settings.pr_reviewer, "final_update_message", True)
+    old_body = add_pr_review_identity("old review", PRReviewIdentity.REGULAR.value)
+    old_comment = SimpleNamespace(body=old_body)
+
+    class StatusNoticeProvider(_ReviewRunProvider):
+        def publish_comment(self, body, is_temporary=False, **kwargs):
+            if body.startswith("**[Persistent review]"):
+                self.status_attempts += 1
+                return status_result
+            return super().publish_comment(body, is_temporary=is_temporary, **kwargs)
+
+    provider = StatusNoticeProvider(
+        comments=[old_comment], supports_state=True, authored=True,
+    )
+    provider.status_attempts = 0
+    reviewer = _reviewer_for_run(provider)
+    reviewer._review_state_result = SimpleNamespace(changed=True)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    assert len(provider.edited) == 1
+    assert old_comment.body != old_body
+    assert provider.status_attempts == 1
+    assert provider.published == []
+
+
+@pytest.mark.asyncio
+async def test_persistent_publish_exception_is_visible_for_auto_review(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True, raising=False)
+    monkeypatch.setattr(settings.config, "propagate_tool_errors", False, raising=False)
+    old_body = add_pr_review_identity("old review", PRReviewIdentity.REGULAR.value)
+    old_comment = SimpleNamespace(body=old_body)
+
+    class RaisingPersistentProvider(_ReviewRunProvider):
+        def publish_persistent_comment_full(self, pr_comment, **kwargs):
+            raise RuntimeError("persistent publication failed")
+
+    provider = RaisingPersistentProvider(
+        comments=[old_comment], supports_state=True, authored=True,
+    )
+    reviewer = _reviewer_for_run(provider)
+    reviewer._review_state_result = SimpleNamespace(changed=True)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    assert old_comment.body == old_body
+    assert provider.edited == []
+    assert [body for body, temporary, _ in provider.published if not temporary] == [
+        "Failed to review PR",
+    ]

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -17,6 +17,7 @@ def _reviewer(provider):
     reviewer.remaining_files_list = []
     reviewer.prediction = "review: {}"
     reviewer.set_review_labels = MagicMock()
+    reviewer._review_state_block_reason = None
     return reviewer
 
 
@@ -63,7 +64,143 @@ def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(m
     assert "<summary>✅ Resolved findings</summary>" in review
     assert "The lock is never released." in review
     assert reviewer._review_state_result.resolved_ids == (previous["findings"][0]["finding_id"],)
+    assert reviewer._review_state_result.state["last_run"]["complete"] is True
     assert settings.pr_reviewer.persistent_finding_state is True
+
+
+def test_load_review_finding_state_uses_latest_matching_comment():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    latest = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    old_body = f"{header}\n\nold review\n\n{serialize_review_state(previous)}"
+    new_body = f"{header}\n\nnew review\n\n{serialize_review_state(latest)}"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=old_body),
+        SimpleNamespace(body=new_body),
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+    assert parsed.valid is True
+    assert parsed.state == latest
+
+
+@pytest.mark.parametrize(
+    ("incremental", "remaining_files", "prediction"),
+    [
+        pytest.param(True, [], "prediction", id="incremental"),
+        pytest.param(False, ["large.py"], "prediction", id="token-excluded"),
+        pytest.param(False, [], "", id="prediction-failed"),
+    ],
+)
+def test_missing_findings_resolve_only_after_complete_successful_review(
+    monkeypatch, incremental, remaining_files, prediction
+):
+    _settings(monkeypatch)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}")
+    ]
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+    reviewer.incremental.is_incremental = incremental
+    reviewer.remaining_files_list = remaining_files
+    reviewer.prediction = prediction
+    # Exercise the reconciliation guard directly even though incremental stateful
+    # publishing is disabled by the feature gate.
+    reviewer._review_finding_state_enabled = MagicMock(return_value=True)
+
+    reviewer._prepare_review_finding_state({"review": {"key_issues_to_review": []}})
+
+    assert reviewer._review_state_result is not None
+    finding = reviewer._review_state_result.state["findings"][0]
+    assert finding["state"] == "ACTIVE"
+    assert reviewer._review_state_result.state["last_run"]["complete"] is False
+
+
+def test_invalid_review_data_blocks_lifecycle_without_using_old_state(monkeypatch):
+    _settings(monkeypatch)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}")
+    ]
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state({"review": {"key_issues_to_review": {"invalid": True}}})
+
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_block_reason == "review_data"
+    assert reviewer._review_state_result is None
+
+
+def test_provider_read_failure_blocks_lifecycle_without_using_old_state(monkeypatch):
+    _settings(monkeypatch)
+    provider = MagicMock()
+    provider.get_issue_comments.side_effect = RuntimeError("provider read failed")
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state({"review": {"key_issues_to_review": []}})
+
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_block_reason == "read_error"
+    assert reviewer._review_state_result is None
+
+
+def test_missing_review_data_blocks_lifecycle_without_using_old_state(monkeypatch):
+    _settings(monkeypatch)
+    provider = MagicMock()
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state({})
+
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_block_reason == "review_data"
+    assert reviewer._review_state_result is None
+
+
+def test_invalid_marker_does_not_mask_invalid_review_data(monkeypatch):
+    _settings(monkeypatch)
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{header}\n\nold review\n\n<!-- pr-agent-review-state:v1\nbad\n-->")
+    ]
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state({"review": {"key_issues_to_review": {"invalid": True}}})
+
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_block_reason == "review_data"
+    assert reviewer._review_state_result is None
 
 
 @pytest.mark.asyncio
@@ -98,17 +235,22 @@ async def test_run_publishes_state_transition_even_when_review_has_no_suggestion
 
 
 @pytest.mark.asyncio
-async def test_invalid_history_does_not_update_persistent_comment(monkeypatch):
-    _settings(monkeypatch)
+async def test_invalid_history_updates_persistent_comment_without_fallback(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True)
     provider = MagicMock()
     provider.get_files.return_value = ["app.py"]
     provider.should_publish_review_as_thread.return_value = False
     reviewer = _reviewer(provider)
     reviewer.vars = {}
     reviewer._prepare_prediction = AsyncMock()
-    reviewer._prepare_pr_review = MagicMock(return_value="A major issue was detected")
+    reviewer._prepare_pr_review = MagicMock(return_value="No major issues detected")
     reviewer._review_state_result = None
     reviewer._review_state_blocked = True
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{PRReviewHeader.REGULAR.value} 🔍\n\nold review\n\n<!-- pr-agent-review-state:v1\nbad\n-->")
+    ]
+    reviewer._load_review_finding_state()
 
     async def fake_extract_tickets(git_provider, vars):
         return None
@@ -121,5 +263,36 @@ async def test_invalid_history_does_not_update_persistent_comment(monkeypatch):
 
     await reviewer.run()
 
-    provider.publish_persistent_comment.assert_not_called()
-    provider.publish_comment.assert_any_call("A major issue was detected")
+    provider.publish_persistent_comment_full.assert_called_once()
+    assert provider.publish_persistent_comment_full.call_args.kwargs["fallback_on_error"] is False
+    provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("block_reason", ["review_data", "read_error"])
+async def test_non_marker_state_block_publishes_without_overwriting_state(monkeypatch, block_reason):
+    _settings(monkeypatch)
+    provider = MagicMock()
+    provider.get_files.return_value = ["app.py"]
+    provider.should_publish_review_as_thread.return_value = False
+    reviewer = _reviewer(provider)
+    reviewer.vars = {}
+    reviewer._prepare_prediction = AsyncMock()
+    reviewer._prepare_pr_review = MagicMock(return_value="review output")
+    reviewer._review_state_result = None
+    reviewer._review_state_blocked = True
+    reviewer._review_state_block_reason = block_reason
+
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.retry_with_fallback_models", fake_retry)
+
+    await reviewer.run()
+
+    provider.publish_comment.assert_any_call("review output")
+    provider.publish_persistent_comment_full.assert_not_called()

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -8,7 +8,7 @@ from pr_agent.algo.review_finding_state import (
     reconcile_review_findings,
     serialize_review_state,
 )
-from pr_agent.algo.utils import PRReviewHeader
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, add_pr_review_identity
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -23,6 +23,11 @@ def _reviewer(provider):
     reviewer.prediction = "review: {}"
     reviewer.set_review_labels = MagicMock()
     reviewer._review_state_block_reason = None
+    provider.supports_review_finding_state.return_value = True
+    provider.is_comment_authored_by_pr_agent.return_value = True
+    provider.get_issue_comments_newest_first.side_effect = (
+        lambda: list(reversed(provider.get_issue_comments()))
+    )
     return reviewer
 
 
@@ -39,6 +44,14 @@ def _settings(monkeypatch):
     monkeypatch.setattr(settings.pr_reviewer, "inline_key_issues", False)
     monkeypatch.setattr(settings.pr_reviewer, "publish_output_no_suggestions", False)
     return settings
+
+
+
+def test_review_finding_state_is_disabled_without_a_provider(monkeypatch):
+    _settings(monkeypatch)
+    reviewer = PRReviewer.__new__(PRReviewer)
+
+    assert reviewer._review_finding_state_enabled() is False
 
 
 def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(monkeypatch):
@@ -71,6 +84,38 @@ def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(m
     assert reviewer._review_state_result.resolved_ids == (previous["findings"][0]["finding_id"],)
     assert reviewer._review_state_result.state["last_run"]["complete"] is True
     assert settings.pr_reviewer.persistent_finding_state is True
+
+
+
+def test_prepare_review_pushes_final_markdown_with_lifecycle_state(monkeypatch):
+    _settings(monkeypatch)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}")
+    ]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value={"review": {"key_issues_to_review": []}}),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch("pr_agent.tools.pr_reviewer.convert_to_markdown_v2", return_value="No major issues detected"),
+        patch("pr_agent.tools.pr_reviewer.push_outputs") as push_outputs,
+    ):
+        review = reviewer._prepare_pr_review()
+
+    assert "<summary>✅ Resolved findings</summary>" in review
+    push_outputs.assert_called_once()
+    assert push_outputs.call_args.kwargs["markdown"] == review
+    assert "<summary>✅ Resolved findings</summary>" in push_outputs.call_args.kwargs["markdown"]
 
 
 def test_load_review_finding_state_uses_latest_matching_comment():
@@ -112,6 +157,143 @@ def test_load_review_finding_state_accepts_dict_comment():
     provider = MagicMock()
     provider.get_issue_comments.return_value = [
         {"body": f"{header}\n\nreview\n\n{serialize_review_state(previous)}"}
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+
+
+
+def _state_body(state, heading, identity=None):
+    body = f"{heading}\n\nreview\n\n{serialize_review_state(state)}"
+    return add_pr_review_identity(body, identity) if identity else body
+
+
+def test_load_review_finding_state_accepts_default_heading_with_full_identity():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    heading = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=_state_body(previous, heading, PRReviewIdentity.REGULAR.value))
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+
+
+def test_load_review_finding_state_accepts_custom_heading_with_full_identity(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "review_heading", "Team Review", raising=False)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=_state_body(
+                previous,
+                "## Team Review 🔍",
+                PRReviewIdentity.REGULAR.value,
+            )
+        )
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+
+
+def test_full_identity_state_beats_legacy_visible_heading():
+    old_state = reconcile_review_findings(
+        None,
+        [_finding("legacy")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    new_state = reconcile_review_findings(
+        None,
+        [_finding("marked")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    ).state
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=_state_body(
+                old_state,
+                f"{PRReviewHeader.REGULAR.value} 🔍",
+            )
+        ),
+        SimpleNamespace(
+            body=_state_body(
+                new_state,
+                "## Team Review 🔍",
+                PRReviewIdentity.REGULAR.value,
+            )
+        ),
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == new_state
+
+
+def test_load_review_finding_state_does_not_adopt_incremental_identity():
+    state = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=_state_body(
+                state,
+                "## Incremental Team Review 🔍",
+                PRReviewIdentity.INCREMENTAL.value,
+            )
+        )
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.present is False
+    assert parsed.state is None
+
+
+def test_load_review_finding_state_accepts_legacy_default_heading_without_identity():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=_state_body(previous, f"{PRReviewHeader.REGULAR.value} 🔍")
+        )
     ]
     reviewer = _reviewer(provider)
 
@@ -413,7 +595,8 @@ def test_review_comment_budget_reserves_persistent_update_header():
 
     update_suffix = "\n\n#### (Review updated until commit commit-url)\n"
 
-    assert reviewer._review_comment_max_chars() == 1000 - len(update_suffix)
+    identity_overhead = len(PRReviewIdentity.REGULAR.value) + 2
+    assert reviewer._review_comment_max_chars() == 1000 - len(update_suffix) - identity_overhead
 
 
 def test_invalid_review_data_blocks_lifecycle_without_using_old_state(monkeypatch):
@@ -544,7 +727,10 @@ async def test_invalid_history_updates_persistent_comment_without_fallback(monke
     await reviewer.run()
 
     provider.publish_persistent_comment_full.assert_called_once()
-    assert provider.publish_persistent_comment_full.call_args.kwargs["fallback_on_error"] is False
+    kwargs = provider.publish_persistent_comment_full.call_args.kwargs
+    assert kwargs["fallback_on_error"] is False
+    assert kwargs["identity_marker"] == PRReviewIdentity.REGULAR.value
+    assert kwargs["legacy_initial_header"] == f"{PRReviewHeader.REGULAR.value} 🔍"
     provider.publish_comment.assert_not_called()
 
 
@@ -576,3 +762,169 @@ async def test_non_marker_state_block_publishes_without_overwriting_state(monkey
 
     provider.publish_comment.assert_any_call("review output")
     provider.publish_persistent_comment_full.assert_not_called()
+
+
+def test_load_review_finding_state_rejects_spoofed_full_identity():
+    previous = reconcile_review_findings(
+        None,
+        [_finding("spoofed state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=_state_body(
+                previous,
+                PRReviewHeader.REGULAR.value + " " + chr(0x1F50D),
+                PRReviewIdentity.REGULAR.value,
+            ),
+            user=SimpleNamespace(login="human"),
+        )
+    ]
+    reviewer = _reviewer(provider)
+    provider.is_comment_authored_by_pr_agent.return_value = False
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.present is False
+    assert parsed.valid is True
+    assert parsed.state is None
+
+
+def test_load_review_finding_state_skips_newer_spoof_and_loads_older_agent_state():
+    old_state = reconcile_review_findings(
+        None,
+        [_finding("old state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    spoofed_state = reconcile_review_findings(
+        None,
+        [_finding("spoofed state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    ).state
+    header = PRReviewHeader.REGULAR.value + " " + chr(0x1F50D)
+    old = SimpleNamespace(
+        body=_state_body(old_state, header, PRReviewIdentity.REGULAR.value),
+        user=SimpleNamespace(login="agent"),
+    )
+    spoofed = SimpleNamespace(
+        body=_state_body(spoofed_state, header, PRReviewIdentity.REGULAR.value),
+        user=SimpleNamespace(login="human"),
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [old, spoofed]
+    reviewer = _reviewer(provider)
+    provider.is_comment_authored_by_pr_agent.side_effect = (
+        lambda comment: comment.user.login == "agent"
+    )
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == old_state
+
+
+def test_legacy_state_requires_verified_comment_ownership():
+    previous = reconcile_review_findings(
+        None,
+        [_finding("legacy state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = PRReviewHeader.REGULAR.value + " " + chr(0x1F50D)
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=_state_body(previous, header), user=SimpleNamespace(login="human"))
+    ]
+    reviewer = _reviewer(provider)
+    provider.is_comment_authored_by_pr_agent.return_value = False
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.present is False
+    assert parsed.state is None
+
+
+def _large_review_issues(count=10):
+    return [
+        {
+            "relevant_file": f"file-{index}.py",
+            "issue_content": f"finding {index} " + ("x" * 120),
+        }
+        for index in range(count)
+    ]
+
+
+def test_oversized_new_state_keeps_review_publishable_without_marker(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 100)
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = []
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    provider.max_comment_chars = 500
+    reviewer = _reviewer(provider)
+
+    data = {"review": {"key_issues_to_review": _large_review_issues()}}
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value=data),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch(
+            "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+            return_value=PRReviewHeader.REGULAR.value + " " + chr(0x1F50D) + "\n\nhuman review",
+        ),
+        patch("pr_agent.tools.pr_reviewer.push_outputs") as push_outputs,
+    ):
+        review = reviewer._prepare_pr_review()
+
+    assert "human review" in review
+    assert parse_review_state(review).present is False
+    assert reviewer._review_state_result is None
+    assert reviewer._review_state_block_reason == "state_size"
+    push_outputs.assert_called_once()
+    assert push_outputs.call_args.kwargs["markdown"] == review
+
+
+def test_oversized_new_state_preserves_previous_valid_marker(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 100)
+    previous = reconcile_review_findings(
+        None,
+        [_finding("previous state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = PRReviewHeader.REGULAR.value + " " + chr(0x1F50D)
+    old = SimpleNamespace(
+        body=_state_body(previous, header, PRReviewIdentity.REGULAR.value),
+        user=SimpleNamespace(login="agent"),
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [old]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    provider.max_comment_chars = 500
+    reviewer = _reviewer(provider)
+
+    data = {"review": {"key_issues_to_review": _large_review_issues()}}
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value=data),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch(
+            "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+            return_value=header + "\n\n" + ("human review " * 100),
+        ),
+        patch("pr_agent.tools.pr_reviewer.push_outputs"),
+    ):
+        review = reviewer._prepare_pr_review()
+
+    parsed = parse_review_state(review)
+    assert parsed.valid is True
+    assert parsed.state == previous
+    assert reviewer._review_state_result is None
+    assert reviewer._review_state_preserved is True
+    assert reviewer._review_state_block_reason == "state_size"
+    assert "human review" in review

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -1,3 +1,4 @@
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,8 +10,13 @@ from pr_agent.algo.review_finding_state import (
     serialize_review_state,
 )
 from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, add_pr_review_identity
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from pr_agent.git_providers.gitea_provider import GiteaProvider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
@@ -928,3 +934,128 @@ def test_oversized_new_state_preserves_previous_valid_marker(monkeypatch):
     assert reviewer._review_state_preserved is True
     assert reviewer._review_state_block_reason == "state_size"
     assert "human review" in review
+
+
+@pytest.mark.asyncio
+async def test_legacy_review_publish_uses_provider_compatible_signature(monkeypatch):
+    _settings(monkeypatch)
+    settings = get_settings()
+    settings.config.is_auto_command = True
+    settings.github.publish_as_check_run = False
+
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.get_files = lambda: ["app.py"]
+    provider.should_publish_review_as_thread = lambda: False
+    provider.publish_comment = MagicMock()
+    provider.publish_persistent_comment_full = MagicMock()
+
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.git_provider = provider
+    reviewer.pr_url = "https://example.test/pull/1"
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.remaining_files_list = []
+    reviewer.vars = {}
+    reviewer.prediction = None
+    reviewer._review_state_result = None
+    reviewer._review_state_blocked = False
+    reviewer._review_state_block_reason = None
+    reviewer._review_state_preserved = False
+    reviewer._prepare_pr_review = MagicMock(return_value="review output")
+    reviewer._should_publish_review_no_suggestions = lambda _review: True
+
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets",
+        fake_extract_tickets,
+    )
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_reviewer.retry_with_fallback_models",
+        fake_retry,
+    )
+
+    await reviewer.run()
+
+    provider.publish_persistent_comment_full.assert_called_once()
+    assert "require_agent_authorship" not in (
+        provider.publish_persistent_comment_full.call_args.kwargs
+    )
+    provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        GithubProvider,
+        GitLabProvider,
+        AzureDevopsProvider,
+        GiteaProvider,
+        BitbucketProvider,
+    ],
+    ids=["github", "gitlab", "azure", "gitea", "bitbucket"],
+)
+def test_legacy_persistent_publish_overrides_accept_shared_arguments(provider_class):
+    parameters = inspect.signature(
+        provider_class.publish_persistent_comment
+    ).parameters
+
+    assert "require_agent_authorship" not in parameters
+
+
+def test_oversized_state_degradation_is_safe_on_the_next_run(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 100)
+    previous = reconcile_review_findings(
+        None,
+        [_finding("previous state")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = PRReviewHeader.REGULAR.value + " " + chr(0x1F50D)
+    old = SimpleNamespace(
+        body=_state_body(previous, header, PRReviewIdentity.REGULAR.value),
+        user=SimpleNamespace(login="agent"),
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [old]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    provider.max_comment_chars = 500
+
+    data = {"review": {"key_issues_to_review": _large_review_issues()}}
+
+    def run_review(reviewer):
+        with (
+            patch("pr_agent.tools.pr_reviewer.load_yaml", return_value=data),
+            patch("pr_agent.tools.pr_reviewer.github_action_output"),
+            patch(
+                "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+                return_value=header + "\n\n" + ("human review " * 100),
+            ),
+            patch("pr_agent.tools.pr_reviewer.push_outputs") as push_outputs,
+        ):
+            review = reviewer._prepare_pr_review()
+        push_outputs.assert_called_once()
+        return review
+
+    first_reviewer = _reviewer(provider)
+    first_review = run_review(first_reviewer)
+    first_state = parse_review_state(first_review)
+    assert first_state.valid is True
+    assert first_state.state["findings"][0]["state"] == "ACTIVE"
+    assert first_reviewer._review_state_block_reason == "state_size"
+
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=first_review, user=SimpleNamespace(login="agent"))
+    ]
+    second_reviewer = _reviewer(provider)
+    second_review = run_review(second_reviewer)
+    second_state = parse_review_state(second_review)
+
+    assert second_state.valid is True
+    assert second_state.state["findings"][0]["state"] == "ACTIVE"
+    assert second_reviewer._review_state_block_reason == "state_size"

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -3,9 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pr_agent.algo.review_finding_state import reconcile_review_findings, serialize_review_state
+from pr_agent.algo.review_finding_state import (
+    parse_review_state,
+    reconcile_review_findings,
+    serialize_review_state,
+)
 from pr_agent.algo.utils import PRReviewHeader
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
@@ -96,6 +101,229 @@ def test_load_review_finding_state_uses_latest_matching_comment():
     assert parsed.state == latest
 
 
+def test_load_review_finding_state_accepts_dict_comment():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        {"body": f"{header}\n\nreview\n\n{serialize_review_state(previous)}"}
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+
+
+def test_load_review_finding_state_falls_back_to_older_valid_marker():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} " + chr(0x1F50D)
+    old_body = f"{header}\n\nold review\n\n{serialize_review_state(previous)}"
+    malformed_body = (
+        f"{header}\n\nlatest review\n\n"
+        "<!-- pr-agent-review-state:v1\nnot-json\n-->"
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=old_body),
+        SimpleNamespace(body=malformed_body),
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+    assert getattr(reviewer, "_review_state_blocked", False) is False
+
+
+def test_load_review_finding_state_returns_none_when_all_markers_are_invalid():
+    header = f"{PRReviewHeader.REGULAR.value} " + chr(0x1F50D)
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=f"{header}\n\nold\n\n"
+            "<!-- pr-agent-review-state:v1\nnot-json\n-->"
+        ),
+        SimpleNamespace(
+            body=f"{header}\n\nlatest\n\n"
+            "<!-- pr-agent-review-state:v2\n{}\n-->"
+        ),
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed is None
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_block_reason == "invalid_marker"
+
+
+def test_load_review_finding_state_skips_newer_comment_without_marker():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} " + chr(0x1F50D)
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(
+            body=f"{header}\n\nreview\n\n{serialize_review_state(previous)}"
+        ),
+        SimpleNamespace(body="A regular review comment without state"),
+    ]
+    reviewer = _reviewer(provider)
+
+    parsed = reviewer._load_review_finding_state()
+
+    assert parsed.valid is True
+    assert parsed.state == previous
+
+
+def test_malformed_marker_self_heals_with_valid_marker(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 3)
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    comment = SimpleNamespace(
+        body=f"{header}\n\nold review\n\n<!-- pr-agent-review-state:v1\nbad\n-->"
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [comment]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    provider.max_comment_chars = 2000
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+
+    def edit_comment(comment_obj, body):
+        comment_obj.body = body
+
+    provider.edit_comment.side_effect = edit_comment
+    reviewer = _reviewer(provider)
+    reviewer._review_finding_state_enabled = MagicMock(return_value=True)
+    issue = {
+        "relevant_file": "app.py",
+        "issue_content": "current issue",
+        "start_line": 2,
+        "end_line": 2,
+    }
+
+    with (
+        patch(
+            "pr_agent.tools.pr_reviewer.load_yaml",
+            return_value={"review": {"key_issues_to_review": [issue]}},
+        ),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch(
+            "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+            return_value=f"{header}\n\nclean review",
+        ),
+    ):
+        review = reviewer._prepare_pr_review()
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        review,
+        initial_header=header,
+        update_header=True,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is comment
+    assert "clean review" in comment.body
+    assert comment.body.count("<!-- pr-agent-review-state:") == 1
+    parsed = parse_review_state(comment.body)
+    assert parsed.valid is True
+    assert parsed.state == reviewer._review_state_result.state
+    provider.publish_comment.assert_not_called()
+
+
+def test_prepare_and_persisted_state_round_trip_preserves_marker_and_history(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 3)
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    previous = reconcile_review_findings(
+        None,
+        [
+            {"body": "a-body", "path": "a.py", "line_start": 2, "line_end": 2},
+            {"body": "b-body", "path": "b.py", "line_start": 3, "line_end": 3},
+        ],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    comment = SimpleNamespace(
+        body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}"
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [comment]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    provider.max_comment_chars = 1600
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+
+    def edit_comment(comment_obj, body):
+        comment_obj.body = GitProvider.limit_output_characters(
+            provider, body, provider.max_comment_chars
+        )
+
+    provider.edit_comment.side_effect = edit_comment
+    reviewer = _reviewer(provider)
+    reviewer._review_finding_state_enabled = MagicMock(return_value=True)
+    issue = {
+        "relevant_file": "a.py",
+        "issue_content": "a-body",
+        "start_line": 2,
+        "end_line": 2,
+    }
+
+    with (
+        patch(
+            "pr_agent.tools.pr_reviewer.load_yaml",
+            return_value={"review": {"key_issues_to_review": [issue]}},
+        ),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch(
+            "pr_agent.tools.pr_reviewer.convert_to_markdown_v2",
+            return_value=f"{header}\n\n" + ("long human review " * 1000),
+        ),
+    ):
+        review = reviewer._prepare_pr_review()
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        review,
+        initial_header=header,
+        update_header=True,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is comment
+    assert len(comment.body) <= provider.max_comment_chars
+    assert comment.body.count("<!-- pr-agent-review-state:") == 1
+    parsed = parse_review_state(comment.body)
+    assert parsed.valid is True
+    states = {finding["body"]: finding["state"] for finding in parsed.state["findings"]}
+    assert states == {"a-body": "ACTIVE", "b-body": "RESOLVED"}
+    assert "long human review" in comment.body
+    provider.publish_comment.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("incremental", "remaining_files", "prediction"),
     [
@@ -134,6 +362,58 @@ def test_missing_findings_resolve_only_after_complete_successful_review(
     finding = reviewer._review_state_result.state["findings"][0]
     assert finding["state"] == "ACTIVE"
     assert reviewer._review_state_result.state["last_run"]["complete"] is False
+
+
+def test_finding_limit_prevents_resolution_of_missing_active_findings(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 3)
+    previous_findings = [
+        {"body": f"previous {label}", "path": f"{label}.py", "line_start": 2, "line_end": 2}
+        for label in ("a", "b", "c")
+    ]
+    current_findings = [
+        {"relevant_file": f"{label}.py", "issue_content": f"current {label}"}
+        for label in ("d", "e", "f")
+    ]
+    previous = reconcile_review_findings(
+        None,
+        previous_findings,
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    header = f"{PRReviewHeader.REGULAR.value} 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [
+        SimpleNamespace(body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}")
+    ]
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+    reviewer._review_finding_state_enabled = MagicMock(return_value=True)
+
+    reviewer._prepare_review_finding_state({"review": {"key_issues_to_review": current_findings}})
+
+    states = {finding["path"]: finding["state"] for finding in reviewer._review_state_result.state["findings"]}
+    assert states == {
+        "a.py": "ACTIVE",
+        "b.py": "ACTIVE",
+        "c.py": "ACTIVE",
+        "d.py": "ACTIVE",
+        "e.py": "ACTIVE",
+        "f.py": "ACTIVE",
+    }
+    assert reviewer._review_state_result.resolved_ids == ()
+    assert reviewer._review_state_result.state["last_run"]["complete"] is False
+
+
+def test_review_comment_budget_reserves_persistent_update_header():
+    provider = MagicMock()
+    provider.max_comment_chars = 1000
+    provider.get_latest_commit_url.return_value = "commit-url"
+    reviewer = _reviewer(provider)
+
+    update_suffix = "\n\n#### (Review updated until commit commit-url)\n"
+
+    assert reviewer._review_comment_max_chars() == 1000 - len(update_suffix)
 
 
 def test_invalid_review_data_blocks_lifecycle_without_using_old_state(monkeypatch):

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -1205,6 +1205,68 @@ def _patch_run_dependencies(monkeypatch, reviewer):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_class",
+    [GiteaProvider, BitbucketProvider],
+    ids=["gitea", "bitbucket"],
+)
+async def test_review_without_lifecycle_capability_uses_ordinary_persistent_review(
+    monkeypatch, provider_class
+):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True, raising=False)
+    provider = _ReviewRunProvider(supports_state=False)
+    provider.supports_review_finding_state = (
+        provider_class.supports_review_finding_state.__get__(
+            provider,
+            provider_class,
+        )
+    )
+    provider.publish_persistent_comment = MagicMock(return_value=object())
+    provider.publish_persistent_comment_full = MagicMock()
+    reviewer = _reviewer_for_run(provider)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+    await reviewer.run()
+
+    assert provider.publish_persistent_comment.call_count == 2
+    provider.publish_persistent_comment_full.assert_not_called()
+    assert provider.published == []
+    for call in provider.publish_persistent_comment.call_args_list:
+        review_body = call.args[0]
+        assert not review_body.startswith("## Standalone PR Review\n")
+        assert "<!-- pr-agent-review-state:" not in review_body
+        assert "require_agent_authorship" not in call.kwargs
+        assert "fallback_on_error" not in call.kwargs
+
+
+@pytest.mark.asyncio
+async def test_disabled_finding_state_uses_ordinary_persistent_review(monkeypatch):
+    settings = _settings(monkeypatch)
+    monkeypatch.setattr(settings.config, "is_auto_command", True, raising=False)
+    monkeypatch.setattr(
+        settings.pr_reviewer,
+        "persistent_finding_state",
+        False,
+        raising=False,
+    )
+    provider = _ReviewRunProvider(supports_state=True, authored=True)
+    provider.publish_persistent_comment = MagicMock(return_value=object())
+    provider.publish_persistent_comment_full = MagicMock()
+    reviewer = _reviewer_for_run(provider)
+    _patch_run_dependencies(monkeypatch, reviewer)
+
+    await reviewer.run()
+
+    provider.publish_persistent_comment.assert_called_once()
+    provider.publish_persistent_comment_full.assert_not_called()
+    assert provider.published == []
+    review_body = provider.publish_persistent_comment.call_args.args[0]
+    assert not review_body.startswith("## Standalone PR Review\n")
+    assert "<!-- pr-agent-review-state:" not in review_body
+
 def test_github_check_setting_does_not_disable_non_check_provider_lifecycle(monkeypatch):
     settings = _settings(monkeypatch)
     monkeypatch.setattr(settings.github, "publish_as_check_run", True)

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -1156,7 +1156,7 @@ class _ReviewRunProvider:
         return GitProvider.publish_persistent_comment_full(self, pr_comment, **kwargs)
 
 
-class _ReviewRunCheckProvider(_ReviewRunProvider, GithubProvider):
+class _ReviewRunCheckProvider(_ReviewRunProvider):
     publish_persistent_comment = GithubProvider.publish_persistent_comment
 
     def __init__(self, check_run_result, comments=None):

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pr_agent.algo.review_finding_state import reconcile_review_findings, serialize_review_state
+from pr_agent.algo.utils import PRReviewHeader
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+
+def _reviewer(provider):
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.git_provider = provider
+    reviewer.pr_url = "https://example.test/pull/1"
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.remaining_files_list = []
+    reviewer.prediction = "review: {}"
+    reviewer.set_review_labels = MagicMock()
+    return reviewer
+
+
+def _finding(body="The lock is never released."):
+    return {"body": body, "path": "app.py", "line_start": 2, "line_end": 2}
+
+
+def _settings(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings.config, "publish_output", True)
+    monkeypatch.setattr(settings.config, "is_auto_command", False, raising=False)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_comment", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_finding_state", True, raising=False)
+    monkeypatch.setattr(settings.pr_reviewer, "inline_key_issues", False)
+    monkeypatch.setattr(settings.pr_reviewer, "publish_output_no_suggestions", False)
+    return settings
+
+
+def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(monkeypatch):
+    settings = _settings(monkeypatch)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    old_body = (
+        f"{PRReviewHeader.REGULAR.value} 🔍\n\nold review\n\n"
+        f"{serialize_review_state(previous)}"
+    )
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=old_body)]
+    provider.get_diff_files.return_value = []
+    provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
+    reviewer = _reviewer(provider)
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value={"review": {"key_issues_to_review": []}}),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch("pr_agent.tools.pr_reviewer.convert_to_markdown_v2", return_value="No major issues detected"),
+    ):
+        review = reviewer._prepare_pr_review()
+
+    assert "<summary>✅ Resolved findings</summary>" in review
+    assert "The lock is never released." in review
+    assert reviewer._review_state_result.resolved_ids == (previous["findings"][0]["finding_id"],)
+    assert settings.pr_reviewer.persistent_finding_state is True
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_state_transition_even_when_review_has_no_suggestions(monkeypatch):
+    settings = _settings(monkeypatch)
+    provider = MagicMock()
+    provider.get_files.return_value = ["app.py"]
+    provider.should_publish_review_as_thread.return_value = False
+    reviewer = _reviewer(provider)
+    reviewer.vars = {}
+    reviewer._prepare_prediction = AsyncMock()
+    reviewer._prepare_pr_review = MagicMock(return_value="No major issues detected")
+    reviewer._review_state_result = SimpleNamespace(changed=True)
+    reviewer._review_state_blocked = False
+
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.retry_with_fallback_models", fake_retry)
+
+    await reviewer.run()
+
+    provider.publish_persistent_comment_full.assert_called_once()
+    assert provider.publish_persistent_comment_full.call_args.kwargs["fallback_on_error"] is False
+    assert provider.publish_persistent_comment_full.call_args.args[0] == "No major issues detected"
+    provider.publish_persistent_comment.assert_not_called()
+    assert settings.pr_reviewer.publish_output_no_suggestions is False
+
+
+@pytest.mark.asyncio
+async def test_invalid_history_does_not_update_persistent_comment(monkeypatch):
+    _settings(monkeypatch)
+    provider = MagicMock()
+    provider.get_files.return_value = ["app.py"]
+    provider.should_publish_review_as_thread.return_value = False
+    reviewer = _reviewer(provider)
+    reviewer.vars = {}
+    reviewer._prepare_prediction = AsyncMock()
+    reviewer._prepare_pr_review = MagicMock(return_value="A major issue was detected")
+    reviewer._review_state_result = None
+    reviewer._review_state_blocked = True
+
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.retry_with_fallback_models", fake_retry)
+
+    await reviewer.run()
+
+    provider.publish_persistent_comment.assert_not_called()
+    provider.publish_comment.assert_any_call("A major issue was detected")

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -73,6 +73,7 @@ def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(m
         None,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     old_body = (
@@ -80,6 +81,7 @@ def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(m
         f"{serialize_review_state(previous)}"
     )
     provider = MagicMock()
+    provider.last_commit_id = "head-2"
     provider.get_issue_comments.return_value = [SimpleNamespace(body=old_body)]
     provider.get_diff_files.return_value = []
     provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"
@@ -99,6 +101,37 @@ def test_prepare_review_reconciles_previous_state_and_renders_resolved_section(m
     assert settings.pr_reviewer.persistent_finding_state is True
 
 
+def test_prepare_review_same_head_absence_preserves_active_finding(monkeypatch):
+    _settings(monkeypatch)
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    old_body = (
+        f"{PRReviewHeader.REGULAR.value} 🔍\n\nold review\n\n"
+        f"{serialize_review_state(previous)}"
+    )
+    provider = MagicMock()
+    provider.last_commit_id = "head-1"
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=old_body)]
+    provider.is_supported.side_effect = (
+        lambda capability: capability == "get_issue_comments"
+    )
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state(
+        {"review": {"key_issues_to_review": []}}
+    )
+
+    finding = reviewer._review_state_result.state["findings"][0]
+    assert finding["state"] == "ACTIVE"
+    assert reviewer._review_state_result.resolved_ids == ()
+    assert "resolved_at" not in finding
+    assert "resolved_head_sha" not in finding
+
 
 def test_prepare_review_pushes_final_markdown_with_lifecycle_state(monkeypatch):
     _settings(monkeypatch)
@@ -106,10 +139,12 @@ def test_prepare_review_pushes_final_markdown_with_lifecycle_state(monkeypatch):
         None,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     header = f"{PRReviewHeader.REGULAR.value} 🔍"
     provider = MagicMock()
+    provider.last_commit_id = "head-2"
     provider.get_issue_comments.return_value = [
         SimpleNamespace(body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}")
     ]
@@ -458,12 +493,14 @@ def test_prepare_and_persisted_state_round_trip_preserves_marker_and_history(mon
             {"body": "b-body", "path": "b.py", "line_start": 3, "line_end": 3},
         ],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     comment = SimpleNamespace(
         body=f"{header}\n\nold review\n\n{serialize_review_state(previous)}"
     )
     provider = MagicMock()
+    provider.last_commit_id = "head-2"
     provider.get_issue_comments.return_value = [comment]
     provider.get_diff_files.return_value = []
     provider.is_supported.side_effect = lambda capability: capability == "get_issue_comments"

--- a/tests/unittest/test_review_comment_identity.py
+++ b/tests/unittest/test_review_comment_identity.py
@@ -198,16 +198,23 @@ def test_azure_comment_path_forwards_review_identity():
     }
 
 
-def test_gitea_keeps_identity_inactive_until_comment_payloads_are_normalized():
+def test_gitea_keeps_identity_inactive_but_preserves_wrapper_arguments():
     provider = GiteaProvider.__new__(GiteaProvider)
-    provider.publish_persistent_comment_full = MagicMock()
+    published = object()
+    provider.publish_persistent_comment_full = MagicMock(return_value=published)
     review = "## Team Review 🔍\n\nbody"
+    legacy_header = "## PR Reviewer Guide 🔍"
 
-    provider.publish_persistent_comment(
+    result = provider.publish_persistent_comment(
         review,
         initial_header="## Team Review 🔍",
         identity_marker=PRReviewIdentity.REGULAR.value,
-        legacy_initial_header="## PR Reviewer Guide 🔍",
+        legacy_initial_header=legacy_header,
     )
 
-    assert provider.publish_persistent_comment_full.call_args.kwargs == {}
+    assert provider.supports_review_comment_identity() is False
+    assert result is published
+    assert provider.publish_persistent_comment_full.call_args.kwargs == {
+        "identity_marker": PRReviewIdentity.REGULAR.value,
+        "legacy_initial_header": legacy_header,
+    }

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -130,3 +130,47 @@ def test_persistent_update_uses_latest_matching_comment():
 
     assert result is latest
     provider.edit_comment.assert_called_once_with(latest, "new review")
+
+
+def test_persistent_update_accepts_dict_comments_and_uses_latest():
+    header = "## PR Reviewer Guide 🔍"
+    old = {"body": f"{header}\n\nold review", "id": 1}
+    latest = {"body": f"{header}\n\nlatest review", "id": 2}
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [old, latest]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is latest
+    provider.edit_comment.assert_called_once_with(latest, "new review")
+    provider.publish_comment.assert_not_called()
+
+
+def test_dict_comment_edit_failure_does_not_fallback():
+    header = "## PR Reviewer Guide 🔍"
+    comment = {"body": header, "id": 42}
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [comment]
+    provider.edit_comment.side_effect = RuntimeError("edit failed")
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is None
+    provider.edit_comment.assert_called_once_with(comment, "new review")
+    provider.publish_comment.assert_not_called()

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -85,3 +85,48 @@ def test_stateful_mode_is_disabled_for_generic_persistent_publisher(monkeypatch)
     provider.is_supported.return_value = True
     reviewer = _reviewer(provider)
     assert reviewer._review_finding_state_enabled() is False
+
+
+def test_malformed_state_marker_is_replaced_without_duplicate_comment():
+    header = "## PR Reviewer Guide 🔍"
+    body = f"{header}\n\nold review\n\n<!-- pr-agent-review-state:v1\nnot-json\n-->"
+    comment = SimpleNamespace(body=body)
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [comment]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is comment
+    provider.edit_comment.assert_called_once_with(comment, "new review")
+    provider.publish_comment.assert_not_called()
+
+
+def test_persistent_update_uses_latest_matching_comment():
+    header = "## PR Reviewer Guide 🔍"
+    old = SimpleNamespace(body=f"{header}\n\nold review")
+    latest = SimpleNamespace(body=f"{header}\n\nlatest review")
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [old, latest]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is latest
+    provider.edit_comment.assert_called_once_with(latest, "new review")

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -6,11 +6,21 @@ from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
+def _set_issue_comments(provider, comments):
+    provider.get_issue_comments.return_value = comments
+    provider.get_issue_comments_newest_first.return_value = list(reversed(comments))
+
+
 def _reviewer(provider):
     reviewer = PRReviewer.__new__(PRReviewer)
     reviewer.git_provider = provider
     reviewer.incremental = SimpleNamespace(is_incremental=False)
     reviewer.remaining_files_list = []
+    provider.supports_review_finding_state.return_value = True
+    provider.is_comment_authored_by_pr_agent.return_value = True
+    provider.get_issue_comments_newest_first.side_effect = (
+        lambda: list(reversed(provider.get_issue_comments()))
+    )
     return reviewer
 
 
@@ -22,7 +32,7 @@ def test_invalid_structured_finding_fails_closed(monkeypatch):
 
     provider = MagicMock()
     provider.is_supported.return_value = True
-    provider.get_issue_comments.return_value = []
+    _set_issue_comments(provider, [])
     reviewer = _reviewer(provider)
 
     reviewer._prepare_review_finding_state({
@@ -40,7 +50,7 @@ def test_missing_structured_finding_collection_fails_closed():
 def test_stateful_persistent_update_does_not_fallback_after_edit_failure():
     header = "## PR Reviewer Guide 🔍"
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    _set_issue_comments(provider, [SimpleNamespace(body=header)])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
     provider.edit_comment.side_effect = RuntimeError("edit failed")
@@ -61,7 +71,7 @@ def test_stateful_persistent_update_does_not_fallback_after_edit_failure():
 def test_stateful_persistent_update_falls_back_when_enabled():
     header = "## PR Reviewer Guide 🔍"
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    _set_issue_comments(provider, [SimpleNamespace(body=header)])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
     provider.edit_comment.side_effect = RuntimeError("edit failed")
@@ -83,7 +93,7 @@ def test_stateful_persistent_update_falls_back_when_enabled():
 def test_stateful_persistent_update_does_not_fallback_after_false_edit_failure():
     header = "## PR Reviewer Guide 🔍"
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    _set_issue_comments(provider, [SimpleNamespace(body=header)])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
     provider.edit_comment.return_value = False
@@ -104,7 +114,7 @@ def test_stateful_persistent_update_does_not_fallback_after_false_edit_failure()
 def test_stateful_persistent_update_falls_back_after_false_edit_failure():
     header = "## PR Reviewer Guide 🔍"
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    _set_issue_comments(provider, [SimpleNamespace(body=header)])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
     provider.edit_comment.return_value = False
@@ -125,7 +135,7 @@ def test_stateful_persistent_update_falls_back_after_false_edit_failure():
 
 def test_stateful_persistent_update_still_creates_first_comment():
     provider = MagicMock()
-    provider.get_issue_comments.return_value = []
+    _set_issue_comments(provider, [])
     provider.publish_comment.return_value = "created"
 
     result = GitProvider.publish_persistent_comment_full(
@@ -157,7 +167,7 @@ def test_malformed_state_marker_is_replaced_without_duplicate_comment():
     body = f"{header}\n\nold review\n\n<!-- pr-agent-review-state:v1\nnot-json\n-->"
     comment = SimpleNamespace(body=body)
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [comment]
+    _set_issue_comments(provider, [comment])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
 
@@ -180,7 +190,7 @@ def test_persistent_update_uses_latest_matching_comment():
     old = SimpleNamespace(body=f"{header}\n\nold review")
     latest = SimpleNamespace(body=f"{header}\n\nlatest review")
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [old, latest]
+    _set_issue_comments(provider, [old, latest])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
 
@@ -202,7 +212,7 @@ def test_persistent_update_accepts_dict_comments_and_uses_latest():
     old = {"body": f"{header}\n\nold review", "id": 1}
     latest = {"body": f"{header}\n\nlatest review", "id": 2}
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [old, latest]
+    _set_issue_comments(provider, [old, latest])
     provider.get_latest_commit_url.return_value = "commit-url"
     provider.get_comment_url.return_value = "comment-url"
 
@@ -224,7 +234,7 @@ def test_dict_comment_edit_failure_does_not_fallback():
     header = "## PR Reviewer Guide 🔍"
     comment = {"body": header, "id": 42}
     provider = MagicMock()
-    provider.get_issue_comments.return_value = [comment]
+    _set_issue_comments(provider, [comment])
     provider.edit_comment.side_effect = RuntimeError("edit failed")
 
     result = GitProvider.publish_persistent_comment_full(

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -80,6 +80,49 @@ def test_stateful_persistent_update_falls_back_when_enabled():
     provider.publish_comment.assert_called_once_with("new review")
 
 
+def test_stateful_persistent_update_does_not_fallback_after_false_edit_failure():
+    header = "## PR Reviewer Guide 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+    provider.edit_comment.return_value = False
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is None
+    provider.publish_comment.assert_not_called()
+
+
+def test_stateful_persistent_update_falls_back_after_false_edit_failure():
+    header = "## PR Reviewer Guide 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+    provider.edit_comment.return_value = False
+    provider.publish_comment.return_value = "fallback"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=True,
+    )
+
+    assert result == "fallback"
+    provider.publish_comment.assert_called_once_with("new review")
+
+
 def test_stateful_persistent_update_still_creates_first_comment():
     provider = MagicMock()
     provider.get_issue_comments.return_value = []

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -58,6 +58,28 @@ def test_stateful_persistent_update_does_not_fallback_after_edit_failure():
     provider.publish_comment.assert_not_called()
 
 
+def test_stateful_persistent_update_falls_back_when_enabled():
+    header = "## PR Reviewer Guide 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+    provider.edit_comment.side_effect = RuntimeError("edit failed")
+    provider.publish_comment.return_value = "fallback"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=True,
+    )
+
+    assert result == "fallback"
+    provider.publish_comment.assert_called_once_with("new review")
+
+
 def test_stateful_persistent_update_still_creates_first_comment():
     provider = MagicMock()
     provider.get_issue_comments.return_value = []

--- a/tests/unittest/test_review_finding_persistence.py
+++ b/tests/unittest/test_review_finding_persistence.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+
+def _reviewer(provider):
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.git_provider = provider
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.remaining_files_list = []
+    return reviewer
+
+
+def test_invalid_structured_finding_fails_closed(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings.config, "publish_output", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_comment", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_finding_state", True, raising=False)
+
+    provider = MagicMock()
+    provider.is_supported.return_value = True
+    provider.get_issue_comments.return_value = []
+    reviewer = _reviewer(provider)
+
+    reviewer._prepare_review_finding_state({
+        "review": {"key_issues_to_review": {"not": "a list"}},
+    })
+
+    assert reviewer._review_state_blocked is True
+    assert reviewer._review_state_result is None
+
+
+def test_missing_structured_finding_collection_fails_closed():
+    assert PRReviewer._review_findings_from_data({"review": {}}) is None
+
+
+def test_stateful_persistent_update_does_not_fallback_after_edit_failure():
+    header = "## PR Reviewer Guide 🔍"
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = [SimpleNamespace(body=header)]
+    provider.get_latest_commit_url.return_value = "commit-url"
+    provider.get_comment_url.return_value = "comment-url"
+    provider.edit_comment.side_effect = RuntimeError("edit failed")
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header=header,
+        update_header=False,
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result is None
+    provider.publish_comment.assert_not_called()
+
+
+def test_stateful_persistent_update_still_creates_first_comment():
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = []
+    provider.publish_comment.return_value = "created"
+
+    result = GitProvider.publish_persistent_comment_full(
+        provider,
+        "new review",
+        initial_header="## PR Reviewer Guide 🔍",
+        final_update_message=False,
+        fallback_on_error=False,
+    )
+
+    assert result == "created"
+    provider.publish_comment.assert_called_once_with("new review")
+
+
+def test_stateful_mode_is_disabled_for_generic_persistent_publisher(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings.config, "publish_output", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_comment", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_finding_state", True, raising=False)
+    provider = MagicMock()
+    provider.publish_persistent_comment = GitProvider.publish_persistent_comment.__get__(provider, type(provider))
+    provider.is_supported.return_value = True
+    reviewer = _reviewer(provider)
+    assert reviewer._review_finding_state_enabled() is False

--- a/tests/unittest/test_review_finding_state.py
+++ b/tests/unittest/test_review_finding_state.py
@@ -58,6 +58,7 @@ def test_complete_full_review_marks_absent_active_finding_resolved():
         None,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
 
@@ -75,6 +76,131 @@ def test_complete_full_review_marks_absent_active_finding_resolved():
     assert finding["resolved_head_sha"] == "head-2"
     assert finding["resolution_run_id"] == "run-2"
     assert result.resolved_ids == (finding["finding_id"],)
+
+
+def test_same_head_absence_does_not_resolve_active_finding():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    finding = result.state["findings"][0]
+    assert finding["state"] == "ACTIVE"
+    assert result.resolved_ids == ()
+    assert "resolved_at" not in finding
+    assert "resolved_head_sha" not in finding
+    assert result.state["last_run"] == {
+        "complete": True,
+        "excluded_files": [],
+        "head_sha": "head-1",
+        "kind": "full",
+        "run_id": "",
+    }
+
+
+def test_different_head_with_resolution_disabled_preserves_active_finding():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=False,
+        head_sha="head-2",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.resolved_ids == ()
+
+
+def test_missing_previous_head_sha_preserves_active_finding():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        head_sha="head-2",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.resolved_ids == ()
+
+
+def test_missing_current_head_sha_preserves_active_finding():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        head_sha="",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.resolved_ids == ()
+
+
+def test_same_head_then_changed_head_resolves_only_after_code_changes():
+    first = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    same_head = reconcile_review_findings(
+        first.state,
+        [],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+    changed_head = reconcile_review_findings(
+        same_head.state,
+        [],
+        allow_resolution=True,
+        head_sha="head-2",
+        timestamp="2026-01-01T00:02:00Z",
+    )
+
+    assert first.state["findings"][0]["state"] == "ACTIVE"
+    assert same_head.state["findings"][0]["state"] == "ACTIVE"
+    assert same_head.resolved_ids == ()
+    assert changed_head.state["findings"][0]["state"] == "RESOLVED"
+    assert changed_head.resolved_ids == (
+        changed_head.state["findings"][0]["finding_id"],
+    )
 
 
 def test_incremental_absence_is_not_negative_evidence():
@@ -121,12 +247,14 @@ def test_resolved_finding_reappearing_becomes_active_with_reopen_metadata():
         None,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     previous = reconcile_review_findings(
         previous,
         [],
         allow_resolution=True,
+        head_sha="head-2",
         timestamp="2026-01-01T00:01:00Z",
     ).state
 
@@ -134,6 +262,7 @@ def test_resolved_finding_reappearing_becomes_active_with_reopen_metadata():
         previous,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-3",
         timestamp="2026-01-01T00:02:00Z",
     )
 
@@ -151,6 +280,7 @@ def test_multiple_findings_reconcile_independently():
         None,
         [finding_a, finding_b],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
 
@@ -158,6 +288,7 @@ def test_multiple_findings_reconcile_independently():
         previous,
         [finding_a, _finding("C", "c.py")],
         allow_resolution=True,
+        head_sha="head-2",
         timestamp="2026-01-01T00:01:00Z",
     )
     states = {item["path"]: item["state"] for item in result.state["findings"]}
@@ -232,12 +363,14 @@ def test_resolved_render_is_collapsed_and_state_marker_is_hidden():
         None,
         [_finding()],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     resolved = reconcile_review_findings(
         previous,
         [],
         allow_resolution=True,
+        head_sha="head-2",
         timestamp="2026-01-01T00:01:00Z",
     ).state
 
@@ -280,12 +413,14 @@ def test_resolved_retention_never_drops_active_findings():
         None,
         [active, *old],
         allow_resolution=True,
+        head_sha="head-1",
         timestamp="2026-01-01T00:00:00Z",
     ).state
     previous = reconcile_review_findings(
         previous,
         [active],
         allow_resolution=True,
+        head_sha="head-2",
         timestamp="2026-01-01T00:01:00Z",
         max_resolved_findings=20,
     ).state

--- a/tests/unittest/test_review_finding_state.py
+++ b/tests/unittest/test_review_finding_state.py
@@ -1,0 +1,291 @@
+import json
+import pytest
+from pr_agent.algo.review_finding_state import (
+    append_review_state,
+    parse_review_state,
+    reconcile_review_findings,
+    serialize_review_state,
+)
+
+
+def _finding(body="The lock is never released.", path="app.py", start=10, end=10):
+    return {
+        "body": body,
+        "path": path,
+        "line_start": start,
+        "line_end": end,
+    }
+
+
+def test_finding_identity_ignores_small_text_normalization_changes():
+    first = reconcile_review_findings(
+        None,
+        [_finding("The   lock is never released.")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    second = reconcile_review_findings(
+        first.state,
+        [_finding("the lock is never released.")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert second.state["findings"][0]["finding_id"] == first.state["findings"][0]["finding_id"]
+    assert second.state["findings"][0]["state"] == "ACTIVE"
+
+
+def test_first_run_marks_current_findings_active_without_resolving_anything():
+    result = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        head_sha="head-1",
+        timestamp="2026-01-01T00:00:00Z",
+    )
+
+    assert result.changed is True
+    assert result.resolved_ids == ()
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.state["findings"][0]["first_seen"] == "2026-01-01T00:00:00Z"
+
+
+def test_complete_full_review_marks_absent_active_finding_resolved():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        head_sha="head-2",
+        run_id="run-2",
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    finding = result.state["findings"][0]
+    assert finding["state"] == "RESOLVED"
+    assert finding["resolved_head_sha"] == "head-2"
+    assert finding["resolution_run_id"] == "run-2"
+    assert result.resolved_ids == (finding["finding_id"],)
+
+
+def test_incremental_absence_is_not_negative_evidence():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=False,
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.resolved_ids == ()
+
+
+def test_token_budget_exclusion_is_not_negative_evidence():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=False,
+        excluded_files=["app.py"],
+        timestamp="2026-01-01T00:01:00Z",
+    )
+
+    assert result.state["findings"][0]["state"] == "ACTIVE"
+    assert result.state["last_run"]["excluded_files"] == ["app.py"]
+
+
+def test_resolved_finding_reappearing_becomes_active_with_reopen_metadata():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    previous = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:02:00Z",
+    )
+
+    finding = result.state["findings"][0]
+    assert finding["state"] == "ACTIVE"
+    assert finding["reopened_count"] == 1
+    assert "reopened_at" in finding
+    assert result.reopened_ids == (finding["finding_id"],)
+
+
+def test_multiple_findings_reconcile_independently():
+    finding_a = _finding("A", "a.py")
+    finding_b = _finding("B", "b.py")
+    previous = reconcile_review_findings(
+        None,
+        [finding_a, finding_b],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    result = reconcile_review_findings(
+        previous,
+        [finding_a, _finding("C", "c.py")],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    )
+    states = {item["path"]: item["state"] for item in result.state["findings"]}
+
+    assert states == {"a.py": "ACTIVE", "b.py": "RESOLVED", "c.py": "ACTIVE"}
+
+
+def test_state_marker_round_trips_deterministically():
+    state = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    body = serialize_review_state(state)
+    parsed = parse_review_state(f"review\n{body}")
+
+    assert parsed.present is True
+    assert parsed.valid is True
+    assert parsed.state == state
+    assert serialize_review_state(parsed.state) == body
+
+
+def test_missing_state_marker_is_a_valid_cold_start():
+    parsed = parse_review_state("## PR Reviewer Guide\n\nCurrent review")
+
+    assert parsed.present is False
+    assert parsed.valid is True
+    assert parsed.state is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "review\n<!-- pr-agent-review-state:v1\nnot-json\n-->",
+        "review\n<!-- pr-agent-review-state:v1\n{\"schema_version\":1",
+        "review\n<!-- pr-agent-review-state:v2\n{}\n-->",
+        "review\n<!-- pr-agent-review-state:v1\n{}\n-->\n<!-- pr-agent-review-state:v1\n{}\n-->",
+    ],
+)
+def test_invalid_state_marker_fails_closed(body):
+    parsed = parse_review_state(body)
+
+    assert parsed.present is True
+    assert parsed.valid is False
+    assert parsed.state is None
+
+
+def test_unknown_finding_state_fails_closed():
+    payload = {
+        "schema_version": 1,
+        "findings": [{
+            "finding_id": "abc",
+            "state": "UNKNOWN",
+            "body": "body",
+            "path": "app.py",
+        }],
+        "last_run": {},
+    }
+    parsed = parse_review_state(
+        f"<!-- pr-agent-review-state:v1\n{json.dumps(payload)}\n-->"
+    )
+
+    assert parsed.present is True
+    assert parsed.valid is False
+    assert parsed.state is None
+
+
+def test_resolved_render_is_collapsed_and_state_marker_is_hidden():
+    previous = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    resolved = reconcile_review_findings(
+        previous,
+        [],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+    ).state
+
+    body = append_review_state("## PR Reviewer Guide\n\nCurrent review", resolved)
+
+    assert "<details>" in body
+    assert "Resolved findings" in body
+    assert "The lock is never released." in body
+    assert "<!-- pr-agent-review-state:v1" in body
+
+
+def test_resolved_retention_never_drops_active_findings():
+    active = _finding("active", "active.py")
+    old = [
+        _finding(f"resolved-{index}", f"resolved-{index}.py")
+        for index in range(25)
+    ]
+    previous = reconcile_review_findings(
+        None,
+        [active, *old],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    previous = reconcile_review_findings(
+        previous,
+        [active],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:01:00Z",
+        max_resolved_findings=20,
+    ).state
+
+    paths = {item["path"] for item in previous["findings"]}
+    resolved = [item for item in previous["findings"] if item["state"] == "RESOLVED"]
+
+    assert "active.py" in paths
+    assert len(resolved) == 20
+
+
+def test_invalid_reopen_metadata_fails_closed():
+    payload = {
+        "schema_version": 1,
+        "findings": [{
+            "finding_id": "abc",
+            "state": "RESOLVED",
+            "body": "body",
+            "path": "app.py",
+            "reopened_count": "not-an-int",
+        }],
+        "last_run": {},
+    }
+    parsed = parse_review_state(f"<!-- pr-agent-review-state:v1\n{json.dumps(payload)}\n-->")
+    assert parsed.present is True
+    assert parsed.valid is False
+    assert parsed.state is None

--- a/tests/unittest/test_review_finding_state.py
+++ b/tests/unittest/test_review_finding_state.py
@@ -1,5 +1,8 @@
 import json
+
 import pytest
+
+from pr_agent.algo import review_finding_state as state_module
 from pr_agent.algo.review_finding_state import (
     append_review_state,
     parse_review_state,
@@ -310,3 +313,43 @@ def test_invalid_reopen_metadata_fails_closed():
     assert parsed.present is True
     assert parsed.valid is False
     assert parsed.state is None
+
+
+def test_parse_duplicate_marker_uses_namespace_guard_before_regex(monkeypatch):
+    class RejectingPattern:
+        def finditer(self, *_args, **_kwargs):
+            raise AssertionError("regex scan should not run for duplicate markers")
+
+    monkeypatch.setattr(state_module, "_STATE_MARKER_RE", RejectingPattern())
+    body = (
+        f"{state_module._STATE_MARKER_NAMESPACE} first\n"
+        f"{state_module._STATE_MARKER_NAMESPACE} second"
+    )
+
+    parsed = state_module.parse_review_state(body)
+
+    assert parsed.present is True
+    assert parsed.valid is False
+
+
+def test_append_duplicate_marker_uses_namespace_guard_before_substitution(monkeypatch):
+    state = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+
+    class RejectingPattern:
+        def sub(self, *_args, **_kwargs):
+            raise AssertionError("regex substitution should not run for duplicate markers")
+
+    monkeypatch.setattr(state_module, "_STATE_MARKER_RE", RejectingPattern())
+    body = (
+        f"human review\n{state_module._STATE_MARKER_NAMESPACE} first\n"
+        f"{state_module._STATE_MARKER_NAMESPACE} second"
+    )
+
+    result = append_review_state(body, state)
+
+    assert result.count(state_module._STATE_MARKER_NAMESPACE) == 1

--- a/tests/unittest/test_review_finding_state.py
+++ b/tests/unittest/test_review_finding_state.py
@@ -246,6 +246,27 @@ def test_resolved_render_is_collapsed_and_state_marker_is_hidden():
     assert "<!-- pr-agent-review-state:v1" in body
 
 
+def test_append_review_state_reserves_space_for_complete_marker():
+    state = reconcile_review_findings(
+        None,
+        [_finding()],
+        allow_resolution=True,
+        timestamp="2026-01-01T00:00:00Z",
+    ).state
+    marker = serialize_review_state(state)
+
+    body = append_review_state(
+        "human-readable review " + "x" * 500,
+        state,
+        max_chars=len(marker) + 32,
+    )
+
+    parsed = parse_review_state(body)
+    assert len(body) <= len(marker) + 32
+    assert parsed.valid is True
+    assert parsed.state == state
+
+
 def test_resolved_retention_never_drops_active_findings():
     active = _finding("active", "active.py")
     old = [


### PR DESCRIPTION
## Summary

- preserve structured review findings across persistent `/review` reruns
- reconcile findings across runs using existing fingerprint primitives
- persist active and resolved finding state in the persistent review comment
- resolve findings only after complete and valid full-scope reviews
- preserve active findings during incremental and token-limited reviews
- verify persistent review authorship before trusting stored lifecycle state
- fail closed to a standalone review when authorship cannot be established
- avoid duplicate authoritative comments when persistent updates fail
- normalize provider comment ordering for lifecycle lookups

## Design notes

Resolution is deliberately conservative.

Findings are only marked resolved after a complete, valid, full-scope review. Incremental reviews, partial analysis, malformed predictions, provider failures, and degraded persistence do not trigger negative state transitions.

Persistent lifecycle state is trusted only when the existing review comment can be verified as authored by PR-Agent. Hidden markers identify the comment type, but are not treated as authentication.

If authorship cannot be verified, `/review` still produces a visible standalone review without adopting or modifying an untrusted canonical comment.

Provider ordering is explicit for persistent-comment lookup. Azure DevOps comments and replies are normalized using timestamp-based chronology rather than relying on raw API response order.

Lifecycle persistence also degrades safely when state grows too large: preserving the human review takes priority, and degraded runs do not silently resolve active findings.

## Upstream integration

This branch has been rebased onto the latest `main` used for this update and incorporates the relevant upstream contracts from:

- #2724 for Azure `edit_comment()` success/failure behavior
- #2797 for configurable review headings and hidden review identities
- #2510 so final lifecycle output is preserved through `push_outputs`

The PR keeps those upstream contracts rather than reintroducing overlapping behavior.

## Validation

Final validation after addressing the provider fallback regression and the same-HEAD false-resolution edge case:

- focused lifecycle/provider tests: `527 passed`
- full unit suite: `3586 passed, 1 skipped, 1 xfailed, 1 failed`
- the single failing test is the unrelated Grok/LiteLLM `reasoning_effort` capability case and was reproduced independently on clean upstream `main`
- `git diff --check`: passed
- GitHub `Build-and-test`: passed
- GitHub `CodeQL`: passed

An additional red-team pass found that a complete rerun on the same commit could incorrectly resolve an ACTIVE finding when model output omitted it nondeterministically.

Resolution now requires both a complete valid full review and a known changed HEAD. Same-HEAD and missing-HEAD reruns preserve ACTIVE findings conservatively.

A real GitHub + real-model smoke test was also completed on `yefuyou/pr-agent#2`:

- canonical persistent review comment remained `5536025289`
- deliberate finding became `ACTIVE`
- same-HEAD rerun preserved `ACTIVE`
- fixing the issue on a new HEAD transitioned it to `RESOLVED`
- same fixed-HEAD rerun preserved `RESOLVED`
- no duplicate canonical or standalone review comments were created
- persisted lifecycle markers remained valid and parseable throughout

Current PR head:

`cc6081822901aa0d9d21e549af8c30b06c3893bd`

## AI disclosure

This PR was developed with assistance from Codex and validated with targeted tests, full unit-suite runs, upstream CI, and manual contract review by the contributor.

Closes #2453