### PR TITLE
fix(pr_agent/algo/pr_processing.py): filling token counts before sorting the compressed diff

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -215,7 +215,7 @@ def pr_generate_compressed_diff(top_langs: list, token_handler: TokenHandler, mo
     deleted_files_list = []
 
     for lang in top_langs:
-        for file in lang['files']:
+        for file in lang["files"]:
             if file.tokens is None or file.tokens < 0:
                 file.tokens = token_handler.count_tokens(file.patch) if file.patch else 0
 

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -214,6 +214,11 @@ def pr_generate_compressed_diff(top_langs: list, token_handler: TokenHandler, mo
                                 large_pr_handling: bool) -> Tuple[list, list, list, list, dict, list]:
     deleted_files_list = []
 
+    for lang in top_langs:
+        for file in lang['files']:
+            if file.tokens is None or file.tokens < 0:
+                file.tokens = token_handler.count_tokens(file.patch) if file.patch else 0
+
     # sort each one of the languages in top_langs by the number of tokens in the diff
     sorted_files = []
     for lang in top_langs:

--- a/tests/unittest/test_compressed_diff_token_sort.py
+++ b/tests/unittest/test_compressed_diff_token_sort.py
@@ -1,0 +1,50 @@
+"""pr_generate_compressed_diff packs files largest-first, so it must know their sizes."""
+from pr_agent.algo.pr_processing import pr_generate_compressed_diff
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+
+
+class FakeTokenHandler:
+    prompt_tokens = 10
+
+    def count_tokens(self, patch, force_accurate=False):
+        return len(patch)
+
+
+def _file(name, body_lines):
+    patch = "@@ -1,1 +1,%d @@\n" % body_lines + "\n".join(f"+l{i}" for i in range(body_lines))
+    return FilePatchInfo(base_file="", head_file="x", patch=patch, filename=name,
+                         edit_type=EDIT_TYPE.MODIFIED)
+
+
+def test_token_counts_are_filled_in_before_sorting():
+    """FilePatchInfo.tokens defaults to -1; the entry point that skips
+    pr_generate_extended_diff must still populate it."""
+    small, large = _file("small.py", 1), _file("large.py", 40)
+    assert small.tokens == -1 and large.tokens == -1
+
+    pr_generate_compressed_diff([{"language": "Python", "files": [small, large]}],
+                                FakeTokenHandler(), "gpt-4", False, False)
+
+    assert small.tokens > 0
+    assert large.tokens > small.tokens
+
+
+def test_files_are_ordered_largest_first():
+    """The packing order must reflect patch size, not provider order."""
+    small, large = _file("small.py", 1), _file("large.py", 40)
+
+    _, _, _, _, file_dict, _ = pr_generate_compressed_diff(
+        [{"language": "Python", "files": [small, large]}], FakeTokenHandler(), "gpt-4", False, False)
+
+    assert list(file_dict) == ["large.py", "small.py"]
+
+
+def test_precomputed_token_counts_are_left_alone():
+    """A file already sized by pr_generate_extended_diff must not be recounted."""
+    f = _file("a.py", 5)
+    f.tokens = 12345
+
+    pr_generate_compressed_diff([{"language": "Python", "files": [f]}],
+                                FakeTokenHandler(), "gpt-4", False, False)
+
+    assert f.tokens == 12345

--- a/tests/unittest/test_compressed_diff_token_sort.py
+++ b/tests/unittest/test_compressed_diff_token_sort.py
@@ -1,4 +1,4 @@
-"""pr_generate_compressed_diff packs files largest-first, so it must know their sizes."""
+"""Size every file before pr_generate_compressed_diff packs them largest-first."""
 from pr_agent.algo.pr_processing import pr_generate_compressed_diff
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
@@ -17,8 +17,8 @@ def _file(name, body_lines):
 
 
 def test_token_counts_are_filled_in_before_sorting():
-    """FilePatchInfo.tokens defaults to -1; the entry point that skips
-    pr_generate_extended_diff must still populate it."""
+    """Populate FilePatchInfo.tokens, which defaults to -1, on the entry point that skips
+    pr_generate_extended_diff."""
     small, large = _file("small.py", 1), _file("large.py", 40)
     assert small.tokens == -1 and large.tokens == -1
 
@@ -30,7 +30,7 @@ def test_token_counts_are_filled_in_before_sorting():
 
 
 def test_files_are_ordered_largest_first():
-    """The packing order must reflect patch size, not provider order."""
+    """Order the packing by patch size rather than by provider order."""
     small, large = _file("small.py", 1), _file("large.py", 40)
 
     _, _, _, _, file_dict, _ = pr_generate_compressed_diff(
@@ -40,7 +40,7 @@ def test_files_are_ordered_largest_first():
 
 
 def test_precomputed_token_counts_are_left_alone():
-    """A file already sized by pr_generate_extended_diff must not be recounted."""
+    """Leave a file already sized by pr_generate_extended_diff untouched."""
     f = _file("a.py", 5)
     f.tokens = 12345
 


### PR DESCRIPTION

Closes #2733.

## Description

`pr_generate_compressed_diff` packs files largest-first, but on the `get_pr_diff_multiple_patchs` path every `FilePatchInfo.tokens` is still its `-1` default, so the sort is a no-op.

### Root cause

`FilePatchInfo.tokens` defaults to `-1` (`algo/types.py:20`) and is only ever set by
`pr_generate_extended_diff`. `get_pr_multi_diffs` calls that first, so it is fine — but
`get_pr_diff_multiple_patchs` goes straight from `sort_files_by_main_languages` to
`pr_generate_compressed_diff`, leaving every count at `-1`. All values being equal, `sorted()`
preserves input order.

### The fix

`pr_generate_compressed_diff` fills in any missing count with `token_handler.count_tokens(file.patch)` before sorting, so the ordering is meaningful regardless of which entry point was used.

## Behaviour change

| | |
|---|---|
| **Before** | `sorted(..., key=lambda x: x.tokens)` sees `-1` for every file and does nothing |
| **After** | Every file has a real token count before the sort, so largest-first packing works on both entry points |

## Files changed

```
pr_agent/algo/pr_processing.py                    |  5 +++++
tests/unittest/test_compressed_diff_token_sort.py | 50 ++++++++++
 2 files changed, 55 insertions(+)
```

## Testing

New regression coverage in `tests/unittest/test_compressed_diff_token_sort.py` — **3 tests**; two fail without the fix and the third guards the already-working `get_pr_multi_diffs` path:

```
$ PYTHONPATH=. pytest tests/unittest/test_compressed_diff_token_sort.py
3 passed
```

Proven to be a genuine regression test: with every changed `pr_agent/` file reverted to its
`origin/main` version and the new test file left in place, the suite **fails**. It only passes
with the fix applied.

Full pipeline, reproduced locally exactly as `.github/workflows/build-and-test.yaml` runs it:

```
docker build -f docker/Dockerfile --target test .
docker run --rm <image> pytest -v tests/unittest
-> 1964 passed, 1 skipped, 1 xfailed
```

on `python:3.12.13-slim` — no failures.

Also checked:

- `pytest tests/unittest` — no new failures vs `main`
- `ruff` — no new findings vs `main`; `isort` — clean on every file touched
- No new code comments authored

## Risk / compatibility

Counts already computed by `pr_generate_extended_diff` are left untouched, so the `get_pr_multi_diffs` path is unaffected and no file is counted twice.

## Checklist

- [x] Focused on a single fix
- [x] Existing tests pass
- [x] New regression tests added, proven to fail without the fix
- [x] No new dependencies
- [ ] Reviewed by a maintainer

*Maintainer edit (IsmaelMartinez): corrected the file list and the test-failure claim to match the diff; see review below.*
