### PR TITLE
fix(pr_agent/algo/file_filter.py): warning when an ignore pattern cannot compile

### DIFF
--- a/pr_agent/algo/file_filter.py
+++ b/pr_agent/algo/file_filter.py
@@ -35,8 +35,10 @@ def filter_ignored(files, platform = 'github'):
         for r in patterns:
             try:
                 compiled_patterns.append(re.compile(r))
-            except re.error:
-                pass
+            except re.error as e:
+                get_logger().warning(
+                    "Skipping invalid ignore pattern; files it was meant to exclude will be "
+                    "sent to the model", artifact={"pattern": r, "error": str(e)})
 
         # keep filenames that _don't_ match the ignore regex
         if files and isinstance(files, list):

--- a/tests/unittest/test_invalid_ignore_pattern_warning.py
+++ b/tests/unittest/test_invalid_ignore_pattern_warning.py
@@ -1,4 +1,7 @@
-"""An unusable ignore pattern must be reported, not silently dropped."""
+"""Report an ignore pattern that cannot compile, instead of dropping it silently."""
+import copy
+import io
+
 import pytest
 
 from pr_agent.algo.file_filter import filter_ignored
@@ -13,16 +16,16 @@ class _File:
 
 @pytest.fixture
 def restore_ignore():
-    import copy
     settings = get_settings(use_context=False)
     original = copy.deepcopy(settings.get("IGNORE", None))
     yield settings
-    if original is not None:
+    if original is None:
+        settings.set("IGNORE", {})
+    else:
         settings.set("IGNORE", original)
 
 
 def _capture(call):
-    import io
     buffer = io.StringIO()
     handler_id = get_logger().add(buffer, level="DEBUG", format="{message}", colorize=False)
     try:

--- a/tests/unittest/test_invalid_ignore_pattern_warning.py
+++ b/tests/unittest/test_invalid_ignore_pattern_warning.py
@@ -1,0 +1,60 @@
+"""An unusable ignore pattern must be reported, not silently dropped."""
+import pytest
+
+from pr_agent.algo.file_filter import filter_ignored
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+
+class _File:
+    def __init__(self, filename):
+        self.filename = filename
+
+
+@pytest.fixture
+def restore_ignore():
+    import copy
+    settings = get_settings(use_context=False)
+    original = copy.deepcopy(settings.get("IGNORE", None))
+    yield settings
+    if original is not None:
+        settings.set("IGNORE", original)
+
+
+def _capture(call):
+    import io
+    buffer = io.StringIO()
+    handler_id = get_logger().add(buffer, level="DEBUG", format="{message}", colorize=False)
+    try:
+        call()
+    finally:
+        get_logger().remove(handler_id)
+    return buffer.getvalue()
+
+
+def test_warn_about_an_invalid_ignore_regex(restore_ignore):
+    """Warn so a typo does not silently stop excluding files."""
+    restore_ignore.set("ignore.regex", ["(((|["])
+    files = [_File("a.py")]
+
+    logged = _capture(lambda: filter_ignored(files))
+
+    assert "invalid ignore pattern" in logged.lower()
+
+
+def test_a_valid_pattern_still_filters(restore_ignore):
+    """A usable pattern keeps working exactly as before."""
+    restore_ignore.set("ignore.regex", [r"^vendor/.*"])
+
+    kept = filter_ignored([_File("vendor/lib.py"), _File("app.py")])
+
+    assert [f.filename for f in kept] == ["app.py"]
+
+
+def test_an_invalid_pattern_does_not_disable_the_valid_ones(restore_ignore):
+    """One bad pattern must not stop the remaining patterns from applying."""
+    restore_ignore.set("ignore.regex", ["(((|[", r"^vendor/.*"])
+
+    kept = filter_ignored([_File("vendor/lib.py"), _File("app.py")])
+
+    assert [f.filename for f in kept] == ["app.py"]


### PR DESCRIPTION
Closes #2747.

## Description

`filter_ignored` compiles each pattern in a `try/except re.error: pass` — no log, no warning.

### Root cause

The bare `pass` is explicit, so this is a deliberate choice — but the consequence is that the user's exclusion silently does not happen.

### The fix

Replace the `pass` with a warning that names the offending pattern, the regex error, and the consequence (the files it was meant to exclude will be sent to the model). Filtering behaviour is unchanged: the invalid pattern is still skipped.

## Behaviour change

| | |
|---|---|
| **Before** | An invalid pattern is skipped in silence |
| **After** | An invalid pattern is skipped with a warning naming the pattern and the error |

## Files changed

```
pr_agent/algo/file_filter.py                        |  6 ++++--
tests/unittest/test_invalid_ignore_pattern_warning.py | 63 +++++++++
 2 files changed, 67 insertions(+), 2 deletions(-)
```

## Testing

New regression coverage in `tests/unittest/test_invalid_ignore_pattern_warning.py` — **3 tests**; one fails without the fix, the other two guard that filtering behaviour stays unchanged:

```
$ PYTHONPATH=. pytest tests/unittest/test_invalid_ignore_pattern_warning.py
3 passed
```

Proven to be a genuine regression test: with every changed `pr_agent/` file reverted to its
`origin/main` version and the new test file left in place, the suite **fails**. It only passes
with the fix applied.

Full pipeline, reproduced locally exactly as `.github/workflows/build-and-test.yaml` runs it:

```
docker build -f docker/Dockerfile --target test .
docker run --rm <image> pytest -v tests/unittest
-> 1964 passed, 1 skipped, 1 xfailed
```

on `python:3.12.13-slim` — no failures.

Also checked:

- `pytest tests/unittest` — no new failures vs `main`
- `ruff` — no new findings vs `main`; `isort` — clean on every file touched
- No new code comments authored

## Risk / compatibility

Log-only change; no filtering behaviour is altered.

## Checklist

- [x] Focused on a single fix
- [x] Existing tests pass
- [x] New regression tests added, proven to fail without the fix
- [x] No new dependencies
- [ ] Reviewed by a maintainer

*Maintainer edit (IsmaelMartinez): corrected the file list and the test-failure claim to match the diff; see review below.*
