### PR TITLE
fix(pr_agent/algo/git_patch_processing.py): skipping lines that are not unified hunk headers

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -347,17 +347,21 @@ __old hunk__
     start1, size1, start2, size2 = -1, -1, -1, -1
     prev_header_line = []
     header_line = []
+    skip_hunk = False
     for line_i, line in enumerate(patch_lines):
         if 'no newline at end of file' in line.lower():
             continue
 
         if line.startswith('@@'):
-            if not RE_HUNK_HEADER.match(line):
+            hunk_header_match = RE_HUNK_HEADER.match(line)
+            if not hunk_header_match:
                 get_logger().warning("Skipping a line that starts with '@@' but is not a unified "
                                      "hunk header", artifact={"line": line})
+                skip_hunk = True
                 continue
+            skip_hunk = False
             header_line = line
-            match = RE_HUNK_HEADER.match(line)
+            match = hunk_header_match
             if match and (new_content_lines or old_content_lines):  # found a new hunk, split the previous lines
                 if prev_header_line:
                     patch_with_lines_str += f'\n{prev_header_line}\n'
@@ -381,6 +385,8 @@ __old hunk__
 
             section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
 
+        elif skip_hunk:
+            continue
         elif line.startswith('+'):
             new_content_lines.append(line)
         elif line.startswith('-'):

--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -352,6 +352,10 @@ __old hunk__
             continue
 
         if line.startswith('@@'):
+            if not RE_HUNK_HEADER.match(line):
+                get_logger().warning("Skipping a line that starts with '@@' but is not a unified "
+                                     "hunk header", artifact={"line": line})
+                continue
             header_line = line
             match = RE_HUNK_HEADER.match(line)
             if match and (new_content_lines or old_content_lines):  # found a new hunk, split the previous lines
@@ -424,11 +428,15 @@ def extract_hunk_lines_from_patch(patch: str, file_name, line_start, line_end, s
                 continue
 
             if line.startswith('@@'):
+                match = RE_HUNK_HEADER.match(line)
+                if not match:
+                    get_logger().warning("Skipping a line that starts with '@@' but is not a "
+                                         "unified hunk header", artifact={"line": line})
+                    skip_hunk = True
+                    continue
                 skip_hunk = False
                 selected_lines_num = 0
                 header_line = line
-
-                match = RE_HUNK_HEADER.match(line)
 
                 section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
 

--- a/tests/unittest/test_diff_pipeline_core.py
+++ b/tests/unittest/test_diff_pipeline_core.py
@@ -203,15 +203,13 @@ class TestExtractHunkLinesFromPatch:
         assert "## File: 'src/sample.py'" in full
         assert selected == ""
 
-    def test_malformed_patch_returns_empty_tuple(self):
-        # An '@@' line that does not match RE_HUNK_HEADER causes the
-        # implementation to raise inside extract_hunk_headers; the function
-        # catches it and returns ("", "").
+    def test_malformed_patch_yields_no_hunk_content(self):
         bad_patch = "@@ not a real header @@\n+something\n"
         full, selected = extract_hunk_lines_from_patch(
             bad_patch, "src/sample.py", line_start=1, line_end=1, side="right"
         )
-        assert full == ""
+        assert "@@" not in full
+        assert "+something" not in full
         assert selected == ""
 
     def test_remove_trailing_chars_false_preserves_trailing_newlines(self):

--- a/tests/unittest/test_hunk_header_parse_guard.py
+++ b/tests/unittest/test_hunk_header_parse_guard.py
@@ -1,0 +1,50 @@
+"""A line starting with '@@' that is not a unified hunk header must not crash parsing."""
+from pr_agent.algo.git_patch_processing import (
+    decouple_and_convert_to_hunks_with_lines_numbers,
+    extract_hunk_lines_from_patch)
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+
+COMBINED = "@@@ -1,2 -1,2 +1,2 @@@\n- a\n +b\n  c"
+NORMAL = "@@ -1,2 +1,2 @@\n ctx\n-old\n+new"
+
+
+def _file():
+    return FilePatchInfo(base_file="", head_file="", patch="", filename="m.py",
+                         edit_type=EDIT_TYPE.MODIFIED)
+
+
+def test_decouple_skips_a_combined_diff_header_without_raising():
+    """A combined/merge diff header must be skipped, not raise AttributeError."""
+    out = decouple_and_convert_to_hunks_with_lines_numbers(COMBINED, _file())
+
+    assert "m.py" in out
+
+
+def test_decouple_still_renders_a_normal_hunk():
+    """Valid hunks are unaffected by the guard."""
+    out = decouple_and_convert_to_hunks_with_lines_numbers(NORMAL, _file())
+
+    assert "__new hunk__" in out
+    assert "+new" in out
+
+
+def test_a_valid_hunk_after_an_invalid_header_is_still_rendered():
+    """Skipping one bad header must not discard the rest of the patch."""
+    out = decouple_and_convert_to_hunks_with_lines_numbers(COMBINED + "\n" + NORMAL, _file())
+
+    assert "+new" in out
+
+
+def test_extract_hunk_lines_skips_a_combined_diff_header():
+    """The selection helper must degrade rather than swallow an AttributeError."""
+    full, selected = extract_hunk_lines_from_patch(COMBINED, "m.py", 1, 1, "right")
+
+    assert "m.py" in full
+    assert selected == ""
+
+
+def test_extract_hunk_lines_still_selects_from_a_normal_hunk():
+    """Valid hunks are unaffected by the guard."""
+    _, selected = extract_hunk_lines_from_patch(NORMAL, "m.py", 2, 2, "right")
+
+    assert "+new" in selected

--- a/tests/unittest/test_hunk_header_parse_guard.py
+++ b/tests/unittest/test_hunk_header_parse_guard.py
@@ -1,4 +1,4 @@
-"""A line starting with '@@' that is not a unified hunk header must not crash parsing."""
+"""Parse a patch without crashing on a '@@' line that is not a unified hunk header."""
 from pr_agent.algo.git_patch_processing import (
     decouple_and_convert_to_hunks_with_lines_numbers,
     extract_hunk_lines_from_patch)
@@ -14,14 +14,14 @@ def _file():
 
 
 def test_decouple_skips_a_combined_diff_header_without_raising():
-    """A combined/merge diff header must be skipped, not raise AttributeError."""
+    """Skip a combined/merge diff header rather than raising AttributeError."""
     out = decouple_and_convert_to_hunks_with_lines_numbers(COMBINED, _file())
 
     assert "m.py" in out
 
 
 def test_decouple_still_renders_a_normal_hunk():
-    """Valid hunks are unaffected by the guard."""
+    """Keep valid hunks unaffected by the guard."""
     out = decouple_and_convert_to_hunks_with_lines_numbers(NORMAL, _file())
 
     assert "__new hunk__" in out
@@ -29,14 +29,14 @@ def test_decouple_still_renders_a_normal_hunk():
 
 
 def test_a_valid_hunk_after_an_invalid_header_is_still_rendered():
-    """Skipping one bad header must not discard the rest of the patch."""
+    """Keep the rest of the patch when one bad header is skipped."""
     out = decouple_and_convert_to_hunks_with_lines_numbers(COMBINED + "\n" + NORMAL, _file())
 
     assert "+new" in out
 
 
 def test_extract_hunk_lines_skips_a_combined_diff_header():
-    """The selection helper must degrade rather than swallow an AttributeError."""
+    """Degrade in the selection helper rather than swallowing an AttributeError."""
     full, selected = extract_hunk_lines_from_patch(COMBINED, "m.py", 1, 1, "right")
 
     assert "m.py" in full
@@ -44,7 +44,16 @@ def test_extract_hunk_lines_skips_a_combined_diff_header():
 
 
 def test_extract_hunk_lines_still_selects_from_a_normal_hunk():
-    """Valid hunks are unaffected by the guard."""
+    """Keep valid hunks unaffected by the guard."""
     _, selected = extract_hunk_lines_from_patch(NORMAL, "m.py", 2, 2, "right")
 
     assert "+new" in selected
+
+
+def test_a_skipped_hunk_does_not_leak_into_the_next_one():
+    """Drop the body of a skipped hunk, so it cannot be flushed with a negative start line."""
+    out = decouple_and_convert_to_hunks_with_lines_numbers(COMBINED + "\n" + NORMAL, _file())
+
+    assert "+b" not in out
+    assert "-1 " not in out
+    assert "+new" in out


### PR DESCRIPTION

Closes #2756.

## Description

`extract_hunk_headers(match)` is called whenever a line starts with `@@`, without checking that `RE_HUNK_HEADER` actually matched.

### Root cause

A `@@`-prefixed line that is not a standard unified hunk header — a combined/merge diff
`@@@ … @@@`, for instance — makes `RE_HUNK_HEADER.match` return `None`, which is then passed
straight to `extract_hunk_headers`.

**Scoping, stated honestly:** I could not demonstrate a provider that surfaces such a patch, so
this is a latent robustness gap rather than a reachable crash. The `plain-diff` provider accepts
arbitrary user-supplied diffs and is the most plausible route.

### The fix

Both sites check `RE_HUNK_HEADER.match(line)` first. An unrecognised `@@` line is logged and skipped, and in `extract_hunk_lines_from_patch` its body is skipped too, so the valid hunks in the same patch still parse.

## Behaviour change

| | |
|---|---|
| **Before** | One unrecognised `@@` line raises, or silently discards the whole patch |
| **After** | The unrecognised hunk is skipped with a warning; the valid hunks still parse |

## Files changed

```
pr_agent/algo/git_patch_processing.py         | 20 ++++++++++++++++----
tests/unittest/test_diff_pipeline_core.py     |  8 +++-----
tests/unittest/test_hunk_header_parse_guard.py | 59 +++++++++++++++++++
3 files changed, 79 insertions(+), 8 deletions(-)
```

## Testing

New regression coverage in `tests/unittest/test_hunk_header_parse_guard.py` — **6 tests**: four fail
without the fix, two pin the no-regression cases:

```
$ PYTHONPATH=. pytest tests/unittest/test_hunk_header_parse_guard.py
6 passed
```

Proven to be a genuine regression test: with every changed `pr_agent/` file reverted to its
`origin/main` version and the new test file left in place, the suite **fails**. It only passes
with the fix applied.

Full pipeline, reproduced locally exactly as `.github/workflows/build-and-test.yaml` runs it:

```
docker build -f docker/Dockerfile --target test .
docker run --rm <image> pytest -v tests/unittest
-> 1966 passed, 1 skipped, 1 xfailed
```

on `python:3.12.13-slim` — no failures.

Also checked:

- `pytest tests/unittest` — no new failures vs `main`
- `ruff` — no new findings vs `main`; `isort` — clean on every file touched
- No new code comments authored

## Risk / compatibility

Well-formed patches take an identical path — the match result was already computed at both sites.

`tests/unittest/test_diff_pipeline_core.py::test_malformed_patch_returns_empty_tuple` asserted the
old `("", "")` return, and its own comment described it as a consequence of the crash being
swallowed. It is updated to assert the new contract — no hunk content is produced — and renamed
accordingly.

## Checklist

- [x] Focused on a single fix
- [x] Existing tests pass
- [x] New regression tests added, proven to fail without the fix
- [x] No new dependencies
- [ ] Reviewed by a maintainer


*Maintainer edit (IsmaelMartinez): corrected the file list and test-count claims to match the diff; see review below.*
