### PR TITLE
feat(gitlab): resolve the agent's own outdated inline threads

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -146,6 +146,24 @@ publish_review_as_thread = true
 - Enabling the flag does not convert a review that was already posted as a plain note: it keeps being updated in place, and GitLab cannot promote a note to a thread. Only MRs whose first review runs after the flag is set get a thread.
 - Set `pr_reviewer.persistent_comment=false` to open a new review thread on each run instead.
 
+## Resolve outdated GitLab inline threads
+
+Each inline suggestion is anchored to the MR head commit it was posted against. When a later push moves the head, GitLab marks that thread as belonging to an outdated diff version: it renders empty, loses its `Resolve` control, and can then only be closed through the API, so superseded suggestions pile up on a long-lived MR. To have PR-Agent resolve those threads before it publishes a fresh batch of inline suggestions, enable (default: `false`):
+
+```toml
+[gitlab]
+resolve_outdated_inline_threads = true
+```
+
+A thread is only resolved when all of the following hold, so a live discussion is never closed:
+
+- the thread was opened by PR-Agent itself, judged from the body: it carries a dedup marker (proof, and present on every inline review finding), or it opens with the `**Suggestion:**` lead that inline suggestions are published with (a strong hint rather than proof, since a person could type it). This is what keeps the cleanup off hand-written comments made from the same account, which matters because the GitLab token often belongs to a person rather than a dedicated bot user;
+- every non-system note in it was written by that same user, so a single human reply leaves the thread alone. GitLab system notes are ignored, because the "changed this line in version N of the diff" note that marks a thread outdated is authored by whoever pushed;
+- the thread is unresolved and anchored to a line of the diff;
+- the head SHA recorded in that anchor differs from the MR's current diff head SHA.
+
+Anything that cannot be confirmed (an unreadable position, an unknown current head SHA, an unresolvable bot identity) is skipped rather than resolved.
+
 ## Log Level
 
 PR-Agent allows you to control the verbosity of logging by using the `log_level` configuration parameter. This is particularly useful for troubleshooting and debugging issues with your PR workflows.

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -155,7 +155,7 @@ Each inline suggestion is anchored to the MR head commit it was posted against. 
 resolve_outdated_inline_threads = true
 ```
 
-A thread is only resolved when all of the following hold, so a live discussion is never closed:
+A thread is only resolved when all of the following hold, so a thread with any human reply is never closed:
 
 - the thread was opened by PR-Agent itself, judged from the body: it carries a dedup marker (proof, and present on every inline review finding), or it opens with the `**Suggestion:**` lead that inline suggestions are published with (a strong hint rather than proof, since a person could type it). This is what keeps the cleanup off hand-written comments made from the same account, which matters because the GitLab token often belongs to a person rather than a dedicated bot user;
 - every non-system note in it was written by that same user, so a single human reply leaves the thread alone. GitLab system notes are ignored, because the "changed this line in version N of the diff" note that marks a thread outdated is authored by whoever pushed;
@@ -163,6 +163,8 @@ A thread is only resolved when all of the following hold, so a live discussion i
 - the head SHA recorded in that anchor differs from the MR's current diff head SHA.
 
 Anything that cannot be confirmed (an unreadable position, an unknown current head SHA, an unresolvable bot identity) is skipped rather than resolved.
+
+Note that the anchor's recorded head SHA never changes after the thread is created, so any PR-Agent thread older than the latest push qualifies, including ones GitLab still renders on unchanged lines. With `config.persistent_inline_comments` enabled the next run re-posts a suggestion that still applies, so the effect is resolve-and-repost rather than removal.
 
 ## Log Level
 

--- a/pr_agent/algo/inline_comment_dedup.py
+++ b/pr_agent/algo/inline_comment_dedup.py
@@ -52,6 +52,11 @@ def has_marker(body: str) -> bool:
     return bool(BODY_MARKER_RE.search(body or "") or CODE_MARKER_RE.search(body or ""))
 
 
+def is_agent_inline_comment(body: str) -> bool:
+    body = (body or "").lstrip()
+    return has_marker(body) or bool(_LEAD_RE.match(body))
+
+
 def _strip_markers(body: str) -> str:
     """Remove embedded dedup markers so a pre-marked body fingerprints the
     same as its original (markers are appended after marking)."""

--- a/pr_agent/algo/inline_comment_dedup.py
+++ b/pr_agent/algo/inline_comment_dedup.py
@@ -57,6 +57,15 @@ def is_agent_inline_comment(body: str) -> bool:
     return has_marker(body) or bool(_LEAD_RE.match(body))
 
 
+def marker_fingerprints(body: str) -> set:
+    """All dedup-marker fingerprints embedded in one comment body."""
+    found = set()
+    for marker_re in _MARKER_RES:
+        for match in marker_re.finditer(body or ""):
+            found.add(match.group(1))
+    return found
+
+
 def _strip_markers(body: str) -> str:
     """Remove embedded dedup markers so a pre-marked body fingerprints the
     same as its original (markers are appended after marking)."""
@@ -187,6 +196,7 @@ class InlineCommentStore:
     def __init__(self, git_provider):
         self._git_provider = git_provider
         self._keys: set = set()
+        self._released: set = set()
         self._loaded = False
         self._load_failed = False
 
@@ -203,6 +213,7 @@ class InlineCommentStore:
                 f"Persistent inline comments: could not load existing comments, "
                 f"within-run dedup only. error={e}"
             )
+        self._keys -= self._released
         self._loaded = True
         return self._keys
 
@@ -220,9 +231,15 @@ class InlineCommentStore:
             self._keys.add(fingerprint)
 
     def add_body(self, body: str) -> None:
-        for marker_re in _MARKER_RES:
-            for match in marker_re.finditer(body or ""):
-                self._keys.add(match.group(1))
+        self._keys |= marker_fingerprints(body)
+
+    def release(self, fingerprints) -> None:
+        """Forget fingerprints whose threads the outdated-thread sweep resolved, so they
+        stop suppressing their own replacements. Applied to what is already loaded and
+        again after any later load, since the sweep and the load can run in either order.
+        Human-resolved threads never reach here and stay suppressive."""
+        self._released |= set(fingerprints)
+        self._keys -= self._released
 
 
 def get_inline_comment_store(git_provider) -> InlineCommentStore:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -389,6 +389,9 @@ class GitProvider(ABC):
         """Providers that implement resolve_comment_thread override this."""
         return False
 
+    def resolve_outdated_inline_threads(self):  # noqa: B027 - intentional no-op
+        pass
+
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -688,7 +688,7 @@ class GitLabProvider(GitProvider):
             except Exception as e:
                 get_logger().warning(
                     f"Could not resolve the authenticated GitLab user; "
-                    f"incremental anchor notes will not be filtered by author: {e}"
+                    f"author-based filtering is disabled for this run: {e}"
                 )
                 self._own_user_id = None
         return self._own_user_id

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -18,7 +18,8 @@ from ..algo.file_filter import filter_ignored
 from ..algo.git_patch_processing import decode_if_bytes
 from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
                                          code_fingerprint,
-                                         get_inline_comment_store)
+                                         get_inline_comment_store,
+                                         is_agent_inline_comment)
 from ..algo.language_handler import is_valid_file
 from ..algo.utils import (clip_tokens, comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
@@ -57,6 +58,35 @@ def _parse_gitlab_iso_datetime(value) -> Optional[datetime]:
         return dt
     except (ValueError, AttributeError):
         return None
+
+
+def _is_outdated_own_inline_thread(discussion, own_user_id: int, current_head_sha: str) -> bool:
+    notes = discussion.attributes.get('notes') or []
+    if not notes or not isinstance(notes[0], dict):
+        return False
+    opener = notes[0]
+    if opener.get('resolved') or opener.get('resolvable') is False:
+        return False
+    position = opener.get('position')
+    if not isinstance(position, dict) or position.get('position_type') != 'text':
+        return False
+    if position.get('new_line') is None and position.get('old_line') is None:
+        return False
+    recorded_head_sha = position.get('head_sha')
+    if not recorded_head_sha or recorded_head_sha == current_head_sha:
+        return False
+    if not is_agent_inline_comment(opener.get('body')):
+        return False
+    for note in notes:
+        if not isinstance(note, dict):
+            return False
+        if note.get('system'):
+            continue
+        author = note.get('author')
+        author_id = author.get('id') if isinstance(author, dict) else None
+        if author_id != own_user_id:
+            return False
+    return True
 
 
 class _GitLabIncrementalCommit:
@@ -914,6 +944,40 @@ class GitLabProvider(GitProvider):
         except Exception as e:
             get_logger().warning(f"Failed to reopen resolved review thread: {e}")
 
+    def resolve_outdated_inline_threads(self):
+        if not get_settings().get("GITLAB.RESOLVE_OUTDATED_INLINE_THREADS", False):
+            return
+        own_user_id = self._get_own_user_id()
+        try:
+            current_head_sha = self.mr.diff_refs['head_sha']
+        except (KeyError, TypeError, AttributeError):
+            current_head_sha = None
+        if own_user_id is None or not current_head_sha:
+            get_logger().warning(
+                f"Skipping outdated inline thread cleanup on merge request {self.id_mr} "
+                f"(bot user: {own_user_id}, current head sha: {current_head_sha})"
+            )
+            return
+        try:
+            discussions = self.mr.discussions.list(get_all=True)
+        except Exception as e:
+            get_logger().warning(f"Failed to list discussions of merge request {self.id_mr}: {e}")
+            return
+        resolved = 0
+        for discussion in discussions:
+            discussion_id = getattr(discussion, 'id', None)
+            try:
+                if not _is_outdated_own_inline_thread(discussion, own_user_id, current_head_sha):
+                    continue
+                discussion.resolved = True
+                discussion.save()
+                resolved += 1
+            except Exception as e:
+                get_logger().warning(f"Failed to resolve outdated inline thread {discussion_id}: {e}")
+        if resolved:
+            get_logger().info(
+                f"Resolved {resolved} outdated inline thread(s) on merge request {self.id_mr}")
+
     def edit_comment_from_comment_id(self, comment_id: int, body: str):
         body = self.limit_output_characters(body, self.max_comment_chars)
         comment = self.mr.notes.get(comment_id)
@@ -1096,6 +1160,8 @@ class GitLabProvider(GitProvider):
         return self.last_diff  # fallback to the latest diff if no relevant diff is found
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
+        # Runs first so the fingerprints it frees are in the store before any dedup lookup.
+        self.resolve_outdated_inline_threads()
         # When true, suggestions are queued as GitLab draft notes and published together in a single
         # batch at the end, instead of each one going out as its own live discussion (and its own
         # notification/email) as soon as it's created.

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -19,7 +19,8 @@ from ..algo.git_patch_processing import decode_if_bytes
 from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
                                          code_fingerprint,
                                          get_inline_comment_store,
-                                         is_agent_inline_comment)
+                                         is_agent_inline_comment,
+                                         marker_fingerprints)
 from ..algo.language_handler import is_valid_file
 from ..algo.utils import (clip_tokens, comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
@@ -964,6 +965,7 @@ class GitLabProvider(GitProvider):
             get_logger().warning(f"Failed to list discussions of merge request {self.id_mr}: {e}")
             return
         resolved = 0
+        released_fps = set()
         for discussion in discussions:
             discussion_id = getattr(discussion, 'id', None)
             try:
@@ -972,8 +974,13 @@ class GitLabProvider(GitProvider):
                 discussion.resolved = True
                 discussion.save()
                 resolved += 1
+                for note in discussion.attributes.get('notes') or []:
+                    if isinstance(note, dict):
+                        released_fps |= marker_fingerprints(note.get('body'))
             except Exception as e:
                 get_logger().warning(f"Failed to resolve outdated inline thread {discussion_id}: {e}")
+        if released_fps:
+            get_inline_comment_store(self).release(released_fps)
         if resolved:
             get_logger().info(
                 f"Resolved {resolved} outdated inline thread(s) on merge request {self.id_mr}")

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -305,6 +305,8 @@ publish_review_as_thread = false
 # note and publish them all together in one batch (like GitLab's own "start a review" flow) instead of
 # posting each as its own live discussion - and its own notification - as soon as it's created.
 publish_code_suggestions_as_review = false
+# Resolve the bot's own inline threads that a later push left on an outdated diff version.
+resolve_outdated_inline_threads = false
 pr_commands = [
     "/describe --pr_description.final_update_message=false",
     "/review",

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -16,13 +16,46 @@ from pr_agent.git_providers.gitlab_provider import (
 )
 
 
-def _mock_settings(publish_review_as_thread=False):
-    """Settings stub whose .get() returns the GitLab review-thread flag and passes other keys through to the default."""
+def _mock_settings(publish_review_as_thread=False, resolve_outdated_inline_threads=False):
+    """Settings stub whose .get() returns the GitLab thread flags and passes other keys through to the default."""
     settings = MagicMock()
     settings.get.side_effect = lambda key, default=None: {
         "GITLAB.PUBLISH_REVIEW_AS_THREAD": publish_review_as_thread,
+        "GITLAB.RESOLVE_OUTDATED_INLINE_THREADS": resolve_outdated_inline_threads,
     }.get(key, default)
     return settings
+
+
+_BOT_USER_ID = 7
+_CURRENT_HEAD_SHA = "head-current"
+_OUTDATED_HEAD_SHA = "head-old"
+
+
+_AGENT_BODY = "**Suggestion:** Rename this [best practice, importance: 5]\n```suggestion\nx = 1\n```"
+_HUMAN_BODY = "Please rename this variable before we merge."
+
+
+def _thread_note(author_id=_BOT_USER_ID, system=False, resolved=False, resolvable=True,
+                 with_position=True, head_sha=_OUTDATED_HEAD_SHA, position_type='text',
+                 line_key='new_line', body=_AGENT_BODY):
+    note = {'author': {'id': author_id}, 'system': system, 'resolved': resolved,
+            'resolvable': resolvable, 'body': body}
+    if with_position:
+        position = {'position_type': position_type, 'new_path': 'src/app.py',
+                    'old_path': 'src/app.py'}
+        if head_sha is not None:
+            position['head_sha'] = head_sha
+        if line_key:
+            position[line_key] = 12
+        note['position'] = position
+    return note
+
+
+def _thread(notes, discussion_id='d1'):
+    discussion = MagicMock()
+    discussion.id = discussion_id
+    discussion.attributes = {'id': discussion_id, 'notes': notes}
+    return discussion
 
 
 class TestGitLabProvider:
@@ -679,6 +712,128 @@ class TestGitLabProvider:
         gitlab_provider.mr.discussions.list.side_effect = Exception("gitlab api error")
 
         gitlab_provider.unresolve_comment_thread(MagicMock(id=1))  # must not raise
+
+    def _prepare_outdated_cleanup(self, gitlab_provider, threads, own_user_id=_BOT_USER_ID,
+                                  current_head_sha=_CURRENT_HEAD_SHA):
+        gitlab_provider._own_user_id = own_user_id
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.diff_refs = {'head_sha': current_head_sha}
+        gitlab_provider.mr.discussions.list.return_value = threads
+
+    def _run_outdated_cleanup(self, gitlab_provider, enabled=True):
+        with patch("pr_agent.git_providers.gitlab_provider.get_settings",
+                   return_value=_mock_settings(resolve_outdated_inline_threads=enabled)):
+            gitlab_provider.resolve_outdated_inline_threads()
+
+    def test_resolve_outdated_inline_threads_is_opt_in(self, gitlab_provider):
+        outdated = _thread([_thread_note()])
+        self._prepare_outdated_cleanup(gitlab_provider, [outdated])
+
+        self._run_outdated_cleanup(gitlab_provider, enabled=False)
+
+        gitlab_provider.mr.discussions.list.assert_not_called()
+        outdated.save.assert_not_called()
+
+    def test_resolve_outdated_inline_threads_resolves_only_the_bots_outdated_threads(self, gitlab_provider):
+        outdated = _thread([_thread_note()], discussion_id='outdated')
+        current = _thread([_thread_note(head_sha=_CURRENT_HEAD_SHA)], discussion_id='current')
+        with_human_reply = _thread([_thread_note(),
+                                    _thread_note(author_id=99, with_position=False)],
+                                   discussion_id='human')
+        self._prepare_outdated_cleanup(gitlab_provider, [outdated, current, with_human_reply])
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        assert outdated.resolved is True
+        outdated.save.assert_called_once()
+        current.save.assert_not_called()
+        with_human_reply.save.assert_not_called()
+
+    def test_resolve_outdated_inline_threads_ignores_gitlab_system_notes(self, gitlab_provider):
+        outdated = _thread([_thread_note(),
+                            _thread_note(author_id=99, system=True, with_position=False)])
+        self._prepare_outdated_cleanup(gitlab_provider, [outdated])
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        assert outdated.resolved is True
+        outdated.save.assert_called_once()
+
+    def test_resolve_outdated_inline_threads_accepts_a_marked_body_without_the_suggestion_lead(self, gitlab_provider):
+        marked = _thread([_thread_note(body="**Possible Issue**\n\nx\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->")])
+        self._prepare_outdated_cleanup(gitlab_provider, [marked])
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        assert marked.resolved is True
+        marked.save.assert_called_once()
+
+    @pytest.mark.parametrize("notes", [
+        pytest.param([], id="no_notes"),
+        pytest.param(["not-a-dict"], id="opener_not_a_dict"),
+        pytest.param([_thread_note(resolved=True)], id="already_resolved"),
+        pytest.param([_thread_note(resolvable=False)], id="not_resolvable"),
+        pytest.param([_thread_note(with_position=False)], id="no_position"),
+        pytest.param([_thread_note(position_type='image')], id="not_a_text_position"),
+        pytest.param([_thread_note(line_key=None)], id="not_line_anchored"),
+        pytest.param([_thread_note(head_sha=None)], id="no_recorded_head_sha"),
+        pytest.param([_thread_note(head_sha=_CURRENT_HEAD_SHA)], id="on_the_current_diff"),
+        pytest.param([_thread_note(body=_HUMAN_BODY)], id="hand_written_by_the_token_owner"),
+        pytest.param([_thread_note(body=None)], id="no_body"),
+        pytest.param([_thread_note(body="<!-- pr-agent-dedup: in prose")], id="malformed_marker"),
+        pytest.param([{'author': 'not-a-dict', 'body': _AGENT_BODY,
+                       'position': {'position_type': 'text', 'new_line': 1,
+                                    'head_sha': _OUTDATED_HEAD_SHA}}],
+                     id="author_not_a_dict"),
+        pytest.param([_thread_note(), 'not-a-dict'], id="reply_not_a_dict"),
+    ])
+    def test_resolve_outdated_inline_threads_leaves_unconfirmed_threads_alone(self, gitlab_provider, notes):
+        thread = _thread(notes)
+        self._prepare_outdated_cleanup(gitlab_provider, [thread])
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        thread.save.assert_not_called()
+
+    @pytest.mark.parametrize("own_user_id,current_head_sha", [
+        (None, _CURRENT_HEAD_SHA),
+        (_BOT_USER_ID, None),
+    ])
+    def test_resolve_outdated_inline_threads_skips_when_identity_or_head_is_unknown(
+            self, gitlab_provider, own_user_id, current_head_sha):
+        outdated = _thread([_thread_note()])
+        self._prepare_outdated_cleanup(gitlab_provider, [outdated], own_user_id=own_user_id,
+                                       current_head_sha=current_head_sha)
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        gitlab_provider.mr.discussions.list.assert_not_called()
+        outdated.save.assert_not_called()
+
+    def test_resolve_outdated_inline_threads_continues_past_a_failing_thread(self, gitlab_provider):
+        failing = _thread([_thread_note()], discussion_id='failing')
+        failing.save.side_effect = Exception("gitlab api error")
+        outdated = _thread([_thread_note()], discussion_id='outdated')
+        self._prepare_outdated_cleanup(gitlab_provider, [failing, outdated])
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+        outdated.save.assert_called_once()
+
+    def test_resolve_outdated_inline_threads_soft_fails(self, gitlab_provider):
+        self._prepare_outdated_cleanup(gitlab_provider, [])
+        gitlab_provider.mr.discussions.list.side_effect = Exception("gitlab api error")
+
+        self._run_outdated_cleanup(gitlab_provider)
+
+    def test_publish_code_suggestions_resolves_outdated_inline_threads_first(self, gitlab_provider):
+        gitlab_provider.resolve_outdated_inline_threads = MagicMock()
+        gitlab_provider.send_inline_comment = MagicMock()
+
+        assert gitlab_provider.publish_code_suggestions([]) is True
+
+        gitlab_provider.resolve_outdated_inline_threads.assert_called_once_with()
+        gitlab_provider.send_inline_comment.assert_not_called()
 
     # ---- publish_labels / get_pr_labels tests ----
 

--- a/tests/unittest/test_inline_comment_dedup.py
+++ b/tests/unittest/test_inline_comment_dedup.py
@@ -569,3 +569,42 @@ def test_is_agent_inline_comment_rejects_hand_written_bodies():
     assert not d.is_agent_inline_comment("Here is my **Suggestion:** rename it")
     assert not d.is_agent_inline_comment("")
     assert not d.is_agent_inline_comment(None)
+
+
+def test_marker_fingerprints_collects_every_marker():
+    body = ("x\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->"
+            "\n<!-- pr-agent-dedup-code: b1b2c3d4e5f6 -->"
+            "\n<!-- pr-agent-key-issue-location: c1b2c3d4e5f6 -->")
+    assert d.marker_fingerprints(body) == {
+        "a1b2c3d4e5f6", "b1b2c3d4e5f6", "c1b2c3d4e5f6"}
+    assert d.marker_fingerprints("") == set()
+    assert d.marker_fingerprints(None) == set()
+
+
+def test_release_frees_a_fingerprint_the_store_had_already_loaded():
+    store = d.InlineCommentStore(MagicMock())
+    with patch.object(d, "iter_existing_inline_comment_bodies",
+                      return_value=["x\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->"]):
+        assert store.seen("a1b2c3d4e5f6")
+        store.release({"a1b2c3d4e5f6"})
+        assert not store.seen("a1b2c3d4e5f6")
+
+
+def test_release_before_the_load_survives_it():
+    # The sweep can run before anything reads the store; the scan must not
+    # re-suppress a fingerprint whose thread it just resolved.
+    store = d.InlineCommentStore(MagicMock())
+    store.release({"a1b2c3d4e5f6"})
+    with patch.object(d, "iter_existing_inline_comment_bodies",
+                      return_value=["x\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->"]):
+        assert not store.seen("a1b2c3d4e5f6")
+
+
+def test_release_leaves_every_other_thread_suppressive():
+    store = d.InlineCommentStore(MagicMock())
+    with patch.object(d, "iter_existing_inline_comment_bodies", return_value=[
+            "x\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->",
+            "y\n\n<!-- pr-agent-dedup: d1b2c3d4e5f6 -->"]):
+        store.release({"a1b2c3d4e5f6"})
+        assert not store.seen("a1b2c3d4e5f6")
+        assert store.seen("d1b2c3d4e5f6")

--- a/tests/unittest/test_inline_comment_dedup.py
+++ b/tests/unittest/test_inline_comment_dedup.py
@@ -555,3 +555,17 @@ def test_has_marker_requires_wellformed_marker():
     assert d.has_marker("body\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->")
     assert not d.has_marker("a comment that merely mentions <!-- pr-agent-dedup: in prose")
     assert not d.has_marker("no marker at all")
+
+
+def test_is_agent_inline_comment_accepts_the_agents_own_bodies():
+    assert d.is_agent_inline_comment(
+        "**Suggestion:** Rename this [best practice, importance: 5]\n```suggestion\nx = 1\n```")
+    assert d.is_agent_inline_comment("\n  **suggestion:** case and leading whitespace are ignored")
+    assert d.is_agent_inline_comment("**Possible Issue**\n\nx\n\n<!-- pr-agent-dedup: a1b2c3d4e5f6 -->")
+
+
+def test_is_agent_inline_comment_rejects_hand_written_bodies():
+    assert not d.is_agent_inline_comment("Please rename this variable before we merge.")
+    assert not d.is_agent_inline_comment("Here is my **Suggestion:** rename it")
+    assert not d.is_agent_inline_comment("")
+    assert not d.is_agent_inline_comment(None)


### PR DESCRIPTION
Closes #2773.

Inline suggestions are anchored to the MR head at post time, so a later push leaves them on an outdated diff version: GitLab renders the thread empty, drops its `Resolve` control, and only the API can close it. On a long-lived MR they pile up one per superseded suggestion. This adds an opt-in `[gitlab] resolve_outdated_inline_threads` flag (default `false`) that resolves those threads before publishing a fresh batch.

The selection is deliberately conservative, since resolving someone's live discussion is far worse than leaving a stale thread open. A thread is only touched when all of:

- its opening body proves PR-Agent wrote it (a dedup marker, or the `**Suggestion:**` lead). Without this, the check would also close hand-written comments made from the same account, which matters because the token is often a person's rather than a dedicated bot's.
- every non-system note is from that same user, so one human reply leaves it alone. System notes have to be skipped here: the "changed this line in version N of the diff" note that marks a thread outdated is authored by whoever pushed, so counting it would disqualify exactly the threads this is for.
- it is unresolved, line-anchored, and its recorded `head_sha` is not the MR's current one.

Anything unconfirmable (unreadable position, unknown head SHA, unresolvable identity) is skipped, and a per-thread API failure is logged without aborting the sweep.

Two things worth a reviewer's judgement:

- the flag only does something where inline suggestions are actually published, so `commitable_code_suggestions`, dual publishing, or `inline_key_issues`. On a default config it is inert.
- with `config.persistent_inline_comments` also on, resolving a thread can let the dedup filter suppress the replacement suggestion. Happy to address that here or in a follow-up, whichever you prefer.

`pytest tests/unittest` passes (1986, up 25 from `main`); `ruff` and `isort` add no findings. Docker was unavailable locally, so the containerised CI target has not been run.
