### PR TITLE
docs: restore pip install pr-agent now that PyPI publishing has resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,8 @@ jobs:
 
 Run PR-Agent locally on your repository:
 
-PyPI publishing is temporarily behind: `pip install pr-agent` currently installs `0.39.0`.
-Until publishing resumes, install the current release (`v0.42.0`) reproducibly from its GitHub tag:
-
 ```bash
-pip install "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@v0.42.0"
+pip install pr-agent
 export OPENAI_KEY=your_key_here
 pr-agent --pr_url https://github.com/owner/repo/pull/123 review
 ```

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -96,11 +96,8 @@ Same goes for other providers, make sure to check the [documentation](../usage-g
 
 Install the package:
 
-PyPI publishing is temporarily behind: `pip install pr-agent` currently installs `0.39.0`.
-Until publishing resumes, install the current release (`v0.42.0`) reproducibly from its GitHub tag:
-
 ```bash
-pip install "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@v0.42.0"
+pip install pr-agent
 ```
 
 Then run the relevant tool with the script below.


### PR DESCRIPTION
## What

Removes the temporary "PyPI publishing is temporarily behind" notice from the install docs and restores `pip install pr-agent` in `README.md` and `docs/docs/installation/locally.md`.

## Why

#2655 added the notice and pinned the docs to `pip install "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@v0.42.0"` because PyPI publishing had lapsed after `0.39.0`.

That's resolved:

- `publish-pypi` succeeded on the `v0.43.0` release run and [`pr-agent 0.43.0`](https://pypi.org/project/pr-agent/0.43.0/) is on PyPI.
- The versions missed during the gap (`0.40.0`, `0.41.0`, `0.42.0`) have been backfilled.

So `pip install pr-agent` resolves to the current release again, and the pinned git+https instructions would otherwise go stale with every release.

## Notes

- This restores the docs to their pre-#2655 wording, apart from keeping the blank line before the README code fence that #2655 introduced.
- `0.41.1` has a GitHub release but is not on PyPI — it wasn't part of the backfill. Nothing in the docs references it, so it doesn't block this change.
