### PR TITLE
fix(gitea): strip the full /api/v1/repos prefix when parsing URLs

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -224,8 +224,8 @@ class GiteaProvider(GitProvider):
     def _parse_pr_url(self, pr_url: str) -> Tuple[str, str, int]:
         parsed_url = urlparse(pr_url)
 
-        if parsed_url.path.startswith('/api/v1'):
-            parsed_url = urlparse(pr_url.replace("/api/v1", ""))
+        if parsed_url.path.startswith("/api/v1/repos"):
+            parsed_url = urlparse(pr_url.replace("/api/v1/repos", ""))
 
         path_parts = parsed_url.path.strip('/').split('/')
         if len(path_parts) < 4 or path_parts[2] != 'pulls':
@@ -244,8 +244,8 @@ class GiteaProvider(GitProvider):
     def _parse_issue_url(self, issue_url: str) -> Tuple[str, str, int]:
         parsed_url = urlparse(issue_url)
 
-        if parsed_url.path.startswith('/api/v1'):
-            parsed_url = urlparse(issue_url.replace("/api/v1", ""))
+        if parsed_url.path.startswith("/api/v1/repos"):
+            parsed_url = urlparse(issue_url.replace("/api/v1/repos", ""))
 
         path_parts = parsed_url.path.strip('/').split('/')
         if len(path_parts) < 4 or path_parts[2] != 'issues':

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -760,3 +760,28 @@ class TestGiteaProviderUserFacingLinks:
         provider.base_url_html = provider._resolve_base_url_html()
 
         assert provider.get_pr_url() == "http://forgejo:3000/owner/repo/pulls/4"
+
+
+class TestGiteaProviderUrlParsing:
+    """Cover both URL forms: Gitea sets ``pull_request.url`` to the web page,
+    Forgejo sets it to ``/api/v1/repos/{owner}/{repo}/pulls/{n}``.
+
+    ``__init__`` performs network calls, so build the provider with ``__new__``
+    and exercise the pure helper only.
+    """
+
+    @staticmethod
+    def _provider():
+        return GiteaProvider.__new__(GiteaProvider)
+
+    def test_parse_pr_url_accepts_web_and_api_forms(self):
+        provider = self._provider()
+        assert provider._parse_pr_url("https://gitea.example.com/owner/repo/pulls/1") == ("owner", "repo", 1)
+        assert provider._parse_pr_url(
+            "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1") == ("owner", "repo", 1)
+
+    def test_parse_issue_url_accepts_web_and_api_forms(self):
+        provider = self._provider()
+        assert provider._parse_issue_url("https://gitea.example.com/owner/repo/issues/5") == ("owner", "repo", 5)
+        assert provider._parse_issue_url(
+            "https://gitea.example.com/api/v1/repos/owner/repo/issues/5") == ("owner", "repo", 5)


### PR DESCRIPTION
## Description

Gitea API paths are `/api/v1/repos/{owner}/{repo}/pulls/{n}`. `_parse_pr_url` and `_parse_issue_url` strip only `/api/v1`, which leaves `repos` at index 0 and shifts every offset by one. The parse then finds the repository name where it expects `pulls` and raises `The provided URL does not appear to be a Gitea PR URL`.

In practice this is Forgejo-specific. Forgejo's `services/convert/pull.go` sets `PullRequest.URL` from `Issue.APIURL()`, so `pull_request.url` in the webhook payload is the API form, and `gitea_app.py` passes it straight to the parser. Gitea sets the same field from `Issue.HTMLURL()`, which takes the web path and parses correctly today.

Nothing surfaces the failure. `handle_gitea_webhooks` queues `handle_request` as a background task and returns before the parse runs, so the forge records a successful delivery — 2xx, green in the hook history — while no review is ever posted. The only trace is a traceback in the container log.

Stripping `/api/v1/repos` leaves the same four trailing segments the web form already has, so both forms follow the existing offset path unchanged. `_parse_issue_url` carries the identical defect and takes the identical fix.

## Type of change

- [x] Bug fix (non-breaking change)

## Verification

```
$ PYTHONPATH=. python -m pytest tests/unittest/test_gitea_provider.py -q
38 passed in 0.55s

$ PYTHONPATH=. python -m pytest tests/unittest -q
2027 passed, 1 skipped, 1 xfailed in 19.63s
```

Both new tests fail against `main` with the parse error quoted above and pass with the fix. `ruff check` on the two touched files reports the same 9 pre-existing violations as `main`.
