### PR TITLE
fix: /ask on outdated review comments crashes with TypeError

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -412,6 +412,14 @@ __old hunk__
 
 def extract_hunk_lines_from_patch(patch: str, file_name, line_start, line_end, side, remove_trailing_chars: bool = True) -> tuple[str, str]:
     try:
+        try:
+            line_start = int(line_start)
+        except (ValueError, TypeError):
+            line_start = -1
+        try:
+            line_end = int(line_end)
+        except (ValueError, TypeError):
+            line_end = -1
         patch_with_lines_str = f"\n\n## File: '{file_name.strip()}'\n\n"
         selected_lines = ""
         patch_lines = patch.splitlines()

--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -415,10 +415,12 @@ def extract_hunk_lines_from_patch(patch: str, file_name, line_start, line_end, s
         try:
             line_start = int(line_start)
         except (ValueError, TypeError):
+            get_logger().warning(f"Ignoring invalid line_start {line_start!r} for '{file_name}'")
             line_start = -1
         try:
             line_end = int(line_end)
         except (ValueError, TypeError):
+            get_logger().warning(f"Ignoring invalid line_end {line_end!r} for '{file_name}'")
             line_end = -1
         patch_with_lines_str = f"\n\n## File: '{file_name.strip()}'\n\n"
         selected_lines = ""

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -361,8 +361,8 @@ async def handle_request(body: Dict[str, Any], event: str):
 def handle_line_comments(body: Dict, comment_body: [str, Any]) -> str:
     if not comment_body:
         return ""
-    start_line = body["comment"]["start_line"]
-    end_line = body["comment"]["line"]
+    start_line = body["comment"]["start_line"] or body["comment"].get("original_start_line")
+    end_line = body["comment"]["line"] or body["comment"].get("original_line")
     start_line = end_line if not start_line else start_line
     question = comment_body.replace('/ask', '').strip()
     diff_hunk = body["comment"]["diff_hunk"]

--- a/tests/unittest/test_diff_pipeline_core.py
+++ b/tests/unittest/test_diff_pipeline_core.py
@@ -14,6 +14,8 @@ formatting tweaks.
 
 from unittest.mock import patch
 
+import pytest
+
 import pr_agent.algo.pr_processing as pr_processing
 from pr_agent.algo.git_patch_processing import (
     decouple_and_convert_to_hunks_with_lines_numbers,
@@ -226,6 +228,28 @@ class TestExtractHunkLinesFromPatch:
         # Trimmed variants are strict suffixes (no trailing whitespace).
         assert full_stripped == full_raw.rstrip()
         assert sel_stripped == sel_raw.rstrip()
+
+    @pytest.mark.parametrize("line_start, line_end", [
+        ("", ""),
+        (None, None),
+        ("None", "None"),
+    ])
+    def test_non_numeric_line_params_do_not_crash(self, line_start, line_end):
+        full, selected = extract_hunk_lines_from_patch(
+            MULTI_HUNK_PATCH, "src/sample.py", line_start=line_start, line_end=line_end, side="right"
+        )
+        assert "## File: 'src/sample.py'" in full
+        assert selected == ""
+
+    def test_string_line_params_are_coerced_to_int(self):
+        full_str, sel_str = extract_hunk_lines_from_patch(
+            MULTI_HUNK_PATCH, "src/sample.py", line_start="2", line_end="2", side="right"
+        )
+        full_int, sel_int = extract_hunk_lines_from_patch(
+            MULTI_HUNK_PATCH, "src/sample.py", line_start=2, line_end=2, side="right"
+        )
+        assert full_str == full_int
+        assert sel_str == sel_int
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -328,6 +328,18 @@ class TestHandleLineComments:
         finally:
             _restore_ask_diff_hunk(settings, outer_original, outer_sentinel)
 
+    def test_outdated_comment_falls_back_to_original_line(self):
+        body = self._payload(start_line=None, line=None, original_start_line=5, original_line=7)
+        result = github_app.handle_line_comments(body, "/ask Is this still relevant?")
+        assert "--line_start=5" in result
+        assert "--line_end=7" in result
+
+    def test_outdated_comment_single_line_falls_back_to_original(self):
+        body = self._payload(start_line=None, line=None, original_start_line=None, original_line=7)
+        result = github_app.handle_line_comments(body, "/ask question")
+        assert "--line_start=7" in result
+        assert "--line_end=7" in result
+
     def test_non_ask_comment_returned_unchanged(self):
         body = self._payload()
         result = github_app.handle_line_comments(body, "just a comment")


### PR DESCRIPTION
## Description

Fixes #2783

**`github_app.py`** — `handle_line_comments()` now falls back to `original_start_line` / `original_line` when `start_line` / `line` are null.

**`git_patch_processing.py`** — `extract_hunk_lines_from_patch()` now converts `line_start` / `line_end` to int at entry, falling back to -1 for invalid values.

## Type of change

- [x] Bug fix (non-breaking change)

## Verification

```
$ PYTHONPATH=. python -m pytest tests/unittest/test_diff_pipeline_core.py::TestExtractHunkLinesFromPatch tests/unittest/test_github_app_timeout_core.py::TestHandleLineComments -q
21 passed in 2.60s
```

New tests:
- `test_non_numeric_line_params_do_not_crash` (parametrized: `""`, `None`, `"None"`)
- `test_string_line_params_are_coerced_to_int`
- `test_outdated_comment_falls_back_to_original_line`
- `test_outdated_comment_single_line_falls_back_to_original`

Manually verified: `/ask` on an outdated review comment now responds instead of crashing silently.