### PR TITLE
fix(azure): handle commits without changes

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -520,8 +520,11 @@ class AzureDevopsProvider(GitProvider):
                 commit_id=i.commit_id,
             )
 
-            for c in changes_obj.changes:
-                files.append(c["item"]["path"])
+            for c in (changes_obj.changes or []):
+                item = c.get("item") or {}
+                path = item.get("path")
+                if path:
+                    files.append(path)
         return list(set(files))
 
     def get_diff_files(self) -> list[FilePatchInfo]:

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -59,6 +59,25 @@ class _AzureCommitAdapter:
         self.parents = list(getattr(raw, "parents", None) or [])
 
 
+def _get_azure_change_path(change):
+    try:
+        item = change["item"]
+    except (KeyError, TypeError):
+        item = getattr(change, "item", None)
+        if item is None:
+            additional = getattr(change, "additional_properties", None) or {}
+            item = additional.get("item") or {}
+
+    if isinstance(item, dict):
+        if item.get("gitObjectType", item.get("git_object_type")) == "tree":
+            return None
+        return item.get("path")
+
+    if getattr(item, "git_object_type", getattr(item, "gitObjectType", None)) == "tree":
+        return None
+    return getattr(item, "path", None)
+
+
 class AzureDevopsProvider(GitProvider):
 
     def __init__(
@@ -361,14 +380,7 @@ class AzureDevopsProvider(GitProvider):
                 get_logger().warning(f"Failed to fetch changes for {commit.commit_id}: {e}")
                 continue
             for change in (getattr(changes_obj, "changes", None) or []):
-                try:
-                    item = change["item"]
-                except (KeyError, TypeError):
-                    additional = getattr(change, "additional_properties", None) or {}
-                    item = additional.get("item") or {}
-                if not isinstance(item, dict) or item.get("gitObjectType") == "tree":
-                    continue
-                path = item.get("path")
+                path = _get_azure_change_path(change)
                 if path:
                     candidate_paths.append(path)
 
@@ -521,14 +533,7 @@ class AzureDevopsProvider(GitProvider):
             )
 
             for c in (changes_obj.changes or []):
-                try:
-                    item = c["item"]
-                except (KeyError, TypeError):
-                    item = getattr(c, "item", None)
-                    if item is None:
-                        additional = getattr(c, "additional_properties", None) or {}
-                        item = additional.get("item") or {}
-                path = item.get("path") if isinstance(item, dict) else getattr(item, "path", None)
+                path = _get_azure_change_path(c)
                 if path:
                     files.append(path)
         return list(set(files))

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -521,8 +521,14 @@ class AzureDevopsProvider(GitProvider):
             )
 
             for c in (changes_obj.changes or []):
-                item = c.get("item") or {}
-                path = item.get("path")
+                try:
+                    item = c["item"]
+                except (KeyError, TypeError):
+                    item = getattr(c, "item", None)
+                    if item is None:
+                        additional = getattr(c, "additional_properties", None) or {}
+                        item = additional.get("item") or {}
+                path = item.get("path") if isinstance(item, dict) else getattr(item, "path", None)
                 if path:
                     files.append(path)
         return list(set(files))

--- a/tests/unittest/test_azure_devops_incremental.py
+++ b/tests/unittest/test_azure_devops_incremental.py
@@ -1,4 +1,5 @@
 import datetime as _dt
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from pr_agent.git_providers import AzureDevopsProvider
@@ -130,6 +131,31 @@ class TestGetIncrementalCommits:
         assert "/bar.py" in provider.unreviewed_files_map
         assert "/somedir" not in provider.unreviewed_files_map
         assert prev.html_url == provider.get_comment_url(prev)
+
+    def test_populates_files_from_sdk_change_objects(self):
+        provider = self._make_provider()
+
+        review_time = _dt.datetime(2024, 6, 1, 10, 0, tzinfo=_dt.timezone.utc)
+        old = _raw_commit(
+            "old1", "first", _dt.datetime(2024, 5, 1, tzinfo=_dt.timezone.utc), parents=["p0"],
+        )
+        new = _raw_commit(
+            "new1", "second", _dt.datetime(2024, 6, 2, tzinfo=_dt.timezone.utc), parents=["old1"],
+        )
+        provider.azure_devops_client.get_pull_request_commits = MagicMock(return_value=[new, old])
+        provider.get_issue_comments = MagicMock(
+            return_value=[_comment("## PR Reviewer Guide\nbody", review_time)]
+        )
+
+        changes_obj = MagicMock()
+        changes_obj.changes = [
+            SimpleNamespace(item=SimpleNamespace(path="/src/sdk.py")),
+        ]
+        provider.azure_devops_client.get_changes = MagicMock(return_value=changes_obj)
+
+        provider.get_incremental_commits(IncrementalPR(True))
+
+        assert "/src/sdk.py" in provider.unreviewed_files_map
 
     def test_skips_merge_commits(self):
         provider = self._make_provider()

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -90,6 +90,14 @@ class TestAzureDevopsProviderFiles:
 
         assert provider._get_files_full() == ["/src/app.py"]
 
+    def test_get_files_full_supports_sdk_change_objects(self):
+        provider = self._provider()
+        provider.azure_devops_client.get_changes.return_value = SimpleNamespace(changes=[
+            SimpleNamespace(item=SimpleNamespace(path="/src/sdk.py")),
+        ])
+
+        assert provider._get_files_full() == ["/src/sdk.py"]
+
 
 def _provider_with_diff(*filenames):
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -98,6 +98,15 @@ class TestAzureDevopsProviderFiles:
 
         assert provider._get_files_full() == ["/src/sdk.py"]
 
+    def test_get_files_full_skips_tree_entries(self):
+        provider = self._provider()
+        provider.azure_devops_client.get_changes.return_value = SimpleNamespace(changes=[
+            {"item": {"path": "/src", "gitObjectType": "tree"}},
+            {"item": {"path": "/src/app.py", "gitObjectType": "blob"}},
+        ])
+
+        assert provider._get_files_full() == ["/src/app.py"]
+
 
 def _provider_with_diff(*filenames):
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -55,6 +55,42 @@ class TestAzureDevopsProviderRepoContext:
         assert provider.get_repo_file_content("MISSING.md") == ""
 
 
+class TestAzureDevopsProviderFiles:
+    @staticmethod
+    def _provider():
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr_num = 1
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_pull_request_commits.return_value = [SimpleNamespace(commit_id="m1")]
+        return provider
+
+    def test_get_files_full_skips_commits_without_changes(self):
+        provider = self._provider()
+        provider.azure_devops_client.get_pull_request_commits.return_value = [
+            SimpleNamespace(commit_id="m1"),
+            SimpleNamespace(commit_id="m2"),
+        ]
+        provider.azure_devops_client.get_changes.side_effect = [
+            SimpleNamespace(changes=None),
+            SimpleNamespace(changes=[{"item": {"path": "/src/app.py"}}]),
+        ]
+
+        assert provider._get_files_full() == ["/src/app.py"]
+
+    def test_get_files_full_skips_changes_without_paths(self):
+        provider = self._provider()
+        provider.azure_devops_client.get_changes.return_value = SimpleNamespace(changes=[
+            {},
+            {"item": None},
+            {"item": {"path": ""}},
+            {"item": {"path": "/src/app.py"}},
+        ])
+
+        assert provider._get_files_full() == ["/src/app.py"]
+
+
 def _provider_with_diff(*filenames):
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
     provider.repo_slug = "my-repo"


### PR DESCRIPTION
Fixes #2781

## Summary

- Guard Azure DevOps full file retrieval when a commit has no changes.
- Skip change entries without an item or file path so malformed entries do not abort the whole PR.
- Add regression coverage for an empty commit followed by a valid commit and missing paths.

## Tests

- `PYTHONPATH=. /tmp/pr-agent-2781-venv/bin/pytest tests/unittest/test_azure_devops_provider.py -q` (51 passed)
- `PYTHONPATH=. /tmp/pr-agent-2781-venv/bin/pytest tests/unittest/test_azure_devops_incremental.py -q -k "not TestPrReviewerGuard"` (12 passed)
- `git diff --check`

The full unit suite will run in the repository CI workflow.