### PR TITLE
fix(codecommit): include deleted files in review diffs

### DIFF
--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -118,7 +118,7 @@ class CodeCommitProvider(GitProvider):
         files = self.get_files()
         for diff_item in files:
             patch_filename = ""
-            if diff_item.a_blob_id is not None:
+            if diff_item.a_blob_id:
                 patch_filename = diff_item.a_path
                 original_file_content_str = self.codecommit_client.get_file(
                     self.repo_name, diff_item.a_path, self.pr.destination_commit)
@@ -127,7 +127,7 @@ class CodeCommitProvider(GitProvider):
             else:
                 original_file_content_str = ""
 
-            if diff_item.b_blob_id is not None:
+            if diff_item.b_blob_id:
                 patch_filename = diff_item.b_path
                 new_file_content_str = self.codecommit_client.get_file(self.repo_name, diff_item.b_path, self.pr.source_commit)
                 if isinstance(new_file_content_str, (bytes, bytearray)):
@@ -142,7 +142,7 @@ class CodeCommitProvider(GitProvider):
                 original_file_content_str,
                 new_file_content_str,
                 patch,
-                diff_item.b_path,
+                diff_item.filename,
                 edit_type=diff_item.edit_type,
                 old_filename=None
                 if diff_item.a_path == diff_item.b_path

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -27,6 +27,30 @@ class TestCodeCommitFile:
 
 
 class TestCodeCommitProvider:
+    def test_get_diff_files_includes_deleted_file(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "my_test_repo"
+        provider.pr = PullRequestCCMimic("Delete file", [])
+        provider.pr.destination_commit = "destination-commit"
+        provider.pr.source_commit = "source-commit"
+        provider.diff_files = None
+        provider.git_files = [
+            CodeCommitFile("deleted.py", "before-id", "", "", EDIT_TYPE.DELETED)
+        ]
+        provider.codecommit_client = MagicMock()
+        provider.codecommit_client.get_file.side_effect = lambda _, path, __: b"old contents\n" if path else ""
+
+        diff_files = provider.get_diff_files()
+
+        assert [diff_file.filename for diff_file in diff_files] == ["deleted.py"]
+        assert diff_files[0].base_file == "old contents\n"
+        assert diff_files[0].head_file == ""
+        assert diff_files[0].edit_type == EDIT_TYPE.DELETED
+        assert "-old contents" in diff_files[0].patch
+        assert provider.codecommit_client.get_file.call_args_list == [
+            call("my_test_repo", "deleted.py", "destination-commit")
+        ]
+
     def test_get_title(self):
         # Test that the get_title() function returns the PR title
         with patch.object(CodeCommitProvider, "__init__", lambda x, y: None):


### PR DESCRIPTION
Fixes #2787.

## Summary

- Keep the before path as the canonical filename when CodeCommit omits `afterBlob` for a deleted file.
- Avoid redundant content lookups when before/after blobs are absent.
- Add an offline provider regression test covering the AWS deletion response shape and generated patch.

## Tests

- `PYTHONPATH=. .venv/bin/pytest tests/unittest/test_codecommit_provider.py tests/unittest/test_codecommit_client.py -q --color=no`
- `PYTHONPATH=. .venv/bin/pytest tests/unittest -q --color=no`
- `git diff --check`