### PR TITLE
fix(bitbucket): propagate repo context fetch errors

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -605,8 +605,8 @@ class BitbucketProvider(GitProvider):
             response = requests.request("GET", url, headers=self.headers)
             if response.status_code == 404:  # not found
                 return ""
-            # Callers must distinguish an unavailable file from a failed request; otherwise an
-            # error response body can be treated as repository instructions or changelog content.
+            # Distinguish an unavailable file from a failed request to prevent an error response
+            # body from being treated as repository instructions or changelog content.
             if propagate_errors:
                 response.raise_for_status()
             contents = response.text

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -127,7 +127,7 @@ class BitbucketProvider(GitProvider):
         # Read from the PR destination (target) branch, matching the other providers,
         # or from the repository default branch when from_default_branch is requested.
         branch = self.get_repo_default_branch() if from_default_branch else self.pr.destination_branch
-        return self.get_pr_file_content(file_path, branch)
+        return self.get_pr_file_content(file_path, branch, propagate_errors=True)
 
     def get_git_repo_url(self, pr_url: str=None) -> str: #bitbucket does not support issue url, so ignore param
         try:
@@ -594,7 +594,7 @@ class BitbucketProvider(GitProvider):
     def _get_pr(self):
         return self._get_repo().pullrequests.get(self.pr_num)
 
-    def get_pr_file_content(self, file_path: str, branch: str) -> str:
+    def get_pr_file_content(self, file_path: str, branch: str, propagate_errors: bool = False) -> str:
         try:
             if branch == self.pr.source_branch:
                 branch = self.pr.data["source"]["commit"]["hash"]
@@ -605,9 +605,15 @@ class BitbucketProvider(GitProvider):
             response = requests.request("GET", url, headers=self.headers)
             if response.status_code == 404:  # not found
                 return ""
+            # Repo-context loading must distinguish an unavailable file from a failed request;
+            # otherwise an error response body can be treated as repository instructions.
+            if propagate_errors:
+                response.raise_for_status()
             contents = response.text
             return contents
         except Exception:
+            if propagate_errors:
+                raise
             return ""
 
     def create_or_update_pr_file(self, file_path: str, branch: str, contents="", message="") -> None:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -594,7 +594,7 @@ class BitbucketProvider(GitProvider):
     def _get_pr(self):
         return self._get_repo().pullrequests.get(self.pr_num)
 
-    def get_pr_file_content(self, file_path: str, branch: str, propagate_errors: bool = False) -> str:
+    def get_pr_file_content(self, file_path: str, branch: str, propagate_errors: bool = True) -> str:
         try:
             if branch == self.pr.source_branch:
                 branch = self.pr.data["source"]["commit"]["hash"]
@@ -605,8 +605,8 @@ class BitbucketProvider(GitProvider):
             response = requests.request("GET", url, headers=self.headers)
             if response.status_code == 404:  # not found
                 return ""
-            # Repo-context loading must distinguish an unavailable file from a failed request;
-            # otherwise an error response body can be treated as repository instructions.
+            # Callers must distinguish an unavailable file from a failed request; otherwise an
+            # error response body can be treated as repository instructions or changelog content.
             if propagate_errors:
                 response.raise_for_status()
             contents = response.text

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -27,7 +27,7 @@ class TestBitbucketProvider:
         content = provider.get_repo_file_content("AGENTS.md")
 
         assert content == "repo context"
-        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "release-1.0")
+        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "release-1.0", propagate_errors=True)
 
     def test_get_repo_file_content_from_default_branch(self):
         provider = BitbucketProvider.__new__(BitbucketProvider)
@@ -38,7 +38,22 @@ class TestBitbucketProvider:
         content = provider.get_repo_file_content("AGENTS.md", from_default_branch=True)
 
         assert content == "repo context"
-        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "main")
+        provider.get_pr_file_content.assert_called_once_with("AGENTS.md", "main", propagate_errors=True)
+
+    def test_get_repo_file_content_propagates_non_404_http_errors(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.workspace_slug = "workspace"
+        provider.repo_slug = "repository"
+        provider.headers = {"Authorization": "Bearer token"}
+        provider.pr = MagicMock(destination_branch="main")
+        response = MagicMock(status_code=500, text="upstream failure")
+        response.raise_for_status.side_effect = HTTPError("500 Internal Server Error")
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response):
+            with pytest.raises(HTTPError, match="500 Internal Server Error"):
+                provider.get_repo_file_content("AGENTS.md")
+
+        response.raise_for_status.assert_called_once_with()
 
 
 class TestBitbucketServerProvider:

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -55,6 +55,25 @@ class TestBitbucketProvider:
 
         response.raise_for_status.assert_called_once_with()
 
+    def test_get_pr_file_content_propagates_non_404_http_errors_by_default(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.workspace_slug = "workspace"
+        provider.repo_slug = "repository"
+        provider.headers = {"Authorization": "Bearer token"}
+        provider.pr = MagicMock(
+            source_branch="feature",
+            destination_branch="main",
+            data={"destination": {"commit": {"hash": "base-sha"}}},
+        )
+        response = MagicMock(status_code=500, text="upstream failure")
+        response.raise_for_status.side_effect = HTTPError("500 Internal Server Error")
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response):
+            with pytest.raises(HTTPError, match="500 Internal Server Error"):
+                provider.get_pr_file_content("CHANGELOG.md", "main")
+
+        response.raise_for_status.assert_called_once_with()
+
 
 class TestBitbucketServerProvider:
     def test_parse_pr_url(self):


### PR DESCRIPTION
Fixes #2790.

## Summary

- propagate non-404 Bitbucket source errors through repo-context loading;
- make error propagation the default for direct `get_pr_file_content` callers, whose higher-level callers handle the exception; and
- add a regression test for a 500 source response.

## Tests

- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_bitbucket_provider.py tests/unittest/test_repo_context.py -q` — 76 passed
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_bitbucket_provider.py tests/unittest/test_pr_update_changelog.py tests/unittest/test_repo_context.py -q` — 92 passed
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest -q` — 2035 passed, 1 skipped, 1 xfailed, 90 warnings
- `git diff --check`
