### PR TITLE
fix(repo-context): propagate provider fetch errors

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import os
+import re
 from typing import Optional, Tuple
 from urllib.parse import quote, unquote, urlparse
 
@@ -19,6 +20,17 @@ from .git_provider import GitProvider, IncrementalPR
 AZURE_DEVOPS_AVAILABLE = True
 ADO_APP_CLIENT_DEFAULT_ID = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 MAX_PR_DESCRIPTION_AZURE_LENGTH = 4000-1
+
+
+def _is_not_found_error(error: Exception) -> bool:
+    status_code = getattr(error, "status_code", None)
+    if status_code is None:
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+    if status_code is not None:
+        return status_code == 404
+    return re.search(r"\b404\b", str(error)) is not None
+
 
 try:
     # noinspection PyUnresolvedReferences
@@ -498,7 +510,9 @@ class AzureDevopsProvider(GitProvider):
         except Exception as e:
             if get_settings().config.verbosity_level >= 2:
                 get_logger().warning(f"Failed to load repo file: {file_path}, error: {e}")
-            return ""
+            if _is_not_found_error(e):
+                return ""
+            raise
 
     def get_files(self):
         if (isinstance(getattr(self, "incremental", None), IncrementalPR)

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -219,7 +219,10 @@ class BitbucketServerProvider(GitProvider):
                                                                      path,
                                                                      commit_id)
         except HTTPError as e:
-            get_logger().debug(f"File {path} not found at commit id: {commit_id}")
+            if getattr(getattr(e, "response", None), "status_code", None) == 404:
+                get_logger().debug(f"File {path} not found at commit id: {commit_id}")
+                return file_content
+            raise
         return file_content
 
     def get_files(self):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1252,8 +1252,12 @@ class GitLabProvider(GitProvider):
                 ref = getattr(self.mr, "target_branch", None) or project.default_branch
             contents = project.files.get(file_path=file_path, ref=ref).decode()
             return decode_if_bytes(contents)
-        except GitlabGetError:
-            return ""
+        except GitlabGetError as e:
+            # A missing optional file is expected, but transient/provider failures must reach
+            # repo_context so the failed result is not cached as a successful empty context.
+            if getattr(e, "response_code", None) == 404:
+                return ""
+            raise
 
     def get_workspace_name(self):
         return self.id_project.split('/')[0]

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -43,16 +43,28 @@ class TestAzureDevopsProviderRepoContext:
         _, kwargs = provider.azure_devops_client.get_item.call_args
         assert kwargs["version_descriptor"] is None  # no version -> default branch
 
-    def test_get_repo_file_content_treats_failure_as_empty(self):
+    def test_get_repo_file_content_treats_missing_file_as_empty(self):
         provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
         provider.repo_slug = "my-repo"
         provider.workspace_slug = "my-project"
         provider.pr = MagicMock()
         provider.pr.last_merge_target_commit.commit_id = "base-sha"
         provider.azure_devops_client = MagicMock()
-        provider.azure_devops_client.get_item.side_effect = Exception("not found")
+        provider.azure_devops_client.get_item.side_effect = Exception("Operation returned a 404 status code.")
 
         assert provider.get_repo_file_content("MISSING.md") == ""
+
+    def test_get_repo_file_content_propagates_non_404_errors(self):
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr = MagicMock()
+        provider.pr.last_merge_target_commit.commit_id = "base-sha"
+        provider.azure_devops_client = MagicMock()
+        provider.azure_devops_client.get_item.side_effect = Exception("Operation returned a 500 status code.")
+
+        with pytest.raises(Exception, match="500 status code"):
+            provider.get_repo_file_content("AGENTS.md")
 
 
 def _provider_with_diff(*filenames):

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -82,6 +82,33 @@ class TestBitbucketServerProvider:
         assert content == "repo context"
         provider.get_file.assert_called_once_with("AGENTS.md", "main")
 
+    def test_get_repo_file_content_treats_404_as_missing(self):
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.workspace_slug = "AAA"
+        provider.repo_slug = "my-repo"
+        provider.pr = MagicMock(toRef={"latestCommit": "base-sha"})
+        provider.bitbucket_client = MagicMock()
+        response = MagicMock(status_code=404)
+        error = HTTPError("404 Not Found")
+        error.response = response
+        provider.bitbucket_client.get_content_of_file.side_effect = error
+
+        assert provider.get_repo_file_content("AGENTS.md") == ""
+
+    def test_get_repo_file_content_propagates_non_404_errors(self):
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.workspace_slug = "AAA"
+        provider.repo_slug = "my-repo"
+        provider.pr = MagicMock(toRef={"latestCommit": "base-sha"})
+        provider.bitbucket_client = MagicMock()
+        response = MagicMock(status_code=500)
+        error = HTTPError("500 Internal Server Error")
+        error.response = response
+        provider.bitbucket_client.get_content_of_file.side_effect = error
+
+        with pytest.raises(HTTPError, match="500 Internal Server Error"):
+            provider.get_repo_file_content("AGENTS.md")
+
     def _make_provider_for_repo_settings(self, get_content_side_effect):
         # Bypass __init__ (which performs live API calls) and only wire up the
         # attributes get_repo_settings() relies on.

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -130,11 +130,21 @@ class TestGitLabProvider:
     def test_get_repo_file_content_treats_missing_file_as_empty(self, gitlab_provider, mock_project):
         mock_project.default_branch = "main"
         gitlab_provider.mr = MagicMock(target_branch="main")
-        mock_project.files.get.side_effect = GitlabGetError("404 Not Found")
+        mock_project.files.get.side_effect = GitlabGetError("404 Not Found", response_code=404)
 
         content = gitlab_provider.get_repo_file_content("AGENTS.md")
 
         assert content == ""
+
+    def test_get_repo_file_content_propagates_non_404_errors(self, gitlab_provider, mock_project):
+        mock_project.default_branch = "main"
+        gitlab_provider.mr = MagicMock(target_branch="main")
+        mock_project.files.get.side_effect = GitlabGetError(
+            "500 Server Error", response_code=500, response_body=b"upstream failure"
+        )
+
+        with pytest.raises(GitlabGetError, match="500 Server Error"):
+            gitlab_provider.get_repo_file_content("AGENTS.md")
 
     def test_create_or_update_pr_file_create_new(self, gitlab_provider, mock_project):
         mock_project.files.get.side_effect = GitlabGetError("404 Not Found")


### PR DESCRIPTION
Fixes #2792.

## Summary

- preserve 404-as-missing behavior for repository-context files;
- propagate non-404 fetch failures from GitLab, Azure DevOps, and Bitbucket Server so `repo_context` can avoid caching a failed result; and
- add provider regression tests for missing files and representative 500 errors.

The existing `repo_context` regression coverage verifies that raised fetch errors are retried instead of cached.

## Tests

- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_gitlab_provider.py tests/unittest/test_azure_devops_provider.py tests/unittest/test_bitbucket_provider.py tests/unittest/test_repo_context.py -q` — 240 passed
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest -q` — 2037 passed, 1 skipped, 1 xfailed, 92 warnings
- `/tmp/pr-agent-full-venv/bin/python -m compileall -q pr_agent tests/unittest`
- `git diff --check`
