### PR TITLE
chore(deps): Upgrade LiteLLM to the latest stable v1.98.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ anthropic>=0.69.0
 atlassian-python-api==3.41.4
 azure-devops==7.1.0b4
 azure-identity==1.25.0
-boto3==1.40.45
+boto3==1.43.78
 certifi==2024.8.30
 dynaconf==3.2.4
 fastapi==0.118.0
@@ -16,7 +16,7 @@ google-cloud-storage==2.10.0; python_version < "3.13"
 google-cloud-storage==3.12.0; python_version >= "3.13"
 protobuf==6.33.6  # grpcio-status 1.80.0 forces >=6.31.1,<7; pinned to lock the resolved transitive version
 Jinja2==3.1.6
-litellm==1.96.2
+litellm==1.98.0
 loguru==0.7.2
 msrest==0.7.1
 openai>=1.55.3
@@ -38,7 +38,7 @@ langfuse==3.14.5
 gunicorn==23.0.0
 pytest-cov==7.0.0
 pydantic==2.13.3
-# litellm 1.96.2 declares pydantic-settings as a base dependency and imports it unconditionally from
+# litellm 1.98.0 declares pydantic-settings as a base dependency and imports it unconditionally from
 # litellm/integrations/otel/model/config.py. Keep the exact pin to lock the resolved transitive version.
 # Version matches litellm's own constraint (>=2.14.1,<3.0); the existing observability guard covers the callback import.
 pydantic-settings==2.14.2


### PR DESCRIPTION
chore(deps): Upgrade LiteLLM to the latest stable v1.98.0

The reviewed releases add provider, routing, streaming, error-handling, and model metadata fixes, including Bedrock and observability hardening. Scoped breaking changes affect Proxy, health, and legacy Langfuse paths; PR-Agent remains compatible on its tested direct LiteLLM SDK path.

Upgrade boto3 from 1.40.45 to 1.43.78 to satisfy LiteLLM's new base dependency requirement of >=1.43.1. Keep aiohttp==3.14.3 and pydantic-settings==2.14.2 unchanged; the existing OTel dependency guard continues to cover callback construction.

Stable release lines reviewed:
- v1.97.0
- v1.98.0

Stable release references:
- https://pypi.org/project/litellm/1.97.0/
- https://pypi.org/project/litellm/1.98.0/

Additional dependency references:
- https://pypi.org/project/boto3/1.43.78/
