### PR TITLE
fix(review): publish failure result for manual runs

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -411,8 +411,13 @@ class BitbucketProvider(GitProvider):
                     d = {"content": {"raw": pr_comment_updated}}
                     response = comment._update_data(comment.put(None, data=d))
                     if final_update_message:
-                        self.publish_comment(
-                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                        try:
+                            self.publish_comment(
+                                f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                        except Exception as e:
+                            # The review was already updated in place; a notification failure must not reach
+                            # the outer except, whose fallback publish would duplicate the review.
+                            get_logger().warning(f"Failed to publish persistent review update message: {e}")
                     return
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -414,10 +414,11 @@ class BitbucketProvider(GitProvider):
                         try:
                             self.publish_comment(
                                 f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                        except Exception as e:
+                        except Exception:
                             # The review was already updated in place; a notification failure must not reach
                             # the outer except, whose fallback publish would duplicate the review.
-                            get_logger().warning(f"Failed to publish persistent review update message: {e}")
+                            get_logger().opt(exception=True).warning(
+                                "Failed to publish persistent review update message; review was already updated")
                     return
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -393,10 +393,11 @@ class GitProvider(ABC):
                         try:
                             return self.publish_comment(
                                 f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                        except Exception as e:
+                        except Exception:
                             # The review was already updated in place; a notification failure must not reach
                             # the outer except, whose fallback publish would duplicate the review.
-                            get_logger().warning(f"Failed to publish persistent review update message: {e}")
+                            get_logger().opt(exception=True).warning(
+                                "Failed to publish persistent review update message; review was already updated")
                             return comment
                     return comment
         except Exception as e:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -390,8 +390,14 @@ class GitProvider(ABC):
                             # outer except, whose fallback publish would duplicate the review.
                             get_logger().warning(f"Failed to reopen review thread: {e}")
                     if final_update_message:
-                        return self.publish_comment(
-                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                        try:
+                            return self.publish_comment(
+                                f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                        except Exception as e:
+                            # The review was already updated in place; a notification failure must not reach
+                            # the outer except, whose fallback publish would duplicate the review.
+                            get_logger().warning(f"Failed to publish persistent review update message: {e}")
+                            return comment
                     return comment
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -137,6 +137,7 @@ class PRReviewer:
     async def run(self) -> None:
         init_run_details()
         progress_response = None
+        review_failed = False
         try:
             if not self.git_provider.get_files():
                 get_logger().info(f"PR has no files: {self.pr_url}, skipping review")
@@ -208,6 +209,7 @@ class PRReviewer:
             else:
                 self.git_provider.publish_comment(pr_review, **review_thread_kwargs)
         except Exception as e:
+            review_failed = True
             get_logger().error(f"Failed to review PR: {e}")
             if get_settings().config.get("propagate_tool_errors", False):
                 raise
@@ -217,6 +219,12 @@ class PRReviewer:
                     self.git_provider.remove_comment(progress_response)
                 except Exception as e:
                     get_logger().exception(f"Failed to remove review progress comment, error: {e}")
+            if (review_failed and get_settings().config.publish_output and
+                    not get_settings().config.get('is_auto_command', False)):
+                try:
+                    self.git_provider.publish_comment("Failed to review PR")
+                except Exception as e:
+                    get_logger().exception(f"Failed to publish review failure result, error: {e}")
 
     def _should_publish_review_no_suggestions(self, pr_review: str) -> bool:
         return get_settings().pr_reviewer.get('publish_output_no_suggestions', True) or "No major issues detected" not in pr_review

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -220,7 +220,7 @@ class PRReviewer:
                 except Exception as e:
                     get_logger().exception(f"Failed to remove review progress comment, error: {e}")
             if (review_failed and get_settings().config.publish_output and
-                    not get_settings().config.get('is_auto_command', False)):
+                    not get_settings().config.get("is_auto_command", False)):
                 try:
                     self.git_provider.publish_comment("Failed to review PR")
                 except Exception as e:

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -101,15 +101,19 @@ class TestBitbucketProvider:
 
         provider.publish_comment = MagicMock(side_effect=publish_comment)
 
-        provider.publish_persistent_comment(f"{header}\n\nnew review",
-                                            initial_header=header,
-                                            update_header=True,
-                                            final_update_message=True)
+        with patch("pr_agent.git_providers.bitbucket_provider.get_logger") as mock_get_logger:
+            provider.publish_persistent_comment(f"{header}\n\nnew review",
+                                                initial_header=header,
+                                                update_header=True,
+                                                final_update_message=True)
 
         existing.put.assert_called_once()
         existing._update_data.assert_called_once()
         provider.publish_comment.assert_called_once()
         assert "updated to latest commit" in provider.publish_comment.call_args.args[0]
+        mock_get_logger.return_value.opt.assert_called_once_with(exception=True)
+        mock_get_logger.return_value.opt.return_value.warning.assert_called_once_with(
+            "Failed to publish persistent review update message; review was already updated")
 
     def test_persistent_review_update_falls_back_when_edit_fails(self):
         provider = BitbucketProvider.__new__(BitbucketProvider)

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -83,6 +83,57 @@ class TestBitbucketProvider:
 
         provider.pr.delete.assert_called_once_with("comments/123")
 
+    def test_persistent_review_update_does_not_duplicate_when_status_message_fails(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock()
+        provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/c/abc")
+        provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/n/1")
+
+        header = "## PR Review"
+        existing = MagicMock()
+        existing.raw = f"{header}\n\nprevious review"
+        provider.pr.comments.return_value = [existing]
+
+        def publish_comment(body):
+            if "updated to latest commit" in body:
+                raise Exception("status publish failed")
+            return MagicMock()
+
+        provider.publish_comment = MagicMock(side_effect=publish_comment)
+
+        provider.publish_persistent_comment(f"{header}\n\nnew review",
+                                            initial_header=header,
+                                            update_header=True,
+                                            final_update_message=True)
+
+        existing.put.assert_called_once()
+        existing._update_data.assert_called_once()
+        provider.publish_comment.assert_called_once()
+        assert "updated to latest commit" in provider.publish_comment.call_args.args[0]
+
+    def test_persistent_review_update_falls_back_when_edit_fails(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock()
+        provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/c/abc")
+        provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/n/1")
+
+        header = "## PR Review"
+        new_review = f"{header}\n\nnew review"
+        existing = MagicMock()
+        existing.raw = f"{header}\n\nprevious review"
+        existing.put.side_effect = Exception("edit failed")
+        provider.pr.comments.return_value = [existing]
+        provider.publish_comment = MagicMock()
+
+        provider.publish_persistent_comment(new_review,
+                                            initial_header=header,
+                                            update_header=True,
+                                            final_update_message=True)
+
+        existing.put.assert_called_once()
+        existing._update_data.assert_not_called()
+        provider.publish_comment.assert_called_once_with(new_review)
+
 
 class TestBitbucketServerProvider:
     def test_parse_pr_url(self):

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -481,6 +481,53 @@ class TestGitLabProvider:
         gitlab_provider.mr.discussions.create.assert_not_called()
         gitlab_provider.mr.notes.create.assert_not_called()
 
+    def test_persistent_review_update_does_not_duplicate_when_status_message_fails(self, gitlab_provider):
+        # The review was already updated successfully, so a failure publishing the optional status
+        # message must not reach the outer fallback and publish the full review again.
+        header = "## PR Review"
+        existing = MagicMock()
+        existing.body = f"{header}\n\nprevious review"
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.get_issue_comments = MagicMock(return_value=[existing])
+        gitlab_provider.get_latest_commit_url = MagicMock(return_value="https://gitlab.com/c/abc")
+        gitlab_provider.get_comment_url = MagicMock(return_value="https://gitlab.com/n/1")
+        gitlab_provider.unresolve_comment_thread = MagicMock()
+        gitlab_provider.mr.notes.create.side_effect = Exception("status publish failed")
+
+        result = gitlab_provider.publish_persistent_comment_full(f"{header}\n\nnew review",
+                                                                 initial_header=header,
+                                                                 update_header=True,
+                                                                 final_update_message=True,
+                                                                 as_thread=True)
+
+        assert result is existing
+        gitlab_provider.mr.notes.update.assert_called_once()
+        gitlab_provider.mr.notes.create.assert_called_once()
+        assert "updated to latest commit" in gitlab_provider.mr.notes.create.call_args.args[0]['body']
+        gitlab_provider.mr.discussions.create.assert_not_called()
+
+    def test_persistent_review_update_falls_back_when_edit_fails(self, gitlab_provider):
+        # A failure before the existing review is updated must retain the full-review fallback.
+        header = "## PR Review"
+        existing = MagicMock()
+        existing.body = f"{header}\n\nprevious review"
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.discussions.create.return_value.attributes = {'notes': [{'id': 42}]}
+        gitlab_provider.get_issue_comments = MagicMock(return_value=[existing])
+        gitlab_provider.get_latest_commit_url = MagicMock(return_value="https://gitlab.com/c/abc")
+        gitlab_provider.get_comment_url = MagicMock(return_value="https://gitlab.com/n/1")
+        gitlab_provider.edit_comment = MagicMock(side_effect=Exception("edit failed"))
+
+        gitlab_provider.publish_persistent_comment_full(f"{header}\n\nnew review",
+                                                        initial_header=header,
+                                                        update_header=True,
+                                                        final_update_message=True,
+                                                        as_thread=True)
+
+        gitlab_provider.edit_comment.assert_called_once()
+        gitlab_provider.mr.discussions.create.assert_called_once_with({'body': f"{header}\n\nnew review"})
+        gitlab_provider.mr.notes.create.assert_not_called()
+
     def test_persistent_review_update_without_thread_keeps_resolution(self, gitlab_provider):
         # Without as_thread (the persistent comment isn't a thread), resolution state must not be touched.
         header = "## PR Review"

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -494,17 +494,21 @@ class TestGitLabProvider:
         gitlab_provider.unresolve_comment_thread = MagicMock()
         gitlab_provider.mr.notes.create.side_effect = Exception("status publish failed")
 
-        result = gitlab_provider.publish_persistent_comment_full(f"{header}\n\nnew review",
-                                                                 initial_header=header,
-                                                                 update_header=True,
-                                                                 final_update_message=True,
-                                                                 as_thread=True)
+        with patch("pr_agent.git_providers.git_provider.get_logger") as mock_get_logger:
+            result = gitlab_provider.publish_persistent_comment_full(f"{header}\n\nnew review",
+                                                                     initial_header=header,
+                                                                     update_header=True,
+                                                                     final_update_message=True,
+                                                                     as_thread=True)
 
         assert result is existing
         gitlab_provider.mr.notes.update.assert_called_once()
         gitlab_provider.mr.notes.create.assert_called_once()
-        assert "updated to latest commit" in gitlab_provider.mr.notes.create.call_args.args[0]['body']
+        assert "updated to latest commit" in gitlab_provider.mr.notes.create.call_args.args[0]["body"]
         gitlab_provider.mr.discussions.create.assert_not_called()
+        mock_get_logger.return_value.opt.assert_called_once_with(exception=True)
+        mock_get_logger.return_value.opt.return_value.warning.assert_called_once_with(
+            "Failed to publish persistent review update message; review was already updated")
 
     def test_persistent_review_update_falls_back_when_edit_fails(self, gitlab_provider):
         # A failure before the existing review is updated must retain the full-review fallback.
@@ -512,7 +516,7 @@ class TestGitLabProvider:
         existing = MagicMock()
         existing.body = f"{header}\n\nprevious review"
         gitlab_provider.mr = MagicMock()
-        gitlab_provider.mr.discussions.create.return_value.attributes = {'notes': [{'id': 42}]}
+        gitlab_provider.mr.discussions.create.return_value.attributes = {"notes": [{"id": 42}]}
         gitlab_provider.get_issue_comments = MagicMock(return_value=[existing])
         gitlab_provider.get_latest_commit_url = MagicMock(return_value="https://gitlab.com/c/abc")
         gitlab_provider.get_comment_url = MagicMock(return_value="https://gitlab.com/n/1")
@@ -525,7 +529,7 @@ class TestGitLabProvider:
                                                         as_thread=True)
 
         gitlab_provider.edit_comment.assert_called_once()
-        gitlab_provider.mr.discussions.create.assert_called_once_with({'body': f"{header}\n\nnew review"})
+        gitlab_provider.mr.discussions.create.assert_called_once_with({"body": f"{header}\n\nnew review"})
         gitlab_provider.mr.notes.create.assert_not_called()
 
     def test_persistent_review_update_without_thread_keeps_resolution(self, gitlab_provider):

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -579,10 +579,11 @@ async def test_run_removes_its_progress_comment_when_review_generation_fails(
     reviewer.prediction = None
 
     monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
+    review_error = RuntimeError("model unavailable")
     monkeypatch.setattr(
         pr_reviewer_module,
         "retry_with_fallback_models",
-        AsyncMock(side_effect=RuntimeError("model unavailable")),
+        AsyncMock(side_effect=review_error),
     )
 
     settings = get_settings()
@@ -597,8 +598,9 @@ async def test_run_removes_its_progress_comment_when_review_generation_fails(
         settings.config.propagate_tool_errors = propagate_tool_errors
 
         if propagate_tool_errors:
-            with pytest.raises(RuntimeError, match="model unavailable"):
+            with pytest.raises(RuntimeError, match="model unavailable") as exc_info:
                 await reviewer.run()
+            assert exc_info.value is review_error
         else:
             await reviewer.run()
     finally:
@@ -606,17 +608,21 @@ async def test_run_removes_its_progress_comment_when_review_generation_fails(
         settings.config.is_auto_command = original["is_auto_command"]
         settings.config.propagate_tool_errors = original["propagate_tool_errors"]
 
-    git_provider.publish_comment.assert_called_once_with("Preparing review...", is_temporary=True)
+    assert git_provider.publish_comment.call_args_list == [
+        (("Preparing review...",), {"is_temporary": True}),
+        (("Failed to review PR",), {}),
+    ]
     git_provider.remove_comment.assert_called_once_with(progress_comment)
     git_provider.remove_initial_comment.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_run_does_not_remove_comments_when_progress_was_not_published(monkeypatch):
+async def test_run_publishes_failure_result_when_progress_comment_has_no_handle(monkeypatch):
     from pr_agent.tools import pr_reviewer as pr_reviewer_module
 
     git_provider = MagicMock()
     git_provider.get_files.return_value = ["app.py"]
+    git_provider.publish_comment.side_effect = [None, MagicMock()]
     reviewer = _make_reviewer(git_provider)
     reviewer.incremental = SimpleNamespace(is_incremental=False)
     reviewer.vars = {}
@@ -633,19 +639,210 @@ async def test_run_does_not_remove_comments_when_progress_was_not_published(monk
     original = {
         "publish_output": settings.config.publish_output,
         "is_auto_command": settings.config.get("is_auto_command", False),
+        "propagate_tool_errors": settings.config.get("propagate_tool_errors", False),
     }
     try:
         settings.config.publish_output = True
-        settings.config.is_auto_command = True
+        settings.config.is_auto_command = False
+        settings.config.propagate_tool_errors = False
 
         await reviewer.run()
     finally:
         settings.config.publish_output = original["publish_output"]
         settings.config.is_auto_command = original["is_auto_command"]
+        settings.config.propagate_tool_errors = original["propagate_tool_errors"]
+
+    assert git_provider.publish_comment.call_args_list == [
+        (("Preparing review...",), {"is_temporary": True}),
+        (("Failed to review PR",), {}),
+    ]
+    git_provider.remove_comment.assert_not_called()
+    git_provider.remove_initial_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_failure_result_when_review_fails_before_progress_comment():
+    review_error = RuntimeError("files unavailable")
+    git_provider = MagicMock()
+    git_provider.get_files.side_effect = review_error
+    reviewer = _make_reviewer(git_provider)
+
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "is_auto_command": settings.config.get("is_auto_command", False),
+        "propagate_tool_errors": settings.config.get("propagate_tool_errors", False),
+    }
+    try:
+        settings.config.publish_output = True
+        settings.config.is_auto_command = False
+        settings.config.propagate_tool_errors = False
+
+        await reviewer.run()
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.config.is_auto_command = original["is_auto_command"]
+        settings.config.propagate_tool_errors = original["propagate_tool_errors"]
+
+    git_provider.publish_comment.assert_called_once_with("Failed to review PR")
+    git_provider.remove_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("publish_output", "is_auto_command", "propagate_tool_errors"),
+    [
+        (False, False, False),
+        (False, False, True),
+        (True, True, False),
+        (True, True, True),
+    ],
+)
+async def test_run_does_not_publish_failure_result_when_output_disabled_or_auto(
+        monkeypatch, publish_output, is_auto_command, propagate_tool_errors):
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    git_provider = MagicMock()
+    git_provider.get_files.return_value = ["app.py"]
+    reviewer = _make_reviewer(git_provider)
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.vars = {}
+    reviewer.prediction = None
+
+    review_error = RuntimeError("model unavailable")
+    monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
+    monkeypatch.setattr(
+        pr_reviewer_module,
+        "retry_with_fallback_models",
+        AsyncMock(side_effect=review_error),
+    )
+
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "is_auto_command": settings.config.get("is_auto_command", False),
+        "propagate_tool_errors": settings.config.get("propagate_tool_errors", False),
+    }
+    try:
+        settings.config.publish_output = publish_output
+        settings.config.is_auto_command = is_auto_command
+        settings.config.propagate_tool_errors = propagate_tool_errors
+
+        if propagate_tool_errors:
+            with pytest.raises(RuntimeError, match="model unavailable") as exc_info:
+                await reviewer.run()
+            assert exc_info.value is review_error
+        else:
+            await reviewer.run()
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.config.is_auto_command = original["is_auto_command"]
+        settings.config.propagate_tool_errors = original["propagate_tool_errors"]
 
     git_provider.publish_comment.assert_not_called()
     git_provider.remove_comment.assert_not_called()
     git_provider.remove_initial_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_failure_result_when_progress_cleanup_fails(monkeypatch):
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    progress_comment = MagicMock()
+    git_provider = MagicMock()
+    git_provider.get_files.return_value = ["app.py"]
+    git_provider.publish_comment.return_value = progress_comment
+    git_provider.remove_comment.side_effect = RuntimeError("cleanup failed")
+    reviewer = _make_reviewer(git_provider)
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.vars = {}
+    reviewer.prediction = None
+
+    review_error = RuntimeError("model unavailable")
+    monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
+    monkeypatch.setattr(
+        pr_reviewer_module,
+        "retry_with_fallback_models",
+        AsyncMock(side_effect=review_error),
+    )
+
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "is_auto_command": settings.config.get("is_auto_command", False),
+        "propagate_tool_errors": settings.config.get("propagate_tool_errors", False),
+    }
+    try:
+        settings.config.publish_output = True
+        settings.config.is_auto_command = False
+        settings.config.propagate_tool_errors = True
+
+        with pytest.raises(RuntimeError, match="model unavailable") as exc_info:
+            await reviewer.run()
+        assert exc_info.value is review_error
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.config.is_auto_command = original["is_auto_command"]
+        settings.config.propagate_tool_errors = original["propagate_tool_errors"]
+
+    assert git_provider.publish_comment.call_args_list == [
+        (("Preparing review...",), {"is_temporary": True}),
+        (("Failed to review PR",), {}),
+    ]
+    git_provider.remove_comment.assert_called_once_with(progress_comment)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_tool_errors", [False, True])
+async def test_run_failure_result_publication_does_not_mask_review_error(
+        monkeypatch, propagate_tool_errors):
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    progress_comment = MagicMock()
+    publication_error = RuntimeError("comment unavailable")
+    git_provider = MagicMock()
+    git_provider.get_files.return_value = ["app.py"]
+    git_provider.publish_comment.side_effect = [progress_comment, publication_error]
+    reviewer = _make_reviewer(git_provider)
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.vars = {}
+    reviewer.prediction = None
+
+    review_error = RuntimeError("model unavailable")
+    monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
+    monkeypatch.setattr(
+        pr_reviewer_module,
+        "retry_with_fallback_models",
+        AsyncMock(side_effect=review_error),
+    )
+
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "is_auto_command": settings.config.get("is_auto_command", False),
+        "propagate_tool_errors": settings.config.get("propagate_tool_errors", False),
+    }
+    try:
+        settings.config.publish_output = True
+        settings.config.is_auto_command = False
+        settings.config.propagate_tool_errors = propagate_tool_errors
+
+        if propagate_tool_errors:
+            with pytest.raises(RuntimeError, match="model unavailable") as exc_info:
+                await reviewer.run()
+            assert exc_info.value is review_error
+        else:
+            await reviewer.run()
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.config.is_auto_command = original["is_auto_command"]
+        settings.config.propagate_tool_errors = original["propagate_tool_errors"]
+
+    assert git_provider.publish_comment.call_args_list == [
+        (("Preparing review...",), {"is_temporary": True}),
+        (("Failed to review PR",), {}),
+    ]
+    git_provider.remove_comment.assert_called_once_with(progress_comment)
 
 
 def test_can_run_incremental_review_skips_auto_mode_without_new_commit():


### PR DESCRIPTION
## Summary

- publish one generic failure result when a manual `/review` run raises
- remove the exact progress comment first while keeping automatic and non-publishing runs silent
- treat an optional persistent-update notice as best-effort after the review was edited, while preserving pre-edit fallback behavior in the shared path and Bitbucket Cloud
- preserve original error propagation and contain cleanup or reporting failures

Follow-up to #2788.

## Result

A failed manual `/review` now leaves `Failed to review PR` instead of leaving no visible outcome. The underlying exception remains in logs and is not exposed in the public comment.

If an existing persistent review was already updated successfully, a failure posting only the latest-commit notice no longer produces a misleading failure result or a duplicate full review.

## Testing

- `PYTHONPATH=. pytest -q tests/unittest/test_pr_reviewer_core.py tests/unittest/test_gitlab_provider.py tests/unittest/test_bitbucket_provider.py` (199 passed)
- `PYTHONPATH=. pytest -q tests/unittest --ignore=tests/unittest/test_extra_config_url.py` (2,059 passed, 1 skipped, 1 xfailed)
- `PYTHONPATH=. pytest -q tests/unittest/test_extra_config_url.py` (41 passed)
