### PR TITLE
feat(ask): resolve review threads via /ask_line

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -656,6 +656,8 @@ Allowing you to automate the review process on your private or public repositori
      - Pull request review comment (required for `/ask` on review threads)
 
    > **Note:** If you enable `pr_questions.resolve_threads`, the GitHub App requires **Contents: Read & write** permission. GitHub's `resolveReviewThread` GraphQL mutation is gated behind the Contents permission, even though it only modifies PR thread metadata. See [GitHub community discussion](https://github.com/orgs/community/discussions/204269) for details.
+   >
+   > **Important:** When enabled, the LLM may resolve threads started by human reviewers — not only bot-generated threads. Use this setting only when your team is comfortable with AI-driven thread resolution. The feature is opt-in and defaults to off.
 
 2) Generate a random secret for your app, and save it for later. For example, you can use:
 

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -657,7 +657,10 @@ Allowing you to automate the review process on your private or public repositori
 
    > **Note:** If you enable `pr_questions.resolve_threads`, the GitHub App requires **Contents: Read & write** permission. GitHub's `resolveReviewThread` GraphQL mutation is gated behind the Contents permission, even though it only modifies PR thread metadata. See [GitHub community discussion](https://github.com/orgs/community/discussions/204269) for details.
    >
-   > **Important:** When enabled, the LLM may resolve threads started by human reviewers — not only bot-generated threads. Use this setting only when your team is comfortable with AI-driven thread resolution. The feature is opt-in and defaults to off.
+   > **Important:** When enabled, the LLM may resolve threads started by
+   > human reviewers — not only bot-generated threads. Use this setting
+   > only when your team is comfortable with AI-driven thread resolution.
+   > The feature is opt-in and defaults to off.
 
 2) Generate a random secret for your app, and save it for later. For example, you can use:
 

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -648,11 +648,14 @@ Allowing you to automate the review process on your private or public repositori
      - Pull requests: Read & write
      - Issue comment: Read & write
      - Metadata: Read-only
-     - Contents: Read-only
+     - Contents: Read-only (or Read & write if using `resolve_threads` — see note below)
    - Set the following events:
      - Issue comment
      - Pull request
      - Push (if you need to enable triggering on PR update)
+     - Pull request review comment (required for `/ask` on review threads)
+
+   > **Note:** If you enable `pr_questions.resolve_threads`, the GitHub App requires **Contents: Read & write** permission. GitHub's `resolveReviewThread` GraphQL mutation is gated behind the Contents permission, even though it only modifies PR thread metadata. See [GitHub community discussion](https://github.com/orgs/community/discussions/204269) for details.
 
 2) Generate a random secret for your app, and save it for later. For example, you can use:
 

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -356,6 +356,10 @@ class GitProvider(ABC):
     def resolve_comment_thread(self, comment_id) -> bool:  # noqa: B027 - intentional no-op
         return False
 
+    def supports_thread_resolution(self) -> bool:
+        """Providers that implement resolve_comment_thread override this."""
+        return False
+
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -353,6 +353,9 @@ class GitProvider(ABC):
     def unresolve_comment_thread(self, comment):  # noqa: B027 - intentional no-op
         pass
 
+    def resolve_comment_thread(self, comment_id) -> bool:  # noqa: B027 - intentional no-op
+        return False
+
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -630,7 +630,7 @@ class GithubProvider(GitProvider):
     def resolve_comment_thread(self, comment_id: int) -> bool:
         """Resolve the review thread containing the given comment via GitHub GraphQL API."""
         try:
-            owner, repo_name = self.repo.split('/')
+            owner, repo_name = self.repo.split("/")
 
             # Get the comment's node_id via REST
             headers, data = self.pr._requester.requestJsonAndCheck(

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -671,10 +671,16 @@ class GithubProvider(GitProvider):
                     "POST", "/graphql", input={"query": query}
                 )
                 if not (isinstance(response_tuple, tuple) and len(response_tuple) == 3):
-                    get_logger().error(f"Unexpected GraphQL response format")
+                    get_logger().error("Unexpected GraphQL response format")
                     return False
 
                 response_json = json.loads(response_tuple[2])
+                errors = response_json.get("errors")
+                if errors:
+                    get_logger().error(
+                        f"GraphQL errors querying review threads: {errors}"
+                    )
+                    return False
                 review_threads = (response_json.get("data", {}).get("repository", {})
                                   .get("pullRequest", {}).get("reviewThreads", {}))
                 threads = review_threads.get("nodes", [])
@@ -727,12 +733,15 @@ class GithubProvider(GitProvider):
             is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
                            .get("thread", {}).get("isResolved", False))
             if not is_resolved:
-                get_logger().warning(f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue")
+                get_logger().warning(
+                    f"Resolve mutation returned isResolved=false for thread "
+                    f"{thread_id} — possible permission issue"
+                )
                 return False
             get_logger().info(f"Resolved review thread {thread_id}")
             return True
         except Exception as e:
-            get_logger().error(f"Failed to resolve comment thread: {e}")
+            get_logger().exception(f"Failed to resolve comment thread: {e}")
             return False
 
     def _publish_inline_comments_fallback_with_verification(self, comments: list[dict]):

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -698,17 +698,19 @@ class GithubProvider(GitProvider):
             resolve_tuple = self.github_client._Github__requester.requestJson(
                 "POST", "/graphql", input={"query": mutation}
             )
-            if isinstance(resolve_tuple, tuple) and len(resolve_tuple) == 3:
-                resolve_json = json.loads(resolve_tuple[2])
-                errors = resolve_json.get("errors")
-                if errors:
-                    get_logger().error(f"GraphQL errors resolving thread {thread_id}: {errors}")
-                    return False
-                is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
-                               .get("thread", {}).get("isResolved", False))
-                if not is_resolved:
-                    get_logger().warning(f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue")
-                    return False
+            if not isinstance(resolve_tuple, tuple) or len(resolve_tuple) != 3:
+                get_logger().error(f"Unexpected mutation response format for thread {thread_id}: {type(resolve_tuple)}")
+                return False
+            resolve_json = json.loads(resolve_tuple[2])
+            errors = resolve_json.get("errors")
+            if errors:
+                get_logger().error(f"GraphQL errors resolving thread {thread_id}: {errors}")
+                return False
+            is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
+                           .get("thread", {}).get("isResolved", False))
+            if not is_resolved:
+                get_logger().warning(f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue")
+                return False
             get_logger().info(f"Resolved review thread {thread_id}")
             return True
         except Exception as e:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -627,6 +627,9 @@ class GithubProvider(GitProvider):
             get_logger().exception(f"Failed to get review comments for an inline ask command", artifact={"comment_id": comment_id, "error": e})
             return []
 
+    def supports_thread_resolution(self) -> bool:
+        return True
+
     def resolve_comment_thread(self, comment_id: int) -> bool:
         """Resolve the review thread containing the given comment via GitHub GraphQL API."""
         try:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -641,48 +641,66 @@ class GithubProvider(GitProvider):
                 get_logger().warning(f"No node_id found for comment {comment_id}")
                 return False
 
-            # Find the review thread containing this comment
-            query = f"""
-            query {{
-                repository(owner: "{owner}", name: "{repo_name}") {{
-                    pullRequest(number: {self.pr_num}) {{
-                        reviewThreads(first: 100) {{
-                            nodes {{
-                                id
-                                isResolved
-                                comments(first: 100) {{
-                                    nodes {{
-                                        id
+            # Find the review thread containing this comment (paginated)
+            thread_id = None
+            is_already_resolved = False
+            cursor = None
+            while True:
+                after_clause = f', after: "{cursor}"' if cursor else ""
+                query = f"""
+                query {{
+                    repository(owner: "{owner}", name: "{repo_name}") {{
+                        pullRequest(number: {self.pr_num}) {{
+                            reviewThreads(first: 100{after_clause}) {{
+                                pageInfo {{ hasNextPage endCursor }}
+                                nodes {{
+                                    id
+                                    isResolved
+                                    comments(first: 100) {{
+                                        nodes {{
+                                            id
+                                        }}
                                     }}
                                 }}
                             }}
                         }}
                     }}
                 }}
-            }}
-            """
-            response_tuple = self.github_client._Github__requester.requestJson(
-                "POST", "/graphql", input={"query": query}
-            )
-            if not (isinstance(response_tuple, tuple) and len(response_tuple) == 3):
-                get_logger().error(f"Unexpected GraphQL response format")
-                return False
+                """
+                response_tuple = self.github_client._Github__requester.requestJson(
+                    "POST", "/graphql", input={"query": query}
+                )
+                if not (isinstance(response_tuple, tuple) and len(response_tuple) == 3):
+                    get_logger().error(f"Unexpected GraphQL response format")
+                    return False
 
-            response_json = json.loads(response_tuple[2])
-            threads = (response_json.get("data", {}).get("repository", {})
-                       .get("pullRequest", {}).get("reviewThreads", {}).get("nodes", []))
+                response_json = json.loads(response_tuple[2])
+                review_threads = (response_json.get("data", {}).get("repository", {})
+                                  .get("pullRequest", {}).get("reviewThreads", {}))
+                threads = review_threads.get("nodes", [])
 
-            thread_id = None
-            for thread in threads:
-                if thread.get("isResolved"):
-                    continue
-                comment_ids = [c["id"] for c in thread.get("comments", {}).get("nodes", [])]
-                if comment_node_id in comment_ids:
-                    thread_id = thread["id"]
+                for thread in threads:
+                    comment_ids = [c["id"] for c in thread.get("comments", {}).get("nodes", [])]
+                    if comment_node_id in comment_ids:
+                        if thread.get("isResolved"):
+                            is_already_resolved = True
+                        else:
+                            thread_id = thread["id"]
+                        break
+
+                if thread_id or is_already_resolved:
                     break
+                page_info = review_threads.get("pageInfo", {})
+                if not page_info.get("hasNextPage"):
+                    break
+                cursor = page_info.get("endCursor")
+
+            if is_already_resolved:
+                get_logger().info(f"Thread for comment {comment_id} is already resolved")
+                return True
 
             if not thread_id:
-                get_logger().info(f"No unresolved thread found for comment {comment_id}")
+                get_logger().warning(f"No thread found for comment {comment_id}")
                 return False
 
             # Resolve the thread

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -627,6 +627,94 @@ class GithubProvider(GitProvider):
             get_logger().exception(f"Failed to get review comments for an inline ask command", artifact={"comment_id": comment_id, "error": e})
             return []
 
+    def resolve_comment_thread(self, comment_id: int) -> bool:
+        """Resolve the review thread containing the given comment via GitHub GraphQL API."""
+        try:
+            owner, repo_name = self.repo.split('/')
+
+            # Get the comment's node_id via REST
+            headers, data = self.pr._requester.requestJsonAndCheck(
+                "GET", f"{self.base_url}/repos/{self.repo}/pulls/comments/{comment_id}"
+            )
+            comment_node_id = data.get("node_id", "")
+            if not comment_node_id:
+                get_logger().warning(f"No node_id found for comment {comment_id}")
+                return False
+
+            # Find the review thread containing this comment
+            query = f"""
+            query {{
+                repository(owner: "{owner}", name: "{repo_name}") {{
+                    pullRequest(number: {self.pr_num}) {{
+                        reviewThreads(first: 100) {{
+                            nodes {{
+                                id
+                                isResolved
+                                comments(first: 100) {{
+                                    nodes {{
+                                        id
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+            """
+            response_tuple = self.github_client._Github__requester.requestJson(
+                "POST", "/graphql", input={"query": query}
+            )
+            if not (isinstance(response_tuple, tuple) and len(response_tuple) == 3):
+                get_logger().error(f"Unexpected GraphQL response format")
+                return False
+
+            response_json = json.loads(response_tuple[2])
+            threads = (response_json.get("data", {}).get("repository", {})
+                       .get("pullRequest", {}).get("reviewThreads", {}).get("nodes", []))
+
+            thread_id = None
+            for thread in threads:
+                if thread.get("isResolved"):
+                    continue
+                comment_ids = [c["id"] for c in thread.get("comments", {}).get("nodes", [])]
+                if comment_node_id in comment_ids:
+                    thread_id = thread["id"]
+                    break
+
+            if not thread_id:
+                get_logger().info(f"No unresolved thread found for comment {comment_id}")
+                return False
+
+            # Resolve the thread
+            mutation = f"""
+            mutation {{
+                resolveReviewThread(input: {{threadId: "{thread_id}"}}) {{
+                    thread {{
+                        isResolved
+                    }}
+                }}
+            }}
+            """
+            resolve_tuple = self.github_client._Github__requester.requestJson(
+                "POST", "/graphql", input={"query": mutation}
+            )
+            if isinstance(resolve_tuple, tuple) and len(resolve_tuple) == 3:
+                resolve_json = json.loads(resolve_tuple[2])
+                errors = resolve_json.get("errors")
+                if errors:
+                    get_logger().error(f"GraphQL errors resolving thread {thread_id}: {errors}")
+                    return False
+                is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
+                               .get("thread", {}).get("isResolved", False))
+                if not is_resolved:
+                    get_logger().warning(f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue")
+                    return False
+            get_logger().info(f"Resolved review thread {thread_id}")
+            return True
+        except Exception as e:
+            get_logger().error(f"Failed to resolve comment thread: {e}")
+            return False
+
     def _publish_inline_comments_fallback_with_verification(self, comments: list[dict]):
         """
         Check each inline comment separately against the GitHub API and discard of invalid comments,

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -154,7 +154,10 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
-resolve_threads=false # when true, /ask_line will resolve the review thread if the LLM judges the issue is addressed. Note: this allows the model to resolve threads started by human reviewers.
+# when true, /ask_line will resolve the review thread if the LLM judges the
+# issue is addressed. Note: this allows the model to resolve threads started
+# by human reviewers.
+resolve_threads=false
 extra_instructions = ""
 
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -154,7 +154,7 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
-resolve_threads=false # when true, /ask_line will resolve the thread if the LLM judges the issue is addressed
+resolve_threads=false # when true, /ask_line will resolve the review thread if the LLM judges the issue is addressed. Note: this allows the model to resolve threads started by human reviewers.
 extra_instructions = ""
 
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -154,6 +154,7 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
+resolve_threads=false # when true, /ask_line will resolve the thread if the LLM judges the issue is addressed
 extra_instructions = ""
 
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -154,9 +154,8 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
-# when true, /ask_line will resolve the review thread if the LLM judges the
-# issue is addressed. Note: this allows the model to resolve threads started
-# by human reviewers.
+# Enable to let /ask_line resolve the review thread when the LLM judges the
+# issue addressed. Note: also resolves threads started by human reviewers.
 resolve_threads=false
 extra_instructions = ""
 

--- a/pr_agent/settings/pr_line_questions_prompts.toml
+++ b/pr_agent/settings/pr_line_questions_prompts.toml
@@ -72,5 +72,16 @@ A question about the selected lines:
 {{ question|trim }}
 ======
 
+{%- if resolve_threads %}
+
+After answering the question, determine whether the discussion thread is now fully resolved based on the conversation history and the current question. A thread is resolved when:
+- The developer confirms they have addressed the feedback (e.g. "fixed", "done", "updated")
+- The question has been fully answered with no remaining open issues
+- The concern raised in the thread is no longer applicable
+
+If the thread is resolved, end your response with the exact marker: [THREAD_RESOLVED]
+Do not include this marker if there are unresolved concerns, open questions, or the developer is still seeking clarification.
+{%- endif %}
+
 Response to the question:
 """

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -94,9 +94,10 @@ class PR_LineQuestions:
             model_answer = await retry_with_fallback_models(self._get_prediction, model_type=ModelType.WEAK)
 
             should_resolve = False
-            if self.resolve_threads and "[THREAD_RESOLVED]" in model_answer:
+            answer_stripped = model_answer.rstrip()
+            if self.resolve_threads and answer_stripped.endswith("[THREAD_RESOLVED]"):
                 should_resolve = True
-                model_answer = model_answer.replace("[THREAD_RESOLVED]", "").rstrip()
+                model_answer = answer_stripped[:-len("[THREAD_RESOLVED]")].rstrip()
 
             # sanitize the answer so that no line will start with "/"
             model_answer_sanitized = model_answer.strip().replace("\n/", "\n /")

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -28,7 +28,7 @@ class PR_LineQuestions:
         self.ai_handler = ai_handler()
         self.ai_handler.main_pr_language = self.main_pr_language
 
-        self.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
+        self.resolve_threads = get_settings().pr_questions.get("resolve_threads", False)
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -28,6 +28,7 @@ class PR_LineQuestions:
         self.ai_handler = ai_handler()
         self.ai_handler.main_pr_language = self.main_pr_language
 
+        self.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
@@ -36,6 +37,7 @@ class PR_LineQuestions:
             "full_hunk": "",
             "selected_lines": "",
             "conversation_history": "",
+            "resolve_threads": self.resolve_threads,
             "extra_instructions": get_settings().pr_questions.extra_instructions,
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
@@ -71,6 +73,8 @@ class PR_LineQuestions:
         side = get_settings().get('side', 'RIGHT')
         file_name = get_settings().get('file_name', '')
         comment_id = get_settings().get('comment_id', '')
+        if not comment_id:
+            self.vars["resolve_threads"] = False
         if ask_diff:
             self.patch_with_lines, self.selected_lines = extract_hunk_lines_from_patch(ask_diff,
                                                                                        file_name,
@@ -88,6 +92,12 @@ class PR_LineQuestions:
                                                                                                side=side)
         if self.patch_with_lines:
             model_answer = await retry_with_fallback_models(self._get_prediction, model_type=ModelType.WEAK)
+
+            should_resolve = False
+            if self.resolve_threads and "[THREAD_RESOLVED]" in model_answer:
+                should_resolve = True
+                model_answer = model_answer.replace("[THREAD_RESOLVED]", "").rstrip()
+
             # sanitize the answer so that no line will start with "/"
             model_answer_sanitized = model_answer.strip().replace("\n/", "\n /")
             if model_answer_sanitized.startswith("/"):
@@ -96,6 +106,11 @@ class PR_LineQuestions:
             get_logger().info('Preparing answer...')
             if comment_id:
                 self.git_provider.reply_to_comment_from_comment_id(comment_id, model_answer_sanitized)
+                if should_resolve:
+                    if self.git_provider.resolve_comment_thread(comment_id):
+                        get_logger().info(f"Resolved review thread for comment {comment_id}")
+                    else:
+                        get_logger().warning(f"Failed to resolve review thread for comment {comment_id}")
             else:
                 self.git_provider.publish_comment(model_answer_sanitized)
 

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -28,7 +28,10 @@ class PR_LineQuestions:
         self.ai_handler = ai_handler()
         self.ai_handler.main_pr_language = self.main_pr_language
 
-        self.resolve_threads = get_settings().pr_questions.get("resolve_threads", False)
+        # only GitHub can resolve threads today; elsewhere the marker would be
+        # requested from the model and every answer would log a failed resolve
+        self.resolve_threads = (get_settings().pr_questions.get("resolve_threads", False)
+                                and self.git_provider.supports_thread_resolution())
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -74,6 +74,7 @@ class PR_LineQuestions:
         file_name = get_settings().get('file_name', '')
         comment_id = get_settings().get('comment_id', '')
         if not comment_id:
+            self.resolve_threads = False
             self.vars["resolve_threads"] = False
         if ask_diff:
             self.patch_with_lines, self.selected_lines = extract_hunk_lines_from_patch(ask_diff,

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -431,18 +431,23 @@ def _make_provider_with_graphql(rest_comment_data, graphql_responses):
     return p, requester
 
 
+def _make_threads_response(threads, has_next_page=False, end_cursor=None):
+    """Build a GraphQL response for reviewThreads with pageInfo."""
+    return _make_graphql_response({
+        "repository": {"pullRequest": {"reviewThreads": {
+            "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+            "nodes": threads,
+        }}},
+    })
+
+
 class TestResolveCommentThread:
     def test_resolves_thread_successfully(self):
         rest_data = {"node_id": "PRR_comment1"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": False,
-                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
         resolve_response = _make_graphql_response({
             "resolveReviewThread": {"thread": {"isResolved": True}},
         })
@@ -456,37 +461,27 @@ class TestResolveCommentThread:
         assert len(requester.calls) == 3
         assert "resolveReviewThread" in requester.calls[2][3]["query"]
 
-    def test_skips_already_resolved_thread(self):
+    def test_already_resolved_thread_returns_true(self):
         rest_data = {"node_id": "PRR_comment1"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": True,
-                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": True,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
 
         provider, requester = _make_provider_with_graphql(
             rest_data, [threads_response]
         )
         result = provider.resolve_comment_thread(123)
 
-        assert result is False
+        assert result is True
         assert len(requester.calls) == 2
 
     def test_handles_no_matching_thread(self):
         rest_data = {"node_id": "PRR_commentX"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": False,
-                    "comments": {"nodes": [{"id": "PRR_other"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_other"}]}},
+        ])
 
         provider, requester = _make_provider_with_graphql(
             rest_data, [threads_response]
@@ -507,15 +502,10 @@ class TestResolveCommentThread:
 
     def test_handles_graphql_errors_in_resolve_mutation(self):
         rest_data = {"node_id": "PRR_comment1"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": False,
-                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
         error_response = _make_graphql_response(
             {"resolveReviewThread": None},
             errors=[{"message": "Insufficient permissions"}],
@@ -531,15 +521,10 @@ class TestResolveCommentThread:
 
     def test_handles_resolve_returning_false(self):
         rest_data = {"node_id": "PRR_comment1"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": False,
-                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
         resolve_response = _make_graphql_response({
             "resolveReviewThread": {"thread": {"isResolved": False}},
         })
@@ -555,15 +540,10 @@ class TestResolveCommentThread:
     def test_handles_unexpected_mutation_response_format(self):
         """Mutation returns non-tuple — should return False, not fall through to True."""
         rest_data = {"node_id": "PRR_comment1"}
-        threads_response = _make_graphql_response({
-            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
-                {
-                    "id": "PRRT_thread1",
-                    "isResolved": False,
-                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
-                },
-            ]}}},
-        })
+        threads_response = _make_threads_response([
+            {"id": "PRRT_thread1", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
 
         provider, requester = _make_provider_with_graphql(
             rest_data, [threads_response, "not-a-tuple"]
@@ -571,6 +551,31 @@ class TestResolveCommentThread:
         result = provider.resolve_comment_thread(123)
 
         assert result is False
+
+    def test_paginates_to_find_thread(self):
+        """Thread is on the second page — pagination must follow."""
+        rest_data = {"node_id": "PRR_comment1"}
+        page1 = _make_threads_response(
+            [{"id": "PRRT_other", "isResolved": False,
+              "comments": {"nodes": [{"id": "PRR_other"}]}}],
+            has_next_page=True, end_cursor="cursor1",
+        )
+        page2 = _make_threads_response([
+            {"id": "PRRT_target", "isResolved": False,
+             "comments": {"nodes": [{"id": "PRR_comment1"}]}},
+        ])
+        resolve_response = _make_graphql_response({
+            "resolveReviewThread": {"thread": {"isResolved": True}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [page1, page2, resolve_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is True
+        assert 'after: "cursor1"' in requester.calls[2][3]["query"]
+        assert "resolveReviewThread" in requester.calls[3][3]["query"]
 
     def test_handles_rest_api_exception(self):
         """REST call to fetch comment throws — should not propagate."""

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -384,3 +384,189 @@ def test_publish_code_suggestions_returns_false_on_publish_error():
         "relevant_lines_start": 1, "relevant_lines_end": 2,
     }])
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_comment_thread
+# ---------------------------------------------------------------------------
+
+import json
+
+
+def _make_graphql_response(data, errors=None):
+    """Build a tuple mimicking PyGitHub's requestJson return for GraphQL."""
+    body = {"data": data}
+    if errors:
+        body["errors"] = errors
+    return (200, {}, json.dumps(body))
+
+
+class _FakeRequester:
+    """Records GraphQL calls and returns canned responses."""
+
+    def __init__(self, responses):
+        self.calls = []
+        self._responses = list(responses)
+
+    def requestJsonAndCheck(self, method, url, input=None):
+        self.calls.append(("check", method, url, input))
+        return ({}, self._responses.pop(0))
+
+    def requestJson(self, method, url, input=None):
+        self.calls.append(("json", method, url, input))
+        return self._responses.pop(0)
+
+
+def _make_provider_with_graphql(rest_comment_data, graphql_responses):
+    """Build a provider wired with fake REST + GraphQL responses."""
+    p = GithubProvider.__new__(GithubProvider)
+    p.repo = "owner/repo"
+    p.pr_num = 42
+    p.base_url = "https://api.github.com"
+
+    all_responses = [rest_comment_data] + graphql_responses
+    requester = _FakeRequester(all_responses)
+    p.pr = SimpleNamespace(_requester=requester)
+    p.github_client = SimpleNamespace(_Github__requester=requester)
+    return p, requester
+
+
+class TestResolveCommentThread:
+    def test_resolves_thread_successfully(self):
+        rest_data = {"node_id": "PRR_comment1"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": False,
+                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
+                },
+            ]}}},
+        })
+        resolve_response = _make_graphql_response({
+            "resolveReviewThread": {"thread": {"isResolved": True}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response, resolve_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is True
+        assert len(requester.calls) == 3
+        assert "resolveReviewThread" in requester.calls[2][3]["query"]
+
+    def test_skips_already_resolved_thread(self):
+        rest_data = {"node_id": "PRR_comment1"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": True,
+                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
+                },
+            ]}}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+        assert len(requester.calls) == 2
+
+    def test_handles_no_matching_thread(self):
+        rest_data = {"node_id": "PRR_commentX"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": False,
+                    "comments": {"nodes": [{"id": "PRR_other"}]},
+                },
+            ]}}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+        assert len(requester.calls) == 2
+
+    def test_handles_missing_node_id(self):
+        rest_data = {}  # no node_id
+
+        provider, requester = _make_provider_with_graphql(rest_data, [])
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+        assert len(requester.calls) == 1
+
+    def test_handles_graphql_errors_in_resolve_mutation(self):
+        rest_data = {"node_id": "PRR_comment1"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": False,
+                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
+                },
+            ]}}},
+        })
+        error_response = _make_graphql_response(
+            {"resolveReviewThread": None},
+            errors=[{"message": "Insufficient permissions"}],
+        )
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response, error_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+        assert len(requester.calls) == 3
+
+    def test_handles_resolve_returning_false(self):
+        rest_data = {"node_id": "PRR_comment1"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": False,
+                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
+                },
+            ]}}},
+        })
+        resolve_response = _make_graphql_response({
+            "resolveReviewThread": {"thread": {"isResolved": False}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response, resolve_response]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+        assert len(requester.calls) == 3
+
+    def test_handles_rest_api_exception(self):
+        """REST call to fetch comment throws — should not propagate."""
+        p = GithubProvider.__new__(GithubProvider)
+        p.repo = "owner/repo"
+        p.pr_num = 42
+        p.base_url = "https://api.github.com"
+
+        class _BrokenRequester:
+            def requestJsonAndCheck(self, *a, **kw):
+                raise RuntimeError("network error")
+            def requestJson(self, *a, **kw):
+                raise RuntimeError("network error")
+
+        p.pr = SimpleNamespace(_requester=_BrokenRequester())
+        p.github_client = SimpleNamespace(_Github__requester=_BrokenRequester())
+
+        result = p.resolve_comment_thread(123)
+        assert result is False

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -552,6 +552,26 @@ class TestResolveCommentThread:
         assert result is False
         assert len(requester.calls) == 3
 
+    def test_handles_unexpected_mutation_response_format(self):
+        """Mutation returns non-tuple — should return False, not fall through to True."""
+        rest_data = {"node_id": "PRR_comment1"}
+        threads_response = _make_graphql_response({
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                    "id": "PRRT_thread1",
+                    "isResolved": False,
+                    "comments": {"nodes": [{"id": "PRR_comment1"}]},
+                },
+            ]}}},
+        })
+
+        provider, requester = _make_provider_with_graphql(
+            rest_data, [threads_response, "not-a-tuple"]
+        )
+        result = provider.resolve_comment_thread(123)
+
+        assert result is False
+
     def test_handles_rest_api_exception(self):
         """REST call to fetch comment throws — should not propagate."""
         p = GithubProvider.__new__(GithubProvider)

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -6,6 +6,7 @@ These tests use ``GithubProvider.__new__(GithubProvider)`` to bypass network-bou
 ``__init__`` and inject minimal fake collaborators. No real GitHub API access.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -389,8 +390,6 @@ def test_publish_code_suggestions_returns_false_on_publish_error():
 # ---------------------------------------------------------------------------
 # resolve_comment_thread
 # ---------------------------------------------------------------------------
-
-import json
 
 
 def _make_graphql_response(data, errors=None):

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -448,10 +448,10 @@ class TestResolveThreadsDisabledWithoutCommentId:
         resolve_settings.set("comment_id", "")
 
         lq = _make_line_questions()
-        lq.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
+        lq.resolve_threads = get_settings().pr_questions.get("resolve_threads", False)
         lq.vars = {"resolve_threads": lq.resolve_threads}
 
-        comment_id = get_settings().get('comment_id', '')
+        comment_id = get_settings().get("comment_id", "")
         if not comment_id:
             lq.resolve_threads = False
             lq.vars["resolve_threads"] = False
@@ -464,10 +464,10 @@ class TestResolveThreadsDisabledWithoutCommentId:
         resolve_settings.set("comment_id", 12345)
 
         lq = _make_line_questions()
-        lq.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
+        lq.resolve_threads = get_settings().pr_questions.get("resolve_threads", False)
         lq.vars = {"resolve_threads": lq.resolve_threads}
 
-        comment_id = get_settings().get('comment_id', '')
+        comment_id = get_settings().get("comment_id", "")
         if not comment_id:
             lq.resolve_threads = False
             lq.vars["resolve_threads"] = False

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -477,17 +477,37 @@ class TestResolveThreadsDisabledWithoutCommentId:
 # ---------------------------------------------------------------------------
 
 class TestThreadResolvedMarkerParsing:
-    """Test the marker-stripping logic that would be in PR_LineQuestions.run()."""
+    """Test the marker-stripping logic that would be in PR_LineQuestions.run().
 
-    @pytest.mark.parametrize("marker_position,answer,expected_clean", [
-        ("end", "The issue is fixed.\n\n[THREAD_RESOLVED]", "The issue is fixed."),
-        ("middle", "Fixed [THREAD_RESOLVED] thanks", "Fixed  thanks"),
-        ("only", "[THREAD_RESOLVED]", ""),
+    The marker is only recognized when it appears at the end of the response
+    (after rstrip). Mid-message occurrences are treated as normal text.
+    """
+
+    def _parse_marker(self, answer):
+        """Replicate the endswith-based parsing from PR_LineQuestions.run()."""
+        answer_stripped = answer.rstrip()
+        if answer_stripped.endswith("[THREAD_RESOLVED]"):
+            return True, answer_stripped[:-len("[THREAD_RESOLVED]")].rstrip()
+        return False, answer
+
+    @pytest.mark.parametrize("marker_position,answer,expected_resolve,expected_clean", [
+        ("end", "The issue is fixed.\n\n[THREAD_RESOLVED]", True, "The issue is fixed."),
+        ("end_with_trailing_whitespace", "Done.\n[THREAD_RESOLVED]  \n", True, "Done."),
+        ("only", "[THREAD_RESOLVED]", True, ""),
     ])
-    def test_marker_is_stripped(self, marker_position, answer, expected_clean):
-        cleaned = answer.replace("[THREAD_RESOLVED]", "").rstrip()
+    def test_trailing_marker_is_stripped(self, marker_position, answer, expected_resolve, expected_clean):
+        should_resolve, cleaned = self._parse_marker(answer)
+        assert should_resolve == expected_resolve
         assert cleaned == expected_clean
+
+    def test_mid_message_marker_is_not_resolved(self):
+        answer = "Fixed [THREAD_RESOLVED] thanks"
+        should_resolve, cleaned = self._parse_marker(answer)
+        assert should_resolve is False
+        assert cleaned == answer
 
     def test_no_marker_means_no_resolve(self):
         answer = "I think this still needs work."
-        assert "[THREAD_RESOLVED]" not in answer
+        should_resolve, cleaned = self._parse_marker(answer)
+        assert should_resolve is False
+        assert cleaned == answer

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -14,7 +14,6 @@ import pytest
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 import pr_agent.tools.pr_line_questions as plq
-from pr_agent.tools.pr_line_questions import PR_LineQuestions
 from pr_agent.tools.pr_questions import PRQuestions
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
 
@@ -35,8 +34,8 @@ def _make_pr_questions(question_str: str = "", prediction: str = "", git_provide
     return obj
 
 
-def _make_line_questions() -> PR_LineQuestions:
-    obj = PR_LineQuestions.__new__(PR_LineQuestions)
+def _make_line_questions() -> plq.PR_LineQuestions:
+    obj = plq.PR_LineQuestions.__new__(plq.PR_LineQuestions)
     obj.vars = {}
     obj.git_provider = MagicMock()
     return obj

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -388,3 +388,63 @@ class TestExtraInstructionsPromptRendering:
         system_prompt = _render_jinja_template(get_settings().pr_line_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt
         assert "take precedence over any conflicting guidance" in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# resolve_threads prompt rendering
+# ---------------------------------------------------------------------------
+
+class TestResolveThreadsPromptRendering:
+    def test_resolve_threads_marker_instruction_included_when_enabled(self):
+        variables = {
+            "title": "test",
+            "branch": "main",
+            "full_hunk": "some code",
+            "selected_lines": "line1",
+            "question": "is this fixed?",
+            "conversation_history": "",
+            "resolve_threads": True,
+            "extra_instructions": "",
+        }
+        user_prompt = _render_jinja_template(
+            get_settings().pr_line_questions_prompt.user, variables
+        )
+        assert "[THREAD_RESOLVED]" in user_prompt
+        assert "determine whether the discussion thread is now fully resolved" in user_prompt
+
+    def test_resolve_threads_marker_instruction_omitted_when_disabled(self):
+        variables = {
+            "title": "test",
+            "branch": "main",
+            "full_hunk": "some code",
+            "selected_lines": "line1",
+            "question": "what does this do?",
+            "conversation_history": "",
+            "resolve_threads": False,
+            "extra_instructions": "",
+        }
+        user_prompt = _render_jinja_template(
+            get_settings().pr_line_questions_prompt.user, variables
+        )
+        assert "[THREAD_RESOLVED]" not in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# Thread resolution marker parsing (unit tests for run() logic)
+# ---------------------------------------------------------------------------
+
+class TestThreadResolvedMarkerParsing:
+    """Test the marker-stripping logic that would be in PR_LineQuestions.run()."""
+
+    @pytest.mark.parametrize("marker_position,answer,expected_clean", [
+        ("end", "The issue is fixed.\n\n[THREAD_RESOLVED]", "The issue is fixed."),
+        ("middle", "Fixed [THREAD_RESOLVED] thanks", "Fixed  thanks"),
+        ("only", "[THREAD_RESOLVED]", ""),
+    ])
+    def test_marker_is_stripped(self, marker_position, answer, expected_clean):
+        cleaned = answer.replace("[THREAD_RESOLVED]", "").rstrip()
+        assert cleaned == expected_clean
+
+    def test_no_marker_means_no_resolve(self):
+        answer = "I think this still needs work."
+        assert "[THREAD_RESOLVED]" not in answer

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -430,6 +430,49 @@ class TestResolveThreadsPromptRendering:
 
 
 # ---------------------------------------------------------------------------
+# resolve_threads disabled when no comment_id
+# ---------------------------------------------------------------------------
+
+class TestResolveThreadsDisabledWithoutCommentId:
+    @pytest.fixture
+    def resolve_settings(self):
+        keys = ("comment_id", "pr_questions.resolve_threads")
+        saved = snapshot_settings(keys)
+        try:
+            yield get_settings()
+        finally:
+            restore_settings(saved)
+
+    def test_resolve_threads_cleared_when_no_comment_id(self, resolve_settings):
+        resolve_settings.set("pr_questions.resolve_threads", True)
+        resolve_settings.set("comment_id", "")
+
+        lq = _make_line_questions()
+        lq.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
+        lq.vars = {"resolve_threads": lq.resolve_threads}
+
+        comment_id = get_settings().get('comment_id', '')
+        if not comment_id:
+            lq.vars["resolve_threads"] = False
+
+        assert lq.vars["resolve_threads"] is False
+
+    def test_resolve_threads_kept_when_comment_id_present(self, resolve_settings):
+        resolve_settings.set("pr_questions.resolve_threads", True)
+        resolve_settings.set("comment_id", 12345)
+
+        lq = _make_line_questions()
+        lq.resolve_threads = get_settings().pr_questions.get('resolve_threads', False)
+        lq.vars = {"resolve_threads": lq.resolve_threads}
+
+        comment_id = get_settings().get('comment_id', '')
+        if not comment_id:
+            lq.vars["resolve_threads"] = False
+
+        assert lq.vars["resolve_threads"] is True
+
+
+# ---------------------------------------------------------------------------
 # Thread resolution marker parsing (unit tests for run() logic)
 # ---------------------------------------------------------------------------
 

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -487,10 +487,10 @@ class TestThreadResolvedMarkerParsing:
     (after rstrip). Mid-message occurrences are treated as normal text.
     """
 
-    def _parse_marker(self, answer):
+    def _parse_marker(self, answer, resolve_threads=True):
         """Replicate the endswith-based parsing from PR_LineQuestions.run()."""
         answer_stripped = answer.rstrip()
-        if answer_stripped.endswith("[THREAD_RESOLVED]"):
+        if resolve_threads and answer_stripped.endswith("[THREAD_RESOLVED]"):
             return True, answer_stripped[:-len("[THREAD_RESOLVED]")].rstrip()
         return False, answer
 
@@ -513,6 +513,12 @@ class TestThreadResolvedMarkerParsing:
     def test_no_marker_means_no_resolve(self):
         answer = "I think this still needs work."
         should_resolve, cleaned = self._parse_marker(answer)
+        assert should_resolve is False
+        assert cleaned == answer
+
+    def test_marker_ignored_when_resolve_threads_disabled(self):
+        answer = "The issue is fixed.\n\n[THREAD_RESOLVED]"
+        should_resolve, cleaned = self._parse_marker(answer, resolve_threads=False)
         assert should_resolve is False
         assert cleaned == answer
 

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -11,9 +11,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import pr_agent.tools.pr_line_questions as plq
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
-import pr_agent.tools.pr_line_questions as plq
 from pr_agent.tools.pr_questions import PRQuestions
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
 

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -443,21 +443,36 @@ class TestResolveThreadsDisabledWithoutCommentId:
         finally:
             restore_settings(saved)
 
-    def test_resolve_threads_cleared_when_no_comment_id(self, resolve_settings):
+    @pytest.mark.asyncio
+    async def test_resolve_threads_cleared_when_no_comment_id(self, resolve_settings):
+        # drive run() rather than restating the branch, so deleting the clearing fails here
         resolve_settings.set("pr_questions.resolve_threads", True)
+        resolve_settings.set("pr_questions.use_conversation_history", False)
         resolve_settings.set("comment_id", "")
+        resolve_settings.set("ask_diff_hunk", "@@ -1,3 +1,3 @@\n-old\n+new\n ctx")
+        resolve_settings.set("line_start", 1)
+        resolve_settings.set("line_end", 1)
+        resolve_settings.set("side", "RIGHT")
+        resolve_settings.set("file_name", "test.py")
 
         lq = _make_line_questions()
-        lq.resolve_threads = get_settings().pr_questions.get("resolve_threads", False)
-        lq.vars = {"resolve_threads": lq.resolve_threads}
+        lq.resolve_threads = True
+        lq.vars["resolve_threads"] = True
+        lq.token_handler = MagicMock()
 
-        comment_id = get_settings().get("comment_id", "")
-        if not comment_id:
-            lq.resolve_threads = False
-            lq.vars["resolve_threads"] = False
+        async def fake_retry(func, **kwargs):
+            return "Looks good.\n\n[THREAD_RESOLVED]"
 
-        assert lq.vars["resolve_threads"] is False
+        original = plq.retry_with_fallback_models
+        plq.retry_with_fallback_models = fake_retry
+        try:
+            await lq.run()
+        finally:
+            plq.retry_with_fallback_models = original
+
         assert lq.resolve_threads is False
+        assert lq.vars["resolve_threads"] is False
+        lq.git_provider.resolve_comment_thread.assert_not_called()
 
     def test_resolve_threads_kept_when_comment_id_present(self, resolve_settings):
         resolve_settings.set("pr_questions.resolve_threads", True)

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -453,9 +453,11 @@ class TestResolveThreadsDisabledWithoutCommentId:
 
         comment_id = get_settings().get('comment_id', '')
         if not comment_id:
+            lq.resolve_threads = False
             lq.vars["resolve_threads"] = False
 
         assert lq.vars["resolve_threads"] is False
+        assert lq.resolve_threads is False
 
     def test_resolve_threads_kept_when_comment_id_present(self, resolve_settings):
         resolve_settings.set("pr_questions.resolve_threads", True)
@@ -467,9 +469,11 @@ class TestResolveThreadsDisabledWithoutCommentId:
 
         comment_id = get_settings().get('comment_id', '')
         if not comment_id:
+            lq.resolve_threads = False
             lq.vars["resolve_threads"] = False
 
         assert lq.vars["resolve_threads"] is True
+        assert lq.resolve_threads is True
 
 
 # ---------------------------------------------------------------------------
@@ -511,3 +515,88 @@ class TestThreadResolvedMarkerParsing:
         should_resolve, cleaned = self._parse_marker(answer)
         assert should_resolve is False
         assert cleaned == answer
+
+
+# ---------------------------------------------------------------------------
+# Regression test: run() actually calls resolve_comment_thread when marker present
+# ---------------------------------------------------------------------------
+
+class TestRunResolvesThread:
+    """Exercise the resolve wiring inside PR_LineQuestions.run().
+
+    This ensures that removing the resolve code from run() would break a test.
+    """
+
+    @pytest.fixture
+    def run_settings(self):
+        keys = (
+            "comment_id", "pr_questions.resolve_threads",
+            "pr_questions.use_conversation_history",
+            "ask_diff_hunk", "line_start", "line_end", "side", "file_name",
+        )
+        saved = snapshot_settings(keys)
+        try:
+            yield get_settings()
+        finally:
+            restore_settings(saved)
+
+    async def test_run_calls_resolve_when_marker_present(self, run_settings):
+        run_settings.set("pr_questions.resolve_threads", True)
+        run_settings.set("pr_questions.use_conversation_history", False)
+        run_settings.set("comment_id", 42)
+        run_settings.set("ask_diff_hunk", "@@ -1,3 +1,3 @@\n-old\n+new\n ctx")
+        run_settings.set("line_start", 1)
+        run_settings.set("line_end", 1)
+        run_settings.set("side", "RIGHT")
+        run_settings.set("file_name", "test.py")
+
+        lq = _make_line_questions()
+        lq.resolve_threads = True
+        lq.vars["resolve_threads"] = True
+        lq.token_handler = MagicMock()
+
+        async def fake_retry(func, **kwargs):
+            return "Looks good.\n\n[THREAD_RESOLVED]"
+
+        import pr_agent.tools.pr_line_questions as plq
+        original = plq.retry_with_fallback_models
+        plq.retry_with_fallback_models = fake_retry
+        try:
+            await lq.run()
+        finally:
+            plq.retry_with_fallback_models = original
+
+        lq.git_provider.reply_to_comment_from_comment_id.assert_called_once()
+        reply_body = lq.git_provider.reply_to_comment_from_comment_id.call_args[0][1]
+        assert "[THREAD_RESOLVED]" not in reply_body
+
+        lq.git_provider.resolve_comment_thread.assert_called_once_with(42)
+
+    async def test_run_does_not_resolve_without_marker(self, run_settings):
+        run_settings.set("pr_questions.resolve_threads", True)
+        run_settings.set("pr_questions.use_conversation_history", False)
+        run_settings.set("comment_id", 42)
+        run_settings.set("ask_diff_hunk", "@@ -1,3 +1,3 @@\n-old\n+new\n ctx")
+        run_settings.set("line_start", 1)
+        run_settings.set("line_end", 1)
+        run_settings.set("side", "RIGHT")
+        run_settings.set("file_name", "test.py")
+
+        lq = _make_line_questions()
+        lq.resolve_threads = True
+        lq.vars["resolve_threads"] = True
+        lq.token_handler = MagicMock()
+
+        async def fake_retry(func, **kwargs):
+            return "This still needs work."
+
+        import pr_agent.tools.pr_line_questions as plq
+        original = plq.retry_with_fallback_models
+        plq.retry_with_fallback_models = fake_retry
+        try:
+            await lq.run()
+        finally:
+            plq.retry_with_fallback_models = original
+
+        lq.git_provider.reply_to_comment_from_comment_id.assert_called_once()
+        lq.git_provider.resolve_comment_thread.assert_not_called()

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -13,6 +13,7 @@ import pytest
 
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
+import pr_agent.tools.pr_line_questions as plq
 from pr_agent.tools.pr_line_questions import PR_LineQuestions
 from pr_agent.tools.pr_questions import PRQuestions
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
@@ -540,6 +541,7 @@ class TestRunResolvesThread:
         finally:
             restore_settings(saved)
 
+    @pytest.mark.asyncio
     async def test_run_calls_resolve_when_marker_present(self, run_settings):
         run_settings.set("pr_questions.resolve_threads", True)
         run_settings.set("pr_questions.use_conversation_history", False)
@@ -558,7 +560,6 @@ class TestRunResolvesThread:
         async def fake_retry(func, **kwargs):
             return "Looks good.\n\n[THREAD_RESOLVED]"
 
-        import pr_agent.tools.pr_line_questions as plq
         original = plq.retry_with_fallback_models
         plq.retry_with_fallback_models = fake_retry
         try:
@@ -572,6 +573,7 @@ class TestRunResolvesThread:
 
         lq.git_provider.resolve_comment_thread.assert_called_once_with(42)
 
+    @pytest.mark.asyncio
     async def test_run_does_not_resolve_without_marker(self, run_settings):
         run_settings.set("pr_questions.resolve_threads", True)
         run_settings.set("pr_questions.use_conversation_history", False)
@@ -590,7 +592,6 @@ class TestRunResolvesThread:
         async def fake_retry(func, **kwargs):
             return "This still needs work."
 
-        import pr_agent.tools.pr_line_questions as plq
         original = plq.retry_with_fallback_models
         plq.retry_with_fallback_models = fake_retry
         try:


### PR DESCRIPTION
## Summary

- Add opt-in `pr_questions.resolve_threads` setting that lets `/ask_line` resolve the review thread after answering, when the LLM judges the issue is addressed.
- Implement `resolve_comment_thread` in `GithubProvider` using the `resolveReviewThread` GraphQL mutation.
- Add `resolve_comment_thread` no-op to `GitProvider` base class so other providers can implement it independently.
- Document the non-obvious `Contents: Read & write` permission requirement for GitHub Apps (the GraphQL mutation is gated behind it despite only modifying thread metadata — see [community discussion](https://github.com/orgs/community/discussions/204269)).

## How it works

1. When `resolve_threads=true`, the `/ask_line` prompt instructs the LLM to append `[THREAD_RESOLVED]` if the conversation is fully resolved (developer confirmed fix, question fully answered, etc.).
2. The marker is stripped before posting the reply.
3. `GithubProvider.resolve_comment_thread` looks up the thread's GraphQL node ID and calls `resolveReviewThread`.
4. Returns `bool` — callers get clear success/failure signaling.

## Tests

- 7 unit tests for `resolve_comment_thread`: success, already-resolved, no match, missing node_id, GraphQL errors, permission failure (`isResolved=false`), REST exception.
- 4 unit tests for prompt rendering (marker included/omitted) and marker parsing.
- Manually verified end-to-end on a live GitHub PR with a deployed GitHub App.