### PR TITLE
feat(review): make the review heading configurable

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -60,7 +60,15 @@ extra_instructions = "..."
       </tr>
       <tr>
         <td><b>review_heading</b></td>
-        <td>Visible base heading for review comments, without the Markdown prefix or the incremental label. For example, <code>review_heading = "Guideline Compliance Check"</code> renders <code>## Guideline Compliance Check 🔍</code> for a full review and <code>## Incremental Guideline Compliance Check 🔍</code> for an incremental review. On GitHub, GitLab, Azure DevOps, and Bitbucket Cloud, changing this value updates the same persistent review comment; it does not create a separate review channel. Default is <code>PR Reviewer Guide</code>.</td>
+        <td>
+          Visible base heading for review comments, without the Markdown prefix or incremental label.
+          For example, <code>review_heading = "Guideline Compliance Check"</code> renders
+          <code>## Guideline Compliance Check 🔍</code> for a full review and
+          <code>## Incremental Guideline Compliance Check 🔍</code> for an incremental review.
+          On GitHub, GitLab, Azure DevOps, and Bitbucket Cloud, changing this value updates the same
+          persistent review comment; it does not create a separate review channel.
+          Default is <code>PR Reviewer Guide</code>.
+        </td>
       </tr>
       <tr>
       <td><b>final_update_message</b></td>

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -59,6 +59,10 @@ extra_instructions = "..."
         <td>If set to true, the review comment will be persistent, meaning that every new review request will edit the previous one. Default is true.</td>
       </tr>
       <tr>
+        <td><b>review_heading</b></td>
+        <td>Visible base heading for review comments, without the Markdown prefix or the incremental label. For example, <code>review_heading = "Guideline Compliance Check"</code> renders <code>## Guideline Compliance Check 🔍</code> for a full review and <code>## Incremental Guideline Compliance Check 🔍</code> for an incremental review. On GitHub, GitLab, Azure DevOps, and Bitbucket Cloud, changing this value updates the same persistent review comment; it does not create a separate review channel. Default is <code>PR Reviewer Guide</code>.</td>
+      </tr>
+      <tr>
       <td><b>final_update_message</b></td>
       <td>When set to true, updating a persistent review comment during online commenting will automatically add a short comment with a link to the updated review in the pull request .Default is true.</td>
       </tr>

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -15,7 +15,7 @@ import traceback
 from datetime import datetime
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any, List, Tuple, TypedDict
+from typing import Any, Iterable, List, Tuple, TypedDict
 
 import html2text
 import requests
@@ -63,6 +63,69 @@ class TodoItem(TypedDict):
 class PRReviewHeader(str, Enum):
     REGULAR = "## PR Reviewer Guide"
     INCREMENTAL = "## Incremental PR Reviewer Guide"
+
+
+class PRReviewIdentity(str, Enum):
+    REGULAR = "<!-- pr-agent:review:full -->"
+    INCREMENTAL = "<!-- pr-agent:review:incremental -->"
+
+
+DEFAULT_REVIEW_HEADING = "PR Reviewer Guide"
+_REVIEW_IDENTITY_HEADER_LINES = 5
+
+
+def format_pr_review_header(incremental: bool = False) -> str:
+    """Return the visible review heading while keeping identity out of presentation."""
+    configured_heading = get_settings().get("pr_reviewer.review_heading", DEFAULT_REVIEW_HEADING)
+    if (
+        not isinstance(configured_heading, str)
+        or not configured_heading.strip()
+        or "\n" in configured_heading
+        or "\r" in configured_heading
+    ):
+        get_logger().warning(
+            "Invalid pr_reviewer.review_heading; using the default review heading"
+        )
+        configured_heading = DEFAULT_REVIEW_HEADING
+    heading = configured_heading.strip()
+    incremental_prefix = "Incremental " if incremental else ""
+    return f"## {incremental_prefix}{heading} 🔍"
+
+
+def comment_matches_identity(body: str, identity: str) -> bool:
+    """Match hidden markers only as exact lines near the top; legacy headers as prefixes."""
+    if not isinstance(body, str) or not isinstance(identity, str) or not identity:
+        return False
+    if identity.startswith("<!--"):
+        return any(
+            line.strip() == identity
+            for line in body.splitlines()[:_REVIEW_IDENTITY_HEADER_LINES]
+        )
+    return body.startswith(identity)
+
+
+def comment_matches_any_identity(body: str, identities: Iterable[str]) -> bool:
+    return any(comment_matches_identity(body, identity) for identity in identities)
+
+
+def get_pr_review_comment_identifiers(*, full: bool, incremental: bool) -> tuple[str, ...]:
+    """Return stable markers followed by legacy visible prefixes for migration."""
+    identifiers = []
+    if full:
+        identifiers.extend((PRReviewIdentity.REGULAR.value, PRReviewHeader.REGULAR.value))
+    if incremental:
+        identifiers.extend((PRReviewIdentity.INCREMENTAL.value, PRReviewHeader.INCREMENTAL.value))
+    return tuple(identifiers)
+
+
+def add_pr_review_identity(pr_comment: str, identity_marker: str | None) -> str:
+    """Insert a hidden identity after the visible heading without changing rendered output."""
+    if not pr_comment or not identity_marker or comment_matches_identity(pr_comment, identity_marker):
+        return pr_comment
+    heading, separator, remainder = pr_comment.partition("\n\n")
+    if not separator:
+        return f"{pr_comment.rstrip()}\n\n{identity_marker}"
+    return f"{heading}\n\n{identity_marker}\n\n{remainder}"
 
 
 class ReasoningEffort(str, Enum):
@@ -168,10 +231,8 @@ def convert_to_markdown_v2(output_data: dict,
         "Ticket compliance check": "🎫",
     }
     markdown_text = ""
-    if not incremental_review:
-        markdown_text += f"{PRReviewHeader.REGULAR.value} 🔍\n\n"
-    else:
-        markdown_text += f"{PRReviewHeader.INCREMENTAL.value} 🔍\n\n"
+    markdown_text += f"{format_pr_review_header(incremental=bool(incremental_review))}\n\n"
+    if incremental_review:
         markdown_text += f"⏮️ Review for commits since previous PR-Agent review {incremental_review}.\n\n"
     if not output_data or not output_data.get('review', {}):
         return ""

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -70,13 +70,12 @@ class PRReviewIdentity(str, Enum):
     INCREMENTAL = "<!-- pr-agent:review:incremental -->"
 
 
-DEFAULT_REVIEW_HEADING = "PR Reviewer Guide"
 _REVIEW_IDENTITY_HEADER_LINES = 5
 
 
 def format_pr_review_header(incremental: bool = False) -> str:
     """Return the visible review heading while keeping identity out of presentation."""
-    configured_heading = get_settings().get("pr_reviewer.review_heading", DEFAULT_REVIEW_HEADING)
+    configured_heading = get_settings().get("pr_reviewer.review_heading")
     if (
         not isinstance(configured_heading, str)
         or not configured_heading.strip()
@@ -86,7 +85,7 @@ def format_pr_review_header(incremental: bool = False) -> str:
         get_logger().warning(
             "Invalid pr_reviewer.review_heading; using the default review heading"
         )
-        configured_heading = DEFAULT_REVIEW_HEADING
+        configured_heading = PRReviewHeader.REGULAR.value.removeprefix("## ")
     heading = configured_heading.strip()
     incremental_prefix = "Incremental " if incremental else ""
     return f"## {incremental_prefix}{heading} 🔍"

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -10,8 +10,7 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 from ..algo.file_filter import filter_ignored
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import (PRDescriptionHeader, clip_tokens,
-                          comment_matches_any_identity,
+from ..algo.utils import (PRDescriptionHeader, comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
                           get_pr_review_comment_identifiers, load_large_diff)
 from ..config_loader import get_settings

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -10,9 +10,10 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 from ..algo.file_filter import filter_ignored
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import (PRDescriptionHeader, PRReviewHeader, clip_tokens,
+from ..algo.utils import (PRDescriptionHeader, clip_tokens,
+                          comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
-                          load_large_diff)
+                          get_pr_review_comment_identifiers, load_large_diff)
 from ..config_loader import get_settings
 from ..log import get_logger
 from .git_provider import GitProvider, IncrementalPR
@@ -464,15 +465,11 @@ class AzureDevopsProvider(GitProvider):
     def get_previous_review(self, *, full: bool, incremental: bool):
         if not (full or incremental):
             raise ValueError("At least one of full or incremental must be True")
-        prefixes = []
-        if full:
-            prefixes.append(PRReviewHeader.REGULAR.value)
-        if incremental:
-            prefixes.append(PRReviewHeader.INCREMENTAL.value)
+        identifiers = get_pr_review_comment_identifiers(full=full, incremental=incremental)
         matches = []
         for comment in self.get_issue_comments():
             body = getattr(comment, "body", None)
-            if body and any(body.startswith(p) for p in prefixes):
+            if body and comment_matches_any_identity(body, identifiers):
                 matches.append(comment)
         if not matches:
             return None
@@ -776,8 +773,21 @@ class AzureDevopsProvider(GitProvider):
                                    initial_header: str,
                                    update_header: bool = True,
                                    name='review',
-                                   final_update_message=True):
-        return self.publish_persistent_comment_full(pr_comment, initial_header, update_header, name, final_update_message)
+                                   final_update_message=True,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        return self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
+
+    def supports_review_comment_identity(self) -> bool:
+        return True
 
     def publish_description(self, pr_title: str, pr_body: str):
         if len(pr_body) > MAX_PR_DESCRIPTION_AZURE_LENGTH:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -413,7 +413,11 @@ class BitbucketProvider(GitProvider):
                 )
                 if comment_to_update is None and legacy_initial_header:
                     comment_to_update = next(
-                        (comment for comment in comments if legacy_initial_header in comment.raw),
+                        (
+                            comment
+                            for comment in comments
+                            if comment_matches_identity(comment.raw, legacy_initial_header)
+                        ),
                         None,
                     )
             else:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -12,7 +12,8 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 from ..algo.file_filter import filter_ignored
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import find_line_number_of_relevant_line_in_file
+from ..algo.utils import (add_pr_review_identity, comment_matches_identity,
+                          find_line_number_of_relevant_line_in_file)
 from ..config_loader import get_settings
 from ..log import get_logger
 from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, get_cached_global_settings
@@ -395,31 +396,56 @@ class BitbucketProvider(GitProvider):
                                    initial_header: str,
                                    update_header: bool = True,
                                    name='review',
-                                   final_update_message=True):
+                                   final_update_message=True,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
         try:
-            for comment in self.pr.comments():
-                body = comment.raw
-                if initial_header in body:
-                    latest_commit_url = self.get_latest_commit_url()
-                    comment_url = self.get_comment_url(comment)
-                    if update_header:
-                        updated_header = f"{initial_header}\n\n#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
-                        pr_comment_updated = pr_comment.replace(initial_header, updated_header)
-                    else:
-                        pr_comment_updated = pr_comment
-                    get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                    d = {"content": {"raw": pr_comment_updated}}
-                    response = comment._update_data(comment.put(None, data=d))
-                    if final_update_message:
-                        try:
-                            self.publish_comment(
-                                f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                        except Exception:
-                            # The review was already updated in place; a notification failure must not reach
-                            # the outer except, whose fallback publish would duplicate the review.
-                            get_logger().opt(exception=True).warning(
-                                "Failed to publish persistent review update message; review was already updated")
-                    return
+            pr_comment = add_pr_review_identity(pr_comment, identity_marker)
+            comments = list(self.pr.comments())
+            if identity_marker:
+                comment_to_update = next(
+                    (
+                        comment
+                        for comment in comments
+                        if comment_matches_identity(comment.raw, identity_marker)
+                    ),
+                    None,
+                )
+                if comment_to_update is None and legacy_initial_header:
+                    comment_to_update = next(
+                        (comment for comment in comments if legacy_initial_header in comment.raw),
+                        None,
+                    )
+            else:
+                # Preserve Bitbucket's existing behavior for non-review persistent comments.
+                comment_to_update = next(
+                    (comment for comment in comments if initial_header in comment.raw),
+                    None,
+                )
+            if comment_to_update is not None:
+                comment = comment_to_update
+                latest_commit_url = self.get_latest_commit_url()
+                comment_url = self.get_comment_url(comment)
+                if update_header:
+                    update_message = f"#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
+                    update_anchor = identity_marker or initial_header
+                    updated_anchor = f"{update_anchor}\n\n{update_message}"
+                    pr_comment_updated = pr_comment.replace(update_anchor, updated_anchor, 1)
+                else:
+                    pr_comment_updated = pr_comment
+                get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
+                d = {"content": {"raw": pr_comment_updated}}
+                comment._update_data(comment.put(None, data=d))
+                if final_update_message:
+                    try:
+                        self.publish_comment(
+                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                    except Exception:
+                        # The review was already updated in place; a notification failure must not reach
+                        # the outer except, whose fallback publish would duplicate the review.
+                        get_logger().opt(exception=True).warning(
+                            "Failed to publish persistent review update message; review was already updated")
+                return
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")
             pass

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -7,7 +7,7 @@ import time
 from typing import Optional, Tuple
 
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.algo.utils import Range, process_description
+from pr_agent.algo.utils import Range, add_pr_review_identity, comment_matches_identity, process_description
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
 
@@ -350,6 +350,9 @@ class GitProvider(ABC):
     def should_publish_review_as_thread(self) -> bool:
         return False
 
+    def supports_review_comment_identity(self) -> bool:
+        return False
+
     def unresolve_comment_thread(self, comment):  # noqa: B027 - intentional no-op
         pass
 
@@ -358,7 +361,9 @@ class GitProvider(ABC):
                                    update_header: bool = True,
                                    name='review',
                                    final_update_message=True,
-                                   as_thread: bool = False):
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
         return self.publish_comment(pr_comment, **({'as_thread': True} if as_thread else {}))
 
     def publish_persistent_comment_full(self, pr_comment: str,
@@ -366,40 +371,60 @@ class GitProvider(ABC):
                                    update_header: bool = True,
                                    name='review',
                                    final_update_message=True,
-                                   as_thread: bool = False):
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
         try:
+            pr_comment = add_pr_review_identity(pr_comment, identity_marker)
             prev_comments = list(self.get_issue_comments())
-            for comment in prev_comments:
-                if comment.body.startswith(initial_header):
-                    latest_commit_url = self.get_latest_commit_url()
-                    comment_url = self.get_comment_url(comment)
-                    if update_header:
-                        updated_header = f"{initial_header}\n\n#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
-                        pr_comment_updated = pr_comment.replace(initial_header, updated_header)
-                    else:
-                        pr_comment_updated = pr_comment
-                    get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                    # response = self.mr.notes.update(comment.id, {'body': pr_comment_updated})
-                    self.edit_comment(comment, pr_comment_updated)
-                    if as_thread:
-                        try:
-                            # Reopen the thread if it was resolved, so the developer revisits the updated review.
-                            self.unresolve_comment_thread(comment)
-                        except Exception as e:
-                            # The review was already updated in place; a reopen failure must not reach the
-                            # outer except, whose fallback publish would duplicate the review.
-                            get_logger().warning(f"Failed to reopen review thread: {e}")
-                    if final_update_message:
-                        try:
-                            return self.publish_comment(
-                                f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                        except Exception:
-                            # The review was already updated in place; a notification failure must not reach
-                            # the outer except, whose fallback publish would duplicate the review.
-                            get_logger().opt(exception=True).warning(
-                                "Failed to publish persistent review update message; review was already updated")
-                            return comment
-                    return comment
+            identifiers = (
+                [identity_marker, legacy_initial_header]
+                if identity_marker
+                else [initial_header]
+            )
+            comment_to_update = next(
+                (
+                    comment
+                    for identifier in identifiers
+                    if identifier
+                    for comment in prev_comments
+                    if comment_matches_identity(comment.body, identifier)
+                ),
+                None,
+            )
+            if comment_to_update is not None:
+                comment = comment_to_update
+                latest_commit_url = self.get_latest_commit_url()
+                comment_url = self.get_comment_url(comment)
+                if update_header:
+                    update_message = f"#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
+                    update_anchor = identity_marker or initial_header
+                    updated_anchor = f"{update_anchor}\n\n{update_message}"
+                    pr_comment_updated = pr_comment.replace(update_anchor, updated_anchor, 1)
+                else:
+                    pr_comment_updated = pr_comment
+                get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
+                # response = self.mr.notes.update(comment.id, {'body': pr_comment_updated})
+                self.edit_comment(comment, pr_comment_updated)
+                if as_thread:
+                    try:
+                        # Reopen the thread if it was resolved, so the developer revisits the updated review.
+                        self.unresolve_comment_thread(comment)
+                    except Exception as e:
+                        # The review was already updated in place; a reopen failure must not reach the
+                        # outer except, whose fallback publish would duplicate the review.
+                        get_logger().warning(f"Failed to reopen review thread: {e}")
+                if final_update_message:
+                    try:
+                        return self.publish_comment(
+                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
+                    except Exception:
+                        # The review was already updated in place; a notification failure must not reach
+                        # the outer except, whose fallback publish would duplicate the review.
+                        get_logger().opt(exception=True).warning(
+                            "Failed to publish persistent review update message; review was already updated")
+                        return comment
+                return comment
         except Exception as e:
             get_logger().exception(f"Failed to update persistent review, error: {e}")
             pass

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -311,8 +311,17 @@ class GiteaProvider(GitProvider):
                                    initial_header: str,
                                    update_header: bool = True,
                                    name='review',
-                                   final_update_message=True):
-        self.publish_persistent_comment_full(pr_comment, initial_header, update_header, name, final_update_message)
+                                   final_update_message=True,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        # Keep the legacy updater path until Gitea normalizes its dictionary-shaped comment payloads.
+        self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+        )
 
     def publish_comment(self, comment: str,is_temporary: bool = False) -> None:
         """Publish a comment to the pull request"""

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -23,9 +23,10 @@ from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
                                          get_inline_comment_store, has_marker)
 from ..algo.language_handler import is_valid_file
 from ..algo.types import EDIT_TYPE
-from ..algo.utils import (PRReviewHeader, Range, clip_tokens,
+from ..algo.utils import (Range, clip_tokens, comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
-                          load_large_diff, set_file_languages)
+                          get_pr_review_comment_identifiers, load_large_diff,
+                          set_file_languages)
 from ..config_loader import get_settings
 from ..log import get_logger
 from ..servers.utils import RateLimitExceeded
@@ -202,13 +203,9 @@ class GithubProvider(GitProvider):
             raise ValueError("At least one of full or incremental must be True")
         if not getattr(self, "comments", None):
             self.comments = list(self.pr.get_issue_comments())
-        prefixes = []
-        if full:
-            prefixes.append(PRReviewHeader.REGULAR.value)
-        if incremental:
-            prefixes.append(PRReviewHeader.INCREMENTAL.value)
+        identifiers = get_pr_review_comment_identifiers(full=full, incremental=incremental)
         for index in range(len(self.comments) - 1, -1, -1):
-            if any(self.comments[index].body.startswith(prefix) for prefix in prefixes):
+            if comment_matches_any_identity(self.comments[index].body, identifiers):
                 return self.comments[index]
         return None
 
@@ -395,11 +392,24 @@ class GithubProvider(GitProvider):
                                    initial_header: str,
                                    update_header: bool = True,
                                    name='review',
-                                   final_update_message=True):
+                                   final_update_message=True,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
         if get_settings().github.publish_as_check_run:
             if self._publish_check_run(pr_comment, name):
                 return
-        self.publish_persistent_comment_full(pr_comment, initial_header, update_header, name, final_update_message)
+        self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
+
+    def supports_review_comment_identity(self) -> bool:
+        return True
 
     def _publish_check_run(self, text: str, name: str) -> bool:
         if not getattr(self, 'last_commit_id', None):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -20,9 +20,9 @@ from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
                                          code_fingerprint,
                                          get_inline_comment_store)
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import (PRReviewHeader, clip_tokens,
+from ..algo.utils import (clip_tokens, comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
-                          load_large_diff)
+                          get_pr_review_comment_identifiers, load_large_diff)
 from ..config_loader import get_settings
 from ..log import get_logger
 from .git_provider import (MAX_FILES_ALLOWED_FULL, GitProvider, IncrementalPR,
@@ -428,13 +428,10 @@ class GitLabProvider(GitProvider):
             get_logger().error(f"Could not get diff for merge request {self.id_mr}")
             raise DiffNotFoundError(f"Could not get diff for merge request {self.id_mr}") from e
 
-    # Anchor-note prefixes per incremental "kind". An incremental run looks for the most recent
-    # prior note matching ANY of these prefixes and uses its timestamp as the timeline anchor.
+    # Anchor-note identities per incremental "kind". An incremental run looks for the most recent
+    # prior note matching any identity and uses its timestamp as the timeline anchor.
     _INCREMENTAL_ANCHOR_PREFIXES = {
-        "review": (
-            PRReviewHeader.REGULAR.value,         # "## PR Reviewer Guide"
-            PRReviewHeader.INCREMENTAL.value,     # "## Incremental PR Reviewer Guide"
-        ),
+        "review": get_pr_review_comment_identifiers(full=True, incremental=True),
         "suggestions": (
             "## PR Code Suggestions ✨",           # summary-table mode
             "**Suggestion:**",                     # commitable-suggestions inline mode
@@ -596,15 +593,11 @@ class GitLabProvider(GitProvider):
     def get_previous_review(self, *, full: bool, incremental: bool):
         if not (full or incremental):
             raise ValueError("At least one of full or incremental must be True")
-        prefixes = []
-        if full:
-            prefixes.append(PRReviewHeader.REGULAR.value)
-        if incremental:
-            prefixes.append(PRReviewHeader.INCREMENTAL.value)
-        return self._find_anchor_note(prefixes)
+        identifiers = get_pr_review_comment_identifiers(full=full, incremental=incremental)
+        return self._find_anchor_note(identifiers)
 
-    def _find_anchor_note(self, prefixes):
-        """Return the most recent MR note whose body starts with any of `prefixes`.
+    def _find_anchor_note(self, identities):
+        """Return the most recent MR note whose body matches any supplied identity.
 
         Used by incremental flows (`/review -i`, `/improve -i`) to find the timestamp
         we anchor the commit timeline on. Returns a `_GitLabIncrementalNote` adapter
@@ -621,9 +614,9 @@ class GitLabProvider(GitProvider):
         Notes authored by other users are skipped when the authenticated (bot) user is
         known: a human comment that merely starts with `**Suggestion:**` must not shift
         the anchor. When authorship can't be established (e.g. job-token auth), we keep
-        the prefix-only behaviour rather than disabling incremental runs.
+        identity-only matching rather than disabling incremental runs.
         """
-        if not prefixes:
+        if not identities:
             return None
         # Use hasattr (not truthy) so a legitimately empty notes list still counts as cached;
         # otherwise we'd re-fetch from GitLab on every call for MRs that have no notes.
@@ -639,7 +632,7 @@ class GitLabProvider(GitProvider):
             body = getattr(note, 'body', None)
             if not isinstance(body, str):
                 continue
-            if not any(body.startswith(prefix) for prefix in prefixes):
+            if not comment_matches_any_identity(body, identities):
                 continue
             if own_user_id is not None:
                 author = getattr(note, 'author', None)
@@ -851,14 +844,27 @@ class GitLabProvider(GitProvider):
     def should_publish_review_as_thread(self) -> bool:
         return bool(get_settings().get("GITLAB.PUBLISH_REVIEW_AS_THREAD", False))
 
+    def supports_review_comment_identity(self) -> bool:
+        return True
+
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,
                                    update_header: bool = True,
                                    name='review',
                                    final_update_message=True,
-                                   as_thread: bool = False):
-        self.publish_persistent_comment_full(pr_comment, initial_header, update_header, name, final_update_message,
-                                             as_thread=as_thread)
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            as_thread=as_thread,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
 
     def publish_comment(self, mr_comment: str, is_temporary: bool = False, as_thread: bool = False):
         if is_temporary and not get_settings().config.publish_output_progress:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -428,8 +428,8 @@ class GitLabProvider(GitProvider):
             get_logger().error(f"Could not get diff for merge request {self.id_mr}")
             raise DiffNotFoundError(f"Could not get diff for merge request {self.id_mr}") from e
 
-    # Anchor-note identities per incremental "kind". An incremental run looks for the most recent
-    # prior note matching any identity and uses its timestamp as the timeline anchor.
+    # Match the most recent prior note for each incremental kind against any accepted identity,
+    # then use its timestamp as the timeline anchor.
     _INCREMENTAL_ANCHOR_PREFIXES = {
         "review": get_pr_review_comment_identifiers(full=True, incremental=True),
         "suggestions": (

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -108,6 +108,8 @@ require_ticket_analysis_review=true
 # general options
 publish_output_no_suggestions=true # Set to "false" if you only need the reviewer's remarks (not labels, not "security audit", etc.) and want to avoid noisy "No major issues detected" comments.
 persistent_comment=true
+# Visible base heading for full and incremental review comments. Identity is tracked separately.
+review_heading = "PR Reviewer Guide"
 inline_key_issues=false
 extra_instructions = ""
 num_max_findings = 3

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -24,6 +24,8 @@ from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
     ModelType,
     PRReviewHeader,
+    PRReviewIdentity,
+    add_pr_review_identity,
     convert_to_markdown_v2,
     github_action_output,
     load_yaml,
@@ -201,12 +203,23 @@ class PRReviewer:
             review_thread_kwargs = {"as_thread": True} if self.git_provider.should_publish_review_as_thread() else {}
             if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
                 final_update_message = get_settings().pr_reviewer.final_update_message
-                self.git_provider.publish_persistent_comment(pr_review,
-                                                            initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
-                                                            update_header=True,
-                                                            final_update_message=final_update_message,
-                                                            **review_thread_kwargs)
+                self.git_provider.publish_persistent_comment(
+                    pr_review,
+                    initial_header=pr_review.split("\n", 1)[0],
+                    update_header=True,
+                    final_update_message=final_update_message,
+                    identity_marker=PRReviewIdentity.REGULAR.value,
+                    legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+                    **review_thread_kwargs,
+                )
             else:
+                if self.git_provider.supports_review_comment_identity() is True:
+                    identity_marker = (
+                        PRReviewIdentity.INCREMENTAL.value
+                        if self.incremental.is_incremental
+                        else PRReviewIdentity.REGULAR.value
+                    )
+                    pr_review = add_pr_review_identity(pr_review, identity_marker)
                 self.git_provider.publish_comment(pr_review, **review_thread_kwargs)
         except Exception as e:
             review_failed = True

--- a/tests/unittest/test_azure_devops_incremental.py
+++ b/tests/unittest/test_azure_devops_incremental.py
@@ -2,6 +2,7 @@ import datetime as _dt
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from pr_agent.algo.utils import PRReviewIdentity
 from pr_agent.git_providers import AzureDevopsProvider
 from pr_agent.git_providers.azuredevops_provider import (
     _AzureCommitAdapter,
@@ -89,6 +90,22 @@ class TestGetIncrementalCommits:
 
         assert provider.incremental.is_incremental is False
         assert provider.previous_review is None
+
+    def test_previous_review_accepts_custom_heading_with_stable_identity(self):
+        provider = self._make_provider()
+        review_time = _dt.datetime(2024, 6, 1, 10, 0, tzinfo=_dt.timezone.utc)
+        marked = _comment(
+            (
+                "## Guideline Compliance Check 🔍\n\n"
+                f"{PRReviewIdentity.REGULAR.value}\n\nbody"
+            ),
+            review_time,
+        )
+        provider.get_issue_comments = MagicMock(return_value=[marked])
+
+        result = provider.get_previous_review(full=True, incremental=False)
+
+        assert result is marked
 
     def test_populates_commits_range_and_files(self):
         provider = self._make_provider()

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -5,6 +5,7 @@ from atlassian.bitbucket import Bitbucket
 from requests.exceptions import HTTPError
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
 from pr_agent.git_providers import BitbucketServerProvider
 from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
 
@@ -137,6 +138,93 @@ class TestBitbucketProvider:
         existing.put.assert_called_once()
         existing._update_data.assert_not_called()
         provider.publish_comment.assert_called_once_with(new_review)
+
+    def _make_persistent_provider(self, comments):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock()
+        provider.pr.comments.return_value = comments
+        provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/commit/abc")
+        provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/comment/1")
+        provider.publish_comment = MagicMock()
+        return provider
+
+    def test_persistent_review_migrates_legacy_heading_to_stable_identity(self):
+        legacy = MagicMock()
+        legacy.raw = "provider prefix\n## PR Reviewer Guide 🔍\n\nprevious review"
+        provider = self._make_persistent_provider([legacy])
+
+        provider.publish_persistent_comment(
+            "## Guideline Compliance Check 🔍\n\nnew review",
+            initial_header="## Guideline Compliance Check 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        legacy.put.assert_called_once()
+        updated_body = legacy.put.call_args.kwargs["data"]["content"]["raw"]
+        assert updated_body.startswith("## Guideline Compliance Check 🔍\n\n")
+        assert PRReviewIdentity.REGULAR.value in updated_body
+        provider.publish_comment.assert_not_called()
+
+    def test_persistent_review_prefers_marked_comment_over_legacy_comment(self):
+        legacy = MagicMock()
+        legacy.raw = "## PR Reviewer Guide 🔍\n\nlegacy review"
+        marked = MagicMock()
+        marked.raw = (
+            "## Old Custom Heading 🔍\n\n"
+            f"{PRReviewIdentity.REGULAR.value}\n\nmarked review"
+        )
+        provider = self._make_persistent_provider([legacy, marked])
+
+        provider.publish_persistent_comment(
+            "## New Custom Heading 🔍\n\nnew review",
+            initial_header="## New Custom Heading 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        marked.put.assert_called_once()
+        legacy.put.assert_not_called()
+
+    def test_persistent_review_does_not_match_marker_outside_header_region(self):
+        unrelated = MagicMock()
+        unrelated.raw = (
+            "## Human comment\n\na\nb\nc\nd\n"
+            f"{PRReviewIdentity.REGULAR.value}\nquoted output"
+        )
+        provider = self._make_persistent_provider([unrelated])
+
+        provider.publish_persistent_comment(
+            "## New Custom Heading 🔍\n\nnew review",
+            initial_header="## New Custom Heading 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        unrelated.put.assert_not_called()
+        provider.publish_comment.assert_called_once()
+        assert PRReviewIdentity.REGULAR.value in provider.publish_comment.call_args.args[0]
+
+    def test_nonreview_persistent_comment_keeps_existing_bitbucket_matching(self):
+        existing = MagicMock()
+        existing.raw = "Configuration prefix\n## PR-Agent Configuration\nbody"
+        provider = self._make_persistent_provider([existing])
+
+        provider.publish_persistent_comment(
+            "## PR-Agent Configuration\nnew body",
+            initial_header="## PR-Agent Configuration",
+            update_header=False,
+            final_update_message=False,
+        )
+
+        existing.put.assert_called_once()
+        provider.publish_comment.assert_not_called()
 
 
 class TestBitbucketServerProvider:

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -150,7 +150,7 @@ class TestBitbucketProvider:
 
     def test_persistent_review_migrates_legacy_heading_to_stable_identity(self):
         legacy = MagicMock()
-        legacy.raw = "provider prefix\n## PR Reviewer Guide 🔍\n\nprevious review"
+        legacy.raw = "## PR Reviewer Guide 🔍\n\nprevious review"
         provider = self._make_persistent_provider([legacy])
 
         provider.publish_persistent_comment(
@@ -190,11 +190,13 @@ class TestBitbucketProvider:
         marked.put.assert_called_once()
         legacy.put.assert_not_called()
 
-    def test_persistent_review_does_not_match_marker_outside_header_region(self):
+    def test_persistent_review_does_not_match_quoted_identity(self):
         unrelated = MagicMock()
         unrelated.raw = (
-            "## Human comment\n\na\nb\nc\nd\n"
-            f"{PRReviewIdentity.REGULAR.value}\nquoted output"
+            "## Human comment\n\n"
+            f"{PRReviewHeader.REGULAR.value} 🔍\n"
+            "quoted review\nmore context\n"
+            f"{PRReviewIdentity.REGULAR.value}\n"
         )
         provider = self._make_persistent_provider([unrelated])
 

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -6,6 +6,7 @@ from gitlab import Gitlab
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectFile, ProjectMergeRequest, ProjectMergeRequestManager
 
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
 from pr_agent.git_providers.git_provider import IncrementalPR
 from pr_agent.git_providers.gitlab_provider import (
     GitLabProvider,
@@ -560,6 +561,72 @@ class TestGitLabProvider:
         gitlab_provider.mr.notes.update.assert_called_once()
         gitlab_provider.unresolve_comment_thread.assert_not_called()
 
+    def test_persistent_review_migrates_legacy_heading_to_stable_identity(self, gitlab_provider):
+        legacy = MagicMock(id=7)
+        legacy.body = "## PR Reviewer Guide 🔍\n\nprevious review"
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.get_issue_comments = MagicMock(return_value=[legacy])
+        gitlab_provider.get_latest_commit_url = MagicMock(return_value="https://gitlab.com/c/abc")
+        gitlab_provider.get_comment_url = MagicMock(return_value="https://gitlab.com/n/7")
+
+        gitlab_provider.publish_persistent_comment(
+            "## Guideline Compliance Check 🔍\n\nnew review",
+            initial_header="## Guideline Compliance Check 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        gitlab_provider.mr.notes.update.assert_called_once()
+        updated_body = gitlab_provider.mr.notes.update.call_args.args[1]["body"]
+        assert updated_body.startswith("## Guideline Compliance Check 🔍\n\n")
+        assert PRReviewIdentity.REGULAR.value in updated_body
+        gitlab_provider.mr.notes.create.assert_not_called()
+
+    def test_persistent_review_prefers_marked_comment_over_legacy_comment(self, gitlab_provider):
+        legacy = MagicMock(id=1)
+        legacy.body = "## PR Reviewer Guide 🔍\n\nlegacy review"
+        marked = MagicMock(id=2)
+        marked.body = (
+            "## Old Custom Heading 🔍\n\n"
+            f"{PRReviewIdentity.REGULAR.value}\n\nmarked review"
+        )
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.get_issue_comments = MagicMock(return_value=[legacy, marked])
+        gitlab_provider.get_latest_commit_url = MagicMock(return_value="https://gitlab.com/c/abc")
+        gitlab_provider.get_comment_url = MagicMock(return_value="https://gitlab.com/n/2")
+
+        gitlab_provider.publish_persistent_comment(
+            "## New Custom Heading 🔍\n\nnew review",
+            initial_header="## New Custom Heading 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert gitlab_provider.mr.notes.update.call_args.args[0] == 2
+        gitlab_provider.mr.notes.create.assert_not_called()
+
+    def test_persistent_review_does_not_adopt_similar_human_heading(self, gitlab_provider):
+        human_comment = MagicMock(id=3)
+        human_comment.body = "## PR Reviewer Guide for maintainers\n\nhuman notes"
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.get_issue_comments = MagicMock(return_value=[human_comment])
+
+        gitlab_provider.publish_persistent_comment(
+            "## New Custom Heading 🔍\n\nnew review",
+            initial_header="## New Custom Heading 🔍",
+            update_header=True,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        gitlab_provider.mr.notes.update.assert_not_called()
+        gitlab_provider.mr.notes.create.assert_called_once()
+
     @pytest.mark.parametrize("resolvable,resolved,should_reopen", [
         (True, True, True),     # resolved thread -> reopen it
         (True, False, False),   # already open -> leave it
@@ -1031,8 +1098,6 @@ class TestGitLabIncrementalReview:
         assert gitlab_provider.get_files() == ["x.py"]
 
     def test_get_previous_review_returns_most_recent_match(self, gitlab_provider):
-        from pr_agent.algo.utils import PRReviewHeader
-
         # GitLab returns notes in created_at-DESC order. The helper relies on that order
         # (no local sort) — the unrelated newest note must be skipped, the newer matching
         # note must win over the older matching note.
@@ -1046,6 +1111,23 @@ class TestGitLabIncrementalReview:
 
         assert result is not None
         assert result.id == 2
+
+    def test_get_previous_review_accepts_custom_heading_with_stable_identity(self, gitlab_provider):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(
+                7,
+                (
+                    "## Guideline Compliance Check 🔍\n\n"
+                    f"{PRReviewIdentity.REGULAR.value}\n\nbody"
+                ),
+                "2024-05-01T10:00:00Z",
+            ),
+        ]
+
+        result = gitlab_provider.get_previous_review(full=True, incremental=False)
+
+        assert result is not None
+        assert result.id == 7
 
     def test_master_merge_files_are_excluded_from_incremental_scope(self, gitlab_provider, mock_project):
         # Reproduction of the MR !1115 bug: user ran `git merge master` on the feature branch,

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -9,6 +9,7 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
 )
 from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -960,6 +961,7 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
     progress_comment = MagicMock()
     git_provider = MagicMock()
     git_provider.should_publish_review_as_thread.return_value = thread_enabled
+    git_provider.supports_review_comment_identity.return_value = False
     git_provider.publish_comment.return_value = progress_comment
     reviewer = _make_reviewer(git_provider)
     reviewer.incremental = SimpleNamespace(is_incremental=False)
@@ -997,6 +999,8 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
     if persistent:
         publish = git_provider.publish_persistent_comment
         publish.assert_called_once()
+        assert publish.call_args.kwargs["identity_marker"] == PRReviewIdentity.REGULAR.value
+        assert publish.call_args.kwargs["legacy_initial_header"] == f"{PRReviewHeader.REGULAR.value} 🔍"
     else:
         publish = git_provider.publish_comment
     assert publish.call_args.args[0] == review_text
@@ -1008,6 +1012,67 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
     git_provider.publish_comment.assert_any_call("Preparing review...", is_temporary=True)
     git_provider.remove_comment.assert_called_once_with(progress_comment)
     git_provider.remove_initial_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("is_incremental", "expected_identity"),
+    [
+        (False, PRReviewIdentity.REGULAR.value),
+        (True, PRReviewIdentity.INCREMENTAL.value),
+    ],
+)
+async def test_nonpersistent_review_adds_identity_for_incremental_capable_provider(
+    monkeypatch,
+    is_incremental,
+    expected_identity,
+):
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    progress_comment = MagicMock()
+    git_provider = MagicMock()
+    git_provider.should_publish_review_as_thread.return_value = False
+    git_provider.supports_review_comment_identity.return_value = True
+    git_provider.publish_comment.return_value = progress_comment
+    reviewer = _make_reviewer(git_provider)
+    reviewer.incremental = SimpleNamespace(is_incremental=is_incremental)
+    if is_incremental:
+        reviewer._can_run_incremental_review = lambda: True
+    reviewer.vars = {}
+    reviewer.prediction = None
+    reviewer._prepare_pr_review = lambda: "## Team Review 🔍\n\nsome findings"
+
+    async def fake_extract_tickets(git_provider, vars):
+        return None
+
+    async def fake_retry(prepare_fn, model_type=None):
+        reviewer.prediction = "prediction"
+
+    monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", fake_extract_tickets)
+    monkeypatch.setattr(pr_reviewer_module, "retry_with_fallback_models", fake_retry)
+
+    settings = get_settings()
+    original_publish_output = settings.config.publish_output
+    original_persistent_comment = settings.pr_reviewer.persistent_comment
+    original_auto_command = settings.config.get("is_auto_command", False)
+    try:
+        settings.config.publish_output = True
+        settings.config.is_auto_command = False
+        settings.pr_reviewer.persistent_comment = False
+
+        await reviewer.run()
+    finally:
+        settings.config.publish_output = original_publish_output
+        settings.config.is_auto_command = original_auto_command
+        settings.pr_reviewer.persistent_comment = original_persistent_comment
+
+    published_review = [
+        call
+        for call in git_provider.publish_comment.call_args_list
+        if call.args and call.args[0].startswith("## Team Review")
+    ]
+    assert len(published_review) == 1
+    assert expected_identity in published_review[0].args[0]
 
 
 def test_init_maps_user_question_and_answer_to_correct_prompt_vars(monkeypatch):

--- a/tests/unittest/test_review_comment_identity.py
+++ b/tests/unittest/test_review_comment_identity.py
@@ -1,0 +1,208 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.algo.utils import (PRReviewIdentity, add_pr_review_identity,
+                                 comment_matches_identity,
+                                 convert_to_markdown_v2,
+                                 format_pr_review_header,
+                                 get_pr_review_comment_identifiers)
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+from pr_agent.git_providers.gitea_provider import GiteaProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from tests.unittest._settings_helpers import (restore_settings,
+                                              snapshot_settings)
+
+
+def _review_data():
+    return {"review": {"security_concerns": "No"}}
+
+
+def test_custom_review_heading_changes_presentation_only():
+    snapshot = snapshot_settings(["pr_reviewer.review_heading"])
+    try:
+        get_settings().set("pr_reviewer.review_heading", "Guideline Compliance Check")
+
+        full = convert_to_markdown_v2(_review_data())
+        incremental = convert_to_markdown_v2(
+            _review_data(),
+            incremental_review="Starting from commit abc123",
+        )
+    finally:
+        restore_settings(snapshot)
+
+    assert full.startswith("## Guideline Compliance Check 🔍\n\n")
+    assert incremental.startswith("## Incremental Guideline Compliance Check 🔍\n\n")
+    assert "<!-- pr-agent:review" not in full
+    assert "<!-- pr-agent:review" not in incremental
+
+
+@pytest.mark.parametrize("invalid_heading", [None, "", "  ", "first\nsecond", 42])
+def test_invalid_review_heading_falls_back_to_default(invalid_heading):
+    snapshot = snapshot_settings(["pr_reviewer.review_heading"])
+    try:
+        get_settings().set("pr_reviewer.review_heading", invalid_heading)
+        header = format_pr_review_header()
+    finally:
+        restore_settings(snapshot)
+
+    assert header == "## PR Reviewer Guide 🔍"
+
+
+def test_identity_is_inserted_after_visible_heading_and_is_idempotent():
+    review = "## Team Review 🔍\n\n<table>review</table>"
+
+    marked = add_pr_review_identity(review, PRReviewIdentity.REGULAR.value)
+
+    assert marked.startswith(
+        "## Team Review 🔍\n\n<!-- pr-agent:review:full -->\n\n"
+    )
+    assert add_pr_review_identity(marked, PRReviewIdentity.REGULAR.value) == marked
+
+
+def test_hidden_identity_only_matches_as_a_bounded_standalone_line():
+    marker = PRReviewIdentity.REGULAR.value
+    valid = f"## Team Review 🔍\n\n{marker}\n\nbody"
+    quoted = f"## Human comment\n\n> {marker}\n\nbody"
+    late = "## Human comment\n\na\nb\nc\nd\n" + marker
+
+    assert comment_matches_identity(valid, marker)
+    assert not comment_matches_identity(quoted, marker)
+    assert not comment_matches_identity(late, marker)
+
+
+def test_full_and_incremental_review_identities_remain_distinct():
+    full_identifiers = get_pr_review_comment_identifiers(full=True, incremental=False)
+    incremental_identifiers = get_pr_review_comment_identifiers(full=False, incremental=True)
+    incremental = add_pr_review_identity(
+        "## Incremental Team Review 🔍\n\nbody",
+        PRReviewIdentity.INCREMENTAL.value,
+    )
+
+    assert PRReviewIdentity.REGULAR.value in full_identifiers
+    assert PRReviewIdentity.INCREMENTAL.value not in full_identifiers
+    assert PRReviewIdentity.INCREMENTAL.value in incremental_identifiers
+    assert not any(comment_matches_identity(incremental, item) for item in full_identifiers)
+
+
+@pytest.mark.parametrize(
+    ("body", "full", "incremental"),
+    [
+        ("## PR Reviewer Guide 🔍\n\nlegacy", True, False),
+        ("## Incremental PR Reviewer Guide 🔍\n\nlegacy", False, True),
+        (
+            "## Team Review 🔍\n\n<!-- pr-agent:review:full -->\n\nmarked",
+            True,
+            False,
+        ),
+        (
+            "## Incremental Team Review 🔍\n\n<!-- pr-agent:review:incremental -->\n\nmarked",
+            False,
+            True,
+        ),
+    ],
+)
+def test_github_previous_review_accepts_markers_and_legacy_headers(body, full, incremental):
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.pr = MagicMock()
+    expected = SimpleNamespace(body=body)
+    provider.pr.get_issue_comments.return_value = [expected]
+
+    result = provider.get_previous_review(full=full, incremental=incremental)
+
+    assert result is expected
+
+
+def test_github_full_lookup_does_not_adopt_incremental_marker():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.pr = MagicMock()
+    incremental = SimpleNamespace(
+        body=(
+            "## Incremental Team Review 🔍\n\n"
+            "<!-- pr-agent:review:incremental -->\n\nbody"
+        )
+    )
+    provider.pr.get_issue_comments.return_value = [incremental]
+
+    assert provider.get_previous_review(full=True, incremental=False) is None
+
+
+def test_github_check_run_receives_presentation_without_comment_identity():
+    snapshot = snapshot_settings(["github.publish_as_check_run"])
+    provider = GithubProvider.__new__(GithubProvider)
+    provider._publish_check_run = MagicMock(return_value=True)
+    provider.publish_persistent_comment_full = MagicMock()
+    review = "## Team Review 🔍\n\nbody"
+    try:
+        get_settings().set("github.publish_as_check_run", True)
+
+        provider.publish_persistent_comment(
+            review,
+            initial_header="## Team Review 🔍",
+            identity_marker=PRReviewIdentity.REGULAR.value,
+        )
+    finally:
+        restore_settings(snapshot)
+
+    provider._publish_check_run.assert_called_once_with(review, "review")
+    provider.publish_persistent_comment_full.assert_not_called()
+
+
+def test_github_comment_path_forwards_review_identity():
+    snapshot = snapshot_settings(["github.publish_as_check_run"])
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.publish_persistent_comment_full = MagicMock()
+    review = "## Team Review 🔍\n\nbody"
+    legacy_header = "## PR Reviewer Guide 🔍"
+    try:
+        get_settings().set("github.publish_as_check_run", False)
+
+        provider.publish_persistent_comment(
+            review,
+            initial_header="## Team Review 🔍",
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=legacy_header,
+        )
+    finally:
+        restore_settings(snapshot)
+
+    assert provider.publish_persistent_comment_full.call_args.kwargs == {
+        "identity_marker": PRReviewIdentity.REGULAR.value,
+        "legacy_initial_header": legacy_header,
+    }
+
+
+def test_azure_comment_path_forwards_review_identity():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.publish_persistent_comment_full = MagicMock()
+    review = "## Team Review 🔍\n\nbody"
+    legacy_header = "## PR Reviewer Guide 🔍"
+
+    provider.publish_persistent_comment(
+        review,
+        initial_header="## Team Review 🔍",
+        identity_marker=PRReviewIdentity.REGULAR.value,
+        legacy_initial_header=legacy_header,
+    )
+
+    assert provider.publish_persistent_comment_full.call_args.kwargs == {
+        "identity_marker": PRReviewIdentity.REGULAR.value,
+        "legacy_initial_header": legacy_header,
+    }
+
+
+def test_gitea_keeps_identity_inactive_until_comment_payloads_are_normalized():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.publish_persistent_comment_full = MagicMock()
+    review = "## Team Review 🔍\n\nbody"
+
+    provider.publish_persistent_comment(
+        review,
+        initial_header="## Team Review 🔍",
+        identity_marker=PRReviewIdentity.REGULAR.value,
+        legacy_initial_header="## PR Reviewer Guide 🔍",
+    )
+
+    assert provider.publish_persistent_comment_full.call_args.kwargs == {}


### PR DESCRIPTION
## Summary

- Add `pr_reviewer.review_heading` while preserving the current visible heading by default.
- Separate presentation from stable hidden full and incremental review identities.
- Migrate legacy default-heading reviews in place and keep incremental review discovery compatible across GitHub, GitLab, and Azure DevOps, with persistent update parity for Bitbucket Cloud.

## Compatibility

- GitHub check runs and non-comment artifacts remain presentation-only.
- Gitea stays on its existing legacy persistence path until #2722 normalizes its comment payloads.
- One stable marker represents one persistent `/review` channel; changing the heading does not create multiple named review channels.

## Output example

`review_heading = "Guideline Compliance Check"` renders:

- `## Guideline Compliance Check 🔍`
- `## Incremental Guideline Compliance Check 🔍`

## Tests

- `PYTHONPATH=. pytest -q tests/unittest` — 2153 passed, 1 skipped, 1 xfailed
- Focused review identity, reviewer, GitLab, Bitbucket, and Azure suite — 256 passed

Addresses the `/review` portion of #2038.
