### PR TITLE
fix(bitbucket-server): preserve MOVE rename semantics in pull request diffs

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -284,6 +284,7 @@ class BitbucketServerProvider(GitProvider):
                 get_logger().info(f"Skipping a non-code file: {file_path}")
                 continue
 
+            old_filename = None
             match change['type']:
                 case 'ADD':
                     edit_type = EDIT_TYPE.ADDED
@@ -295,8 +296,15 @@ class BitbucketServerProvider(GitProvider):
                     new_file_content_str = ""
                     original_file_content_str = self.get_file(file_path, base_sha)
                     original_file_content_str = decode_if_bytes(original_file_content_str)
-                case 'RENAME':
+                case 'MOVE' | 'RENAME':
                     edit_type = EDIT_TYPE.RENAMED
+                    source_path = change.get('srcPath') or {}
+                    original_file_path = source_path.get('toString', file_path)
+                    old_filename = original_file_path if original_file_path != file_path else None
+                    original_file_content_str = self.get_file(original_file_path, base_sha)
+                    original_file_content_str = decode_if_bytes(original_file_content_str)
+                    new_file_content_str = self.get_file(file_path, head_sha)
+                    new_file_content_str = decode_if_bytes(new_file_content_str)
                 case _:
                     edit_type = EDIT_TYPE.MODIFIED
                     original_file_content_str = self.get_file(file_path, base_sha)
@@ -313,6 +321,7 @@ class BitbucketServerProvider(GitProvider):
                     patch,
                     file_path,
                     edit_type=edit_type,
+                    old_filename=old_filename,
                 )
             )
 

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -170,6 +170,48 @@ class TestBitbucketServerProvider:
         logger.error.assert_not_called()
         logger.info.assert_not_called()
 
+    def test_get_diff_files_preserves_bitbucket_server_move_semantics(self):
+        bitbucket_client = MagicMock(Bitbucket)
+        bitbucket_client.get_pull_request.return_value = {
+            'toRef': {'latestCommit': 'base-sha'},
+            'fromRef': {'latestCommit': 'head-sha'},
+        }
+        bitbucket_client.get_pull_requests_commits.return_value = [
+            {'id': 'head-sha', 'parents': [{'id': 'base-sha'}]},
+        ]
+        bitbucket_client.get_pull_requests_changes.return_value = [
+            {
+                'path': {'toString': 'new.py'},
+                'srcPath': {'toString': 'old.py'},
+                'type': 'MOVE',
+            },
+        ]
+
+        def get_content_of_file(project_key, repository_slug, path, at=None, markup=None):
+            contents = {
+                ('old.py', 'base-sha'): 'old content\n',
+                ('new.py', 'head-sha'): 'new content\n',
+            }
+            return contents.get((path, at), '')
+
+        bitbucket_client.get_content_of_file.side_effect = get_content_of_file
+
+        provider = BitbucketServerProvider(
+            "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1",
+            bitbucket_client=bitbucket_client,
+        )
+
+        actual = provider.get_diff_files()
+
+        assert len(actual) == 1
+        assert actual[0].base_file == 'old content\n'
+        assert actual[0].head_file == 'new content\n'
+        assert actual[0].filename == 'new.py'
+        assert actual[0].old_filename == 'old.py'
+        assert actual[0].edit_type == EDIT_TYPE.RENAMED
+        assert '-old content' in actual[0].patch
+        assert '+new content' in actual[0].patch
+
     def mock_get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
         content_map = {
             '9c1cffdd9f276074bfb6fb3b70fbee62d298b058': 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n',


### PR DESCRIPTION
## Summary

- Handle Bitbucket Server `MOVE` changes (and the existing `RENAME` spelling) using the source path for base content.
- Preserve `FilePatchInfo.old_filename` and `EDIT_TYPE.RENAMED` for moved files.
- Add a deterministic regression test using the official Bitbucket Server change payload shape.

Fixes #2800

## Root cause

Bitbucket Server represents a moved or renamed file with `type: "MOVE"`, `path` as the destination path, and `srcPath` as the source path. The provider only matched `"RENAME"`; official `MOVE` entries therefore used the modified-file branch and fetched the destination path from the base commit.

## Validation

- Baseline red: `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_bitbucket_provider.py::TestBitbucketServerProvider::test_get_diff_files_preserves_bitbucket_server_move_semantics -q` — failed with `AssertionError: assert '' == 'old content\\n'`.
- Target green: same command — `1 passed`.
- Provider regression: `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_bitbucket_provider.py -q` — `25 passed`.
- Full unit suite: `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest -q` — `2089 passed, 1 skipped, 1 xfailed, 92 warnings`.
- Compile check: `/tmp/pr-agent-full-venv/bin/python -m compileall -q pr_agent` — passed.
- Whitespace check: `git diff --check` and staged `git diff --cached --check` — passed.

Ruff and pre-commit were not available in the local environment. The CI-equivalent `docker build --target test` was attempted but canceled during the first ARM64 dependency installation after about five minutes; this was an environment/dependency-download limitation, not a test failure.

## Scope

This change is limited to Bitbucket Server diff-file conversion and its regression test. No other provider, API, or historical contribution is included.
