### PR TITLE
fix(gitlab): restore ticket context in reviews

### DIFF
--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -54,10 +54,11 @@ MAX_ASANA_TICKETS = 3
 MAX_GITHUB_TICKETS = 3
 MAX_GITLAB_TICKETS = 3
 GITLAB_TICKET_PATTERN = re.compile(
-    r"(?P<url>https?://[^\s<>()]+?/-/issues/(?P<url_issue>\d+))(?=$|[^\w])"
+    r"(?P<url>https?://[^\s<>(),;]+)"
     r"|(?<![\w./-])(?P<project>[\w.-]+(?:/[\w.-]+)+)#(?P<project_issue>\d+)\b"
     r"|(?<![\w/])#(?P<local_issue>\d+)\b"
 )
+GITLAB_ISSUE_PATH_PATTERN = re.compile(r"/-/issues/(?P<iid>\d+)(?=/|$)")
 
 
 def find_asana_tickets(text: str | None) -> list:
@@ -201,7 +202,7 @@ def extract_gitlab_ticket_references(pr_description, repo_path, gitlab_url):
     for match in GITLAB_TICKET_PATTERN.finditer(pr_description):
         if match.group("url"):
             try:
-                parsed_ticket_url = urlparse(match.group("url"))
+                parsed_ticket_url = urlparse(match.group("url").rstrip(".:!?'\\\"]}`*"))
             except ValueError:
                 continue
             if not provider_host or parsed_ticket_url.hostname != provider_host:
@@ -213,11 +214,11 @@ def extract_gitlab_ticket_references(pr_description, repo_path, gitlab_url):
                     continue
                 ticket_path = ticket_path[len(provider_base_path):]
 
-            issue_iid = int(match.group("url_issue"))
-            issue_suffix = f"/-/issues/{issue_iid}"
-            if not ticket_path.endswith(issue_suffix):
+            path_match = GITLAB_ISSUE_PATH_PATTERN.search(ticket_path)
+            if not path_match:
                 continue
-            issue_project = ticket_path[:-len(issue_suffix)].strip("/")
+            issue_iid = int(path_match.group("iid"))
+            issue_project = ticket_path[:path_match.start()].strip("/")
         elif match.group("project"):
             issue_project = match.group("project")
             issue_iid = int(match.group("project_issue"))

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import aiohttp
 
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import AzureDevopsProvider, GithubProvider
+from pr_agent.git_providers import AzureDevopsProvider, GithubProvider, GitLabProvider
 from pr_agent.log import get_logger
 
 # Compile the regex pattern once, outside the function
@@ -52,6 +52,12 @@ DEFAULT_ASANA_REQUEST_TIMEOUT = 10
 MAX_ASANA_REQUEST_TIMEOUT = 60
 MAX_ASANA_TICKETS = 3
 MAX_GITHUB_TICKETS = 3
+MAX_GITLAB_TICKETS = 3
+GITLAB_TICKET_PATTERN = re.compile(
+    r"(?P<url>https?://[^\s<>()]+?/-/issues/(?P<url_issue>\d+))(?=$|[^\w])"
+    r"|(?<![\w./-])(?P<project>[\w.-]+(?:/[\w.-]+)+)#(?P<project_issue>\d+)\b"
+    r"|(?<![\w/])#(?P<local_issue>\d+)\b"
+)
 
 
 def find_asana_tickets(text: str | None) -> list:
@@ -175,6 +181,61 @@ def _get_user_description_for_asana(git_provider) -> str:
         get_logger().warning(f"Failed to read PR description for Asana references: {e}")
         return ""
     return description if isinstance(description, str) else ""
+
+
+def extract_gitlab_ticket_references(pr_description, repo_path, gitlab_url):
+    """Extract ``(project_path, issue_iid)`` references from a GitLab MR description."""
+    if not isinstance(pr_description, str) or not pr_description:
+        return []
+
+    try:
+        provider_url = urlparse(gitlab_url or "")
+        provider_host = provider_url.hostname or ""
+        provider_base_path = provider_url.path.rstrip("/")
+    except (AttributeError, TypeError, ValueError):
+        provider_host = ""
+        provider_base_path = ""
+
+    references = []
+    seen = set()
+    for match in GITLAB_TICKET_PATTERN.finditer(pr_description):
+        if match.group("url"):
+            try:
+                parsed_ticket_url = urlparse(match.group("url"))
+            except ValueError:
+                continue
+            if not provider_host or parsed_ticket_url.hostname != provider_host:
+                continue
+
+            ticket_path = parsed_ticket_url.path
+            if provider_base_path:
+                if not ticket_path.startswith(f"{provider_base_path}/"):
+                    continue
+                ticket_path = ticket_path[len(provider_base_path):]
+
+            issue_iid = int(match.group("url_issue"))
+            issue_suffix = f"/-/issues/{issue_iid}"
+            if not ticket_path.endswith(issue_suffix):
+                continue
+            issue_project = ticket_path[:-len(issue_suffix)].strip("/")
+        elif match.group("project"):
+            issue_project = match.group("project")
+            issue_iid = int(match.group("project_issue"))
+        else:
+            issue_project = repo_path
+            issue_iid = int(match.group("local_issue"))
+
+        if not issue_project:
+            continue
+        reference = (issue_project, issue_iid)
+        dedupe_key = (issue_project.casefold(), issue_iid)
+        if dedupe_key not in seen:
+            seen.add(dedupe_key)
+            references.append(reference)
+
+    if len(references) > MAX_GITLAB_TICKETS:
+        get_logger().info(f"Too many GitLab tickets found in MR description: {len(references)}")
+    return references[:MAX_GITLAB_TICKETS]
 
 
 def extract_ticket_links_from_pr_description(pr_description, repo_path, base_url_html='https://github.com'):
@@ -430,6 +491,41 @@ async def extract_tickets(git_provider):
                         'labels': ", ".join(labels),
                         'sub_issues': sub_issues_content  # Store sub-issues content
                     })
+
+            tickets_content.extend(asana_tickets_content)
+            return tickets_content
+
+        elif isinstance(git_provider, GitLabProvider):
+            references = extract_gitlab_ticket_references(
+                user_description,
+                git_provider.id_project,
+                git_provider.gitlab_url,
+            )
+            tickets_content = []
+            for project_path, issue_iid in references:
+                try:
+                    project = git_provider.gl.projects.get(project_path)
+                    issue = project.issues.get(issue_iid)
+                except Exception as e:
+                    get_logger().error(
+                        f"Error getting GitLab issue {project_path}#{issue_iid}: {e}",
+                        artifact={"traceback": traceback.format_exc()},
+                    )
+                    continue
+
+                issue_body = issue.description or ""
+                if len(issue_body) > MAX_TICKET_CHARACTERS:
+                    issue_body = issue_body[:MAX_TICKET_CHARACTERS] + "..."
+
+                tickets_content.append(
+                    {
+                        "ticket_id": issue.iid,
+                        "ticket_url": issue.web_url,
+                        "title": issue.title,
+                        "body": issue_body,
+                        "labels": ", ".join(issue.labels or []),
+                    }
+                )
 
             tickets_content.extend(asana_tickets_content)
             return tickets_content

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -56,7 +56,7 @@ MAX_GITLAB_TICKETS = 3
 GITLAB_TICKET_PATTERN = re.compile(
     r"(?P<url>https?://[^\s<>(),;]+)"
     r"|(?<![\w./-])(?P<project>[\w.-]+(?:/[\w.-]+)+)#(?P<project_issue>\d+)\b"
-    r"|(?<![\w/])#(?P<local_issue>\d+)\b"
+    r"|(?<![\w/#])#(?P<local_issue>\d+)\b"
 )
 GITLAB_ISSUE_PATH_PATTERN = re.compile(r"/-/issues/(?P<iid>\d+)(?=/|$)")
 

--- a/tests/unittest/test_ticket_extraction_async.py
+++ b/tests/unittest/test_ticket_extraction_async.py
@@ -6,11 +6,12 @@ These tests are deterministic and fake-provider based — no live API or
 network access is performed.
 """
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import AzureDevopsProvider, GithubProvider
+from pr_agent.git_providers import AzureDevopsProvider, GithubProvider, GitLabProvider
 from pr_agent.tools import ticket_pr_compliance_check as tpc
 from pr_agent.tools.ticket_pr_compliance_check import (
     extract_and_cache_pr_tickets,
@@ -99,6 +100,26 @@ def _make_azure_provider(work_items):
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
     provider.get_linked_work_items = lambda: work_items
     return provider
+
+
+def _make_gitlab_provider(user_description):
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.id_project = "group/repo"
+    provider.gitlab_url = "https://gitlab.com"
+    provider.get_user_description = lambda: user_description
+
+    issue = MagicMock(
+        iid=7,
+        web_url="https://gitlab.com/group/repo/-/issues/7",
+        title="GitLab issue",
+        description="Issue body",
+        labels=["bug", "backend"],
+    )
+    project = MagicMock()
+    project.issues.get.return_value = issue
+    provider.gl = MagicMock()
+    provider.gl.projects.get.return_value = project
+    return provider, project
 
 
 # ---------------------------------------------------------------------------
@@ -571,6 +592,38 @@ class TestAzureDevopsExtraction:
         assert result[1]["body"] == "short"
         assert result[1]["labels"] == ""
         assert result[1].get("requirements", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7b: GitLab issues referenced in the MR description
+# ---------------------------------------------------------------------------
+
+class TestGitLabExtraction:
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "https://gitlab.com/group/repo/-/issues/7",
+            "group/repo#7",
+            "#7",
+        ],
+    )
+    def test_issue_reference_is_mapped_to_ticket_context(self, reference, settings_snapshot):
+        provider, project = _make_gitlab_provider(f"Fixes {reference}")
+
+        result = asyncio.run(extract_tickets(provider))
+
+        assert result is not None, "GitLab issue references must produce ticket context"
+        assert result == [
+            {
+                "ticket_id": 7,
+                "ticket_url": "https://gitlab.com/group/repo/-/issues/7",
+                "title": "GitLab issue",
+                "body": "Issue body",
+                "labels": "bug, backend",
+            }
+        ]
+        provider.gl.projects.get.assert_called_once_with("group/repo")
+        project.issues.get.assert_called_once_with(7)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/test_ticket_extraction_async.py
+++ b/tests/unittest/test_ticket_extraction_async.py
@@ -15,6 +15,7 @@ from pr_agent.git_providers import AzureDevopsProvider, GithubProvider, GitLabPr
 from pr_agent.tools import ticket_pr_compliance_check as tpc
 from pr_agent.tools.ticket_pr_compliance_check import (
     extract_and_cache_pr_tickets,
+    extract_gitlab_ticket_references,
     extract_tickets,
 )
 from tests.unittest._settings_helpers import restore_settings, snapshot_settings
@@ -599,6 +600,50 @@ class TestAzureDevopsExtraction:
 # ---------------------------------------------------------------------------
 
 class TestGitLabExtraction:
+    @pytest.mark.parametrize(
+        ("description", "repo_path", "gitlab_url", "expected"),
+        [
+            (
+                "See https://gitlab.com/group/repo/-/issues/7.",
+                "group/repo",
+                "https://gitlab.com",
+                [("group/repo", 7)],
+            ),
+            (
+                "See (**`https://gitlab.com/group/repo/-/issues/7`**)",
+                "group/repo",
+                "https://gitlab.com",
+                [("group/repo", 7)],
+            ),
+            (
+                "https://gitlab.example.com:8443/gitlab/group/sub/repo/-/issues/7#note_42",
+                "group/sub/repo",
+                "https://gitlab.example.com:8443/gitlab",
+                [("group/sub/repo", 7)],
+            ),
+            (
+                "https://gitlab.com/group/repo/-/issues/007",
+                "group/repo",
+                "https://gitlab.com",
+                [("group/repo", 7)],
+            ),
+            (
+                "https://gitlab.com/group/repo/-/issues/7abc",
+                "group/repo",
+                "https://gitlab.com",
+                [],
+            ),
+            (
+                "https://gitlab.com/not-an-issue,https://gitlab.com/group/repo/-/issues/7",
+                "group/repo",
+                "https://gitlab.com",
+                [("group/repo", 7)],
+            ),
+        ],
+    )
+    def test_url_reference_boundaries(self, description, repo_path, gitlab_url, expected):
+        assert extract_gitlab_ticket_references(description, repo_path, gitlab_url) == expected
+
     @pytest.mark.parametrize(
         "reference",
         [

--- a/tests/unittest/test_ticket_extraction_async.py
+++ b/tests/unittest/test_ticket_extraction_async.py
@@ -645,6 +645,17 @@ class TestGitLabExtraction:
         assert extract_gitlab_ticket_references(description, repo_path, gitlab_url) == expected
 
     @pytest.mark.parametrize(
+        ("description", "expected"),
+        [
+            ("##7", []),
+            ("group/proj#7", [("group/proj", 7)]),
+            ("#7", [("group/repo", 7)]),
+        ],
+    )
+    def test_shorthand_reference_boundaries(self, description, expected):
+        assert extract_gitlab_ticket_references(description, "group/repo", "https://gitlab.com") == expected
+
+    @pytest.mark.parametrize(
         "reference",
         [
             "https://gitlab.com/group/repo/-/issues/7",


### PR DESCRIPTION
Fixes #2799.

## Summary

- Parse documented GitLab issue references from merge request descriptions.
- Fetch each issue through the configured GitLab project client and map it to the existing ticket context shape.
- Keep branch-name detection GitHub-only and preserve the three-ticket and body-length bounds.

## Tests

- RED: the focused GitLab extraction test returns no ticket context on the unmodified base.
- GREEN: `PYTHONPATH=. .venv/bin/pytest tests/unittest -q --color=no`