### PR TITLE
fix(gitlab): strip sub-path prefix when parsing merge request URLs

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1317,8 +1317,13 @@ class GitLabProvider(GitProvider):
 
         # Strip the deployment sub-path prefix (e.g. '/gitlab') from the URL path
         # so projects hosted on a GitLab instance using a relative URL parse correctly.
-        base_path_parts = [part for part in urlparse(self.gitlab_url).path.split("/") if part]
-        if base_path_parts and path_parts[:len(base_path_parts)] == base_path_parts:
+        # Only strip when the URL points at the configured GitLab host, so a prefix
+        # from another host is never rewritten into a project on this instance.
+        gitlab_base = urlparse(self.gitlab_url)
+        base_path_parts = [part for part in gitlab_base.path.split("/") if part]
+        same_host = (parsed_url.scheme.lower() == gitlab_base.scheme.lower()
+                     and parsed_url.netloc.lower() == gitlab_base.netloc.lower())
+        if same_host and base_path_parts and path_parts[:len(base_path_parts)] == base_path_parts:
             path_parts = path_parts[len(base_path_parts):]
 
         if 'merge_requests' not in path_parts:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1314,6 +1314,13 @@ class GitLabProvider(GitProvider):
         parsed_url = urlparse(merge_request_url)
 
         path_parts = parsed_url.path.strip('/').split('/')
+
+        # Strip the deployment sub-path prefix (e.g. '/gitlab') from the URL path
+        # so projects hosted on a GitLab instance using a relative URL parse correctly.
+        base_path_parts = [part for part in urlparse(self.gitlab_url).path.split("/") if part]
+        if base_path_parts and path_parts[:len(base_path_parts)] == base_path_parts:
+            path_parts = path_parts[len(base_path_parts):]
+
         if 'merge_requests' not in path_parts:
             raise ValueError("The provided URL does not appear to be a GitLab merge request URL")
 

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1449,6 +1449,16 @@ class TestGitLabProviderUrlParsing:
         assert provider._parse_merge_request_url(
             "https://host.local/gitlab/shai/pr-agent/-/merge_requests/12") == ("shai/pr-agent", 12)
 
+    def test_parse_merge_request_url_matches_host_with_port(self):
+        provider = self._provider("https://host.local:8443/gitlab")
+        assert provider._parse_merge_request_url(
+            "https://host.local:8443/gitlab/shai/pr-agent/-/merge_requests/12") == ("shai/pr-agent", 12)
+
+    def test_parse_merge_request_url_prefix_on_other_host_is_not_stripped(self):
+        provider = self._provider("https://host.local/gitlab")
+        assert provider._parse_merge_request_url(
+            "https://other.example/gitlab/acme/repo/-/merge_requests/7") == ("gitlab/acme/repo", 7)
+
     def test_parse_merge_request_url_prefix_mismatch_keeps_current_behavior(self):
         provider = self._provider("https://gitlab.com")
         assert provider._parse_merge_request_url(

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1409,3 +1409,52 @@ class TestGitLabRelevantDiff:
             provider.get_relevant_diff("app.py", "+added line")
 
         assert mock_logger.return_value.debug.call_count == 1
+
+
+class TestGitLabProviderUrlParsing:
+    """Cover MR URL parsing on GitLab instances deployed under a relative URL (sub-path).
+
+    `__init__` performs network calls, so build the provider with `__new__`
+    and exercise the pure helper only.
+    """
+
+    @staticmethod
+    def _provider(gitlab_url="https://gitlab.com"):
+        provider = GitLabProvider.__new__(GitLabProvider)
+        provider.gitlab_url = gitlab_url
+        return provider
+
+    def test_parse_merge_request_url_plain(self):
+        provider = self._provider("https://gitlab.com")
+        assert provider._parse_merge_request_url(
+            "https://gitlab.com/group/subgroup/repo/-/merge_requests/123") == ("group/subgroup/repo", 123)
+
+    def test_parse_merge_request_url_strips_sub_path_prefix(self):
+        provider = self._provider("https://host.local/gitlab")
+        assert provider._parse_merge_request_url(
+            "https://host.local/gitlab/shai/pr-agent/-/merge_requests/12") == ("shai/pr-agent", 12)
+
+    def test_parse_merge_request_url_sub_path_nested_groups(self):
+        provider = self._provider("https://host.local/gitlab")
+        assert provider._parse_merge_request_url(
+            "https://host.local/gitlab/group/sub/repo/-/merge_requests/9") == ("group/sub/repo", 9)
+
+    def test_parse_merge_request_url_multi_segment_sub_path(self):
+        provider = self._provider("https://gitlab.example.com/gitlab/app")
+        assert provider._parse_merge_request_url(
+            "https://gitlab.example.com/gitlab/app/shai/pr-agent/-/merge_requests/5") == ("shai/pr-agent", 5)
+
+    def test_parse_merge_request_url_config_with_trailing_slash(self):
+        provider = self._provider("https://host.local/gitlab/")
+        assert provider._parse_merge_request_url(
+            "https://host.local/gitlab/shai/pr-agent/-/merge_requests/12") == ("shai/pr-agent", 12)
+
+    def test_parse_merge_request_url_prefix_mismatch_keeps_current_behavior(self):
+        provider = self._provider("https://gitlab.com")
+        assert provider._parse_merge_request_url(
+            "https://host.local/gitlab/shai/pr-agent/-/merge_requests/12") == ("gitlab/shai/pr-agent", 12)
+
+    def test_parse_merge_request_url_rejects_non_mr_url_with_sub_path(self):
+        provider = self._provider("https://host.local/gitlab")
+        with pytest.raises(ValueError):
+            provider._parse_merge_request_url("https://host.local/gitlab/shai/pr-agent")


### PR DESCRIPTION
Fixes #2803.

## Summary

Self-hosted GitLab instances deployed under a relative URL / sub-path (e.g. `https://host.local/gitlab`) include the sub-path prefix in every merge request URL. `_parse_merge_request_url` blindly took everything before the `merge_requests` marker as the project path, so the prefix leaked into the project ID (`gitlab/shai/pr-agent` instead of `shai/pr-agent`) and the resulting API request crashed with `InvalidSchema`.

## Fix

Strip the deployment sub-path prefix — taken from the path component of `settings.gitlab.url` (e.g. `/gitlab`) — from the beginning of the URL path before locating the `merge_requests` marker. The strip only happens when the configured prefix matches the start of the path segment-by-segment, so deployments without a sub-path prefix keep their current behavior.

## Tests

Added 9 regression tests to `tests/unittest/test_gitlab_provider.py` (using the existing `GitLabProvider.__new__` pure-helper pattern) covering:
- standard and nested-group URLs (unchanged behavior)
- single and multi-segment sub-path prefixes
- trailing slash in the configured URL
- prefix mismatch keeping current behavior
- non-MR URLs still raising `ValueError`

Verified: `pytest tests/unittest/test_gitlab_provider.py -q` -> 120 passed. Full `tests/unittest` suite shows no new failures vs `main` (only pre-existing Windows-environment cases). flake8 with the repo config (line-length 120) reports no new findings.

## Coordination

I'm aware #2719 also touches `_parse_merge_request_url` (numeric project-ID aliases). That change is independent — the prefix strip happens before the marker lookup — and I'll rebase if #2719 lands first.

*Maintainer edit (IsmaelMartinez): corrected the test count for the two added in e823dc6d; see review below.*
