### PR TITLE
chore(deps): bump Python base image from 3.12.13 to 3.12.14

### DIFF
--- a/Dockerfile.github_action
+++ b/Dockerfile.github_action
@@ -1,4 +1,4 @@
-FROM python:3.12.13-slim AS base
+FROM python:3.12.14-slim AS base
 
 RUN apt-get update && apt-get install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.13-slim AS base
+FROM python:3.12.14-slim AS base
 
 RUN apt update && apt install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Python 3.12.14 is a security release of the 3.12 series, fixing:

- CVE-2026-2297: SourcelessFileLoader bypasses io.open_code()
- CVE-2026-3644: http.cookies control characters allow header injection
- CVE-2026-4224: xml.parsers.expat crash on deeply nested XML
- tarfile extraction filter symlink escape (bypass of CVE-2025-4330)
- bundled libexpat 2.8.3, plus various DoS hardening

Refs:
- https://www.python.org/downloads/release/python-31214/