### PR TITLE
fix(gitlab): retry overflowed merge request diffs

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -361,6 +361,17 @@ class GitLabProvider(GitProvider):
                 })
         return out
 
+    def _get_merge_request_changes(self) -> dict:
+        """Retrieve the complete merge request change set when GitLab reports overflow."""
+        changes = self.mr.changes()
+        if isinstance(changes, dict) and changes.get("overflow"):
+            get_logger().warning(
+                f"GitLab returned an overflowed diff for merge request {self.id_mr}; "
+                "retrying with access_raw_diffs=True"
+            )
+            return self.mr.changes(access_raw_diffs=True)
+        return changes
+
     def is_supported(self, capability: str) -> bool:
         if capability in ['create_inline_comment', 'publish_inline_comments',
             'publish_file_comments']: # gfm_markdown is supported in gitlab !
@@ -539,7 +550,7 @@ class GitLabProvider(GitProvider):
         try:
             mr_change_paths = {
                 c.get('new_path')
-                for c in self.mr.changes().get('changes', [])
+                for c in self._get_merge_request_changes().get('changes', [])
                 if c.get('new_path')
             }
         except Exception as e:
@@ -744,7 +755,7 @@ class GitLabProvider(GitProvider):
             if not head_sha_for_content:
                 head_sha_for_content = (self.mr.diff_refs or {}).get('head_sha')
         else:
-            raw_changes = self.mr.changes().get('changes', [])
+            raw_changes = self._get_merge_request_changes().get('changes', [])
             raw_changes = self._expand_submodule_changes(raw_changes)
             base_sha_for_content = self.mr.diff_refs['base_sha']
             head_sha_for_content = self.mr.diff_refs['head_sha']
@@ -822,7 +833,7 @@ class GitLabProvider(GitProvider):
                 and getattr(self, 'unreviewed_files_map', None)):
             return list(self.unreviewed_files_map.keys())
         if not self.git_files:
-            raw_changes = self.mr.changes().get('changes', [])
+            raw_changes = self._get_merge_request_changes().get('changes', [])
             raw_changes = self._expand_submodule_changes(raw_changes)
             self.git_files = [c.get('new_path') for c in raw_changes if c.get('new_path')]
         return self.git_files
@@ -1045,7 +1056,7 @@ class GitLabProvider(GitProvider):
                     get_logger().exception(f"Failed to create comment in MR {self.id_mr}")
 
     def get_relevant_diff(self, relevant_file: str, relevant_line_in_file: str) -> Optional[dict]:
-        _changes = self.mr.changes()  # dict
+        _changes = self._get_merge_request_changes()
         _changes['changes'] = self._expand_submodule_changes(_changes.get('changes', []))
         changes = _changes
         if not changes:

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from gitlab import Gitlab
@@ -1029,6 +1029,84 @@ class TestGitLabIncrementalReview:
         gitlab_provider.mr.changes.return_value = {"changes": [{"new_path": "x.py"}]}
 
         assert gitlab_provider.get_files() == ["x.py"]
+
+    def test_get_files_retries_raw_diffs_when_changes_overflow(self, gitlab_provider):
+        gitlab_provider.git_files = None
+        gitlab_provider.mr.changes.side_effect = [
+            {"changes": [{"new_path": "visible.py"}], "overflow": True},
+            {
+                "changes": [
+                    {"new_path": "visible.py"},
+                    {"new_path": "hidden.py"},
+                ],
+                "overflow": False,
+            },
+        ]
+
+        assert gitlab_provider.get_files() == ["visible.py", "hidden.py"]
+        assert gitlab_provider.mr.changes.call_args_list == [
+            call(),
+            call(access_raw_diffs=True),
+        ]
+
+    def test_get_diff_files_retries_raw_diffs_when_changes_overflow(self, gitlab_provider):
+        change = {
+            "old_path": "visible.py",
+            "new_path": "visible.py",
+            "diff": "@@ -1 +1 @@\n-old\n+new\n",
+            "new_file": False,
+            "deleted_file": False,
+            "renamed_file": False,
+        }
+        hidden_change = {**change, "old_path": "hidden.py", "new_path": "hidden.py"}
+        gitlab_provider.mr.changes.side_effect = [
+            {"changes": [change], "overflow": True},
+            {"changes": [change, hidden_change], "overflow": False},
+        ]
+        gitlab_provider.get_pr_file_content = MagicMock(return_value="")
+
+        diff_files = gitlab_provider.get_diff_files()
+
+        assert [file.filename for file in diff_files] == ["visible.py", "hidden.py"]
+        assert gitlab_provider.mr.changes.call_args_list == [
+            call(),
+            call(access_raw_diffs=True),
+        ]
+
+    def test_incremental_scope_retries_raw_diffs_when_changes_overflow(
+        self, gitlab_provider, mock_project
+    ):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(7, "## PR Reviewer Guide 🔍\nbody", "2024-05-01T10:00:00Z"),
+        ]
+        gitlab_provider.mr.commits.return_value = [
+            self._make_commit("c1", "2024-05-01T11:00:00Z"),
+            self._make_commit("c0", "2024-05-01T09:00:00Z"),
+        ]
+        mock_project.repository_compare.return_value = {
+            "diffs": [
+                {"new_path": "visible.py"},
+                {"new_path": "hidden.py"},
+            ]
+        }
+        gitlab_provider.mr.changes.side_effect = [
+            {"changes": [{"new_path": "visible.py"}], "overflow": True},
+            {
+                "changes": [
+                    {"new_path": "visible.py"},
+                    {"new_path": "hidden.py"},
+                ],
+                "overflow": False,
+            },
+        ]
+
+        gitlab_provider.get_incremental_commits(IncrementalPR(True))
+
+        assert set(gitlab_provider.unreviewed_files_map) == {"visible.py", "hidden.py"}
+        assert gitlab_provider.mr.changes.call_args_list == [
+            call(),
+            call(access_raw_diffs=True),
+        ]
 
     def test_get_previous_review_returns_most_recent_match(self, gitlab_provider):
         from pr_agent.algo.utils import PRReviewHeader


### PR DESCRIPTION
Fixes #2805

## What does this PR do?

GitLab can return a partial merge-request `changes` response with
`overflow=true`. The provider previously treated that partial list as complete,
so the omitted files never reached normal or incremental review.

This change centralizes the GitLab merge-request changes request. When the first
response reports overflow, it retries with `access_raw_diffs=True`, the
python-gitlab-supported request option for retrieving the raw diff set. The
complete result is then used by the existing full-review file discovery, diff
construction, incremental-scope filtering, and relevant-diff paths. Responses
without overflow are unchanged.

## Tests

- Added regression coverage for `get_files()` discovering a file returned only by
  the raw response.
- Added regression coverage for `get_diff_files()` including the omitted file in
  the review diff.
- Added regression coverage for incremental scope filtering using the complete
  merge-request file set.
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_gitlab_provider.py -q`: 127 passed
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_gitlab_provider.py tests/unittest/test_gitea_provider.py -q`: 165 passed
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest -q`: 2253 passed, 1 skipped, 1 xfailed, 89 warnings
- `git diff origin/main...HEAD --check`: passed

Ruff, flake8, and pre-commit were unavailable in the local environment.

## Scope

No new dependency or provider-wide refactor is introduced. This handles GitLab's
explicit response-level overflow signal; hard limits that remain after the raw
diff request are outside this focused change.

## AI disclosure

This contribution was prepared with AI assistance. The implementation, tests,
and verification results were reviewed by the contributor, who takes
responsibility for the submitted changes.
