### PR TITLE
fix: fall back for oversized Claude token requests

### DIFF
--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -1,6 +1,6 @@
-from threading import Lock
-from math import ceil
 import re
+from math import ceil
+from threading import Lock
 
 from jinja2 import Environment, StrictUndefined
 from tiktoken import encoding_for_model, get_encoding
@@ -13,7 +13,7 @@ class ModelTypeValidator:
     @staticmethod
     def is_openai_model(model_name: str) -> bool:
         return 'gpt' in model_name or re.match(r"^o[1-9](-mini|-preview)?$", model_name)
-    
+
     @staticmethod
     def is_anthropic_model(model_name: str) -> bool:
         return 'claude' in model_name
@@ -67,7 +67,7 @@ class TokenHandler:
         - user: The user string.
         """
         self.encoder = TokenEncoder.get_token_encoder()
-        
+
         if pr is not None:
             self.prompt_tokens = self._get_system_user_tokens(pr, self.encoder, vars, system, user)
 
@@ -99,16 +99,14 @@ class TokenHandler:
     def _calc_claude_tokens(self, patch: str) -> int:
         try:
             import anthropic
-            from pr_agent.algo import MAX_TOKENS
-            
+
             client = anthropic.Anthropic(api_key=get_settings(use_context=False).get('anthropic.key'))
-            max_tokens = MAX_TOKENS[get_settings().config.model]
 
             if len(patch.encode('utf-8')) > self.CLAUDE_MAX_CONTENT_SIZE:
                 get_logger().warning(
                     "Content too large for Anthropic token counting API, falling back to local tokenizer"
                 )
-                return max_tokens
+                return 0
 
             response = client.messages.count_tokens(
                 model=self.CLAUDE_MODEL,
@@ -155,7 +153,7 @@ class TokenHandler:
             int: The calculated token count.
         """
         model_name = get_settings().config.model.lower()
-        
+
         if ModelTypeValidator.is_openai_model(model_name) and get_settings(use_context=False).get('openai.key'):
             return default_estimate
 
@@ -166,7 +164,7 @@ class TokenHandler:
             return self._apply_estimation_factor(model_name, default_estimate)
 
         return self._apply_estimation_factor(model_name, default_estimate)
-    
+
     def count_tokens(self, patch: str, force_accurate: bool = False) -> int:
         """
         Counts the number of tokens in a given patch string.

--- a/tests/unittest/test_token_handler.py
+++ b/tests/unittest/test_token_handler.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pr_agent.algo import token_handler
+
+
+def test_oversized_claude_patch_falls_back_to_local_estimate(monkeypatch):
+    settings = SimpleNamespace(
+        config=SimpleNamespace(model="claude-3-7-sonnet-20250219"),
+        get=lambda key, default=None: {
+            "anthropic.key": "test-key",
+            "config.model_token_count_estimate_factor": 0.3,
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        token_handler, "get_settings", lambda use_context=False: settings
+    )
+
+    client = MagicMock()
+    anthropic_module = types.ModuleType("anthropic")
+    anthropic_module.Anthropic = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+
+    handler = token_handler.TokenHandler.__new__(token_handler.TokenHandler)
+    handler.encoder = MagicMock()
+    handler.encoder.encode.return_value = [0] * 10
+    handler.CLAUDE_MAX_CONTENT_SIZE = 3
+
+    assert handler.count_tokens("abcd", force_accurate=True) == 13
+    client.messages.count_tokens.assert_not_called()


### PR DESCRIPTION
Fixes #2680

### What does this PR do?

When accurate Claude token counting receives content larger than Anthropic's 9 MB
request limit, PR-Agent logs that it is falling back to the local tokenizer but
returns the configured model's fixed `MAX_TOKENS` value instead. For a Claude
model with a 200,000-token limit, a large patch is therefore reported as exactly
200,000 tokens rather than using the existing local estimate and estimation
factor.

This change returns `0` from the oversized-content branch so the existing
`_get_token_count_by_model_type()` fallback applies `_apply_estimation_factor()`
to the local tokenizer estimate. The unused `MAX_TOKENS` lookup is removed from
this path.

### Tests

- Added a unit regression test for an oversized Claude patch.
- The test verifies that the existing local estimate is used and that the
  Anthropic `messages.count_tokens` API is not called.
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest/test_token_handler.py -q`: `1 passed`
- `PYTHONPATH=. /tmp/pr-agent-full-venv/bin/pytest tests/unittest -q`: `2251 passed, 1 skipped, 1 xfailed, 91 warnings`
- `/tmp/pr-agent-full-venv/bin/pre-commit run --files pr_agent/algo/token_handler.py tests/unittest/test_token_handler.py`: passed
- `/tmp/pr-agent-full-venv/bin/pyflakes pr_agent/algo/token_handler.py tests/unittest/test_token_handler.py`: passed
- `git diff --check`: passed

### Scope

The original exception-handler path in #2680 was already corrected upstream by
#2256. This patch only completes the remaining content-too-large fallback called
out by the maintainer; normal-size Claude token requests keep their existing API
path.

### AI disclosure

This contribution was prepared with AI assistance. The implementation, tests,
and verification results were reviewed by the contributor, who takes
responsibility for the submitted changes.
