### PR TITLE
fix(agent): preserve quoted webhook command arguments

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -47,6 +47,23 @@ command2class = {
 commands = list(command2class.keys())
 
 
+def prepare_command(command: str) -> list[str]:
+    """Apply command-line settings while preserving quoted argument boundaries.
+
+    Webhook adapters use this before handing configured commands to ``PRAgent``. Parsing
+    with ``str.split(" ")`` breaks values such as ``--section.key=\"words with spaces\"``;
+    ``shlex`` keeps the value as one argument. Returning the token list avoids serializing
+    it back to a string, which would otherwise be re-parsed by ``PRAgent`` and could alter
+    quoted arguments.
+    """
+    tokens = shlex.split(command)
+    if not tokens:
+        return []
+
+    action, *args = tokens
+    other_args = update_settings_from_args(args)
+    return [action] + other_args
+
 
 class PRAgent:
     def __init__(self, ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler):
@@ -85,7 +102,7 @@ class PRAgent:
                 if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
                     if hasattr(setting, 'extra_instructions'):
                         current_extra_instructions = setting.extra_instructions
-                        
+
                         # Define the language-specific instruction and the separator
                         lang_instruction_text = f"Your response MUST be written in the language corresponding to locale code: '{response_language}'. This is crucial."
                         separator_text = "\n======\n\nIn addition, "

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -65,16 +65,18 @@ def _split_command(command: str) -> list[tuple[str, bool]]:
     tokens = []
     token = []
     quote = None
-    has_quote = False
+    value_was_quoted = False
+    equals_seen = False
     token_started = False
 
     def flush_token():
-        nonlocal has_quote, token_started, token
+        nonlocal equals_seen, token_started, token, value_was_quoted
         if token_started:
-            tokens.append(("".join(token), has_quote))
+            tokens.append(("".join(token), value_was_quoted))
         token = []
-        has_quote = False
+        equals_seen = False
         token_started = False
+        value_was_quoted = False
 
     index = 0
     while index < len(command):
@@ -88,13 +90,17 @@ def _split_command(command: str) -> list[tuple[str, bool]]:
                 token.append(command[index + 1])
                 token_started = True
                 index += 1
+            elif character == "=":
+                token.append(character)
+                equals_seen = True
+                token_started = True
             elif character == '"':
                 quote = character
-                has_quote = True
+                value_was_quoted = equals_seen
                 token_started = True
             elif character == "'" and (not token_started or command[index - 1] == "="):
                 quote = character
-                has_quote = True
+                value_was_quoted = equals_seen
                 token_started = True
             else:
                 token.append(character)
@@ -141,8 +147,8 @@ def prepare_command(command: str) -> list[str]:
 
     (action, _), *token_args = tokens
     args = []
-    for argument, was_quoted in token_args:
-        if was_quoted and argument.startswith("--") and "=" in argument:
+    for argument, value_was_quoted in token_args:
+        if value_was_quoted and argument.startswith("--") and "=" in argument:
             key, value = argument.split("=", 1)
             argument = f"{key}={json.dumps(value, ensure_ascii=False)}"
         args.append(argument)

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -1,3 +1,4 @@
+import json
 import shlex
 from functools import partial
 
@@ -47,20 +48,104 @@ command2class = {
 commands = list(command2class.keys())
 
 
+def _split_command(command: str) -> list[tuple[str, bool]]:
+    """Split an auto command and retain whether each token was quoted.
+
+    ``shlex.split`` removes quote markers before setting overrides are handed to
+    ``yaml.safe_load``. That makes a quoted ``#`` look like a YAML comment and
+    changes quoted scalar values such as ``"true"`` into booleans. This small
+    tokenizer keeps the normal shell-style token boundaries while recording the
+    presence of quotes so setting values can be normalized as strings later.
+
+    Apostrophes inside a word remain literal, matching the legacy request parser
+    (for example, ``What's``). An apostrophe at a token boundary or immediately
+    after ``=`` still starts a single-quoted value, as used by the documented
+    webhook configuration examples.
+    """
+    tokens = []
+    token = []
+    quote = None
+    has_quote = False
+    token_started = False
+
+    def flush_token():
+        nonlocal has_quote, token_started, token
+        if token_started:
+            tokens.append(("".join(token), has_quote))
+        token = []
+        has_quote = False
+        token_started = False
+
+    index = 0
+    while index < len(command):
+        character = command[index]
+        if quote is None:
+            if character.isspace():
+                flush_token()
+            elif character == "\\":
+                if index + 1 >= len(command):
+                    raise ValueError("No escaped character")
+                token.append(command[index + 1])
+                token_started = True
+                index += 1
+            elif character == '"':
+                quote = character
+                has_quote = True
+                token_started = True
+            elif character == "'" and (not token_started or command[index - 1] == "="):
+                quote = character
+                has_quote = True
+                token_started = True
+            else:
+                token.append(character)
+                token_started = True
+        elif quote == "'":
+            if character == "'":
+                quote = None
+            else:
+                token.append(character)
+        else:
+            if character == '"':
+                quote = None
+            elif character == "\\":
+                if index + 1 >= len(command):
+                    raise ValueError("No escaped character")
+                escaped = command[index + 1]
+                if escaped in {'"', "\\", "$", "`"}:
+                    token.append(escaped)
+                elif escaped != "\n":
+                    token.extend(("\\", escaped))
+                index += 1
+            else:
+                token.append(character)
+        index += 1
+
+    if quote is not None:
+        raise ValueError("No closing quotation")
+    flush_token()
+    return tokens
+
+
 def prepare_command(command: str) -> list[str]:
     """Apply command-line settings while preserving quoted argument boundaries.
 
     Webhook adapters use this before handing configured commands to ``PRAgent``. Parsing
     with ``str.split(" ")`` breaks values such as ``--section.key=\"words with spaces\"``;
-    ``shlex`` keeps the value as one argument. Returning the token list avoids serializing
-    it back to a string, which would otherwise be re-parsed by ``PRAgent`` and could alter
-    quoted arguments.
+    the tokenizer keeps the value as one argument and preserves explicit quoting for YAML.
+    Returning the token list avoids serializing it back to a string, which would otherwise
+    be re-parsed by ``PRAgent`` and could alter quoted arguments.
     """
-    tokens = shlex.split(command)
+    tokens = _split_command(command)
     if not tokens:
         return []
 
-    action, *args = tokens
+    (action, _), *token_args = tokens
+    args = []
+    for argument, was_quoted in token_args:
+        if was_quoted and argument.startswith("--") and "=" in argument:
+            key, value = argument.split("=", 1)
+            argument = f"{key}={json.dumps(value, ensure_ascii=False)}"
+        args.append(argument)
     other_args = update_settings_from_args(args)
     return [action] + other_args
 

--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -21,8 +21,7 @@ from starlette.responses import JSONResponse
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent, command2class
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, command2class, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
@@ -112,11 +111,7 @@ async def _perform_commands_azure(commands_conf: str, agent: PRAgent, api_url: s
     get_settings().set("config.is_auto_command", True)
     for command in commands:
         try:
-            split_command = command.split(" ")
-            command = split_command[0]
-            args = split_command[1:]
-            other_args = update_settings_from_args(args)
-            new_command = ' '.join([command] + other_args)
+            new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
                 await agent.handle_request(api_url, new_command)

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -16,8 +16,7 @@ from starlette.responses import JSONResponse
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.identity_providers import get_identity_provider
@@ -172,11 +171,7 @@ async def _perform_commands_bitbucket(commands_conf: str, agent: PRAgent, api_ur
             return
     for command in commands:
         try:
-            split_command = command.split(" ")
-            command = split_command[0]
-            args = split_command[1:]
-            other_args = update_settings_from_args(args)
-            new_command = ' '.join([command] + other_args)
+            new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
                 await agent.handle_request(api_url, new_command)

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -17,8 +17,7 @@ from starlette.responses import JSONResponse
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
@@ -225,17 +224,10 @@ async def _run_commands_sequentially(commands: List[str], url: str, log_context:
         except Exception as e:
             get_logger().error(f"Failed to handle command: {command} , error: {e}")
 
-def _process_command(command: str, url) -> str:
+def _process_command(command: str, url) -> list[str]:
     # don't think we need this
     apply_repo_settings(url)
-    # Process the command string
-    split_command = command.split(" ")
-    command = split_command[0]
-    args = split_command[1:]
-    # do I need this? if yes, shouldn't this be done in PRAgent?
-    other_args = update_settings_from_args(args)
-    new_command = ' '.join([command] + other_args)
-    return new_command
+    return prepare_command(command)
 
 
 def _to_list(command_string: str) -> list:

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -139,9 +139,12 @@ async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict
         return
     get_settings().set("config.is_auto_command", True)
     for command in commands:
-        new_command = prepare_command(command)
-        get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
-        await agent.handle_request(api_url, new_command)
+        try:
+            new_command = prepare_command(command)
+            get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
+            await agent.handle_request(api_url, new_command)
+        except Exception as e:
+            get_logger().error(f"Failed to perform command {command}: {e}")
 
 def should_process_pr_logic(body) -> bool:
     try:

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -9,8 +9,7 @@ from starlette.middleware import Middleware
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
@@ -140,11 +139,7 @@ async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict
         return
     get_settings().set("config.is_auto_command", True)
     for command in commands:
-        split_command = command.split(" ")
-        command = split_command[0]
-        args = split_command[1:]
-        other_args = update_settings_from_args(args)
-        new_command = ' '.join([command] + other_args)
+        new_command = prepare_command(command)
         get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
         await agent.handle_request(api_url, new_command)
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -412,9 +412,12 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         return
     get_settings().set("config.is_auto_command", True)
     for command in commands:
-        new_command = prepare_command(command)
-        get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
-        await agent.handle_request(api_url, new_command)
+        try:
+            new_command = prepare_command(command)
+            get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
+            await agent.handle_request(api_url, new_command)
+        except Exception as e:
+            get_logger().error(f"Failed to perform command {command}: {e}")
 
 
 @router.get("/")

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -12,8 +12,7 @@ from starlette.middleware import Middleware
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import (get_git_provider,
                                     get_git_provider_with_context)
@@ -413,11 +412,7 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         return
     get_settings().set("config.is_auto_command", True)
     for command in commands:
-        split_command = command.split(" ")
-        command = split_command[0]
-        args = split_command[1:]
-        other_args = update_settings_from_args(args)
-        new_command = ' '.join([command] + other_args)
+        new_command = prepare_command(command)
         get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
         await agent.handle_request(api_url, new_command)
 

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -14,8 +14,7 @@ from starlette.middleware import Middleware
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.agent.pr_agent import PRAgent
-from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
@@ -75,11 +74,7 @@ async def _perform_commands_gitlab(commands_conf: str, agent: PRAgent, api_url: 
     get_settings().set("config.is_auto_command", True)
     for command in commands:
         try:
-            split_command = command.split(" ")
-            command = split_command[0]
-            args = split_command[1:]
-            other_args = update_settings_from_args(args)
-            new_command = ' '.join([command] + other_args)
+            new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
                 await agent.handle_request(api_url, new_command)
@@ -295,7 +290,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
 
                 get_logger().debug(f'A push event has been received: {url}')
                 await _perform_commands_gitlab("push_commands", PRAgent(), url, log_context, data)
-                
+
             # for draft to ready triggered merge requests
             elif object_attributes.get('action') == 'update' and is_draft_ready(data):
                 url = object_attributes.get('url')

--- a/tests/unittest/test_pr_agent_routing.py
+++ b/tests/unittest/test_pr_agent_routing.py
@@ -81,6 +81,28 @@ async def test_handle_request_routes_list_request_without_string_parsing(monkeyp
     assert runs == [("https://example/pr/1", "fake-ai", ["don't split", "--flag=value"])]
 
 
+def test_prepare_command_preserves_spaces_in_quoted_config_values():
+    settings = get_settings()
+    setting_key = "PR_REVIEWER.EXTRA_INSTRUCTIONS"
+    original = settings.get(setting_key)
+
+    try:
+        command = pr_agent_module.prepare_command(
+            '/review --pr_reviewer.extra_instructions="Focus on authentication and authorization"'
+        )
+
+        assert command == ["/review"]
+        assert settings.get(setting_key) == "Focus on authentication and authorization"
+    finally:
+        settings.set(setting_key, original)
+
+
+def test_prepare_command_preserves_quoted_non_setting_arguments():
+    command = pr_agent_module.prepare_command('/ask "why is this change risky?"')
+
+    assert command == ["/ask", "why is this change risky?"]
+
+
 @pytest.mark.asyncio
 async def test_handle_request_rejects_forbidden_cli_args(monkeypatch):
     class FakeTool:

--- a/tests/unittest/test_pr_agent_routing.py
+++ b/tests/unittest/test_pr_agent_routing.py
@@ -103,6 +103,52 @@ def test_prepare_command_preserves_quoted_non_setting_arguments():
     assert command == ["/ask", "why is this change risky?"]
 
 
+@pytest.mark.parametrize(
+    ("quoted_value", "expected_value"),
+    [
+        ('"Focus on # authentication"', "Focus on # authentication"),
+        ('"true"', "true"),
+        ('"null"', "null"),
+        ("'Focus on # authentication'", "Focus on # authentication"),
+    ],
+)
+def test_prepare_command_preserves_quoted_yaml_sensitive_values(quoted_value, expected_value):
+    settings = get_settings()
+    setting_key = "PR_REVIEWER.EXTRA_INSTRUCTIONS"
+    original = settings.get(setting_key)
+
+    try:
+        command = pr_agent_module.prepare_command(
+            f"/review --pr_reviewer.extra_instructions={quoted_value}"
+        )
+
+        assert command == ["/review"]
+        assert settings.get(setting_key) == expected_value
+    finally:
+        settings.set(setting_key, original)
+
+
+def test_prepare_command_accepts_apostrophes_in_unquoted_arguments_and_values():
+    settings = get_settings()
+    setting_key = "PR_REVIEWER.EXTRA_INSTRUCTIONS"
+    original = settings.get(setting_key)
+
+    try:
+        command = pr_agent_module.prepare_command(
+            "/review --pr_reviewer.extra_instructions=O'Reilly"
+        )
+
+        assert command == ["/review"]
+        assert settings.get(setting_key) == "O'Reilly"
+        assert pr_agent_module.prepare_command("/ask What's wrong?") == [
+            "/ask",
+            "What's",
+            "wrong?",
+        ]
+    finally:
+        settings.set(setting_key, original)
+
+
 @pytest.mark.asyncio
 async def test_handle_request_rejects_forbidden_cli_args(monkeypatch):
     class FakeTool:

--- a/tests/unittest/test_pr_agent_routing.py
+++ b/tests/unittest/test_pr_agent_routing.py
@@ -149,6 +149,23 @@ def test_prepare_command_accepts_apostrophes_in_unquoted_arguments_and_values():
         settings.set(setting_key, original)
 
 
+def test_prepare_command_keeps_unquoted_value_type_when_key_is_quoted():
+    settings = get_settings()
+    setting_key = "PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS"
+    original = settings.get(setting_key)
+
+    try:
+        command = pr_agent_module.prepare_command(
+            '/review --"pr_code_suggestions.num_code_suggestions"=3'
+        )
+
+        assert command == ["/review"]
+        assert settings.get(setting_key) == 3
+        assert isinstance(settings.get(setting_key), int)
+    finally:
+        settings.set(setting_key, original)
+
+
 @pytest.mark.asyncio
 async def test_handle_request_rejects_forbidden_cli_args(monkeypatch):
     class FakeTool:

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -7,7 +7,7 @@ from starlette.testclient import TestClient
 
 from pr_agent.config_loader import get_settings
 from pr_agent.identity_providers.identity_provider import Eligibility
-from pr_agent.servers import bitbucket_server_webhook, github_app
+from pr_agent.servers import bitbucket_server_webhook, gitea_app, github_app
 
 
 @pytest.fixture
@@ -268,6 +268,51 @@ async def test_github_automatic_feedback_preserves_quoted_command_arguments(monk
 
     assert commands == [["/ask", "why is this change risky?"]]
     assert repo_settings_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_github_automatic_feedback_continues_after_invalid_command(monkeypatch):
+    commands, repo_settings_calls = await _run_github_pr_commands(
+        monkeypatch,
+        repo_setting=True,
+        configured_commands=['/ask "unterminated', "/review"],
+    )
+
+    assert commands == [["/review"]]
+    assert repo_settings_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_gitea_automatic_feedback_continues_after_invalid_command(monkeypatch):
+    settings = get_settings()
+    original_gitea = copy.deepcopy(settings.get("GITEA"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITEA.PR_COMMANDS", ['/ask "unterminated', "/review"])
+
+    agent = RecordingAgent()
+    body = {
+        "action": "opened",
+        "pull_request": {
+            "url": "https://gitea.example.com/org/repo/pulls/1",
+            "title": "Regular PR",
+            "labels": [],
+            "head": {"ref": "feature/cache"},
+            "base": {"ref": "main"},
+        },
+        "sender": {"login": "alice"},
+        "repository": {"full_name": "org/repo"},
+    }
+
+    monkeypatch.setattr(gitea_app, "apply_repo_settings", lambda _url: None)
+    try:
+        await gitea_app._perform_commands_gitea(
+            "pr_commands", agent, body, body["pull_request"]["url"]
+        )
+    finally:
+        settings.set("GITEA", original_gitea)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == [["/review"]]
 
 
 def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="open"):

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -101,14 +101,15 @@ def test_bitbucket_server_should_process_pr_logic_ignores_author_title_and_branc
         settings.set("CONFIG.IGNORE_PR_TARGET_BRANCHES", original["ignore_pr_target_branches"])
 
 
-def test_bitbucket_server_process_command_applies_repo_settings_and_filters_args(monkeypatch):
+def test_bitbucket_server_process_command_applies_repo_settings_before_preparing_command(monkeypatch):
     calls = []
 
     monkeypatch.setattr(bitbucket_server_webhook, "apply_repo_settings", lambda url: calls.append(("repo", url)))
+    prepared = []
     monkeypatch.setattr(
         bitbucket_server_webhook,
-        "update_settings_from_args",
-        lambda args: [arg for arg in args if not arg.startswith("--config.")],
+        "prepare_command",
+        lambda command: prepared.append(command) or ["/review"],
     )
 
     command = bitbucket_server_webhook._process_command(
@@ -117,7 +118,8 @@ def test_bitbucket_server_process_command_applies_repo_settings_and_filters_args
     )
 
     assert calls == [("repo", "https://example/pr/1")]
-    assert command == "/review --pr_reviewer.extra_instructions=test"
+    assert prepared == ["/review --config.temperature=0 --pr_reviewer.extra_instructions=test"]
+    assert command == ["/review"]
 
 
 def test_bitbucket_server_to_list_rejects_non_list_strings():
@@ -182,13 +184,18 @@ class RecordingAgent:
         self.commands.append(command)
 
 
-async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", draft=True):
+async def _run_github_pr_commands(
+    monkeypatch, repo_setting, action="opened", draft=True, configured_commands=None
+):
     # draft=None omits the field from the payload.
     settings = get_settings()
     original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
     settings.set("GITHUB_APP.HANDLE_PR_ACTIONS", ["opened", "reopened", "ready_for_review"])
-    settings.set("GITHUB_APP.PR_COMMANDS", ["/review"])
+    settings.set(
+        "GITHUB_APP.PR_COMMANDS",
+        configured_commands if configured_commands is not None else ["/review"],
+    )
     # Prove the repo setting, not the global default, decides.
     settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", not repo_setting)
 
@@ -235,8 +242,8 @@ async def _run_github_pr_commands(monkeypatch, repo_setting, action="opened", dr
         ("opened", True, False, []),
         # A missing draft field defaults to draft and is rejected.
         ("opened", None, False, []),
-        ("opened", True, True, ["/review"]),
-        ("ready_for_review", False, False, ["/review"]),
+        ("opened", True, True, [["/review"]]),
+        ("ready_for_review", False, False, [["/review"]]),
         ("ready_for_review", False, True, []),
     ],
 )
@@ -248,6 +255,18 @@ async def test_github_automatic_feedback_follows_draft_setting(
     )
 
     assert commands == expected_commands
+    assert repo_settings_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_github_automatic_feedback_preserves_quoted_command_arguments(monkeypatch):
+    commands, repo_settings_calls = await _run_github_pr_commands(
+        monkeypatch,
+        repo_setting=True,
+        configured_commands=['/ask "why is this change risky?"'],
+    )
+
+    assert commands == [["/ask", "why is this change risky?"]]
     assert repo_settings_calls == 1
 
 
@@ -303,13 +322,13 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="ope
     ("event", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
         ("open", True, False, []),
-        ("open", True, True, ["/review"]),
-        ("open", False, False, ["/review"]),
+        ("open", True, True, [["/review"]]),
+        ("open", False, False, [["/review"]]),
         ("reopen", True, False, []),
-        ("reopen", True, True, ["/review"]),
+        ("reopen", True, True, [["/review"]]),
         ("update", True, False, []),
-        ("update", True, True, ["/review"]),
-        ("draft_ready", False, False, ["/review"]),
+        ("update", True, True, [["/review"]]),
+        ("draft_ready", False, False, [["/review"]]),
         ("draft_ready", False, True, []),
     ],
 )


### PR DESCRIPTION
Fixes #2812

### Problem

Webhook auto commands are split with `command.split(" ")` before they reach
`PRAgent`. This loses the argument boundaries of valid configured commands that
contain quoted text. For example:

```text
/review --pr_reviewer.extra_instructions="Focus on authentication and authorization"
```

The first fragment is parsed as the setting value, while the remaining words
are treated as separate command arguments. A quoted `/ask` question is affected
in the same way.

### Root cause

The GitHub, GitLab, Azure DevOps, Bitbucket Cloud, Gitea, and Bitbucket Server
webhook adapters each implemented the same space-splitting and string-joining
logic. `PRAgent._handle_request()` already accepts a tokenized request, but the
adapters converted it back to a string before handing it off.

### Change

- Add `prepare_command()` beside the agent command dispatch map.
- Parse configured commands with `_split_command()`, a small quote-aware
  tokenizer, so quoted values remain one token. `shlex.split()` was the first
  approach but strips the quote markers before the value reaches
  `yaml.safe_load`, which turns a quoted `#` into a YAML comment and coerces
  `"true"` and `"null"` into a bool and `None`. The tokenizer records whether a
  value was quoted so those stay strings, and keeps a mid-word apostrophe
  literal so `/ask What's wrong?` parses as it does today.
- Apply settings arguments once and return the remaining request as a token
  list, avoiding a second string parse in `PRAgent`.
- Use the shared preparation path in all six webhook adapters.
- Keep Bitbucket Server's repository-settings application before command
  preparation.
- Add regression coverage for quoted setting values, quoted `/ask` arguments,
  Bitbucket Server ordering, and the GitHub auto-command handoff.

### Compatibility and scope

This preserves the existing command syntax and changes only the handling of
quoted auto-command arguments. Direct comment/CLI requests continue to use the
existing `PRAgent` path. No provider API or configuration key is added.

### Validation

- `tests/unittest/test_pr_agent_routing.py tests/unittest/test_webhook_logic_core.py`
  — 53 passed.
- `tests/unittest` on the tree merged with current main — 2328 passed, 1 skipped,
  1 xfailed.
- Reverting only the seven source files to main while keeping the new tests
  leaves 19 failing, so the tests exercise the change rather than the branch.
- `_split_command` agrees with `shlex.split` on 200,000 randomly generated
  inputs over the double-quote alphabet, including which inputs raise.
- Tokenizer cost is linear, about 2.0x per doubling up to 1M characters across
  unterminated quotes, all-escape, alternating-quote and repeated-equals inputs.
- An unbalanced quote raises `ValueError`, and all six adapters catch it per
  command, so one malformed entry no longer stops the ones queued behind it.
- Target-file pre-commit hooks passed: large-file, end-of-file,
  trailing-whitespace, and isort; TOML/YAML hooks skipped because no such
  changed files were selected.
- `git diff --check` and `git show --check` passed.
- Ruff on the nine changed files reports no new findings relative to main.

### AI assistance disclosure

AI assistance was used to investigate the repository, reproduce the argument
boundary failure, draft the implementation and tests, and run verification. The
contributor reviewed the source, test behavior, and final diff and remains
responsible for the changes and claims in this PR.
