### PR TITLE
feat(improve): make suggestions heading configurable

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,9 +7,6 @@
 enable_review_labels_effort = true
 enable_auto_approval = true
 
-[pr_code_suggestions]
-suggestions_heading = "PR Code Suggestions"
-
 [github_app]
 pr_commands = [
     "/describe --pr_description.publish_description_as_comment=true",

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,6 +7,9 @@
 enable_review_labels_effort = true
 enable_auto_approval = true
 
+[pr_code_suggestions]
+suggestions_heading = "PR Code Suggestions"
+
 [github_app]
 pr_commands = [
     "/describe --pr_description.publish_description_as_comment=true",

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -294,6 +294,18 @@ Note: Chunking is primarily relevant for large PRs. For most PRs (up to 600 line
         <td>Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".</td>
       </tr>
       <tr>
+        <td><b>suggestions_heading</b></td>
+        <td>
+          Visible base heading for summary-table improve comments, without the Markdown prefix.
+          For example, <code>suggestions_heading = "Guideline Improvement Suggestions"</code> renders
+          <code>## Guideline Improvement Suggestions ✨</code>. On GitHub, GitLab, and Azure DevOps,
+          changing this value updates the same persistent suggestions comment; it does not create a separate
+          suggestions channel. LocalGit uses the same visible heading in <code>improve.md</code>, without a
+          hidden identity marker. The setting does not affect committable inline suggestions. Default is
+          <code>PR Code Suggestions</code>.
+        </td>
+      </tr>
+      <tr>
         <td><b>commitable_code_suggestions</b></td>
         <td>If set to true, the tool will display the suggestions as committable code comments. Default is false.</td>
       </tr>

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -70,12 +70,20 @@ class PRReviewIdentity(str, Enum):
     INCREMENTAL = "<!-- pr-agent:review:incremental -->"
 
 
+class PRCodeSuggestionsHeader(str, Enum):
+    SUMMARY = "## PR Code Suggestions ✨"
+
+
+class PRCodeSuggestionsIdentity(str, Enum):
+    SUMMARY = "<!-- pr-agent:improve:summary -->"
+    NO_SUGGESTIONS = "<!-- pr-agent:improve:no-suggestions -->"
+
+
 _REVIEW_IDENTITY_HEADER_LINES = 5
 
 
-def format_pr_review_header(incremental: bool = False) -> str:
-    """Return the visible review heading while keeping identity out of presentation."""
-    configured_heading = get_settings().get("pr_reviewer.review_heading")
+def _get_configured_heading(setting_name: str, default_heading: str) -> str:
+    configured_heading = get_settings().get(setting_name)
     if (
         not isinstance(configured_heading, str)
         or not configured_heading.strip()
@@ -83,12 +91,33 @@ def format_pr_review_header(incremental: bool = False) -> str:
         or "\r" in configured_heading
     ):
         get_logger().warning(
-            "Invalid pr_reviewer.review_heading; using the default review heading"
+            f"Invalid {setting_name}; using the default heading"
         )
-        configured_heading = PRReviewHeader.REGULAR.value.removeprefix("## ")
-    heading = configured_heading.strip()
+        configured_heading = default_heading
+    return configured_heading.strip()
+
+
+def format_pr_review_header(incremental: bool = False) -> str:
+    """Return the visible review heading while keeping identity out of presentation."""
+    default_heading = PRReviewHeader.REGULAR.value.removeprefix("## ")
+    heading = _get_configured_heading("pr_reviewer.review_heading", default_heading)
     incremental_prefix = "Incremental " if incremental else ""
     return f"## {incremental_prefix}{heading} 🔍"
+
+
+def format_pr_code_suggestions_header(markdown_level: int = 2) -> str:
+    """Return the visible suggestions heading while keeping identity out of presentation."""
+    default_heading = (
+        PRCodeSuggestionsHeader.SUMMARY.value
+        .removeprefix("## ")
+        .removesuffix(" ✨")
+    )
+    heading = _get_configured_heading(
+        "pr_code_suggestions.suggestions_heading",
+        default_heading,
+    )
+    markdown_prefix = "#" * markdown_level
+    return f"{markdown_prefix} {heading} ✨"
 
 
 def comment_matches_identity(body: str, identity: str) -> bool:
@@ -117,7 +146,7 @@ def get_pr_review_comment_identifiers(*, full: bool, incremental: bool) -> tuple
     return tuple(identifiers)
 
 
-def add_pr_review_identity(pr_comment: str, identity_marker: str | None) -> str:
+def add_comment_identity(pr_comment: str, identity_marker: str | None) -> str:
     """Insert a hidden identity after the visible heading without changing rendered output."""
     if not pr_comment or not identity_marker or comment_matches_identity(pr_comment, identity_marker):
         return pr_comment
@@ -125,6 +154,10 @@ def add_pr_review_identity(pr_comment: str, identity_marker: str | None) -> str:
     if not separator:
         return f"{pr_comment.rstrip()}\n\n{identity_marker}"
     return f"{heading}\n\n{identity_marker}\n\n{remainder}"
+
+
+def add_pr_review_identity(pr_comment: str, identity_marker: str | None) -> str:
+    return add_comment_identity(pr_comment, identity_marker)
 
 
 class ReasoningEffort(str, Enum):

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -126,6 +126,10 @@ class GitProvider(ABC):
         fall back to a full run."""
         return False
 
+    def supports_code_suggestions_artifact(self) -> bool:
+        """Return whether `publish_code_suggestions()` writes a standalone output artifact."""
+        return False
+
     #Given a url (issues or PR/MR) - get the .git repo url to which they belong. Needs to be implemented by the provider.
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
         get_logger().warning("Not implemented! Returning empty url")

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -22,7 +22,9 @@ from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
                                          is_agent_inline_comment,
                                          marker_fingerprints)
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import (clip_tokens, comment_matches_any_identity,
+from ..algo.utils import (PRCodeSuggestionsHeader,
+                          PRCodeSuggestionsIdentity, clip_tokens,
+                          comment_matches_any_identity,
                           find_line_number_of_relevant_line_in_file,
                           get_pr_review_comment_identifiers, load_large_diff)
 from ..config_loader import get_settings
@@ -473,12 +475,15 @@ class GitLabProvider(GitProvider):
 
     # Match the most recent prior note for each incremental kind against any accepted identity,
     # then use its timestamp as the timeline anchor.
+    _SUGGESTIONS_STABLE_ANCHORS = (
+        PRCodeSuggestionsIdentity.SUMMARY.value,
+        PRCodeSuggestionsIdentity.NO_SUGGESTIONS.value,
+        "**Suggestion:**",  # commitable-suggestions inline mode
+    )
+    _SUGGESTIONS_LEGACY_ANCHORS = (PRCodeSuggestionsHeader.SUMMARY.value,)
     _INCREMENTAL_ANCHOR_PREFIXES = {
         "review": get_pr_review_comment_identifiers(full=True, incremental=True),
-        "suggestions": (
-            "## PR Code Suggestions ✨",           # summary-table mode
-            "**Suggestion:**",                     # commitable-suggestions inline mode
-        ),
+        "suggestions": _SUGGESTIONS_STABLE_ANCHORS + _SUGGESTIONS_LEGACY_ANCHORS,
     }
 
     def get_incremental_commits(self, incremental: Optional[IncrementalPR] = None, kind: str = "review"):
@@ -509,7 +514,12 @@ class GitLabProvider(GitProvider):
 
         kind = getattr(self, '_incremental_kind', 'review')
         prefixes = self._INCREMENTAL_ANCHOR_PREFIXES.get(kind, ())
-        self.previous_review = self._find_anchor_note(prefixes) if prefixes else None
+        if kind == "suggestions":
+            self.previous_review = self._find_anchor_note(self._SUGGESTIONS_STABLE_ANCHORS)
+            if self.previous_review is None:
+                self.previous_review = self._find_anchor_note(self._SUGGESTIONS_LEGACY_ANCHORS)
+        else:
+            self.previous_review = self._find_anchor_note(prefixes) if prefixes else None
         if not self.previous_review:
             get_logger().info(
                 f"No previous {kind} comment found, will fall back to a full run"

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -514,12 +514,11 @@ class GitLabProvider(GitProvider):
 
         kind = getattr(self, '_incremental_kind', 'review')
         prefixes = self._INCREMENTAL_ANCHOR_PREFIXES.get(kind, ())
-        if kind == "suggestions":
-            self.previous_review = self._find_anchor_note(self._SUGGESTIONS_STABLE_ANCHORS)
-            if self.previous_review is None:
-                self.previous_review = self._find_anchor_note(self._SUGGESTIONS_LEGACY_ANCHORS)
-        else:
-            self.previous_review = self._find_anchor_note(prefixes) if prefixes else None
+        self.previous_review = (
+            self._find_anchor_note(prefixes, prefer_latest_activity=kind == "suggestions")
+            if prefixes
+            else None
+        )
         if not self.previous_review:
             get_logger().info(
                 f"No previous {kind} comment found, will fall back to a full run"
@@ -649,7 +648,7 @@ class GitLabProvider(GitProvider):
         identifiers = get_pr_review_comment_identifiers(full=full, incremental=incremental)
         return self._find_anchor_note(identifiers)
 
-    def _find_anchor_note(self, identities):
+    def _find_anchor_note(self, identities, *, prefer_latest_activity: bool = False):
         """Return the most recent MR note whose body matches any supplied identity.
 
         Used by incremental flows (`/review -i`, `/improve -i`) to find the timestamp
@@ -657,12 +656,12 @@ class GitLabProvider(GitProvider):
         with `.created_at` parsed to a naive UTC datetime (possibly `None` when the
         GitLab payload had an unexpected shape), or `None` if no match.
 
-        We rely on GitLab returning notes in `created_at DESC` order (the API default)
-        and take the first match — re-sorting locally with a `datetime.min` fallback
-        for unparseable timestamps would silently demote the newest match in favour
-        of an older parseable one, leading to commits being re-reviewed. If the chosen
-        anchor's timestamp doesn't parse, `_get_incremental_commits` falls back to a
-        full run via the existing `last_seen_commit is None` branch.
+        By default, rely on GitLab returning notes in `created_at DESC` order (the API
+        default) and take the first match. Suggestions can instead compare `anchor_time`
+        across every matching stable or legacy identity so an older persistent note that
+        was edited more recently wins. If the newest-created match has an unparseable
+        timestamp, retain it so `_get_incremental_commits` safely falls back to a full run
+        instead of silently demoting it in favour of an older parseable note.
 
         Notes authored by other users are skipped when the authenticated (bot) user is
         known: a human comment that merely starts with `**Suggestion:**` must not shift
@@ -681,6 +680,7 @@ class GitLabProvider(GitProvider):
                 return None
         mr_web_url = getattr(self.mr, 'web_url', None)
         own_user_id = self._get_own_user_id()
+        selected_note = None
         for note in self._incremental_notes_cache:
             body = getattr(note, 'body', None)
             if not isinstance(body, str):
@@ -696,8 +696,16 @@ class GitLabProvider(GitProvider):
                         f"user (author {author_id}, bot {own_user_id})"
                     )
                     continue
-            return _GitLabIncrementalNote(note, mr_web_url=mr_web_url)
-        return None
+            candidate = _GitLabIncrementalNote(note, mr_web_url=mr_web_url)
+            if not prefer_latest_activity:
+                return candidate
+            if selected_note is None:
+                selected_note = candidate
+                if selected_note.anchor_time is None:
+                    return selected_note
+            elif candidate.anchor_time is not None and candidate.anchor_time > selected_note.anchor_time:
+                selected_note = candidate
+        return selected_note
 
     def _get_own_user_id(self) -> Optional[int]:
         """ID of the authenticated user (the one posting pr-agent notes), or None when

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -5,7 +5,8 @@ from typing import List
 from git import Repo
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
-from pr_agent.algo.utils import format_pr_code_suggestions_header
+from pr_agent.algo.utils import (format_pr_code_suggestions_header,
+                                 show_run_details)
 from pr_agent.config_loader import _find_repository_root, get_settings
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.log import get_logger
@@ -164,6 +165,8 @@ class LocalGitProvider(GitProvider):
         header = format_pr_code_suggestions_header(markdown_level=1)
         pr_body = f"{header}\n\n" + "\n\n".join(sections) if sections \
             else f"{header}\n\nNo code suggestions found for the PR."
+        if not sections and get_settings().get("config.output_run_details", False):
+            pr_body += show_run_details(False)
         with open(self.improve_path, "w", encoding="utf-8") as file:
             file.write(pr_body)
         return True

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -70,6 +70,9 @@ class LocalGitProvider(GitProvider):
             return False
         return True
 
+    def supports_code_suggestions_artifact(self) -> bool:
+        return True
+
     def get_diff_files(self) -> list[FilePatchInfo]:
         diffs = self.repo.head.commit.diff(
             self.repo.merge_base(self.repo.head, self.repo.branches[self.target_branch_name]),

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -5,6 +5,7 @@ from typing import List
 from git import Repo
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.algo.utils import format_pr_code_suggestions_header
 from pr_agent.config_loader import _find_repository_root, get_settings
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.log import get_logger
@@ -160,8 +161,9 @@ class LocalGitProvider(GitProvider):
                 location += f" [{start}-{end}]" if end is not None and end != start else f" [{start}]"
             header = f"### {location}" if location else "### Suggestion"
             sections.append(f"{header}\n\n{suggestion.get('body', '').strip()}")
-        pr_body = "# PR Code Suggestions ✨\n\n" + "\n\n".join(sections) if sections \
-            else "# PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
+        header = format_pr_code_suggestions_header(markdown_level=1)
+        pr_body = f"{header}\n\n" + "\n\n".join(sections) if sections \
+            else f"{header}\n\nNo code suggestions found for the PR."
         with open(self.improve_path, "w", encoding="utf-8") as file:
             file.write(pr_body)
         return True

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -169,6 +169,8 @@ dual_publishing_score_threshold=-1 # -1 to disable, [0-10] to set the threshold 
 focus_only_on_problems=true
 #
 extra_instructions = ""
+# Visible base heading for summary-table /improve comments. Identity is tracked separately.
+suggestions_heading = "PR Code Suggestions"
 enable_help_text=false
 enable_chat_text=false
 persistent_comment=true

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -33,7 +33,7 @@ from pr_agent.algo.utils import (ModelType, PRCodeSuggestionsHeader,
                                  show_relevant_configurations, show_run_details)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
-                                    GitLabProvider, LocalGitProvider, get_git_provider,
+                                    GitLabProvider, get_git_provider,
                                     get_git_provider_with_context)
 from pr_agent.git_providers.git_provider import (GitProvider, IncrementalPR,
                                                  get_main_pr_language)
@@ -301,7 +301,7 @@ class PRCodeSuggestions:
         if (get_settings().config.publish_output and
                 get_settings().pr_code_suggestions.get('publish_output_no_suggestions', True)):
             get_logger().warning("No code suggestions found for the PR.")
-            if isinstance(self.git_provider, LocalGitProvider):
+            if self.git_provider.supports_code_suggestions_artifact():
                 self.git_provider.publish_code_suggestions([])
                 return
             pr_body = add_comment_identity(

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -33,7 +33,7 @@ from pr_agent.algo.utils import (ModelType, PRCodeSuggestionsHeader,
                                  show_relevant_configurations, show_run_details)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
-                                    GitLabProvider, get_git_provider,
+                                    GitLabProvider, LocalGitProvider, get_git_provider,
                                     get_git_provider_with_context)
 from pr_agent.git_providers.git_provider import (GitProvider, IncrementalPR,
                                                  get_main_pr_language)
@@ -300,6 +300,10 @@ class PRCodeSuggestions:
         pr_body = f"{format_pr_code_suggestions_header()}\n\nNo code suggestions found for the PR."
         if (get_settings().config.publish_output and
                 get_settings().pr_code_suggestions.get('publish_output_no_suggestions', True)):
+            get_logger().warning("No code suggestions found for the PR.")
+            if isinstance(self.git_provider, LocalGitProvider):
+                self.git_provider.publish_code_suggestions([])
+                return
             pr_body = add_comment_identity(
                 pr_body,
                 PRCodeSuggestionsIdentity.NO_SUGGESTIONS.value,
@@ -308,7 +312,6 @@ class PRCodeSuggestions:
             # "no suggestions" result still shows which model produced it.
             if get_settings().get('config', {}).get('output_run_details', False):
                 pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
-            get_logger().warning('No code suggestions found for the PR.')
             get_logger().debug(f"PR output", artifact=pr_body)
             if self.progress_response:
                 self.git_provider.edit_comment(self.progress_response, body=pr_body)

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -23,10 +23,14 @@ from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.run_details import init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
-from pr_agent.algo.utils import (ModelType, clip_tokens, get_max_tokens,
-                                 get_model, load_yaml, replace_code_tags,
-                                 show_relevant_configurations,
-                                 show_run_details)
+from pr_agent.algo.utils import (ModelType, PRCodeSuggestionsHeader,
+                                 PRCodeSuggestionsIdentity,
+                                 add_comment_identity, clip_tokens,
+                                 comment_matches_identity,
+                                 format_pr_code_suggestions_header,
+                                 get_max_tokens, get_model, load_yaml,
+                                 replace_code_tags,
+                                 show_relevant_configurations, show_run_details)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import (AzureDevopsProvider, GithubProvider,
                                     GitLabProvider, get_git_provider,
@@ -230,15 +234,23 @@ class PRCodeSuggestions:
 
                     # publish the PR comment
                     if get_settings().pr_code_suggestions.persistent_comment: # true by default
-                        self.publish_persistent_comment_with_history(self.git_provider,
-                                                                     pr_body,
-                                                                     initial_header="## PR Code Suggestions ✨",
-                                                                     update_header=True,
-                                                                     name="suggestions",
-                                                                     final_update_message=False,
-                                                                     max_previous_comments=get_settings().pr_code_suggestions.max_history_len,
-                                                                     progress_response=self.progress_response)
+                        self.publish_persistent_comment_with_history(
+                            self.git_provider,
+                            pr_body,
+                            initial_header=format_pr_code_suggestions_header(),
+                            update_header=True,
+                            name="suggestions",
+                            final_update_message=False,
+                            max_previous_comments=get_settings().pr_code_suggestions.max_history_len,
+                            progress_response=self.progress_response,
+                            identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+                            legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+                        )
                     else:
+                        pr_body = add_comment_identity(
+                            pr_body,
+                            PRCodeSuggestionsIdentity.SUMMARY.value,
+                        )
                         if self.progress_response:
                             self.git_provider.edit_comment(self.progress_response, body=pr_body)
                         else:
@@ -285,9 +297,13 @@ class PRCodeSuggestions:
         return pr_body
 
     async def publish_no_suggestions(self):
-        pr_body = "## PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
+        pr_body = f"{format_pr_code_suggestions_header()}\n\nNo code suggestions found for the PR."
         if (get_settings().config.publish_output and
                 get_settings().pr_code_suggestions.get('publish_output_no_suggestions', True)):
+            pr_body = add_comment_identity(
+                pr_body,
+                PRCodeSuggestionsIdentity.NO_SUGGESTIONS.value,
+            )
             # Output the agent run details (model, tokens, time cost) if enabled, so the
             # "no suggestions" result still shows which model produced it.
             if get_settings().get('config', {}).get('output_run_details', False):
@@ -331,19 +347,64 @@ class PRCodeSuggestions:
                                                 final_update_message=True,
                                                 max_previous_comments=4,
                                                 progress_response=None,
-                                                only_fold=False):
+                                                only_fold=False,
+                                                identity_marker: str | None = None,
+                                                legacy_initial_header: str | None = None):
         if hasattr(git_provider, '_publish_check_run') and get_settings().github.publish_as_check_run:
             if git_provider._publish_check_run(pr_comment, name):
                 return
 
         def _extract_link(comment_text: str):
-            r = re.compile(r"<!--.*?-->")
-            match = r.search(comment_text)
+            match = re.search(r"<!--\s*([0-9a-fA-F]{7,40})\s*-->", comment_text)
 
             up_to_commit_txt = ""
             if match:
-                up_to_commit_txt = f" up to commit {match.group(0)[4:-3].strip()}"
+                up_to_commit_txt = f" up to commit {match.group(1)}"
             return up_to_commit_txt
+
+        def _comment_body(comment) -> str:
+            body = getattr(comment, "body", None)
+            if body is None and isinstance(comment, dict):
+                body = comment.get("body")
+            return body if isinstance(body, str) else ""
+
+        def _is_legacy_suggestions_comment(comment_text: str) -> bool:
+            if not legacy_initial_header or not comment_text.startswith(f"{legacy_initial_header}\n"):
+                return False
+            table_index = comment_text.find("<table>")
+            if table_index == -1:
+                return False
+            return bool(
+                re.search(
+                    r"<!--\s*[0-9a-fA-F]{7,40}\s*-->",
+                    comment_text[len(legacy_initial_header):table_index],
+                )
+            )
+
+        def _without_heading(comment_text: str) -> str:
+            if comment_text.startswith(initial_header):
+                comment_text = comment_text[len(initial_header):].lstrip("\n")
+            if identity_marker and comment_text.startswith(identity_marker):
+                comment_text = comment_text[len(identity_marker):].lstrip("\n")
+            return comment_text.strip()
+
+        def _with_identity(comment_text: str) -> str:
+            return add_comment_identity(comment_text, identity_marker)
+
+        def _clean_up_progress_note():
+            if not progress_response:
+                return
+            try:
+                git_provider.edit_comment(
+                    progress_response,
+                    "Code suggestions published in the persistent thread above.",
+                )
+                git_provider.remove_comment(progress_response)
+            except Exception as cleanup_error:
+                get_logger().warning(
+                    "Failed to clean up progress note after persistent update, "
+                    f"leaving it in place: {cleanup_error}"
+                )
 
         history_header = f"#### Previous suggestions\n"
         last_commit_num = git_provider.get_latest_commit_url().split('/')[-1][:7]
@@ -353,90 +414,117 @@ class PRCodeSuggestions:
         else:
             latest_suggestion_header = f"Latest suggestions up to {last_commit_num}"
         latest_commit_html_comment = f"<!-- {last_commit_num} -->"
-        found_comment = None
+        new_suggestion_table = _without_heading(pr_comment)
 
         if max_previous_comments > 0:
             try:
                 prev_comments = list(git_provider.get_issue_comments())
-                for comment in prev_comments:
-                    if comment.body.startswith(initial_header):
-                        prev_suggestions = comment.body
-                        found_comment = comment
-                        comment_url = git_provider.get_comment_url(comment)
+                if identity_marker:
+                    comment = next(
+                        (
+                            candidate
+                            for candidate in prev_comments
+                            if comment_matches_identity(_comment_body(candidate), identity_marker)
+                        ),
+                        None,
+                    )
+                    if comment is None:
+                        comment = next(
+                            (
+                                candidate
+                                for candidate in prev_comments
+                                if _is_legacy_suggestions_comment(_comment_body(candidate))
+                            ),
+                            None,
+                        )
+                else:
+                    comment = next(
+                        (
+                            candidate
+                            for candidate in prev_comments
+                            if comment_matches_identity(_comment_body(candidate), initial_header)
+                        ),
+                        None,
+                    )
+                if comment:
+                    prev_suggestions = _comment_body(comment)
+                    comment_url = git_provider.get_comment_url(comment)
 
-                        if history_header.strip() not in comment.body:
-                            # no history section
-                            # extract everything between <table> and </table> in comment.body including <table> and </table>
-                            table_index = comment.body.find("<table>")
-                            if table_index == -1:
-                                git_provider.edit_comment(comment, pr_comment)
-                                continue
-                            # find http link from comment.body[:table_index]
-                            up_to_commit_txt = _extract_link(comment.body[:table_index])
-                            prev_suggestion_table = comment.body[
-                                                    table_index:comment.body.rfind("</table>") + len("</table>")]
+                    if history_header.strip() not in prev_suggestions:
+                        # no history section
+                        # extract everything between <table> and </table> in comment.body including <table> and </table>
+                        table_index = prev_suggestions.find("<table>")
+                        if table_index == -1:
+                            pr_comment_updated = _with_identity(
+                                f"{initial_header}\n\n{latest_commit_html_comment}\n\n"
+                                f"{new_suggestion_table}\n\n"
+                            )
+                            git_provider.edit_comment(comment, pr_comment_updated)
+                            _clean_up_progress_note()
+                            return comment
+                        # find http link from comment.body[:table_index]
+                        up_to_commit_txt = _extract_link(prev_suggestions[:table_index])
+                        prev_suggestion_table = prev_suggestions[
+                                                table_index:prev_suggestions.rfind("</table>") + len("</table>")]
 
-                            tick = "✅ " if "✅" in prev_suggestion_table else ""
-                            # surround with details tag
-                            prev_suggestion_table = f"<details><summary>{tick}{name.capitalize()}{up_to_commit_txt}</summary>\n<br>{prev_suggestion_table}\n\n</details>"
+                        tick = "✅ " if "✅" in prev_suggestion_table else ""
+                        # surround with details tag
+                        prev_suggestion_table = (
+                            f"<details><summary>{tick}{name.capitalize()}{up_to_commit_txt}</summary>\n"
+                            f"<br>{prev_suggestion_table}\n\n</details>"
+                        )
 
-                            new_suggestion_table = pr_comment.replace(initial_header, "").strip()
+                        pr_comment_updated = _with_identity(
+                            f"{initial_header}\n\n{latest_commit_html_comment}\n\n"
+                            f"{latest_suggestion_header}\n\n{new_suggestion_table}\n\n___\n\n"
+                            f"{history_header}{prev_suggestion_table}\n"
+                        )
+                    else:
+                        # get the text of the previous suggestions until the latest commit
+                        sections = prev_suggestions.split(history_header.strip())
+                        latest_table = sections[0].strip()
+                        prev_suggestion_table = sections[1].replace(history_header, "").strip()
 
-                            pr_comment_updated = f"{initial_header}\n{latest_commit_html_comment}\n\n"
-                            pr_comment_updated += f"{latest_suggestion_header}\n{new_suggestion_table}\n\n___\n\n"
-                            pr_comment_updated += f"{history_header}{prev_suggestion_table}\n"
-                        else:
-                            # get the text of the previous suggestions until the latest commit
-                            sections = prev_suggestions.split(history_header.strip())
-                            latest_table = sections[0].strip()
-                            prev_suggestion_table = sections[1].replace(history_header, "").strip()
+                        # get text after the latest_suggestion_header in comment.body
+                        table_ind = latest_table.find("<table>")
+                        up_to_commit_txt = _extract_link(latest_table[:table_ind])
 
-                            # get text after the latest_suggestion_header in comment.body
-                            table_ind = latest_table.find("<table>")
-                            up_to_commit_txt = _extract_link(latest_table[:table_ind])
+                        latest_table = latest_table[table_ind:latest_table.rfind("</table>") + len("</table>")]
+                        # enforce max_previous_comments
+                        count = prev_suggestions.count(f"\n<details><summary>{name.capitalize()}")
+                        count += prev_suggestions.count(f"\n<details><summary>✅ {name.capitalize()}")
+                        if count >= max_previous_comments:
+                            # remove the oldest suggestion
+                            prev_suggestion_table = prev_suggestion_table[:prev_suggestion_table.rfind(
+                                f"<details><summary>{name.capitalize()} up to commit")]
 
-                            latest_table = latest_table[table_ind:latest_table.rfind("</table>") + len("</table>")]
-                            # enforce max_previous_comments
-                            count = prev_suggestions.count(f"\n<details><summary>{name.capitalize()}")
-                            count += prev_suggestions.count(f"\n<details><summary>✅ {name.capitalize()}")
-                            if count >= max_previous_comments:
-                                # remove the oldest suggestion
-                                prev_suggestion_table = prev_suggestion_table[:prev_suggestion_table.rfind(
-                                    f"<details><summary>{name.capitalize()} up to commit")]
+                        tick = "✅ " if "✅" in latest_table else ""
+                        # Add to the prev_suggestions section
+                        last_prev_table = (
+                            f"\n<details><summary>{tick}{name.capitalize()}{up_to_commit_txt}</summary>\n"
+                            f"<br>{latest_table}\n\n</details>"
+                        )
+                        prev_suggestion_table = last_prev_table + "\n" + prev_suggestion_table
 
-                            tick = "✅ " if "✅" in latest_table else ""
-                            # Add to the prev_suggestions section
-                            last_prev_table = f"\n<details><summary>{tick}{name.capitalize()}{up_to_commit_txt}</summary>\n<br>{latest_table}\n\n</details>"
-                            prev_suggestion_table = last_prev_table + "\n" + prev_suggestion_table
+                        pr_comment_updated = _with_identity(
+                            f"{initial_header}\n\n{latest_commit_html_comment}\n\n"
+                            f"{latest_suggestion_header}\n\n{new_suggestion_table}\n\n"
+                            f"___\n\n{history_header}\n{prev_suggestion_table}\n"
+                        )
 
-                            new_suggestion_table = pr_comment.replace(initial_header, "").strip()
-
-                            pr_comment_updated = f"{initial_header}\n"
-                            pr_comment_updated += f"{latest_commit_html_comment}\n\n"
-                            pr_comment_updated += f"{latest_suggestion_header}\n\n{new_suggestion_table}\n\n"
-                            pr_comment_updated += "___\n\n"
-                            pr_comment_updated += f"{history_header}\n"
-                            pr_comment_updated += f"{prev_suggestion_table}\n"
-
-                        get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                        git_provider.edit_comment(comment, pr_comment_updated)
-                        if progress_response:
-                            # best-effort: propagating would re-trigger the duplicate-thread fallback below
-                            try:
-                                git_provider.edit_comment(progress_response, "Code suggestions published in the persistent thread above.")
-                                git_provider.remove_comment(progress_response)
-                            except Exception as cleanup_error:
-                                get_logger().warning(
-                                    f"Failed to clean up progress note after persistent update, leaving it in place: {cleanup_error}"
-                                )
-                        return comment
+                    get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
+                    git_provider.edit_comment(comment, pr_comment_updated)
+                    _clean_up_progress_note()
+                    return comment
             except Exception as e:
                 get_logger().exception(f"Failed to update persistent review, error: {e}")
                 pass
 
         # if we are here, we did not find a previous comment to update
-        body = pr_comment.replace(initial_header, "").strip()
-        pr_comment = f"{initial_header}\n\n{latest_commit_html_comment}\n\n{body}\n\n"
+        pr_comment = _with_identity(
+            f"{initial_header}\n\n{latest_commit_html_comment}\n\n"
+            f"{new_suggestion_table}\n\n"
+        )
         if progress_response:
             git_provider.edit_comment(progress_response, pr_comment)
             new_comment = progress_response
@@ -984,7 +1072,7 @@ class PRCodeSuggestions:
 
     def generate_summarized_suggestions(self, data: Dict) -> str:
         try:
-            pr_body = "## PR Code Suggestions ✨\n\n"
+            pr_body = f"{format_pr_code_suggestions_header()}\n\n"
 
             if len(data.get('code_suggestions', [])) == 0:
                 pr_body += "No suggestions found to improve this PR."

--- a/tests/e2e_tests/e2e_utils.py
+++ b/tests/e2e_tests/e2e_utils.py
@@ -1,7 +1,7 @@
 FILE_PATH: str = "pr_agent/cli_pip.py"
 
 PR_HEADER_START_WITH = '### **User description**\nupdate cli_pip.py\n\n\n___\n\n### **PR Type**'
-REVIEW_START_WITH = '## PR Reviewer Guide 🔍\n\n<table>\n<tr><td>⏱️&nbsp;<strong>Estimated effort to review</strong>:'
+REVIEW_START_WITH = '## PR Reviewer Guide 🔍\n\n<!-- pr-agent:review:full -->\n\n<table>\n<tr><td>⏱️&nbsp;<strong>Estimated effort to review</strong>:'
 IMPROVE_START_WITH_REGEX_PATTERN = (
     r"^## PR Code Suggestions ✨\n\n"
     r"<!-- pr-agent:improve:summary -->\n\n"

--- a/tests/e2e_tests/e2e_utils.py
+++ b/tests/e2e_tests/e2e_utils.py
@@ -2,7 +2,11 @@ FILE_PATH: str = "pr_agent/cli_pip.py"
 
 PR_HEADER_START_WITH = '### **User description**\nupdate cli_pip.py\n\n\n___\n\n### **PR Type**'
 REVIEW_START_WITH = '## PR Reviewer Guide 🔍\n\n<table>\n<tr><td>⏱️&nbsp;<strong>Estimated effort to review</strong>:'
-IMPROVE_START_WITH_REGEX_PATTERN = r'^## PR Code Suggestions ✨\n\n<!-- [a-z0-9]+ -->\n\n<table><thead><tr><td>Category</td>'
+IMPROVE_START_WITH_REGEX_PATTERN = (
+    r"^## PR Code Suggestions ✨\n\n"
+    r"<!-- pr-agent:improve:summary -->\n\n"
+    r"<!-- [a-z0-9]+ -->\n\n<table><thead><tr><td>Category</td>"
+)
 
 NUM_MINUTES: int = 5
 

--- a/tests/unittest/test_code_suggestions_comment_identity.py
+++ b/tests/unittest/test_code_suggestions_comment_identity.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.algo.utils import (PRCodeSuggestionsIdentity,
+                                 add_comment_identity,
+                                 comment_matches_identity,
+                                 format_pr_code_suggestions_header)
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+from tests.unittest._settings_helpers import (restore_settings,
+                                              snapshot_settings)
+
+
+def test_custom_suggestions_heading_changes_presentation_only():
+    snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])
+    try:
+        get_settings().set(
+            "pr_code_suggestions.suggestions_heading",
+            "Guideline Improvement Suggestions",
+        )
+
+        header = format_pr_code_suggestions_header()
+    finally:
+        restore_settings(snapshot)
+
+    assert header == "## Guideline Improvement Suggestions ✨"
+    assert "<!-- pr-agent:improve" not in header
+
+
+def test_suggestions_heading_is_trimmed():
+    snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])
+    try:
+        get_settings().set("pr_code_suggestions.suggestions_heading", "  Team Suggestions  ")
+
+        header = format_pr_code_suggestions_header()
+    finally:
+        restore_settings(snapshot)
+
+    assert header == "## Team Suggestions ✨"
+
+
+def test_default_suggestions_heading_is_unchanged():
+    assert format_pr_code_suggestions_header() == "## PR Code Suggestions ✨"
+
+
+@pytest.mark.parametrize(
+    "invalid_heading",
+    [None, "", "  ", "first\nsecond", "first\rsecond", 42],
+)
+def test_invalid_suggestions_heading_falls_back_to_default(invalid_heading):
+    snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])
+    try:
+        get_settings().set("pr_code_suggestions.suggestions_heading", invalid_heading)
+        header = format_pr_code_suggestions_header()
+    finally:
+        restore_settings(snapshot)
+
+    assert header == "## PR Code Suggestions ✨"
+
+
+def test_suggestions_identity_is_inserted_after_heading_and_is_idempotent():
+    comment = "## Team Suggestions ✨\n\n<table>suggestions</table>"
+    marker = PRCodeSuggestionsIdentity.SUMMARY.value
+
+    marked = add_comment_identity(comment, marker)
+
+    assert marked.startswith(
+        "## Team Suggestions ✨\n\n"
+        "<!-- pr-agent:improve:summary -->\n\n"
+    )
+    assert add_comment_identity(marked, marker) == marked
+
+
+def test_suggestions_identity_is_bounded_and_does_not_match_quoted_marker():
+    marker = PRCodeSuggestionsIdentity.SUMMARY.value
+    valid = f"## Team Suggestions ✨\n\n{marker}\n\nbody"
+    quoted = f"## Human comment\n\n> {marker}\n\nbody"
+    late = "## Human comment\n\na\nb\nc\nd\n" + marker
+
+    assert comment_matches_identity(valid, marker)
+    assert not comment_matches_identity(quoted, marker)
+    assert not comment_matches_identity(late, marker)
+
+
+def test_summarized_artifact_uses_custom_heading_without_identity():
+    snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    try:
+        get_settings().set("pr_code_suggestions.suggestions_heading", "Team Suggestions")
+
+        artifact = tool.generate_summarized_suggestions({"code_suggestions": []})
+    finally:
+        restore_settings(snapshot)
+
+    assert artifact.startswith("## Team Suggestions ✨\n\n")
+    assert "<!-- pr-agent:improve" not in artifact
+
+
+@pytest.mark.asyncio
+async def test_no_suggestions_uses_custom_heading_with_separate_result_identity():
+    snapshot = snapshot_settings(
+        [
+            "config.publish_output",
+            "pr_code_suggestions.publish_output_no_suggestions",
+            "pr_code_suggestions.suggestions_heading",
+        ]
+    )
+    provider = MagicMock()
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.progress_response = None
+    try:
+        get_settings().set("config.publish_output", True)
+        get_settings().set("pr_code_suggestions.publish_output_no_suggestions", True)
+        get_settings().set("pr_code_suggestions.suggestions_heading", "Team Suggestions")
+
+        await tool.publish_no_suggestions()
+    finally:
+        restore_settings(snapshot)
+
+    published = provider.publish_comment.call_args.args[0]
+    assert published.startswith(
+        "## Team Suggestions ✨\n\n"
+        f"{PRCodeSuggestionsIdentity.NO_SUGGESTIONS.value}\n\n"
+    )
+    assert PRCodeSuggestionsIdentity.SUMMARY.value not in published
+
+
+def test_github_check_run_receives_configured_presentation_without_identity():
+    snapshot = snapshot_settings(["github.publish_as_check_run"])
+    provider = MagicMock()
+    provider._publish_check_run.return_value = True
+    comment = "## Team Suggestions ✨\n\n<table>suggestions</table>"
+    try:
+        get_settings().set("github.publish_as_check_run", True)
+
+        PRCodeSuggestions.publish_persistent_comment_with_history(
+            provider,
+            comment,
+            initial_header="## Team Suggestions ✨",
+            name="suggestions",
+            identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+            legacy_initial_header="## PR Code Suggestions ✨",
+        )
+    finally:
+        restore_settings(snapshot)
+
+    provider._publish_check_run.assert_called_once_with(comment, "suggestions")
+    provider.get_issue_comments.assert_not_called()

--- a/tests/unittest/test_code_suggestions_comment_identity.py
+++ b/tests/unittest/test_code_suggestions_comment_identity.py
@@ -107,6 +107,7 @@ async def test_no_suggestions_uses_custom_heading_with_separate_result_identity(
         ]
     )
     provider = MagicMock()
+    provider.supports_code_suggestions_artifact.return_value = False
     tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
     tool.git_provider = provider
     tool.progress_response = None

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -1657,7 +1657,7 @@ class TestGitLabIncrementalReview:
         assert gitlab_provider.incremental.last_seen_commit_sha == "c1"
         mock_project.repository_compare.assert_called_once_with("c1", "head")
 
-    def test_incremental_suggestions_prefers_stable_marker_over_legacy_heading(
+    def test_incremental_suggestions_uses_newest_stable_or_legacy_anchor(
             self, gitlab_provider, mock_project):
         gitlab_provider.mr.notes.list.return_value = [
             self._make_note(
@@ -1674,7 +1674,8 @@ class TestGitLabIncrementalReview:
             ),
         ]
         gitlab_provider.mr.commits.return_value = [
-            self._make_commit("c2", "2026-05-15T11:00:00Z"),
+            self._make_commit("c2", "2026-05-15T13:00:00Z"),
+            self._make_commit("c1", "2026-05-15T11:00:00Z"),
             self._make_commit("c0", "2026-05-15T09:00:00Z"),
         ]
         mock_project.repository_compare.return_value = {
@@ -1687,8 +1688,68 @@ class TestGitLabIncrementalReview:
 
         assert gitlab_provider.incremental.is_incremental is True
         assert gitlab_provider.incremental.first_new_commit_sha == "c2"
-        assert gitlab_provider.incremental.last_seen_commit_sha == "c0"
-        mock_project.repository_compare.assert_called_once_with("c0", "head")
+        assert gitlab_provider.incremental.last_seen_commit_sha == "c1"
+        mock_project.repository_compare.assert_called_once_with("c1", "head")
+
+    def test_incremental_suggestions_uses_latest_activity_across_stable_and_legacy_anchors(
+            self, gitlab_provider, mock_project):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(
+                9,
+                "## PR Code Suggestions ✨\n\n<!-- aaa1111 -->\n\n<table>legacy</table>",
+                "2026-05-15T12:00:00Z",
+            ),
+            self._make_note(
+                8,
+                "## Team Suggestions ✨\n\n"
+                f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+                "<!-- bbb2222 -->\n\n<table>marked</table>",
+                created_at="2026-05-15T09:00:00Z",
+                updated_at="2026-05-15T15:00:00Z",
+            ),
+        ]
+        gitlab_provider.mr.commits.return_value = [
+            self._make_commit("c3", "2026-05-15T16:00:00Z"),
+            self._make_commit("c2", "2026-05-15T14:00:00Z"),
+            self._make_commit("c1", "2026-05-15T11:00:00Z"),
+        ]
+        mock_project.repository_compare.return_value = {
+            "diffs": [{"new_path": "a.py", "old_path": "a.py", "diff": "@@ ... @@",
+                       "new_file": False, "deleted_file": False, "renamed_file": False}],
+        }
+        gitlab_provider.mr.changes.return_value = {"changes": [{"new_path": "a.py"}]}
+
+        gitlab_provider.get_incremental_commits(IncrementalPR(True), kind="suggestions")
+
+        assert gitlab_provider.incremental.is_incremental is True
+        assert gitlab_provider.incremental.first_new_commit_sha == "c3"
+        assert gitlab_provider.incremental.last_seen_commit_sha == "c2"
+        mock_project.repository_compare.assert_called_once_with("c2", "head")
+
+    def test_incremental_suggestions_unparseable_newest_anchor_falls_back_to_full(
+            self, gitlab_provider, mock_project):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(
+                9,
+                "## PR Code Suggestions ✨\n\n<!-- aaa1111 -->\n\n<table>legacy</table>",
+                "not-a-date",
+            ),
+            self._make_note(
+                8,
+                "## Team Suggestions ✨\n\n"
+                f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+                "<!-- bbb2222 -->\n\n<table>marked</table>",
+                "2026-05-15T10:00:00Z",
+            ),
+        ]
+        gitlab_provider.mr.commits.return_value = [
+            self._make_commit("c1", "2026-05-15T11:00:00Z"),
+        ]
+
+        gitlab_provider.get_incremental_commits(IncrementalPR(True), kind="suggestions")
+
+        assert gitlab_provider.incremental.is_incremental is False
+        mock_project.repository_compare.assert_not_called()
 
     def test_incremental_suggestions_uses_newer_custom_no_suggestions_result(
             self, gitlab_provider, mock_project):

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -6,7 +6,8 @@ from gitlab import Gitlab
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectFile, ProjectMergeRequest, ProjectMergeRequestManager
 
-from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
+from pr_agent.algo.utils import (PRCodeSuggestionsIdentity, PRReviewHeader,
+                                 PRReviewIdentity)
 from pr_agent.git_providers.git_provider import IncrementalPR
 from pr_agent.git_providers.gitlab_provider import (
     GitLabProvider,
@@ -1651,6 +1652,74 @@ class TestGitLabIncrementalReview:
         gitlab_provider.get_incremental_commits(IncrementalPR(True), kind="suggestions")
 
         # Only c2 is in scope; c1 must NOT be re-included (that was the reported bug).
+        assert gitlab_provider.incremental.is_incremental is True
+        assert gitlab_provider.incremental.first_new_commit_sha == "c2"
+        assert gitlab_provider.incremental.last_seen_commit_sha == "c1"
+        mock_project.repository_compare.assert_called_once_with("c1", "head")
+
+    def test_incremental_suggestions_prefers_stable_marker_over_legacy_heading(
+            self, gitlab_provider, mock_project):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(
+                9,
+                "## PR Code Suggestions ✨\n\n<!-- aaa1111 -->\n\n<table>legacy</table>",
+                "2026-05-15T12:00:00Z",
+            ),
+            self._make_note(
+                8,
+                "## Team Suggestions ✨\n\n"
+                f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+                "<!-- bbb2222 -->\n\n<table>marked</table>",
+                "2026-05-15T10:00:00Z",
+            ),
+        ]
+        gitlab_provider.mr.commits.return_value = [
+            self._make_commit("c2", "2026-05-15T11:00:00Z"),
+            self._make_commit("c0", "2026-05-15T09:00:00Z"),
+        ]
+        mock_project.repository_compare.return_value = {
+            "diffs": [{"new_path": "a.py", "old_path": "a.py", "diff": "@@ ... @@",
+                       "new_file": False, "deleted_file": False, "renamed_file": False}],
+        }
+        gitlab_provider.mr.changes.return_value = {"changes": [{"new_path": "a.py"}]}
+
+        gitlab_provider.get_incremental_commits(IncrementalPR(True), kind="suggestions")
+
+        assert gitlab_provider.incremental.is_incremental is True
+        assert gitlab_provider.incremental.first_new_commit_sha == "c2"
+        assert gitlab_provider.incremental.last_seen_commit_sha == "c0"
+        mock_project.repository_compare.assert_called_once_with("c0", "head")
+
+    def test_incremental_suggestions_uses_newer_custom_no_suggestions_result(
+            self, gitlab_provider, mock_project):
+        gitlab_provider.mr.notes.list.return_value = [
+            self._make_note(
+                9,
+                "## Team Suggestions ✨\n\n"
+                f"{PRCodeSuggestionsIdentity.NO_SUGGESTIONS.value}\n\n"
+                "No code suggestions found for the PR.",
+                "2026-05-15T12:00:00Z",
+            ),
+            self._make_note(
+                8,
+                "## Previous Suggestions ✨\n\n"
+                f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+                "<!-- bbb2222 -->\n\n<table>marked</table>",
+                "2026-05-15T10:00:00Z",
+            ),
+        ]
+        gitlab_provider.mr.commits.return_value = [
+            self._make_commit("c2", "2026-05-15T13:00:00Z"),
+            self._make_commit("c1", "2026-05-15T11:00:00Z"),
+        ]
+        mock_project.repository_compare.return_value = {
+            "diffs": [{"new_path": "a.py", "old_path": "a.py", "diff": "@@ ... @@",
+                       "new_file": False, "deleted_file": False, "renamed_file": False}],
+        }
+        gitlab_provider.mr.changes.return_value = {"changes": [{"new_path": "a.py"}]}
+
+        gitlab_provider.get_incremental_commits(IncrementalPR(True), kind="suggestions")
+
         assert gitlab_provider.incremental.is_incremental is True
         assert gitlab_provider.incremental.first_new_commit_sha == "c2"
         assert gitlab_provider.incremental.last_seen_commit_sha == "c1"

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -1,8 +1,10 @@
 import git
+import pytest
 
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.local_git_provider import LocalGitProvider
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from tests.unittest._settings_helpers import (restore_settings,
                                               snapshot_settings)
 
@@ -134,6 +136,44 @@ def test_publish_code_suggestions_uses_custom_heading_without_identity(tmp_path)
     content = improve_path.read_text()
     assert content.startswith("# Team Suggestions ✨\n\n")
     assert "<!-- pr-agent:improve" not in content
+
+
+@pytest.mark.asyncio
+async def test_publish_no_suggestions_routes_local_git_output_to_improve_file(tmp_path, monkeypatch):
+    snapshot = snapshot_settings([
+        "config.output_run_details",
+        "config.publish_output",
+        "pr_code_suggestions.publish_output_no_suggestions",
+        "pr_code_suggestions.suggestions_heading",
+    ])
+    improve_path = tmp_path / "improve.md"
+    review_path = tmp_path / "review.md"
+    provider = object.__new__(LocalGitProvider)
+    provider.improve_path = improve_path
+    provider.review_path = review_path
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.progress_response = None
+    try:
+        get_settings().set("config.output_run_details", True)
+        get_settings().set("config.publish_output", True)
+        get_settings().set("pr_code_suggestions.publish_output_no_suggestions", True)
+        get_settings().set("pr_code_suggestions.suggestions_heading", "Team Suggestions")
+        monkeypatch.setattr(
+            "pr_agent.git_providers.local_git_provider.show_run_details",
+            lambda gfm_supported: "\n\nRun details" if not gfm_supported else "",
+        )
+
+        await tool.publish_no_suggestions()
+    finally:
+        restore_settings(snapshot)
+
+    content = improve_path.read_text()
+    assert content.startswith("# Team Suggestions ✨\n\n")
+    assert "No code suggestions found for the PR." in content
+    assert "Run details" in content
+    assert "<!-- pr-agent:improve" not in content
+    assert not review_path.exists()
 
 
 def test_publish_comment_skips_temporary(tmp_path):

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -168,6 +168,7 @@ async def test_publish_no_suggestions_routes_local_git_output_to_improve_file(tm
     finally:
         restore_settings(snapshot)
 
+    assert provider.supports_code_suggestions_artifact() is True
     content = improve_path.read_text()
     assert content.startswith("# Team Suggestions ✨\n\n")
     assert "No code suggestions found for the PR." in content

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -1,7 +1,10 @@
 import git
 
 from pr_agent.algo.types import EDIT_TYPE
+from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.local_git_provider import LocalGitProvider
+from tests.unittest._settings_helpers import (restore_settings,
+                                              snapshot_settings)
 
 
 def _make_repo(tmp_path, filenames):
@@ -114,6 +117,23 @@ def test_publish_code_suggestions_no_suggestions(tmp_path):
 
     assert provider.publish_code_suggestions([]) is True
     assert "No code suggestions found" in improve_path.read_text()
+
+
+def test_publish_code_suggestions_uses_custom_heading_without_identity(tmp_path):
+    snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])
+    improve_path = tmp_path / "improve.md"
+    provider = object.__new__(LocalGitProvider)
+    provider.improve_path = improve_path
+    try:
+        get_settings().set("pr_code_suggestions.suggestions_heading", "Team Suggestions")
+
+        provider.publish_code_suggestions([])
+    finally:
+        restore_settings(snapshot)
+
+    content = improve_path.read_text()
+    assert content.startswith("# Team Suggestions ✨\n\n")
+    assert "<!-- pr-agent:improve" not in content
 
 
 def test_publish_comment_skips_temporary(tmp_path):

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -762,3 +762,37 @@ def test_legacy_heading_without_generated_shape_is_not_adopted():
     provider.edit_comment.assert_not_called()
     published = provider.publish_comment.call_args.args[0]
     assert PRCodeSuggestionsIdentity.SUMMARY.value in published
+
+
+def test_custom_heading_is_kept_when_a_history_section_already_exists():
+    existing = MagicMock()
+    existing.body = (
+        "## Previous Custom Heading ✨\n\n"
+        f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        "<!-- aaa1111 -->\n\n"
+        "Latest suggestions up to commit aaa1111\n\n"
+        "<table>latest</table>\n\n___\n\n"
+        "#### Previous suggestions\n"
+        "<details><summary>Suggestions up to commit 0000000</summary>\n"
+        "<br><table>older</table>\n\n</details>\n"
+    )
+    provider = _persistent_provider([existing])
+    custom_header = "## Latest Custom Heading ✨"
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{custom_header}\n\n<table>new suggestions</table>",
+        initial_header=custom_header,
+        name="suggestions",
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is existing
+    updated = provider.edit_comment.call_args.args[1]
+    assert updated.startswith(
+        f"{custom_header}\n\n{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n<!-- deadbee -->"
+    )
+    assert "Suggestions up to commit aaa1111" in updated
+    assert "Suggestions up to commit 0000000" in updated
+    provider.publish_comment.assert_not_called()

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -376,6 +376,7 @@ async def test_publish_no_suggestions_still_overwrites_the_progress_comment_when
         publish_output_no_suggestions):
     publish_output_no_suggestions(True)
     git_provider = MagicMock()
+    git_provider.supports_code_suggestions_artifact.return_value = False
     tool = _make_tool(git_provider)
     tool.progress_response = MagicMock()
 
@@ -384,6 +385,20 @@ async def test_publish_no_suggestions_still_overwrites_the_progress_comment_when
     _, kwargs = git_provider.edit_comment.call_args
     assert "No code suggestions found for the PR." in kwargs["body"]
     git_provider.remove_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_no_suggestions_uses_provider_artifact_capability(publish_output_no_suggestions):
+    publish_output_no_suggestions(True)
+    git_provider = MagicMock()
+    git_provider.supports_code_suggestions_artifact.return_value = True
+    tool = _make_tool(git_provider)
+
+    await tool.publish_no_suggestions()
+
+    git_provider.publish_code_suggestions.assert_called_once_with([])
+    git_provider.publish_comment.assert_not_called()
+    git_provider.edit_comment.assert_not_called()
 
 
 def test_setup_incremental_scope_calls_provider_when_supported():
@@ -426,6 +441,10 @@ def test_supports_incremental_kind_defaults_to_false_on_base_provider():
     # The base-class default must be "no support" so tools fall back to a full run
     # on providers that never implemented kind-aware incremental anchoring.
     assert GitProvider.supports_incremental_kind(MagicMock(), "suggestions") is False
+
+
+def test_supports_code_suggestions_artifact_defaults_to_false_on_base_provider():
+    assert GitProvider.supports_code_suggestions_artifact(MagicMock()) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.utils import (PRCodeSuggestionsHeader,
+                                 PRCodeSuggestionsIdentity)
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider, IncrementalPR
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
@@ -621,3 +623,123 @@ def test_persistent_update_survives_progress_cleanup_failure():
     assert provider.edit_comment.call_count == 2
     provider.remove_comment.assert_not_called()
     provider.publish_comment.assert_not_called()
+
+
+def _persistent_provider(existing_comments):
+    provider = MagicMock()
+    provider.get_issue_comments.return_value = existing_comments
+    provider.get_comment_url.return_value = "https://example.test/comment/1"
+    provider.get_latest_commit_url.return_value = "https://example.test/commit/deadbee"
+    return provider
+
+
+def test_custom_heading_migrates_legacy_persistent_suggestions_in_place():
+    legacy = MagicMock()
+    legacy.body = (
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n"
+        "<!-- aaa1111 -->\n\n<table>old suggestions</table>"
+    )
+    provider = _persistent_provider([legacy])
+    custom_header = "## Guideline Improvement Suggestions ✨"
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{custom_header}\n\n<table>new suggestions</table>",
+        initial_header=custom_header,
+        name="suggestions",
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is legacy
+    updated = provider.edit_comment.call_args.args[1]
+    assert updated.startswith(
+        f"{custom_header}\n\n"
+        f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        "<!-- deadbee -->"
+    )
+    assert "Suggestions up to commit aaa1111" in updated
+    provider.publish_comment.assert_not_called()
+
+
+def test_marked_persistent_suggestions_take_precedence_over_legacy_comment():
+    legacy = MagicMock()
+    legacy.body = (
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n"
+        "<!-- aaa1111 -->\n\n<table>legacy</table>"
+    )
+    marked = MagicMock()
+    marked.body = (
+        "## Previous Custom Heading ✨\n\n"
+        f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        "<!-- bbb2222 -->\n\n<table>marked</table>"
+    )
+    provider = _persistent_provider([legacy, marked])
+    custom_header = "## Latest Custom Heading ✨"
+
+    result = PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{custom_header}\n\n<table>new suggestions</table>",
+        initial_header=custom_header,
+        name="suggestions",
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    assert result is marked
+    assert provider.edit_comment.call_args.args[0] is marked
+    assert provider.edit_comment.call_args.args[1].startswith(
+        f"{custom_header}\n\n{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+    )
+    provider.publish_comment.assert_not_called()
+
+
+def test_persistent_suggestions_do_not_adopt_quoted_or_late_identity():
+    human = MagicMock()
+    human.body = (
+        "## Human discussion\n\n"
+        f"> {PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        f"Quoted output:\n{PRCodeSuggestionsHeader.SUMMARY.value}\n"
+    )
+    provider = _persistent_provider([human])
+    custom_header = "## Team Suggestions ✨"
+
+    PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{custom_header}\n\n<table>new suggestions</table>",
+        initial_header=custom_header,
+        name="suggestions",
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    provider.edit_comment.assert_not_called()
+    published = provider.publish_comment.call_args.args[0]
+    assert published.startswith(
+        f"{custom_header}\n\n"
+        f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+        "<!-- deadbee -->\n\n"
+    )
+
+
+def test_legacy_heading_without_generated_shape_is_not_adopted():
+    human = MagicMock()
+    human.body = (
+        f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n"
+        "A human-authored comment using the same heading."
+    )
+    provider = _persistent_provider([human])
+    custom_header = "## Team Suggestions ✨"
+
+    PRCodeSuggestions.publish_persistent_comment_with_history(
+        provider,
+        f"{custom_header}\n\n<table>new suggestions</table>",
+        initial_header=custom_header,
+        name="suggestions",
+        identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+        legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+    )
+
+    provider.edit_comment.assert_not_called()
+    published = provider.publish_comment.call_args.args[0]
+    assert PRCodeSuggestionsIdentity.SUMMARY.value in published

--- a/tests/unittest/test_run_details_wiring.py
+++ b/tests/unittest/test_run_details_wiring.py
@@ -224,6 +224,7 @@ async def test_pr_code_suggestions_appends_run_details_when_no_suggestions(monke
         suggestions.progress_response = None
         suggestions.git_provider = MagicMock()
         suggestions.git_provider.get_files.return_value = ["changed.py"]
+        suggestions.git_provider.supports_code_suggestions_artifact.return_value = False
         suggestions.git_provider.is_supported.side_effect = lambda cap: cap == "gfm_markdown" and gfm_supported
 
         async def _fake_retry_empty(*_args, **_kwargs):


### PR DESCRIPTION
Related to #2038 (Part 2)

## Summary

- add `pr_code_suggestions.suggestions_heading` for summary-table `/improve` output
- keep persistent history on a stable hidden identity and migrate generated legacy comments in place
- preserve GitLab incremental anchors and route LocalGit output, including no-suggestions results, to `improve.md`

For example, `suggestions_heading = "Guideline Improvement Suggestions"` renders `## Guideline Improvement Suggestions ✨` while continuing to update the same persistent summary.

## Testing

- focused improve, review-identity, GitLab, and LocalGit suites: 261 passed
- full unit suite: 2480 passed, 1 skipped, 1 xfailed
