### PR TITLE
feat(ask): make the ask heading configurable

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,6 +7,9 @@
 enable_review_labels_effort = true
 enable_auto_approval = true
 
+[pr_questions]
+ask_heading = "Ask"
+
 [github_app]
 pr_commands = [
     "/describe --pr_description.publish_description_as_comment=true",

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,9 +7,6 @@
 enable_review_labels_effort = true
 enable_auto_approval = true
 
-[pr_questions]
-ask_heading = "Ask"
-
 [github_app]
 pr_commands = [
     "/describe --pr_description.publish_description_as_comment=true",

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -97,7 +97,7 @@ ask_heading = "Architecture Question"
 extra_instructions = "Do not answer questions that ask to rate PR quality on a scale of 1 to 10."
 ```
 
-The heading above renders as <code>### **Architecture Question**❓</code>.
+The heading above renders as `### **Architecture Question** ❓`.
 
 Example usage in a PR comment:
 

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -70,7 +70,8 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
         <td><b>ask_heading</b></td>
         <td>
           Plain-text heading for top-level <code>/ask</code> answers. The default is <code>Ask</code>.
-          Markdown punctuation is escaped, while the surrounding formatting and ❓ emoji remain fixed.
+          Markdown renderers escape punctuation to keep the surrounding formatting and ❓ emoji fixed,
+          while plain-text converters receive the configured text without escape characters.
           This does not affect <code>/ask_line</code> replies or the <code>Answer</code> section heading.
         </td>
       </tr>

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -67,6 +67,14 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
 
     <table>
       <tr>
+        <td><b>ask_heading</b></td>
+        <td>
+          Visible base heading for top-level <code>/ask</code> answers. The default is <code>Ask</code>.
+          Markdown formatting and the ❓ emoji remain fixed. This does not affect <code>/ask_line</code>
+          replies or the <code>Answer</code> section heading.
+        </td>
+      </tr>
+      <tr>
         <td><b>extra_instructions</b></td>
         <td>Optional extra instructions to the tool. For example: "Do not answer questions that ask to rate PR quality on a scale of 1 to 10. Instead, tell the user this type of question is not allowed."</td>
       </tr>
@@ -84,8 +92,11 @@ Example usage in a configuration file:
 
 ```toml
 [pr_questions]
+ask_heading = "Architecture Question"
 extra_instructions = "Do not answer questions that ask to rate PR quality on a scale of 1 to 10."
 ```
+
+The heading above renders as <code>### **Architecture Question**❓</code>.
 
 Example usage in a PR comment:
 

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -71,7 +71,7 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
         <td>
           Plain-text heading for top-level <code>/ask</code> answers. The default is <code>Ask</code>.
           Markdown renderers escape punctuation to keep the surrounding formatting and ❓ emoji fixed,
-          while plain-text converters receive the configured text without escape characters.
+          while plain-text converters publish the configured text without escape characters.
           This does not affect <code>/ask_line</code> replies or the <code>Answer</code> section heading.
         </td>
       </tr>

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -69,9 +69,9 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
       <tr>
         <td><b>ask_heading</b></td>
         <td>
-          Visible base heading for top-level <code>/ask</code> answers. The default is <code>Ask</code>.
-          Markdown formatting and the ❓ emoji remain fixed. This does not affect <code>/ask_line</code>
-          replies or the <code>Answer</code> section heading.
+          Plain-text heading for top-level <code>/ask</code> answers. The default is <code>Ask</code>.
+          Markdown punctuation is escaped, while the surrounding formatting and ❓ emoji remain fixed.
+          This does not affect <code>/ask_line</code> replies or the <code>Answer</code> section heading.
         </td>
       </tr>
       <tr>

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -92,8 +92,7 @@ def _get_configured_heading(setting_name: str, default_heading: str) -> str:
     if (
         not isinstance(configured_heading, str)
         or not configured_heading.strip()
-        or "\n" in configured_heading
-        or "\r" in configured_heading
+        or configured_heading.splitlines() != [configured_heading]
     ):
         get_logger().warning(
             f"Invalid {setting_name}; using the default heading"

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -8,6 +8,7 @@ import html
 import json
 import os
 import re
+import string
 import sys
 import textwrap
 import time
@@ -81,6 +82,9 @@ class PRCodeSuggestionsIdentity(str, Enum):
 
 
 _REVIEW_IDENTITY_HEADER_LINES = 5
+_MARKDOWN_PUNCTUATION_ESCAPE_TABLE = str.maketrans(
+    {character: f"\\{character}" for character in string.punctuation}
+)
 
 
 def _get_configured_heading(setting_name: str, default_heading: str) -> str:
@@ -124,7 +128,8 @@ def format_pr_code_suggestions_header(markdown_level: int = 2) -> str:
 def format_pr_questions_header() -> str:
     """Return the visible heading for top-level /ask answers."""
     heading = _get_configured_heading("pr_questions.ask_heading", "Ask")
-    return f"### **{heading}**❓"
+    escaped_heading = heading.translate(_MARKDOWN_PUNCTUATION_ESCAPE_TABLE)
+    return f"### **{escaped_heading}**❓"
 
 
 def comment_matches_identity(body: str, identity: str) -> bool:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -130,7 +130,7 @@ def format_pr_questions_header(*, escape_markdown: bool = True) -> str:
     heading = _get_configured_heading("pr_questions.ask_heading", "Ask")
     if escape_markdown:
         heading = heading.translate(_MARKDOWN_PUNCTUATION_ESCAPE_TABLE)
-    return f"### **{heading}**❓"
+    return f"### **{heading}** ❓"
 
 
 def comment_matches_identity(body: str, identity: str) -> bool:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -125,11 +125,12 @@ def format_pr_code_suggestions_header(markdown_level: int = 2) -> str:
     return f"{markdown_prefix} {heading} ✨"
 
 
-def format_pr_questions_header() -> str:
+def format_pr_questions_header(*, escape_markdown: bool = True) -> str:
     """Return the visible heading for top-level /ask answers."""
     heading = _get_configured_heading("pr_questions.ask_heading", "Ask")
-    escaped_heading = heading.translate(_MARKDOWN_PUNCTUATION_ESCAPE_TABLE)
-    return f"### **{escaped_heading}**❓"
+    if escape_markdown:
+        heading = heading.translate(_MARKDOWN_PUNCTUATION_ESCAPE_TABLE)
+    return f"### **{heading}**❓"
 
 
 def comment_matches_identity(body: str, identity: str) -> bool:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -121,6 +121,12 @@ def format_pr_code_suggestions_header(markdown_level: int = 2) -> str:
     return f"{markdown_prefix} {heading} ✨"
 
 
+def format_pr_questions_header() -> str:
+    """Return the visible heading for top-level /ask answers."""
+    heading = _get_configured_heading("pr_questions.ask_heading", "Ask")
+    return f"### **{heading}**❓"
+
+
 def comment_matches_identity(body: str, identity: str) -> bool:
     """Match hidden markers only as exact lines near the top; legacy headers as prefixes."""
     if not isinstance(body, str) or not isinstance(identity, str) or not identity:

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -76,7 +76,8 @@ class CodeCommitProvider(GitProvider):
             "create_inline_comment",
             "publish_inline_comments",
             "get_labels",
-            "gfm_markdown"
+            "gfm_markdown",
+            "markdown_backslash_escapes",
         ]:
             return False
         return True

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -312,6 +312,7 @@ class GerritProvider(GitProvider):
             'create_inline_comment',
             'publish_inline_comments',
             'get_labels',
+            "markdown_backslash_escapes",
             'gfm_markdown'
         ]:
             return False

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -1,7 +1,9 @@
 import json
 import os
 import pathlib
+import re
 import shutil
+import string
 import subprocess
 import uuid
 from collections import Counter, namedtuple
@@ -109,10 +111,35 @@ def prepare_repo(url: urllib3.util.Url, project, refspec):
     return directory
 
 
+_ASK_HEADING_PREFIX = "### **"
+_ASK_HEADING_SUFFIX = "**❓"
+_ESCAPED_MARKDOWN_PUNCTUATION = re.compile(
+    r"\\([" + re.escape(string.punctuation) + r"])"
+)
+
+
+def _convert_gerrit_ask_heading(line: str) -> str | None:
+    """Convert only the generated /ask heading to Gerrit's plain-text form."""
+    if not line.startswith(_ASK_HEADING_PREFIX) or not line.endswith(_ASK_HEADING_SUFFIX):
+        return None
+    escaped_heading = line[len(_ASK_HEADING_PREFIX):-len(_ASK_HEADING_SUFFIX)]
+    heading = _ESCAPED_MARKDOWN_PUNCTUATION.sub(
+        lambda match: match.group(1),
+        escaped_heading,
+    )
+    return f"{heading}❓"
+
+
 def adopt_to_gerrit_message(message):
     lines = message.splitlines()
     buf = []
-    for line in lines:
+    for line_number, line in enumerate(lines):
+        if line_number == 0:
+            ask_heading = _convert_gerrit_ask_heading(line.strip())
+            if ask_heading is not None:
+                buf.append(f"\n{ask_heading}:")
+                continue
+
         # remove markdown formatting
         line = (line.replace("*", "")
                 .replace("``", "`")
@@ -312,7 +339,6 @@ class GerritProvider(GitProvider):
             'create_inline_comment',
             'publish_inline_comments',
             'get_labels',
-            "markdown_backslash_escapes",
             'gfm_markdown'
         ]:
             return False

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -112,7 +112,7 @@ def prepare_repo(url: urllib3.util.Url, project, refspec):
 
 
 _ASK_HEADING_PREFIX = "### **"
-_ASK_HEADING_SUFFIX = "**❓"
+_ASK_HEADING_SUFFIX = "** ❓"
 _ESCAPED_MARKDOWN_PUNCTUATION = re.compile(
     r"\\([" + re.escape(string.punctuation) + r"])"
 )

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -158,7 +158,7 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
-# Visible base heading for top-level /ask answer comments. Markdown and emoji are added automatically.
+# Set the plain-text heading for top-level /ask answers; Markdown formatting and the emoji are added automatically.
 ask_heading = "Ask"
 # Enable to let /ask_line resolve the review thread when the LLM judges the
 # issue addressed. Note: also resolves threads started by human reviewers.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -158,6 +158,8 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
+# Visible base heading for top-level /ask answer comments. Markdown and emoji are added automatically.
+ask_heading = "Ask"
 # Enable to let /ask_line resolve the review thread when the LLM judges the
 # issue addressed. Note: also resolves threads started by human reviewers.
 resolve_threads=false

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -158,7 +158,7 @@ async_ai_calls=true
 [pr_questions] # /ask #
 enable_help_text=false
 use_conversation_history=true
-# Set the plain-text heading for top-level /ask answers; Markdown formatting and the emoji are added automatically.
+# Set the plain-text heading for top-level /ask answers; provider-specific presentation is added automatically.
 ask_heading = "Ask"
 # Enable to let /ask_line resolve the review thread when the LLM judges the
 # issue addressed. Note: also resolves threads started by human reviewers.

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -7,7 +7,7 @@ from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenHandler
-from pr_agent.algo.utils import ModelType
+from pr_agent.algo.utils import ModelType, format_pr_questions_header
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
@@ -130,6 +130,6 @@ class PRQuestions:
                                artifact={"model_answer": model_answer, "sanitized_answer": model_answer_sanitized})
 
 
-        answer_str = f"### **Ask**❓\n{self.question_str}\n\n"
+        answer_str = f"{format_pr_questions_header()}\n{self.question_str}\n\n"
         answer_str += f"### **Answer:**\n{model_answer_sanitized}\n\n"
         return answer_str

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -128,8 +128,9 @@ class PRQuestions:
         if model_answer_sanitized != model_answer:
             get_logger().debug(f"Sanitized model answer",
                                artifact={"model_answer": model_answer, "sanitized_answer": model_answer_sanitized})
-
-
-        answer_str = f"{format_pr_questions_header()}\n{self.question_str}\n\n"
+        answer_header = format_pr_questions_header(
+            escape_markdown=self.git_provider.is_supported("markdown_backslash_escapes")
+        )
+        answer_str = f"{answer_header}\n{self.question_str}\n\n"
         answer_str += f"### **Answer:**\n{model_answer_sanitized}\n\n"
         return answer_str

--- a/tests/unittest/test_code_suggestions_comment_identity.py
+++ b/tests/unittest/test_code_suggestions_comment_identity.py
@@ -46,7 +46,7 @@ def test_default_suggestions_heading_is_unchanged():
 
 @pytest.mark.parametrize(
     "invalid_heading",
-    [None, "", "  ", "first\nsecond", "first\rsecond", 42],
+    [None, "", "  ", "first\nsecond", "first\rsecond", "first\u2028second", 42],
 )
 def test_invalid_suggestions_heading_falls_back_to_default(invalid_heading):
     snapshot = snapshot_settings(["pr_code_suggestions.suggestions_heading"])

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -146,6 +146,28 @@ class TestPreparePrAnswer:
 
         assert header == "### **Ask**❓"
 
+    @pytest.mark.parametrize(
+        ("heading", "expected"),
+        [
+            ("Architecture **Question**", r"### **Architecture \*\*Question\*\***❓"),
+            (
+                r"Use [SDK](docs/v2) `now` \\ safely",
+                r"### **Use \[SDK\]\(docs\/v2\) \`now\` \\\\ safely**❓",
+            ),
+            ("Architecture Ω", "### **Architecture Ω**❓"),
+        ],
+    )
+    def test_heading_is_rendered_as_literal_text(self, heading, expected):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        try:
+            settings.set("pr_questions.ask_heading", heading)
+            header = format_pr_questions_header()
+        finally:
+            restore_settings(saved)
+
+        assert header == expected
+
     def test_sanitizes_leading_slash(self):
         pr = _make_pr_questions(
             question_str="q", prediction="/merge looks fine", git_provider=MagicMock()

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import pr_agent.tools.pr_line_questions as plq
+from pr_agent.algo.utils import format_pr_questions_header
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 from pr_agent.tools.pr_questions import PRQuestions
@@ -119,10 +120,31 @@ class TestPreparePrAnswer:
             git_provider=MagicMock(),  # not GitLab
         )
         out = pr._prepare_pr_answer()
-        assert "### **Ask**❓" in out
-        assert "why?" in out
-        assert "### **Answer:**" in out
-        assert "because reasons" in out
+        assert out == "### **Ask**❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
+
+    def test_custom_heading_changes_only_the_ask_header(self):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        pr = _make_pr_questions(question_str="why?", prediction="because reasons")
+        try:
+            settings.set("pr_questions.ask_heading", "  Architecture Question  ")
+            out = pr._prepare_pr_answer()
+        finally:
+            restore_settings(saved)
+
+        assert out == "### **Architecture Question**❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
+
+    @pytest.mark.parametrize("invalid_heading", [None, "", "   ", "Ask\nNow", "Ask\rNow", 42])
+    def test_invalid_heading_falls_back_to_ask(self, invalid_heading):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        try:
+            settings.set("pr_questions.ask_heading", invalid_heading)
+            header = format_pr_questions_header()
+        finally:
+            restore_settings(saved)
+
+        assert header == "### **Ask**❓"
 
     def test_sanitizes_leading_slash(self):
         pr = _make_pr_questions(

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -14,6 +14,8 @@ import pytest
 import pr_agent.tools.pr_line_questions as plq
 from pr_agent.algo.utils import format_pr_questions_header
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.codecommit_provider import CodeCommitProvider
+from pr_agent.git_providers.gerrit_provider import GerritProvider, adopt_to_gerrit_message
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 from pr_agent.tools.pr_questions import PRQuestions
 from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
@@ -167,6 +169,43 @@ class TestPreparePrAnswer:
             restore_settings(saved)
 
         assert header == expected
+
+    @pytest.mark.parametrize("provider_class", [CodeCommitProvider, GerritProvider])
+    def test_plaintext_providers_do_not_receive_markdown_escapes(self, provider_class):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        provider = provider_class.__new__(provider_class)
+        pr = _make_pr_questions(
+            question_str="why?",
+            prediction="because reasons",
+            git_provider=provider,
+        )
+        try:
+            settings.set("pr_questions.ask_heading", "Q&A / Security")
+            out = pr._prepare_pr_answer()
+        finally:
+            restore_settings(saved)
+
+        assert out.startswith("### **Q&A / Security**❓\n")
+        assert "\\" not in out.splitlines()[0]
+
+    def test_gerrit_plaintext_conversion_does_not_leak_heading_escapes(self):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        provider = GerritProvider.__new__(GerritProvider)
+        pr = _make_pr_questions(
+            question_str="why?",
+            prediction="because reasons",
+            git_provider=provider,
+        )
+        try:
+            settings.set("pr_questions.ask_heading", "Q&A / Security")
+            out = adopt_to_gerrit_message(pr._prepare_pr_answer())
+        finally:
+            restore_settings(saved)
+
+        assert out.startswith("Q&A / Security❓:")
+        assert "\\" not in out.splitlines()[0]
 
     def test_sanitizes_leading_slash(self):
         pr = _make_pr_questions(

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -136,7 +136,26 @@ class TestPreparePrAnswer:
 
         assert out == "### **Architecture Question** ❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
 
-    @pytest.mark.parametrize("invalid_heading", [None, "", "   ", "Ask\nNow", "Ask\rNow", 42])
+    @pytest.mark.parametrize(
+        "invalid_heading",
+        [
+            None,
+            "",
+            "   ",
+            "Ask\nNow",
+            "Ask\rNow",
+            "Ask\vNow",
+            "Ask\fNow",
+            "Ask\x1cNow",
+            "Ask\x1dNow",
+            "Ask\x1eNow",
+            "Ask\x85Now",
+            "Ask\u2028Now",
+            "Ask\u2029Now",
+            "Ask\u2028",
+            42,
+        ],
+    )
     def test_invalid_heading_falls_back_to_ask(self, invalid_heading):
         settings = get_settings()
         saved = snapshot_settings(("pr_questions.ask_heading",))
@@ -210,6 +229,25 @@ class TestPreparePrAnswer:
         assert r"\*" in raw_heading
         assert r"\\" in raw_heading
         assert out.splitlines()[0] == f"{heading}❓:"
+
+    def test_gerrit_falls_back_for_a_unicode_line_separator(self):
+        settings = get_settings()
+        saved = snapshot_settings(("pr_questions.ask_heading",))
+        provider = GerritProvider.__new__(GerritProvider)
+        pr = _make_pr_questions(
+            question_str="why?",
+            prediction="because reasons",
+            git_provider=provider,
+        )
+        try:
+            settings.set("pr_questions.ask_heading", "Architecture\u2028Question")
+            answer = pr._prepare_pr_answer()
+            out = adopt_to_gerrit_message(answer)
+        finally:
+            restore_settings(saved)
+
+        assert answer.startswith("### **Ask** ❓\n")
+        assert out.splitlines()[0] == "Ask❓:"
 
     def test_gerrit_keeps_existing_conversion_for_other_markdown_headings(self):
         message = "### **Answer:**\n- item\n### **Model # Heading:**"

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -122,7 +122,7 @@ class TestPreparePrAnswer:
             git_provider=MagicMock(),  # not GitLab
         )
         out = pr._prepare_pr_answer()
-        assert out == "### **Ask**❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
+        assert out == "### **Ask** ❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
 
     def test_custom_heading_changes_only_the_ask_header(self):
         settings = get_settings()
@@ -134,7 +134,7 @@ class TestPreparePrAnswer:
         finally:
             restore_settings(saved)
 
-        assert out == "### **Architecture Question**❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
+        assert out == "### **Architecture Question** ❓\nwhy?\n\n### **Answer:**\nbecause reasons\n\n"
 
     @pytest.mark.parametrize("invalid_heading", [None, "", "   ", "Ask\nNow", "Ask\rNow", 42])
     def test_invalid_heading_falls_back_to_ask(self, invalid_heading):
@@ -146,17 +146,17 @@ class TestPreparePrAnswer:
         finally:
             restore_settings(saved)
 
-        assert header == "### **Ask**❓"
+        assert header == "### **Ask** ❓"
 
     @pytest.mark.parametrize(
         ("heading", "expected"),
         [
-            ("Architecture **Question**", r"### **Architecture \*\*Question\*\***❓"),
+            ("Architecture **Question**", r"### **Architecture \*\*Question\*\*** ❓"),
             (
                 r"Use [SDK](docs/v2) `now` \\ safely",
-                r"### **Use \[SDK\]\(docs\/v2\) \`now\` \\\\ safely**❓",
+                r"### **Use \[SDK\]\(docs\/v2\) \`now\` \\\\ safely** ❓",
             ),
-            ("Architecture Ω", "### **Architecture Ω**❓"),
+            ("Architecture Ω", "### **Architecture Ω** ❓"),
         ],
     )
     def test_heading_is_rendered_as_literal_text(self, heading, expected):
@@ -185,7 +185,7 @@ class TestPreparePrAnswer:
         finally:
             restore_settings(saved)
 
-        assert out.startswith("### **Q&A / Security**❓\n")
+        assert out.startswith("### **Q&A / Security** ❓\n")
         assert "\\" not in out.splitlines()[0]
 
     def test_gerrit_preserves_literal_heading_punctuation(self):

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -170,11 +170,10 @@ class TestPreparePrAnswer:
 
         assert header == expected
 
-    @pytest.mark.parametrize("provider_class", [CodeCommitProvider, GerritProvider])
-    def test_plaintext_providers_do_not_receive_markdown_escapes(self, provider_class):
+    def test_codecommit_does_not_receive_markdown_escapes(self):
         settings = get_settings()
         saved = snapshot_settings(("pr_questions.ask_heading",))
-        provider = provider_class.__new__(provider_class)
+        provider = CodeCommitProvider.__new__(CodeCommitProvider)
         pr = _make_pr_questions(
             question_str="why?",
             prediction="because reasons",
@@ -189,7 +188,7 @@ class TestPreparePrAnswer:
         assert out.startswith("### **Q&A / Security**❓\n")
         assert "\\" not in out.splitlines()[0]
 
-    def test_gerrit_plaintext_conversion_does_not_leak_heading_escapes(self):
+    def test_gerrit_preserves_literal_heading_punctuation(self):
         settings = get_settings()
         saved = snapshot_settings(("pr_questions.ask_heading",))
         provider = GerritProvider.__new__(GerritProvider)
@@ -198,14 +197,24 @@ class TestPreparePrAnswer:
             prediction="because reasons",
             git_provider=provider,
         )
+        heading = r"Hash #, star *, [docs](v2), /, `tick`, |, \ path"
         try:
-            settings.set("pr_questions.ask_heading", "Q&A / Security")
-            out = adopt_to_gerrit_message(pr._prepare_pr_answer())
+            settings.set("pr_questions.ask_heading", heading)
+            answer = pr._prepare_pr_answer()
+            out = adopt_to_gerrit_message(answer)
         finally:
             restore_settings(saved)
 
-        assert out.startswith("Q&A / Security❓:")
-        assert "\\" not in out.splitlines()[0]
+        raw_heading = answer.splitlines()[0]
+        assert r"\#" in raw_heading
+        assert r"\*" in raw_heading
+        assert r"\\" in raw_heading
+        assert out.splitlines()[0] == f"{heading}❓:"
+
+    def test_gerrit_keeps_existing_conversion_for_other_markdown_headings(self):
+        message = "### **Answer:**\n- item\n### **Model # Heading:**"
+
+        assert adopt_to_gerrit_message(message) == "Answer:\nitem\n\nModel  Heading:"
 
     def test_sanitizes_leading_slash(self):
         pr = _make_pr_questions(

--- a/tests/unittest/test_review_comment_identity.py
+++ b/tests/unittest/test_review_comment_identity.py
@@ -39,7 +39,10 @@ def test_custom_review_heading_changes_presentation_only():
     assert "<!-- pr-agent:review" not in incremental
 
 
-@pytest.mark.parametrize("invalid_heading", [None, "", "  ", "first\nsecond", 42])
+@pytest.mark.parametrize(
+    "invalid_heading",
+    [None, "", "  ", "first\nsecond", "first\u2028second", 42],
+)
 def test_invalid_review_heading_falls_back_to_default(invalid_heading):
     snapshot = snapshot_settings(["pr_reviewer.review_heading"])
     try:


### PR DESCRIPTION
Fixes #2038 (Part 3)

## Summary

- add `pr_questions.ask_heading` for top-level `/ask` answers
- preserve literal headings on Markdown providers without leaking escape characters into plain-text converters
- reject logical line separators so configured headings remain one line across providers
- keep the `Answer` section and `/ask_line` replies unchanged
- use the shared heading validation introduced by the earlier `/review` and `/improve` changes

## Result

`ask_heading = "Architecture Question"` renders:

```markdown
### **Architecture Question** ❓
```

## Testing

- focused ask, provider, and shared-heading suites: 139 passed
- full unit suite: 2522 passed, 1 skipped, 1 xfailed
