### PR TITLE
ci: smoke-start github_app container so a broken launcher fails CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,3 +37,35 @@ jobs:
         name: Test dev docker
         run: |
           docker run --rm pragent/pr-agent:test pytest -v tests/unittest
+
+      # Unit tests override CMD, so a broken server launcher never fails CI.
+      # Smoke-start github_app (gunicorn + uvicorn) with no secrets; GET / → 200.
+      - id: build-smoke
+        name: Build github_app docker
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: false
+          load: true
+          tags: pragent/pr-agent:smoke
+          cache-from: type=gha,scope=dev
+          cache-to: type=gha,mode=max,scope=dev
+          target: github_app
+
+      - id: smoke
+        name: Smoke-start the github_app container
+        run: |
+          docker run -d --name pr-agent-smoke -p 3000:3000 pragent/pr-agent:smoke
+          for i in $(seq 1 15); do
+            if curl -sf -o /dev/null http://localhost:3000/; then
+              echo "container is serving"
+              docker rm -f pr-agent-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "container did not come up"
+          docker logs pr-agent-smoke
+          docker rm -f pr-agent-smoke
+          exit 1


### PR DESCRIPTION
## Summary

Fixes #2824.

No workflow ever starts a server container. `build-and-test` (and the other docker workflows) override the image `CMD` with pytest, so a broken launcher such as a missing `gunicorn` module still produces a fully green CI.

This PR adds a small smoke step after the unit tests:

1. Build the `github_app` Docker target (via the existing `docker/build-push-action` + GHA cache, matching the file's style).
2. Run the container with no secrets / env vars.
3. Poll `GET /` on port 3000 until it returns 200 (or fail with container logs after ~30s).

That is enough to catch `No module named gunicorn` and similar process-launcher breakages. Other server targets can get the same treatment later; one target is a complete first change.

## Test plan

- [x] Workflow YAML validates locally (structure matches existing steps)
- [ ] CI: Build-and-test job builds `github_app` and smoke step passes on this PR
- [ ] Optional local check from the issue:
  `ash
  docker build -f docker/Dockerfile --target github_app -t pragent/pr-agent:smoke .
  docker run -d --name pr-agent-smoke -p 3000:3000 pragent/pr-agent:smoke
  curl -sf http://localhost:3000/
  docker rm -f pr-agent-smoke
  `

Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>