### PR TITLE
fix(github): release cancelled push-trigger waiters

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -184,16 +184,16 @@ async def handle_push_trigger_for_new_commits(body: Dict[str, Any],
             f"Skipping push trigger for {api_url=} because another event already triggered the same processing"
         )
         return {}
-    async with _pending_task_duplicate_push_conditions[api_url]:
-        if current_active_tasks == 1:
-            # second task waits
-            get_logger().info(
-                f"Waiting to process push trigger for {api_url=} because the first task is still in progress"
-            )
-            await _pending_task_duplicate_push_conditions[api_url].wait()
-            get_logger().info(f"Finished waiting to process push trigger for {api_url=} - continue with flow")
-
     try:
+        async with _pending_task_duplicate_push_conditions[api_url]:
+            if current_active_tasks == 1:
+                # second task waits
+                get_logger().info(
+                    f"Waiting to process push trigger for {api_url=} because the first task is still in progress"
+                )
+                await _pending_task_duplicate_push_conditions[api_url].wait()
+                get_logger().info(f"Finished waiting to process push trigger for {api_url=} - continue with flow")
+
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
             get_logger().info(f"Performing incremental review for {api_url=} because of {event=} and {action=}")
             await _perform_auto_commands_github("push_commands", agent, body, api_url, log_context)

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -533,6 +533,63 @@ class TestPushTriggerDedupe:
         assert push_trigger_env["count"] == 0
         assert github_app._duplicate_push_triggers[api_url] == 1
 
+    def test_cancelled_backlog_waiter_releases_dedupe_slot(self, push_trigger_env, monkeypatch):
+        settings = github_app.get_settings()
+        settings.github_app.push_trigger_pending_tasks_backlog = True
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def fake_perform(*args, **kwargs):
+            push_trigger_env["count"] += 1
+            if push_trigger_env["count"] == 1:
+                first_started.set()
+                await release_first.wait()
+
+        monkeypatch.setattr(github_app, "_perform_auto_commands_github", fake_perform)
+
+        async def exercise_cancelled_waiter():
+            body = _push_body()
+            api_url = body["pull_request"]["url"]
+            first = asyncio.create_task(
+                github_app.handle_push_trigger_for_new_commits(
+                    body, "push", "alice", "1", "synchronize", {}, agent=None
+                )
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1)
+
+            second = asyncio.create_task(
+                github_app.handle_push_trigger_for_new_commits(
+                    body, "push", "alice", "1", "synchronize", {}, agent=None
+                )
+            )
+            for _ in range(10):
+                if github_app._duplicate_push_triggers[api_url] == 2:
+                    break
+                await asyncio.sleep(0)
+            assert github_app._duplicate_push_triggers[api_url] == 2
+
+            second.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await second
+
+            try:
+                # Cancelling the waiting task must return its reserved slot.
+                assert github_app._duplicate_push_triggers[api_url] == 1
+            finally:
+                release_first.set()
+                await first
+
+            assert github_app._duplicate_push_triggers[api_url] == 0
+            await asyncio.wait_for(
+                github_app.handle_push_trigger_for_new_commits(
+                    body, "push", "alice", "1", "synchronize", {}, agent=None
+                ),
+                timeout=1,
+            )
+            assert push_trigger_env["count"] == 2
+
+        asyncio.run(exercise_cancelled_waiter())
+
     def test_invalid_pr_event_short_circuits(self, push_trigger_env):
         body = _push_body()
         body["pull_request"]["state"] = "closed"


### PR DESCRIPTION
Fixes #2826

## Summary

When `github_app.push_trigger_pending_tasks_backlog` is enabled, the second
GitHub `synchronize` event for a PR reserves a dedupe slot and waits for the
first review. The cleanup `try/finally` began after that wait, so cancelling the
waiting task leaked its slot. The first task then left the counter at 1, and
later events could wait forever or be discarded as duplicates.

This change puts the existing condition wait inside the cleanup scope. The
counter is now released when the waiter is cancelled, while the existing
one-running-plus-one-waiting policy and notification behaviour stay unchanged.

## Tests

- `pytest -q tests/unittest/test_github_app_timeout_core.py::TestPushTriggerDedupe::test_cancelled_backlog_waiter_releases_dedupe_slot`
  - fails on `origin/main` (`assert 2 == 1`)
  - passes with this change
- `pytest -q tests/unittest/test_github_app_timeout_core.py` — 37 passed
- `pytest -q tests/unittest` — 2449 passed, 1 skipped, 1 xfailed
- `python -m compileall -q pr_agent/servers/github_app.py tests/unittest/test_github_app_timeout_core.py`
- `git diff --check`

The tests ran in the repository's Python 3.12 Docker test image. The full run
reported the repository's existing warnings; no external GitHub/model or
credentialed E2E test was claimed.

## Scope

- `pr_agent/servers/github_app.py`
- `tests/unittest/test_github_app_timeout_core.py`

No configuration or public API changes.
