### PR TITLE
fix(agent): preserve asyncio cancellation at request boundary

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -230,6 +230,6 @@ class PRAgent:
     async def handle_request(self, pr_url, request, notify=None) -> bool:
         try:
             return await self._handle_request(pr_url, request, notify)
-        except:
+        except Exception:
             get_logger().exception("Failed to process the command.")
             return False

--- a/tests/unittest/test_pr_agent_routing.py
+++ b/tests/unittest/test_pr_agent_routing.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import Mock
 
 import pytest
@@ -190,6 +191,35 @@ async def test_handle_request_wrapper_returns_false_on_exception(monkeypatch):
     handled = await pr_agent_module.PRAgent().handle_request("https://example/pr/1", "/review")
 
     assert handled is False
+
+
+@pytest.mark.asyncio
+async def test_handle_request_propagates_cancellation(monkeypatch):
+    started = asyncio.Event()
+
+    class BlockingTool:
+        def __init__(self, pr_url, ai_handler, args):
+            pass
+
+        async def run(self):
+            started.set()
+            await asyncio.Event().wait()
+
+    _patch_request_dependencies(monkeypatch)
+    monkeypatch.setitem(
+        pr_agent_module.command2class, "blocking", BlockingTool
+    )
+
+    task = asyncio.create_task(
+        pr_agent_module.PRAgent(ai_handler="fake-ai").handle_request(
+            "https://example/pr/1", "/blocking"
+        )
+    )
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #2830

`PRAgent.handle_request()` used a bare `except` around the command pipeline. In Python 3.12 this catches `asyncio.CancelledError`, causing cancelled requests to be logged as ordinary command failures and returned as `False`.

## Root cause

The wrapper conflated ordinary command failures with task cancellation:

```text
command/provider await -> task.cancel() -> CancelledError
                                  -> bare except
                                  -> log + False
```

That removes cancellation from the caller-visible state machine. In particular, a caller using `asyncio.wait_for()` receives `False` rather than a timeout, and an orchestrator cannot distinguish a cancelled request from an ordinary failed command.

## Change

- Catch only `Exception` in `PRAgent.handle_request()`.
- Preserve cancellation propagation for `asyncio.CancelledError` and other `BaseException` signals.
- Add a deterministic public-boundary regression using a fake blocking command.
- Keep the existing ordinary-exception regression to document the `False` contract.

## Tests

Executed in the existing Python 3.12 Docker test image:

```text
pytest -q tests/unittest/test_pr_agent_routing.py::test_handle_request_propagates_cancellation tests/unittest/test_pr_agent_routing.py::test_handle_request_wrapper_returns_false_on_exception
2 passed, 1 warning

pytest -q tests/unittest/test_pr_agent_routing.py
17 passed, 1 warning

pytest -q tests/unittest/test_mosaico_router.py tests/unittest/test_mosaico_provider.py tests/unittest/test_mosaico_executor.py tests/unittest/test_github_app_timeout_core.py tests/unittest/test_github_action_runner_core.py
154 passed, 1 warning

pytest -q tests/unittest
2449 passed, 1 skipped, 1 xfailed, 89 warnings

python -m compileall -q pr_agent tests/unittest
git diff --check
```

## Compatibility and scope

Ordinary `Exception` handling remains unchanged. No provider adapter, model selection, configuration, command syntax, or external API behavior is changed. The fix is intentionally limited to the common request boundary and its regression test.

The tests validate the checked-out code only; no real model, provider, deployment shutdown, or production timeout frequency was exercised.
