### PR TITLE
fix(gerrit): align diff metadata and filtering

### DIFF
--- a/pr_agent/algo/file_filter.py
+++ b/pr_agent/algo/file_filter.py
@@ -75,6 +75,13 @@ def filter_ignored(files, platform = 'github'):
                     files = [f for f in files if not r.match(f)]
                 elif platform == 'gitea':
                     files = [f for f in files if not r.match(f.get("filename", ""))]
+                elif platform == 'gerrit':
+                    files_o = []
+                    for f in files:
+                        path = f.b_path or f.a_path
+                        if path and not r.match(path):
+                            files_o.append(f)
+                    files = files_o
 
 
     except Exception as e:

--- a/pr_agent/algo/file_filter.py
+++ b/pr_agent/algo/file_filter.py
@@ -75,7 +75,7 @@ def filter_ignored(files, platform = 'github'):
                     files = [f for f in files if not r.match(f)]
                 elif platform == 'gitea':
                     files = [f for f in files if not r.match(f.get("filename", ""))]
-                elif platform == 'gerrit':
+                elif platform == "gerrit":
                     files_o = []
                     for f in files:
                         path = f.b_path or f.a_path

--- a/pr_agent/algo/language_handler.py
+++ b/pr_agent/algo/language_handler.py
@@ -1,4 +1,5 @@
 # Language Selection, source: https://github.com/bigcode-project/bigcode-dataset/blob/main/language_selection/programming-languages-to-file-extensions.json  # noqa E501
+from collections.abc import Callable
 from typing import Dict
 
 from pr_agent.config_loader import get_settings
@@ -34,6 +35,37 @@ def is_valid_file(filename:str, bad_extensions=None) -> bool:
     return filename.split('.')[-1] not in bad_extensions
 
 
+def build_language_file_matcher(language_extension_map: Dict) -> Callable[[str], str | None]:
+    """Build a filename classifier from the configured language extensions."""
+    exact_to_language = {}
+    folded_to_languages = {}
+    for language, extensions in language_extension_map.items():
+        for extension in extensions:
+            token = extension.lstrip("*")
+            exact_to_language.setdefault(token, language)
+            folded_to_languages.setdefault(token.casefold(), set()).add(language)
+
+    def get_language(filename: str) -> str | None:
+        name = filename.replace("\\", "/").rsplit("/", 1)[-1]
+        parts = name.split(".")
+        candidates = [name] + [
+            "." + ".".join(parts[i:])
+            for i in range(1, len(parts))
+        ]
+
+        for candidate in candidates:
+            language = exact_to_language.get(candidate)
+            if language:
+                return language
+            languages = folded_to_languages.get(candidate.casefold(), set())
+            if len(languages) == 1:
+                return next(iter(languages))
+
+        return None
+
+    return get_language
+
+
 def sort_files_by_main_languages(languages: Dict, files: list):
     """
     Sort files by their main language, put the files that are in the main language first and the rest files after
@@ -42,19 +74,22 @@ def sort_files_by_main_languages(languages: Dict, files: list):
     languages_sorted_list = [k for k, v in sorted(languages.items(), key=lambda item: item[1], reverse=True)]
     # languages_sorted = sorted(languages, key=lambda x: x[1], reverse=True)
     # get all extensions for the languages
-    main_extensions = []
     language_extension_map_org = get_settings().language_extension_map_org
-    language_extension_map = {k.lower(): v for k, v in language_extension_map_org.items()}
-    for language in languages_sorted_list:
-        if language.lower() in language_extension_map:
-            main_extensions.append(language_extension_map[language.lower()])
-        else:
-            main_extensions.append([])
+    configured_language_names = {
+        language.lower(): language
+        for language in language_extension_map_org
+    }
+    selected_language_names = {
+        configured_language_names[language.lower()]: language
+        for language in languages_sorted_list
+        if language.lower() in configured_language_names
+    }
+    get_language = build_language_file_matcher(language_extension_map_org)
 
     # filter out files bad extensions
     files_filtered = filter_bad_extensions(files)
 
-    # sort files by their extension, put the files that are in the main extension first
+    # sort files by their language, put the files that are in the main language first
     # and the rest files after, map languages_sorted to their respective files
     files_sorted = []
     rest_files = {}
@@ -64,20 +99,17 @@ def sort_files_by_main_languages(languages: Dict, files: list):
         files_sorted = [({"language": "Other", "files": list(files_filtered)})]
         return files_sorted
 
-    main_extensions_flat = []
-    for ext in main_extensions:
-        main_extensions_flat.extend(ext)
+    files_by_language = {language: [] for language in languages_sorted_list}
+    for file in files_filtered:
+        configured_language = get_language(file.filename)
+        selected_language = selected_language_names.get(configured_language)
+        if selected_language:
+            files_by_language[selected_language].append(file)
+        else:
+            rest_files.setdefault(file.filename, file)
 
-    for extensions, lang in zip(main_extensions, languages_sorted_list):  # noqa: B905
-        tmp = []
-        for file in files_filtered:
-            extension_str = f".{file.filename.split('.')[-1]}"
-            if extension_str in extensions:
-                tmp.append(file)
-            else:
-                if (file.filename not in rest_files) and (extension_str not in main_extensions_flat):
-                    rest_files[file.filename] = file
-        if len(tmp) > 0:
-            files_sorted.append({"language": lang, "files": tmp})
+    for language in languages_sorted_list:
+        if files_by_language[language]:
+            files_sorted.append({"language": language, "files": files_by_language[language]})
     files_sorted.append({"language": "Other", "files": list(rest_files.values())})
     return files_sorted

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -14,6 +14,7 @@ import requests
 import urllib3.util
 from git import Repo
 
+from pr_agent.algo.file_filter import filter_ignored
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
@@ -259,11 +260,14 @@ class GerritProvider(GitProvider):
             return b""
 
     def get_diff_files(self) -> list[FilePatchInfo]:
-        diffs = self.repo.head.commit.diff(
-            self.repo.head.commit.parents[0],  # previous commit
-            create_patch=True,
-            R=True
+        diffs = list(
+            self.repo.head.commit.diff(
+                self.repo.head.commit.parents[0],  # previous commit
+                create_patch=True,
+                R=True
+            )
         )
+        diffs = filter_ignored(diffs, "gerrit")
 
         diff_files = []
         for diff_item in diffs:
@@ -290,7 +294,7 @@ class GerritProvider(GitProvider):
                     original_file_content_str,
                     new_file_content_str,
                     diff_item.diff.decode('utf-8'),
-                    diff_item.b_path,
+                    diff_item.b_path or diff_item.a_path,
                     edit_type=edit_type,
                     old_filename=None
                     if diff_item.a_path == diff_item.b_path
@@ -314,18 +318,35 @@ class GerritProvider(GitProvider):
         Calculate percentage of languages in repository. Used for hunk
         prioritisation.
         """
+        ext_to_lang = {}
+        lang_map = get_settings().get("language_extension_map_org", {}) or {}
+        for language, extensions in lang_map.items():
+            for ext in extensions:
+                ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
+
+        def _match_language(name: str):
+            language = ext_to_lang.get(name.lower())
+            if language:
+                return language
+            parts = name.split(".")
+            for i in range(1, len(parts)):
+                language = ext_to_lang.get("." + ".".join(parts[i:]).lower())
+                if language:
+                    return language
+            return None
+
         # Get all files in repository
         filepaths = [Path(item.path) for item in
                      self.repo.tree().traverse() if item.type == 'blob']
-        # Identify language by file extension and count
-        lang_count = Counter(
-            ext.lstrip('.') for filepath in filepaths for ext in
-            [filepath.suffix.lower()])
+        # Identify language by filename and count
+        lang_count = Counter()
+        for filepath in filepaths:
+            language = _match_language(filepath.name)
+            if language:
+                lang_count[language] += 1
         # Convert counts to percentages
-        total_files = len(filepaths)
-        lang_percentage = {lang: count / total_files * 100 for lang, count
-                           in lang_count.items()}
-        return lang_percentage
+        total = sum(lang_count.values()) or 1
+        return {lang: count / total * 100 for lang, count in lang_count.items()}
 
     def get_pr_description_full(self):
         return self.repo.head.commit.message

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -15,6 +15,7 @@ import urllib3.util
 from git import Repo
 
 from pr_agent.algo.file_filter import filter_ignored
+from pr_agent.algo.language_handler import build_language_file_matcher
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
@@ -318,22 +319,8 @@ class GerritProvider(GitProvider):
         Calculate percentage of languages in repository. Used for hunk
         prioritisation.
         """
-        ext_to_lang = {}
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
-        for language, extensions in lang_map.items():
-            for ext in extensions:
-                ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
-
-        def _match_language(name: str):
-            language = ext_to_lang.get(name.lower())
-            if language:
-                return language
-            parts = name.split(".")
-            for i in range(1, len(parts)):
-                language = ext_to_lang.get("." + ".".join(parts[i:]).lower())
-                if language:
-                    return language
-            return None
+        get_language = build_language_file_matcher(lang_map)
 
         # Get all files in repository
         filepaths = [Path(item.path) for item in
@@ -341,7 +328,7 @@ class GerritProvider(GitProvider):
         # Identify language by filename and count
         lang_count = Counter()
         for filepath in filepaths:
-            language = _match_language(filepath.name)
+            language = get_language(filepath.name)
             if language:
                 lang_count[language] += 1
         # Convert counts to percentages

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -1,5 +1,6 @@
 import git
 
+from pr_agent.algo.language_handler import sort_files_by_main_languages
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gerrit_provider import GerritProvider
@@ -42,8 +43,6 @@ def test_get_languages_returns_names_used_for_hunk_prioritization(tmp_path):
 
     assert languages == {"Python": 75.0, "JavaScript": 25.0}
 
-    from pr_agent.algo.language_handler import sort_files_by_main_languages
-
     files = [type("File", (), {"filename": name})() for name in ["a.py", "app.js", "notes.unknown"]]
     buckets = {
         bucket["language"]: {file.filename for file in bucket["files"]}
@@ -65,8 +64,6 @@ def test_get_languages_matches_filenames_and_multipart_extensions(tmp_path):
 
     assert set(languages) == {"Dockerfile", "CMake", "Python"}
     assert all(abs(percentage - 100 / 3) < 1e-6 for percentage in languages.values())
-
-    from pr_agent.algo.language_handler import sort_files_by_main_languages
 
     files = [
         type("File", (), {"filename": name})()
@@ -92,8 +89,6 @@ def test_get_languages_preserves_case_sensitive_extensions(tmp_path):
     languages = provider.get_languages()
     assert languages == {"C": 50.0, "C++": 50.0}
 
-    from pr_agent.algo.language_handler import sort_files_by_main_languages
-
     files = [
         type("File", (), {"filename": name})()
         for name in ["lower.c", "upper.C"]
@@ -116,8 +111,6 @@ def test_language_prioritization_falls_back_for_unambiguous_case(tmp_path):
 
     languages = provider.get_languages()
     assert languages == {"Python": 100.0}
-
-    from pr_agent.algo.language_handler import sort_files_by_main_languages
 
     file = type("File", (), {"filename": "module.PY"})()
     assert sort_files_by_main_languages(languages, [file]) == [

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -1,0 +1,125 @@
+import git
+
+from pr_agent.algo.types import EDIT_TYPE
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.gerrit_provider import GerritProvider
+from tests.unittest._settings_helpers import (restore_settings,
+                                              snapshot_settings)
+
+
+def _make_repo(tmp_path, filenames):
+    repo = git.Repo.init(tmp_path)
+    for name in filenames:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{name}\n")
+        repo.index.add([str(path)])
+    repo.index.commit("initial files")
+    return repo
+
+
+def test_get_diff_files_preserves_deleted_filename(tmp_path):
+    repo = _make_repo(tmp_path, ["keep.py", "gone.py"])
+    (tmp_path / "gone.py").unlink()
+    repo.index.remove(["gone.py"])
+    repo.index.commit("delete gone.py")
+
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    diff_files = provider.get_diff_files()
+
+    deleted = [file for file in diff_files if file.edit_type == EDIT_TYPE.DELETED]
+    assert len(deleted) == 1
+    assert deleted[0].filename == "gone.py"
+
+
+def test_get_languages_returns_names_used_for_hunk_prioritization(tmp_path):
+    repo = _make_repo(tmp_path, ["a.py", "b.py", "c.py", "app.js", "notes.unknown"])
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    languages = provider.get_languages()
+
+    assert languages == {"Python": 75.0, "JavaScript": 25.0}
+
+    from pr_agent.algo.language_handler import sort_files_by_main_languages
+
+    files = [type("File", (), {"filename": name})() for name in ["a.py", "app.js", "notes.unknown"]]
+    buckets = {
+        bucket["language"]: {file.filename for file in bucket["files"]}
+        for bucket in sort_files_by_main_languages(languages, files)
+    }
+    assert buckets == {
+        "Python": {"a.py"},
+        "JavaScript": {"app.js"},
+        "Other": {"notes.unknown"},
+    }
+
+
+def test_get_languages_matches_filenames_and_multipart_extensions(tmp_path):
+    repo = _make_repo(tmp_path, ["Dockerfile", "build.cmake.in", "app.py", "notes.unknown"])
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    languages = provider.get_languages()
+
+    assert set(languages) == {"Dockerfile", "CMake", "Python"}
+    assert all(abs(percentage - 100 / 3) < 1e-6 for percentage in languages.values())
+
+
+def test_get_diff_files_applies_glob_and_regex_ignore_rules(tmp_path):
+    repo = _make_repo(tmp_path, ["src/keep.py", "generated/skip.py", "notes.ignore.py"])
+    for name in ["src/keep.py", "generated/skip.py", "notes.ignore.py"]:
+        (tmp_path / name).write_text("changed\n")
+    repo.index.add(["src/keep.py", "generated/skip.py", "notes.ignore.py"])
+    repo.index.commit("change files")
+
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+    settings_snapshot = snapshot_settings(["ignore.glob", "ignore.regex"])
+    try:
+        get_settings().set("ignore.glob", ["generated/**"])
+        get_settings().set("ignore.regex", [r"^notes\."])
+
+        diff_files = provider.get_diff_files()
+    finally:
+        restore_settings(settings_snapshot)
+
+    assert [file.filename for file in diff_files] == ["src/keep.py"]
+
+
+def test_get_diff_files_filters_each_gitpython_path_shape(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        [
+            "src/keep.py",
+            "generated/delete.py",
+            "src/rename_into.py",
+            "generated/rename_out.py",
+        ],
+    )
+    (tmp_path / "src/keep.py").write_text("keep changed\n")
+    (tmp_path / "generated/delete.py").unlink()
+    repo.index.remove(["generated/delete.py"])
+    repo.git.mv("src/rename_into.py", "generated/rename_into.py")
+    repo.git.mv("generated/rename_out.py", "src/rename_out.py")
+    (tmp_path / "generated/new.py").write_text("new file\n")
+    repo.index.add(["src/keep.py", "generated/new.py"])
+    repo.index.commit("mix changed paths")
+
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+    settings_snapshot = snapshot_settings(["ignore.glob", "ignore.regex"])
+    try:
+        get_settings().set("ignore.glob", ["generated/**"])
+        get_settings().set("ignore.regex", [])
+
+        diff_files = provider.get_diff_files()
+    finally:
+        restore_settings(settings_snapshot)
+
+    assert {file.filename for file in diff_files} == {"src/keep.py", "src/rename_out.py"}
+    renamed = next(file for file in diff_files if file.filename == "src/rename_out.py")
+    assert renamed.edit_type == EDIT_TYPE.RENAMED
+    assert renamed.old_filename == "generated/rename_out.py"

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -3,8 +3,7 @@ import git
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.gerrit_provider import GerritProvider
-from tests.unittest._settings_helpers import (restore_settings,
-                                              snapshot_settings)
+from tests.unittest import _settings_helpers as settings_helpers
 
 
 def _make_repo(tmp_path, filenames):
@@ -67,6 +66,65 @@ def test_get_languages_matches_filenames_and_multipart_extensions(tmp_path):
     assert set(languages) == {"Dockerfile", "CMake", "Python"}
     assert all(abs(percentage - 100 / 3) < 1e-6 for percentage in languages.values())
 
+    from pr_agent.algo.language_handler import sort_files_by_main_languages
+
+    files = [
+        type("File", (), {"filename": name})()
+        for name in ["Dockerfile", "build.cmake.in", "app.py", "notes.unknown"]
+    ]
+    buckets = {
+        bucket["language"]: {file.filename for file in bucket["files"]}
+        for bucket in sort_files_by_main_languages(languages, files)
+    }
+    assert buckets == {
+        "Dockerfile": {"Dockerfile"},
+        "CMake": {"build.cmake.in"},
+        "Python": {"app.py"},
+        "Other": {"notes.unknown"},
+    }
+
+
+def test_get_languages_preserves_case_sensitive_extensions(tmp_path):
+    repo = _make_repo(tmp_path, ["lower.c", "upper.C"])
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    languages = provider.get_languages()
+    assert languages == {"C": 50.0, "C++": 50.0}
+
+    from pr_agent.algo.language_handler import sort_files_by_main_languages
+
+    files = [
+        type("File", (), {"filename": name})()
+        for name in ["lower.c", "upper.C"]
+    ]
+    buckets = {
+        bucket["language"]: {file.filename for file in bucket["files"]}
+        for bucket in sort_files_by_main_languages(languages, files)
+    }
+    assert buckets == {
+        "C": {"lower.c"},
+        "C++": {"upper.C"},
+        "Other": set(),
+    }
+
+
+def test_language_prioritization_falls_back_for_unambiguous_case(tmp_path):
+    repo = _make_repo(tmp_path, ["module.PY"])
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    languages = provider.get_languages()
+    assert languages == {"Python": 100.0}
+
+    from pr_agent.algo.language_handler import sort_files_by_main_languages
+
+    file = type("File", (), {"filename": "module.PY"})()
+    assert sort_files_by_main_languages(languages, [file]) == [
+        {"language": "Python", "files": [file]},
+        {"language": "Other", "files": []},
+    ]
+
 
 def test_get_diff_files_applies_glob_and_regex_ignore_rules(tmp_path):
     repo = _make_repo(tmp_path, ["src/keep.py", "generated/skip.py", "notes.ignore.py"])
@@ -77,14 +135,14 @@ def test_get_diff_files_applies_glob_and_regex_ignore_rules(tmp_path):
 
     provider = object.__new__(GerritProvider)
     provider.repo = repo
-    settings_snapshot = snapshot_settings(["ignore.glob", "ignore.regex"])
+    settings_snapshot = settings_helpers.snapshot_settings(["ignore.glob", "ignore.regex"])
     try:
         get_settings().set("ignore.glob", ["generated/**"])
         get_settings().set("ignore.regex", [r"^notes\."])
 
         diff_files = provider.get_diff_files()
     finally:
-        restore_settings(settings_snapshot)
+        settings_helpers.restore_settings(settings_snapshot)
 
     assert [file.filename for file in diff_files] == ["src/keep.py"]
 
@@ -110,14 +168,14 @@ def test_get_diff_files_filters_each_gitpython_path_shape(tmp_path):
 
     provider = object.__new__(GerritProvider)
     provider.repo = repo
-    settings_snapshot = snapshot_settings(["ignore.glob", "ignore.regex"])
+    settings_snapshot = settings_helpers.snapshot_settings(["ignore.glob", "ignore.regex"])
     try:
         get_settings().set("ignore.glob", ["generated/**"])
         get_settings().set("ignore.regex", [])
 
         diff_files = provider.get_diff_files()
     finally:
-        restore_settings(settings_snapshot)
+        settings_helpers.restore_settings(settings_snapshot)
 
     assert {file.filename for file in diff_files} == {"src/keep.py", "src/rename_out.py"}
     renamed = next(file for file in diff_files if file.filename == "src/rename_out.py")

--- a/tests/unittest/test_language_handler.py
+++ b/tests/unittest/test_language_handler.py
@@ -90,6 +90,23 @@ class TestSortFilesByMainLanguages:
         ]
         assert sort_files_by_main_languages(languages, files) == expected_output
 
+    def test_case_fallback_preserves_global_extension_ambiguity(self):
+        languages = {"C": 100}
+        file = type("", (object,), {"filename": "upper.C"})()
+
+        assert sort_files_by_main_languages(languages, [file]) == [
+            {"language": "Other", "files": [file]},
+        ]
+
+    def test_longest_multipart_extension_precedes_shorter_exact_match(self):
+        languages = {"reStructuredText": 60, "Text": 40}
+        file = type("", (object,), {"filename": "guide.REST.txt"})()
+
+        assert sort_files_by_main_languages(languages, [file]) == [
+            {"language": "reStructuredText", "files": [file]},
+            {"language": "Other", "files": []},
+        ]
+
     # Tests the behavior of the function when all files have bad extensions and only one new valid file is added.
     def test_edge_case_files_with_bad_extensions_only(self):
         languages = {'Python': 10, 'Java': 5, 'C++': 3}


### PR DESCRIPTION
## Summary

- preserve the old path as the filename for deleted Gerrit files
- return language names for Gerrit repositories and keep downstream hunk bucketing consistent for exact filenames, multipart suffixes, and case-sensitive extensions
- apply configured glob and regex ignore rules to Gerrit diffs

## Tests

- `PYTHONPATH=. pytest tests/unittest/test_gerrit_provider.py tests/unittest/test_language_handler.py tests/unittest/test_file_filter.py tests/unittest/test_invalid_ignore_pattern_warning.py tests/unittest/test_local_git_provider.py tests/unittest/test_plain_diff_provider.py tests/unittest/test_codecommit_provider.py -q`
- `pre-commit run --files pr_agent/algo/file_filter.py pr_agent/algo/language_handler.py pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py tests/unittest/test_language_handler.py`
- `ruff check pr_agent/algo/language_handler.py pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py tests/unittest/test_language_handler.py`

Fixes #2835