### PR TITLE
fix: accept case-insensitive YAML fence labels

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -917,7 +917,7 @@ def load_yaml(response_text: str, keys_fix_yaml: List[str] = [], first_key="", l
     response_text = response_text.strip('\n')
     # strip the fence label only when it is a complete info string, so a key such as
     # "yml_config" is not truncated to "_config"
-    unfenced = re.sub(r'^```[ \t]*(?:yaml|yml)?[ \t]*(?=\r?\n)', '', response_text)
+    unfenced = re.sub(r'^```[ \t]*(?:(?i:yaml|yml))?[ \t]*(?=\r?\n)', '', response_text)
     if unfenced == response_text:
         unfenced = response_text.removeprefix('yaml')
     response_text = unfenced.rstrip().removesuffix('```')
@@ -998,7 +998,7 @@ def try_fix_yaml(response_text: str,
         pass
 
     # second fallback - try to extract only range from first ```yaml to the last ```
-    snippet_pattern = r'```[ \t]*(?:(?:yaml|yml)[ \t]*)?\r?\n([\s\S]*?)```(?=\s*$|")'
+    snippet_pattern = r'```[ \t]*(?:(?i:yaml|yml)[ \t]*)?\r?\n([\s\S]*?)```(?=\s*$|")'
     snippet = re.search(snippet_pattern, '\n'.join(response_text_lines_copy))
     if not snippet:
         snippet = re.search(snippet_pattern, response_text_original) # before we removed the "```"

--- a/tests/unittest/test_load_yaml.py
+++ b/tests/unittest/test_load_yaml.py
@@ -112,6 +112,10 @@ PR Feedback:
         assert load_yaml("``` yaml\nname: John\n```") == expected
         assert load_yaml("``` yml\nname: John\n```") == expected
 
+    @pytest.mark.parametrize("label", ["YAML", "YML", "Yaml", "yMl"])
+    def test_yaml_info_string_is_case_insensitive(self, label):
+        assert load_yaml(f"```\t{label}\t\nname: John\n```") == {"name": "John"}
+
     # A fence labeled with a non-YAML info string (e.g. ```text or ```python)
     # must not be extracted and parsed as a YAML snippet. The old pattern's
     # optional (yaml|yml) group let any info string through, so the body


### PR DESCRIPTION
Fixes #2839

Make the supported `yaml` and `yml` Markdown fence labels case-insensitive in both `load_yaml` fence-processing paths. Bare fences, whitespace handling, and unrelated language labels remain unchanged.

Validation:
- `PYTHONPATH=. .venv/bin/pytest tests/unittest/test_load_yaml.py -q` (18 passed)
- `PYTHONPATH=. .venv/bin/pytest tests/unittest -q` (2548 passed, 1 skipped, 1 xfailed)