### PR TITLE
fix(gh-action): pass workflow_run conclusion to auto tools

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -57,27 +57,44 @@ def _inject_artifact_context():
         artifact_text = load_artifact()
         if not artifact_text:
             return
-        target_tools = get_settings().get(
-            "ARTIFACTS.TARGET_TOOLS",
-            ["pr_reviewer", "pr_description", "pr_code_suggestions"]
-        )
-        if isinstance(target_tools, str):
-            target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
-        target_tools = {str(t).lower() for t in target_tools}
-        separator = "\n======\n\n"
-        for key in get_settings():
-            setting = get_settings().get(key)
-            if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
-                if key.lower() in target_tools and hasattr(setting, 'extra_instructions'):
-                    extra_instructions = str(setting.extra_instructions or "")
-                    if artifact_text not in extra_instructions:
-                        setting.extra_instructions = (
-                            extra_instructions + separator + artifact_text
-                            if extra_instructions else artifact_text
-                        )
-        get_logger().info(f"Injected artifact context into tools: {target_tools}")
+        _append_tool_context(artifact_text)
+        get_logger().info("Injected artifact context into tools")
     except (OSError, ValueError, TypeError) as e:
         get_logger().warning(f"github action: failed to process artifacts: {e}", exc_info=True)
+
+
+def _append_tool_context(text: str) -> None:
+    """Append a labelled block to the extra_instructions of each artifact target tool."""
+    target_tools = get_settings().get(
+        "ARTIFACTS.TARGET_TOOLS",
+        ["pr_reviewer", "pr_description", "pr_code_suggestions"],
+    )
+    if isinstance(target_tools, str):
+        target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
+    target_tools = {str(t).lower() for t in target_tools}
+    for key in get_settings():
+        setting = get_settings().get(key)
+        if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+            if key.lower() in target_tools and hasattr(setting, "extra_instructions"):
+                existing = str(setting.extra_instructions or "")
+                if text not in existing:
+                    setting.extra_instructions = (
+                        existing + "\n======\n\n" + text if existing else text
+                    )
+
+
+def _inject_ci_conclusion(conclusion: str) -> None:
+    """Tell the model how the workflow that triggered this run finished."""
+    if not conclusion:
+        return
+    _append_tool_context(
+        "CI status\n"
+        "=====\n"
+        f"The workflow run that triggered this review concluded: {conclusion}.\n"
+        "=====\n"
+        "If the conclusion is not 'success', the change has not passed CI. "
+        "Say so in your output rather than implying the change is clean."
+    )
 
 
 async def run_action():
@@ -316,6 +333,7 @@ async def run_action():
 
         # Inject artifact context after repo settings are applied for workflow_run
         _inject_artifact_context()
+        _inject_ci_conclusion(workflow_run.get("conclusion"))
 
         auto_review = get_setting_or_env("GITHUB_ACTION.AUTO_REVIEW", None)
         if auto_review is None:

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -364,18 +364,20 @@ async def test_issue_comment_from_user_is_processed(monkeypatch, tmp_path, resto
     assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]
 
 
-def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None):
+def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None, conclusion="success"):
     if pull_requests is None:
         pull_requests = [{"url": "https://api.github.com/repos/org/repo/pulls/42", "number": 42}]
+    workflow_run = {
+        "id": 9999,
+        "event": originating_event,
+        "pull_requests": pull_requests,
+    }
+    if conclusion is not None:
+        workflow_run["conclusion"] = conclusion
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({
         "action": "completed",
-        "workflow_run": {
-            "id": 9999,
-            "event": originating_event,
-            "conclusion": "success",
-            "pull_requests": pull_requests,
-        },
+        "workflow_run": workflow_run,
     }))
     return event_path
 
@@ -431,6 +433,74 @@ async def test_workflow_run_runs_auto_tools(monkeypatch, tmp_path, restore_githu
         ("describe", "https://api.github.com/repos/org/repo/pulls/42"),
         ("review", "https://api.github.com/repos/org/repo/pulls/42"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_injects_ci_conclusion(monkeypatch, tmp_path, restore_github_settings):
+    """The workflow_run handler must pass the triggering workflow's conclusion to the tools."""
+    runs = []
+    _patch_workflow_run_deps(monkeypatch, runs)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion="failure"))
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fake_get_setting_or_env(key, default=None):
+        values = {
+            "GITHUB_ACTION.AUTO_DESCRIBE": False,
+            "GITHUB_ACTION.AUTO_REVIEW": True,
+            "GITHUB_ACTION.AUTO_IMPROVE": False,
+            "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+        }
+        return values.get(key, default)
+
+    monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+    await github_action_runner.run_action()
+
+    assert "concluded: failure" in str(get_settings().pr_reviewer.extra_instructions)
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_without_conclusion_injects_nothing(monkeypatch, tmp_path, restore_github_settings):
+    """A payload without a conclusion key must not append any CI context."""
+    settings = get_settings()
+    saved = {}
+    try:
+        for key in ("pr_reviewer", "pr_description", "pr_code_suggestions"):
+            setting = settings.get(key)
+            if setting is not None and hasattr(setting, "extra_instructions"):
+                saved[key] = setting.extra_instructions
+                setting.extra_instructions = None
+
+        runs = []
+        _patch_workflow_run_deps(monkeypatch, runs)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+        monkeypatch.setenv(
+            "GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion=None))
+        )
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+        def fake_get_setting_or_env(key, default=None):
+            values = {
+                "GITHUB_ACTION.AUTO_DESCRIBE": False,
+                "GITHUB_ACTION.AUTO_REVIEW": True,
+                "GITHUB_ACTION.AUTO_IMPROVE": False,
+                "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            }
+            return values.get(key, default)
+
+        monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+        await github_action_runner.run_action()
+
+        assert "CI status" not in str(get_settings().pr_reviewer.extra_instructions)
+    finally:
+        for key, value in saved.items():
+            setting = settings.get(key)
+            if setting is not None and hasattr(setting, "extra_instructions"):
+                setting.extra_instructions = value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The `workflow_run` handler now reads `workflow_run.conclusion` from the payload and tells the auto tools (PR Description, PR Review, PR Code Suggestions) how the triggering workflow finished, by appending a labelled CI status block to their `extra_instructions`.

The append loop previously embedded in `_inject_artifact_context()` was extracted into a shared `_append_tool_context(text)` helper, and a new `_inject_ci_conclusion(conclusion)` uses it. The new call sits next to the existing artifact injection in the `workflow_run` branch.

## Why

The whole point of running after CI is to review with the pipeline's findings in hand. The handler read `workflow_run.event` and `workflow_run.pull_requests` but never `workflow_run.conclusion`, so a post-CI review behaved identically whether the triggering workflow succeeded, failed, or was cancelled — and the model was never told which. If the conclusion is not `success`, the injected context instructs the tools to say so rather than implying the change is clean.

This is purely additive: no control flow changes, no prompt files touched, and it reuses the `ARTIFACTS.TARGET_TOOLS` settings key (no new configuration).

## Testing

- Ran `PYTHONPATH=. pytest -q tests/unittest/test_github_action_runner_core.py` — 19 passed.
- Added two tests:
  - `test_workflow_run_injects_ci_conclusion`: a run with `conclusion: "failure"` results in the conclusion text appearing in `get_settings().pr_reviewer.extra_instructions`.
  - `test_workflow_run_without_conclusion_injects_nothing`: a payload without a `conclusion` key appends no CI context.
- Updated `_write_workflow_run_event` to accept a `conclusion` parameter (`None` omits the key).
