### PR TITLE
fix(github): use committer date for commit range to handle rebases

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -175,6 +175,16 @@ class GithubProvider(GitProvider):
         self.previous_review = self.get_previous_review(full=True, incremental=True)
         if self.previous_review:
             self.incremental.commits_range = self.get_commit_range()
+            if self.incremental.commits_range and self.incremental.last_seen_commit is None:
+                # Every commit post-dates the review (e.g. the branch was fully rebased), so there
+                # is no baseline commit to diff against. Fall back to a full review rather than
+                # diffing against a None ref, which silently yields empty original content.
+                get_logger().info(
+                    "Incremental review cannot anchor a base commit (no commit predates the "
+                    "previous review); falling back to a full review"
+                )
+                self.incremental.is_incremental = False
+                return
             # Get all files changed during the commit range
 
             for commit in self.incremental.commits_range:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -186,11 +186,18 @@ class GithubProvider(GitProvider):
             get_logger().info("No previous review found, will review the entire PR")
             self.incremental.is_incremental = False
 
+    @staticmethod
+    def _commit_timeline_date(commit):
+        """Prefer the committer date: rebasing rewrites content but preserves the author
+        date, so anchoring on it classifies rewritten commits as already-reviewed."""
+        committer_date = getattr(getattr(commit.commit, 'committer', None), 'date', None)
+        return committer_date or commit.commit.author.date
+
     def get_commit_range(self):
         last_review_time = self.previous_review.created_at
         first_new_commit_index = None
         for index in range(len(self.pr_commits) - 1, -1, -1):
-            if self.pr_commits[index].commit.author.date > last_review_time:
+            if self._commit_timeline_date(self.pr_commits[index]) > last_review_time:
                 self.incremental.first_new_commit = self.pr_commits[index]
                 first_new_commit_index = index
             else:

--- a/tests/unittest/test_github_provider_incremental.py
+++ b/tests/unittest/test_github_provider_incremental.py
@@ -47,6 +47,23 @@ def test_falls_back_to_author_date_when_committer_is_missing():
     assert provider.get_commit_range() == [commit]
 
 
+def test_fully_rebased_branch_falls_back_to_full_review():
+    # Every commit post-dates the review, so there is no baseline commit to diff against.
+    commits = [
+        _commit("a", author_date=datetime(2026, 1, 1), committer_date=datetime(2026, 1, 5)),
+        _commit("b", author_date=datetime(2026, 1, 2), committer_date=datetime(2026, 1, 5)),
+    ]
+    provider = _make_provider(commits)
+    provider.pr = SimpleNamespace(get_commits=lambda: commits)
+    provider.unreviewed_files_map = {}
+    provider.get_previous_review = lambda **kwargs: provider.previous_review
+
+    provider._get_incremental_commits()
+
+    assert provider.incremental.is_incremental is False
+    assert provider.incremental.last_seen_commit_sha is None
+
+
 def test_only_commits_after_the_review_are_returned():
     reviewed = _commit("reviewed", author_date=datetime(2026, 1, 1), committer_date=datetime(2026, 1, 1))
     pushed = _commit("pushed", author_date=datetime(2026, 1, 4), committer_date=datetime(2026, 1, 4))

--- a/tests/unittest/test_github_provider_incremental.py
+++ b/tests/unittest/test_github_provider_incremental.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+from pr_agent.git_providers.git_provider import IncrementalPR
+from pr_agent.git_providers.github_provider import GithubProvider
+
+REVIEW_TIME = datetime(2026, 1, 3, 10, 0, 0)
+
+
+def _commit(sha, author_date, committer_date=None):
+    committer = SimpleNamespace(date=committer_date) if committer_date else None
+    return SimpleNamespace(
+        sha=sha,
+        commit=SimpleNamespace(author=SimpleNamespace(date=author_date), committer=committer),
+    )
+
+
+def _make_provider(pr_commits):
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.pr_commits = pr_commits
+    provider.previous_review = SimpleNamespace(created_at=REVIEW_TIME)
+    provider.incremental = IncrementalPR(True)
+    return provider
+
+
+def test_rebased_commit_is_detected_as_new():
+    # A force-push rewrites the commit after the review, but git preserves the author date.
+    commit = _commit("rebased", author_date=datetime(2026, 1, 2), committer_date=datetime(2026, 1, 5))
+    provider = _make_provider([commit])
+
+    assert provider.get_commit_range() == [commit]
+    assert provider.incremental.first_new_commit is commit
+
+
+def test_commit_older_than_review_is_not_new():
+    commit = _commit("old", author_date=datetime(2026, 1, 1), committer_date=datetime(2026, 1, 1))
+    provider = _make_provider([commit])
+
+    assert provider.get_commit_range() == []
+    assert provider.incremental.last_seen_commit is commit
+
+
+def test_falls_back_to_author_date_when_committer_is_missing():
+    commit = _commit("no-committer", author_date=datetime(2026, 1, 5))
+    provider = _make_provider([commit])
+
+    assert provider.get_commit_range() == [commit]
+
+
+def test_only_commits_after_the_review_are_returned():
+    reviewed = _commit("reviewed", author_date=datetime(2026, 1, 1), committer_date=datetime(2026, 1, 1))
+    pushed = _commit("pushed", author_date=datetime(2026, 1, 4), committer_date=datetime(2026, 1, 4))
+    provider = _make_provider([reviewed, pushed])
+
+    assert provider.get_commit_range() == [pushed]
+    assert provider.incremental.last_seen_commit is reviewed


### PR DESCRIPTION
Fixes #2844.

`get_commit_range` compared author dates against the previous review timestamp. Git preserves the author date across a rebase, so after a force-push the commit range came back empty and the reviewer reported no changes when the code had changed.

Now prefers the committer date, which advances on rebase, falling back to the author date when a committer is absent. This is what `_GitLabIncrementalCommit` already does on the GitLab side.

Four regression tests: rebased commit detected as new, pre-review commit still excluded, author-date fallback, and mixed-commit scoping. The first fails on `main` and passes with the fix.
