### PR TITLE
fix: bound language filename matching

### DIFF
--- a/pr_agent/algo/language_handler.py
+++ b/pr_agent/algo/language_handler.py
@@ -44,13 +44,20 @@ def build_language_file_matcher(language_extension_map: Dict) -> Callable[[str],
             token = extension.lstrip("*")
             exact_to_language.setdefault(token, language)
             folded_to_languages.setdefault(token.casefold(), set()).add(language)
+    max_suffix_depth = max(
+        (token.count(".") for token in exact_to_language if token.startswith(".")),
+        default=0,
+    )
 
     def get_language(filename: str) -> str | None:
         name = filename.replace("\\", "/").rsplit("/", 1)[-1]
         parts = name.split(".")
         candidates = [name] + [
             "." + ".".join(parts[i:])
-            for i in range(1, len(parts))
+            for i in range(
+                max(1, len(parts) - max_suffix_depth),
+                len(parts),
+            )
         ]
 
         for candidate in candidates:

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -4,6 +4,7 @@ from typing import List
 
 from git import Repo
 
+from pr_agent.algo.language_handler import build_language_file_matcher
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.algo.utils import (format_pr_code_suggestions_header,
                                  show_run_details)
@@ -202,39 +203,19 @@ class LocalGitProvider(GitProvider):
         Keys are language NAMES (e.g. "Python"), not raw extensions: the consumer
         sort_files_by_main_languages() maps each name back to its extensions, so
         returning extensions ("py") silently drops every file into the "Other"
-        bucket and defeats the prioritisation this method exists for. Invert the
-        settings map (name -> [extensions]) into an extension -> name lookup;
-        files with unknown extensions are left out and fall through to "Other".
+        bucket and defeats the prioritisation this method exists for. Use the
+        shared configured filename matcher so all providers apply the same
+        full-filename, multipart-extension, and case-sensitive rules.
         """
-        # Invert to a filename-token -> language lookup. Map entries are mostly
-        # ".ext", but also include multi-part extensions (".cmake.in") and full
-        # filenames ("Dockerfile", "Makefile"); normalize the glob form ("*.bsl").
-        ext_to_lang = {}
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
-        for language, extensions in lang_map.items():
-            for ext in extensions:
-                ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
-
-        def _match_language(name: str):
-            # Full-filename rules (Dockerfile, Makefile) carry no extension.
-            language = ext_to_lang.get(name.lower())
-            if language:
-                return language
-            # Try progressively shorter dotted suffixes so multi-part extensions
-            # (".cmake.in") win over their simple tail (".in") when both exist.
-            parts = name.split(".")
-            for i in range(1, len(parts)):
-                language = ext_to_lang.get("." + ".".join(parts[i:]).lower())
-                if language:
-                    return language
-            return None
+        get_language = build_language_file_matcher(lang_map)
 
         # Get all files in repository
         filepaths = [Path(item.path) for item in self.repo.tree().traverse() if item.type == 'blob']
         # Identify language by filename (mapped to its language name) and count
         lang_count = Counter()
         for filepath in filepaths:
-            language = _match_language(filepath.name)
+            language = get_language(filepath.name)
             if language:
                 lang_count[language] += 1
         # Convert counts to percentages

--- a/tests/unittest/test_language_file_matcher.py
+++ b/tests/unittest/test_language_file_matcher.py
@@ -1,0 +1,36 @@
+import tracemalloc
+
+from pr_agent.algo.language_handler import build_language_file_matcher
+
+
+def _assert_bounded_match(matcher, filename, expected_language):
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+    baseline_memory, _ = tracemalloc.get_traced_memory()
+    tracemalloc.reset_peak()
+    try:
+        assert matcher(filename) == expected_language
+        _, peak_memory = tracemalloc.get_traced_memory()
+    finally:
+        if not was_tracing:
+            tracemalloc.stop()
+
+    assert peak_memory - baseline_memory < 2_000_000
+
+
+def test_matcher_uses_bounded_memory_for_heavily_dotted_filename():
+    matcher = build_language_file_matcher({"Python": [".py"]})
+    filename = ".".join(["segment"] * 1000) + ".py"
+
+    _assert_bounded_match(matcher, filename, "Python")
+
+
+def test_full_filename_tokens_do_not_expand_suffix_candidates():
+    configured_filename = ".".join(["configured"] * 1000)
+    matcher = build_language_file_matcher(
+        {"Config": [configured_filename], "Python": [".py"]}
+    )
+    filename = ".".join(["segment"] * 1000) + ".py"
+
+    _assert_bounded_match(matcher, filename, "Python")

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -62,6 +62,14 @@ def test_get_languages_matches_full_names_and_multipart_extensions(tmp_path):
     assert all(abs(v - 100 / 3) < 1e-6 for v in languages.values())
 
 
+def test_get_languages_preserves_case_sensitive_extensions(tmp_path):
+    repo = _make_repo(tmp_path, ["lower.c", "upper.C"])
+    provider = object.__new__(LocalGitProvider)
+    provider.repo = repo
+
+    assert provider.get_languages() == {"C": 50.0, "C++": 50.0}
+
+
 def test_get_diff_files_deleted_file_falls_back_to_old_path(tmp_path):
     # A plain deletion has no "new side": GitPython sets diff_item.b_path to None.
     # The filename must fall back to a_path (the old path) instead of None, or


### PR DESCRIPTION
## Summary

- bound dotted suffix generation by the deepest configured extension token, keeping matching linear in filename length
- reuse the shared filename matcher in `LocalGitProvider` so full filenames, multipart extensions, and case-sensitive pairs follow the same rules
- add regression coverage for heavily dotted filenames, dotted full-name tokens, and the `.c` / `.C` language pair

## Performance

For a 4,000-segment filename ending in `.py`, peak traced memory fell from about 64.5 MB to 0.26 MB in a local run, while matching time fell from about 0.164 seconds to 0.002 seconds.

## Testing

- `python -m pytest tests/unittest/test_language_file_matcher.py tests/unittest/test_language_handler.py tests/unittest/test_local_git_provider.py tests/unittest/test_gerrit_provider.py -q` (27 passed)
- `pre-commit run --files pr_agent/algo/language_handler.py pr_agent/git_providers/local_git_provider.py tests/unittest/test_language_file_matcher.py tests/unittest/test_local_git_provider.py`

Follow-up to #2836 and the review suggestion in https://github.com/The-PR-Agent/pr-agent/pull/2836#discussion_r3875625632.