### PR TITLE
Fix workflow_run trigger ignoring conclusion (#2841)

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -33,6 +33,40 @@ def get_setting_or_env(key: str, default: Union[str, bool] = None) -> Union[str,
     return value
 
 
+def _append_tool_context(text: str) -> None:
+    """Append a labelled block to the extra_instructions of each artifact target tool."""
+    target_tools = get_settings().get(
+        "ARTIFACTS.TARGET_TOOLS",
+        ["pr_reviewer", "pr_description", "pr_code_suggestions"],
+    )
+    if isinstance(target_tools, str):
+        target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
+    target_tools = {str(t).lower() for t in target_tools}
+    for key in get_settings():
+        setting = get_settings().get(key)
+        if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+            if key.lower() in target_tools and hasattr(setting, "extra_instructions"):
+                existing = str(setting.extra_instructions or "")
+                if text not in existing:
+                    setting.extra_instructions = (
+                        existing + "\n======\n\n" + text if existing else text
+                    )
+
+
+def _inject_ci_conclusion(conclusion: str) -> None:
+    """Tell the model how the workflow that triggered this run finished."""
+    if not conclusion:
+        return
+    _append_tool_context(
+        "CI status\n"
+        "=====\n"
+        f"The workflow run that triggered this review concluded: {conclusion}.\n"
+        "=====\n"
+        "If the conclusion is not 'success', the change has not passed CI. "
+        "Say so in your output rather than implying the change is clean."
+    )
+
+
 def _inject_artifact_context():
     """Inject CI artifact content into extra_instructions for configured tools."""
     artifact_path_env = (
@@ -57,25 +91,8 @@ def _inject_artifact_context():
         artifact_text = load_artifact()
         if not artifact_text:
             return
-        target_tools = get_settings().get(
-            "ARTIFACTS.TARGET_TOOLS",
-            ["pr_reviewer", "pr_description", "pr_code_suggestions"]
-        )
-        if isinstance(target_tools, str):
-            target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
-        target_tools = {str(t).lower() for t in target_tools}
-        separator = "\n======\n\n"
-        for key in get_settings():
-            setting = get_settings().get(key)
-            if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
-                if key.lower() in target_tools and hasattr(setting, 'extra_instructions'):
-                    extra_instructions = str(setting.extra_instructions or "")
-                    if artifact_text not in extra_instructions:
-                        setting.extra_instructions = (
-                            extra_instructions + separator + artifact_text
-                            if extra_instructions else artifact_text
-                        )
-        get_logger().info(f"Injected artifact context into tools: {target_tools}")
+        _append_tool_context(artifact_text)
+        get_logger().info("Injected artifact context into tools")
     except (OSError, ValueError, TypeError) as e:
         get_logger().warning(f"github action: failed to process artifacts: {e}", exc_info=True)
 
@@ -316,6 +333,7 @@ async def run_action():
 
         # Inject artifact context after repo settings are applied for workflow_run
         _inject_artifact_context()
+        _inject_ci_conclusion(workflow_run.get("conclusion"))
 
         auto_review = get_setting_or_env("GITHUB_ACTION.AUTO_REVIEW", None)
         if auto_review is None:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -41,12 +41,19 @@ def _append_tool_context(text: str) -> None:
     )
     if isinstance(target_tools, str):
         target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
+    elif not isinstance(target_tools, (list, set, tuple)):
+        target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
     target_tools = {str(t).lower() for t in target_tools}
     for key in get_settings():
         setting = get_settings().get(key)
         if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
             if key.lower() in target_tools and hasattr(setting, "extra_instructions"):
-                existing = str(setting.extra_instructions or "")
+                try:
+                    existing = setting.extra_instructions
+                    if not isinstance(existing, str):
+                        existing = str(existing or "")
+                except Exception:
+                    existing = ""
                 if text not in existing:
                     setting.extra_instructions = (
                         existing + "\n======\n\n" + text if existing else text
@@ -57,6 +64,11 @@ def _inject_ci_conclusion(conclusion: str) -> None:
     """Tell the model how the workflow that triggered this run finished."""
     if not conclusion:
         return
+    if not isinstance(conclusion, str):
+        try:
+            conclusion = str(conclusion)
+        except Exception:
+            return
     _append_tool_context(
         "CI status\n"
         "=====\n"

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -17,6 +17,9 @@ from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_reviewer import PRReviewer
 
 
+DEFAULT_ARTIFACT_TARGET_TOOLS = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
+
+
 def is_true(value: Union[str, bool]) -> bool:
     if isinstance(value, bool):
         return value
@@ -37,12 +40,12 @@ def _append_tool_context(text: str) -> None:
     """Append a labelled block to the extra_instructions of each artifact target tool."""
     target_tools = get_settings().get(
         "ARTIFACTS.TARGET_TOOLS",
-        ["pr_reviewer", "pr_description", "pr_code_suggestions"],
+        DEFAULT_ARTIFACT_TARGET_TOOLS,
     )
     if isinstance(target_tools, str):
         target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
     elif not isinstance(target_tools, (list, set, tuple)):
-        target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
+        target_tools = DEFAULT_ARTIFACT_TARGET_TOOLS
     target_tools = {str(t).lower() for t in target_tools}
     for key in get_settings():
         setting = get_settings().get(key)

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -364,18 +364,20 @@ async def test_issue_comment_from_user_is_processed(monkeypatch, tmp_path, resto
     assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]
 
 
-def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None):
+def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None, conclusion="success"):
     if pull_requests is None:
         pull_requests = [{"url": "https://api.github.com/repos/org/repo/pulls/42", "number": 42}]
     event_path = tmp_path / "event.json"
+    workflow_run_payload = {
+        "id": 9999,
+        "event": originating_event,
+        "pull_requests": pull_requests,
+    }
+    if conclusion is not None:
+        workflow_run_payload["conclusion"] = conclusion
     event_path.write_text(json.dumps({
         "action": "completed",
-        "workflow_run": {
-            "id": 9999,
-            "event": originating_event,
-            "conclusion": "success",
-            "pull_requests": pull_requests,
-        },
+        "workflow_run": workflow_run_payload,
     }))
     return event_path
 
@@ -431,6 +433,102 @@ async def test_workflow_run_runs_auto_tools(monkeypatch, tmp_path, restore_githu
         ("describe", "https://api.github.com/repos/org/repo/pulls/42"),
         ("review", "https://api.github.com/repos/org/repo/pulls/42"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_injects_ci_conclusion_failure(monkeypatch, tmp_path, restore_github_settings):
+    settings = get_settings()
+    orig_reviewer = getattr(settings.pr_reviewer, "extra_instructions", None)
+    orig_description = getattr(settings.pr_description, "extra_instructions", None)
+    orig_suggestions = getattr(settings.pr_code_suggestions, "extra_instructions", None)
+    
+    try:
+        settings.pr_reviewer.extra_instructions = ""
+        settings.pr_description.extra_instructions = ""
+        settings.pr_code_suggestions.extra_instructions = ""
+
+        runs = []
+        _patch_workflow_run_deps(monkeypatch, runs)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion="failure")))
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+        def fake_get_setting_or_env(key, default=None):
+            values = {
+                "GITHUB_ACTION.AUTO_DESCRIBE": True,
+                "GITHUB_ACTION.AUTO_REVIEW": True,
+                "GITHUB_ACTION.AUTO_IMPROVE": False,
+                "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            }
+            return values.get(key, default)
+
+        monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+        await github_action_runner.run_action()
+
+        assert "failure" in settings.pr_reviewer.extra_instructions
+        assert "The workflow run that triggered this review concluded: failure" in settings.pr_reviewer.extra_instructions
+        assert "If the conclusion is not 'success'" in settings.pr_reviewer.extra_instructions
+    finally:
+        if orig_reviewer is not None:
+            settings.pr_reviewer.extra_instructions = orig_reviewer
+        else:
+            settings.pr_reviewer.extra_instructions = ""
+        if orig_description is not None:
+            settings.pr_description.extra_instructions = orig_description
+        else:
+            settings.pr_description.extra_instructions = ""
+        if orig_suggestions is not None:
+            settings.pr_code_suggestions.extra_instructions = orig_suggestions
+        else:
+            settings.pr_code_suggestions.extra_instructions = ""
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_no_conclusion_does_not_inject(monkeypatch, tmp_path, restore_github_settings):
+    settings = get_settings()
+    orig_reviewer = getattr(settings.pr_reviewer, "extra_instructions", None)
+    orig_description = getattr(settings.pr_description, "extra_instructions", None)
+    orig_suggestions = getattr(settings.pr_code_suggestions, "extra_instructions", None)
+    
+    try:
+        settings.pr_reviewer.extra_instructions = ""
+        settings.pr_description.extra_instructions = ""
+        settings.pr_code_suggestions.extra_instructions = ""
+
+        runs = []
+        _patch_workflow_run_deps(monkeypatch, runs)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion=None)))
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+        def fake_get_setting_or_env(key, default=None):
+            values = {
+                "GITHUB_ACTION.AUTO_DESCRIBE": True,
+                "GITHUB_ACTION.AUTO_REVIEW": True,
+                "GITHUB_ACTION.AUTO_IMPROVE": False,
+                "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            }
+            return values.get(key, default)
+
+        monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+        await github_action_runner.run_action()
+
+        assert "CI status" not in settings.pr_reviewer.extra_instructions
+    finally:
+        if orig_reviewer is not None:
+            settings.pr_reviewer.extra_instructions = orig_reviewer
+        else:
+            settings.pr_reviewer.extra_instructions = ""
+        if orig_description is not None:
+            settings.pr_description.extra_instructions = orig_description
+        else:
+            settings.pr_description.extra_instructions = ""
+        if orig_suggestions is not None:
+            settings.pr_code_suggestions.extra_instructions = orig_suggestions
+        else:
+            settings.pr_code_suggestions.extra_instructions = ""
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -441,7 +441,7 @@ async def test_workflow_run_injects_ci_conclusion_failure(monkeypatch, tmp_path,
     orig_reviewer = getattr(settings.pr_reviewer, "extra_instructions", None)
     orig_description = getattr(settings.pr_description, "extra_instructions", None)
     orig_suggestions = getattr(settings.pr_code_suggestions, "extra_instructions", None)
-    
+
     try:
         settings.pr_reviewer.extra_instructions = ""
         settings.pr_description.extra_instructions = ""
@@ -490,7 +490,7 @@ async def test_workflow_run_no_conclusion_does_not_inject(monkeypatch, tmp_path,
     orig_reviewer = getattr(settings.pr_reviewer, "extra_instructions", None)
     orig_description = getattr(settings.pr_description, "extra_instructions", None)
     orig_suggestions = getattr(settings.pr_code_suggestions, "extra_instructions", None)
-    
+
     try:
         settings.pr_reviewer.extra_instructions = ""
         settings.pr_description.extra_instructions = ""
@@ -529,6 +529,63 @@ async def test_workflow_run_no_conclusion_does_not_inject(monkeypatch, tmp_path,
             settings.pr_code_suggestions.extra_instructions = orig_suggestions
         else:
             settings.pr_code_suggestions.extra_instructions = ""
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_malformed_target_tools_does_not_crash(monkeypatch, tmp_path, restore_github_settings):
+    settings = get_settings()
+    orig_reviewer = getattr(settings.pr_reviewer, "extra_instructions", None)
+    orig_description = getattr(settings.pr_description, "extra_instructions", None)
+    orig_suggestions = getattr(settings.pr_code_suggestions, "extra_instructions", None)
+    orig_target_tools = settings.get("ARTIFACTS.TARGET_TOOLS", None)
+
+    try:
+        settings.pr_reviewer.extra_instructions = ""
+        settings.pr_description.extra_instructions = ""
+        settings.pr_code_suggestions.extra_instructions = ""
+
+        # Set TARGET_TOOLS to a non-iterable malformed value
+        settings.set("ARTIFACTS.TARGET_TOOLS", 123)
+
+        runs = []
+        _patch_workflow_run_deps(monkeypatch, runs)
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion="failure")))
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+        def fake_get_setting_or_env(key, default=None):
+            values = {
+                "GITHUB_ACTION.AUTO_DESCRIBE": True,
+                "GITHUB_ACTION.AUTO_REVIEW": True,
+                "GITHUB_ACTION.AUTO_IMPROVE": False,
+                "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            }
+            return values.get(key, default)
+
+        monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+        # Should not crash on malformed target_tools
+        await github_action_runner.run_action()
+
+        # The fallback should target "pr_reviewer"
+        assert "failure" in settings.pr_reviewer.extra_instructions
+    finally:
+        if orig_reviewer is not None:
+            settings.pr_reviewer.extra_instructions = orig_reviewer
+        else:
+            settings.pr_reviewer.extra_instructions = ""
+        if orig_description is not None:
+            settings.pr_description.extra_instructions = orig_description
+        else:
+            settings.pr_description.extra_instructions = ""
+        if orig_suggestions is not None:
+            settings.pr_code_suggestions.extra_instructions = orig_suggestions
+        else:
+            settings.pr_code_suggestions.extra_instructions = ""
+        if orig_target_tools is not None:
+            settings.set("ARTIFACTS.TARGET_TOOLS", orig_target_tools)
+        else:
+            settings.unset("ARTIFACTS.TARGET_TOOLS", force=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #2841

## What
The `workflow_run` handler read `event` and `pull_requests` from the payload but ignored
`conclusion`, so post-CI reviews looked identical whether CI passed, failed, or was
cancelled.

## Change
- Extracted the append loop in `_inject_artifact_context()` into a shared helper,
  `_append_tool_context(text)`.
- Added `_inject_ci_conclusion(conclusion)`, which uses it to tell the model how the
  triggering workflow concluded and to flag when the change hasn't passed CI.
- Called it right after `_inject_artifact_context()` in the `workflow_run` branch only —
  the other two call sites are untouched.

Purely additive: no new config, no prompt changes, no control-flow changes. Reuses
`ARTIFACTS.TARGET_TOOLS`.

## Tests
- `test_workflow_run_injects_ci_conclusion_failure`: `conclusion="failure"` → CI status
  block appears in `pr_reviewer.extra_instructions`.
- `test_workflow_run_no_conclusion_does_not_inject`: no `conclusion` key → nothing appended.

`pytest -q tests/unittest/test_github_action_runner_core.py` → 19 passed. Full suite run
with 9 pre-existing, unrelated failures (Windows path handling / timing-sensitive tests).