### PR TITLE
fix: surface the triggering workflow's conclusion in workflow_run reviews

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -365,8 +365,8 @@ def _inject_ci_conclusion(conclusion):
     for key in get_settings():
         setting = get_settings().get(key)
         if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
-            if key.lower() in ('pr_reviewer', 'pr_description', 'pr_code_suggestions'):
-                if hasattr(setting, 'extra_instructions'):
+            if key.lower() in ("pr_reviewer", "pr_description", "pr_code_suggestions"):
+                if hasattr(setting, "extra_instructions"):
                     extra_instructions = str(setting.extra_instructions or "")
                     if text not in extra_instructions:
                         setting.extra_instructions = (

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -316,6 +316,7 @@ async def run_action():
 
         # Inject artifact context after repo settings are applied for workflow_run
         _inject_artifact_context()
+        _inject_ci_conclusion(workflow_run.get("conclusion"))
 
         auto_review = get_setting_or_env("GITHUB_ACTION.AUTO_REVIEW", None)
         if auto_review is None:
@@ -340,6 +341,38 @@ async def run_action():
             await PRReviewer(pr_url).run()
         if auto_improve is None or is_true(auto_improve):
             await PRCodeSuggestions(pr_url).run()
+
+
+def _inject_ci_conclusion(conclusion):
+    """Tell the model how the workflow that triggered this run finished.
+
+    Mirrors the append-to-extra_instructions pattern already used for the
+    response-language instruction above and by _inject_artifact_context, so a
+    reviewer running after CI knows a failed/cancelled run without config
+    changes or new prompt variables.
+    """
+    if not conclusion:
+        return
+    text = (
+        "CI status\n"
+        "=====\n"
+        f"The workflow run that triggered this review concluded: {conclusion}.\n"
+        "=====\n"
+        "If the conclusion is not 'success', the change has not passed CI. "
+        "Say so in your output rather than implying the change is clean."
+    )
+    separator = "\n======\n\n"
+    for key in get_settings():
+        setting = get_settings().get(key)
+        if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+            if key.lower() in ('pr_reviewer', 'pr_description', 'pr_code_suggestions'):
+                if hasattr(setting, 'extra_instructions'):
+                    extra_instructions = str(setting.extra_instructions or "")
+                    if text not in extra_instructions:
+                        setting.extra_instructions = (
+                            extra_instructions + separator + text
+                            if extra_instructions else text
+                        )
 
 
 async def _run_action_and_drain():

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -362,10 +362,17 @@ def _inject_ci_conclusion(conclusion):
         "Say so in your output rather than implying the change is clean."
     )
     separator = "\n======\n\n"
+    default_target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]
+    target_tools = get_settings().get("ARTIFACTS.TARGET_TOOLS", default_target_tools)
+    if isinstance(target_tools, str):
+        target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
+    elif not isinstance(target_tools, (list, set, tuple)):
+        target_tools = default_target_tools
+    target_tools = {str(t).lower() for t in target_tools}
     for key in get_settings():
         setting = get_settings().get(key)
         if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
-            if key.lower() in ("pr_reviewer", "pr_description", "pr_code_suggestions"):
+            if key.lower() in target_tools:
                 if hasattr(setting, "extra_instructions"):
                     extra_instructions = str(setting.extra_instructions or "")
                     if text not in extra_instructions:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -358,8 +358,8 @@ def _inject_ci_conclusion(conclusion):
         "=====\n"
         f"The workflow run that triggered this review concluded: {conclusion}.\n"
         "=====\n"
-        "If the conclusion is not 'success', the change has not passed CI. "
-        "Say so in your output rather than implying the change is clean."
+        "Treat any conclusion other than 'success' as CI not having passed cleanly, "
+        "and mention it rather than implying the change is clean."
     )
     separator = "\n======\n\n"
     default_target_tools = ["pr_reviewer", "pr_description", "pr_code_suggestions"]

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -107,9 +107,12 @@ async def test_run_action_invokes_enabled_auto_tools_for_pull_request_event(monk
 
 @pytest.fixture
 def restore_github_settings():
-    """run_action mutates global GITHUB/GITHUB_ACTION_CONFIG/GITHUB_APP settings, plus the
-    extra_instructions of the three auto-run tools (artifact/CI-conclusion injection);
-    snapshot and restore them so these tests don't leak state into others."""
+    """Snapshot and restore global settings that run_action mutates.
+
+    Covers GITHUB/GITHUB_ACTION_CONFIG/GITHUB_APP plus the extra_instructions
+    of the three auto-run tools (artifact/CI-conclusion injection), so these
+    tests don't leak state into others.
+    """
     settings = get_settings()
     had_github = "GITHUB" in settings
     original_github = copy.deepcopy(settings.get("GITHUB", None))
@@ -471,8 +474,10 @@ async def test_workflow_run_skips_when_pull_requests_empty(monkeypatch, tmp_path
 
 @pytest.mark.asyncio
 async def test_workflow_run_injects_ci_conclusion_when_not_success(monkeypatch, tmp_path, restore_github_settings):
-    """A failing/cancelled triggering workflow must be surfaced to the model, not silently
-    reviewed as if CI were green (see issue #2841)."""
+    """Verify a failing/cancelled triggering workflow is surfaced to the model.
+
+    Not silently reviewed as if CI were green (see issue #2841).
+    """
     runs = []
     _patch_workflow_run_deps(monkeypatch, runs)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
@@ -488,8 +493,10 @@ async def test_workflow_run_injects_ci_conclusion_when_not_success(monkeypatch, 
 
 @pytest.mark.asyncio
 async def test_workflow_run_does_not_inject_ci_conclusion_when_absent(monkeypatch, tmp_path, restore_github_settings):
-    """No conclusion in the payload (e.g. an older event shape) must not append a
-    'concluded: None' instruction."""
+    """Verify an absent conclusion does not append a 'concluded: None' instruction.
+
+    Covers an older event shape that has no conclusion field at all.
+    """
     runs = []
     _patch_workflow_run_deps(monkeypatch, runs)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -107,8 +107,9 @@ async def test_run_action_invokes_enabled_auto_tools_for_pull_request_event(monk
 
 @pytest.fixture
 def restore_github_settings():
-    """run_action mutates global GITHUB/GITHUB_ACTION_CONFIG/GITHUB_APP settings; snapshot
-    and restore them so these tests don't leak state into others."""
+    """run_action mutates global GITHUB/GITHUB_ACTION_CONFIG/GITHUB_APP settings, plus the
+    extra_instructions of the three auto-run tools (artifact/CI-conclusion injection);
+    snapshot and restore them so these tests don't leak state into others."""
     settings = get_settings()
     had_github = "GITHUB" in settings
     original_github = copy.deepcopy(settings.get("GITHUB", None))
@@ -118,6 +119,10 @@ def restore_github_settings():
     original_app = copy.deepcopy(settings.get("GITHUB_APP", None))
     original_is_auto = getattr(settings.config, "is_auto_command", None)
     original_final_update = getattr(settings.pr_description, "final_update_message", None)
+    original_extra_instructions = {
+        section: getattr(getattr(settings, section, None), "extra_instructions", None)
+        for section in ("pr_reviewer", "pr_description", "pr_code_suggestions")
+    }
     yield
     if had_github:
         settings.set("GITHUB", original_github)
@@ -135,6 +140,9 @@ def restore_github_settings():
         settings.config.is_auto_command = original_is_auto
     if original_final_update is not None:
         settings.pr_description.final_update_message = original_final_update
+    for section, extra_instructions in original_extra_instructions.items():
+        if extra_instructions is not None:
+            getattr(settings, section).extra_instructions = extra_instructions
 
 
 def _write_synchronize_event(tmp_path, before_sha="abc", after_sha="def", merge_commit_sha=None, sender_type="User"):
@@ -364,18 +372,20 @@ async def test_issue_comment_from_user_is_processed(monkeypatch, tmp_path, resto
     assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]
 
 
-def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None):
+def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None, conclusion="success"):
     if pull_requests is None:
         pull_requests = [{"url": "https://api.github.com/repos/org/repo/pulls/42", "number": 42}]
+    workflow_run = {
+        "id": 9999,
+        "event": originating_event,
+        "pull_requests": pull_requests,
+    }
+    if conclusion is not None:
+        workflow_run["conclusion"] = conclusion
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({
         "action": "completed",
-        "workflow_run": {
-            "id": 9999,
-            "event": originating_event,
-            "conclusion": "success",
-            "pull_requests": pull_requests,
-        },
+        "workflow_run": workflow_run,
     }))
     return event_path
 
@@ -457,6 +467,40 @@ async def test_workflow_run_skips_when_pull_requests_empty(monkeypatch, tmp_path
     await github_action_runner.run_action()
 
     assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_injects_ci_conclusion_when_not_success(monkeypatch, tmp_path, restore_github_settings):
+    """A failing/cancelled triggering workflow must be surfaced to the model, not silently
+    reviewed as if CI were green (see issue #2841)."""
+    runs = []
+    _patch_workflow_run_deps(monkeypatch, runs)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion="failure"))
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    await github_action_runner.run_action()
+
+    assert "concluded: failure" in str(get_settings().pr_reviewer.extra_instructions)
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_does_not_inject_ci_conclusion_when_absent(monkeypatch, tmp_path, restore_github_settings):
+    """No conclusion in the payload (e.g. an older event shape) must not append a
+    'concluded: None' instruction."""
+    runs = []
+    _patch_workflow_run_deps(monkeypatch, runs)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH", str(_write_workflow_run_event(tmp_path, conclusion=None))
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    await github_action_runner.run_action()
+
+    assert "CI status" not in str(get_settings().pr_reviewer.extra_instructions)
 
 
 def _write_issue_comment_event_with_body(tmp_path, body):


### PR DESCRIPTION
Fixes #2841.

## What

`workflow_run` handling in `pr_agent/servers/github_action_runner.py` reads `event` and `pull_requests` from the payload but never `conclusion`, so a review triggered after another workflow finishes reads identically whether that workflow succeeded, failed, or was cancelled — the model is never told which. `conclusion` is already parsed in the test fixture and otherwise unused in the codebase (aside from where PR-Agent itself creates a check run).

## Change

Added `_inject_ci_conclusion(conclusion)`, which appends a short note to the `extra_instructions` of the same three tools (`pr_reviewer`, `pr_description`, `pr_code_suggestions`) that `_inject_artifact_context` already targets, telling the model explicitly when the triggering workflow did not conclude with `success`. Called right after the existing artifact-context injection in the `workflow_run` branch. Purely additive — no control flow changes, no new config keys, no prompt template edits.

Also extended the `restore_github_settings` test fixture to snapshot/restore `extra_instructions` for those three tool sections. `run_action` now mutates that state unconditionally on every `workflow_run` run (previously only `_inject_artifact_context` did, which no-ops unless artifacts are explicitly enabled in config) — without this the existing `test_workflow_run_runs_auto_tools` test would leak `"...concluded: success"` into later tests' settings.

## Tests

Two new tests in `tests/unittest/test_github_action_runner_core.py`:
- `test_workflow_run_injects_ci_conclusion_when_not_success` — asserts the conclusion text lands in `pr_reviewer.extra_instructions` for a `"failure"` conclusion.
- `test_workflow_run_does_not_inject_ci_conclusion_when_absent` — asserts nothing is appended when the payload has no `conclusion` key at all.

Verified both against the pre-fix code (via `git stash` on just the implementation file): the first fails as expected (`assert 'concluded: failure' in ''`), the second still passes (there's nothing to guard against there). Full `tests/unittest/test_github_action_runner_core.py`: 19 passed.

```
PYTHONPATH=. pytest -q tests/unittest/test_github_action_runner_core.py
```
