### PR TITLE
fix(improve): clean up progress comment on cancellation

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -268,6 +268,16 @@ class PRCodeSuggestions:
                 pr_body = self.generate_summarized_suggestions(data)
                 get_settings().data = {"artifact": pr_body}
                 return
+        except asyncio.CancelledError:
+            if self.progress_response is not None:
+                try:
+                    self.git_provider.remove_comment(self.progress_response)
+                except Exception as cleanup_error:
+                    get_logger().exception(
+                        f"Failed to remove code suggestions progress comment after cancellation, "
+                        f"error: {cleanup_error}"
+                    )
+            raise
         except Exception as e:
             get_logger().error(f"Failed to generate code suggestions for PR, error: {e}",
                                artifact={"traceback": traceback.format_exc()})

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -376,9 +376,25 @@ class PRCodeSuggestions:
                                                 only_fold=False,
                                                 identity_marker: str | None = None,
                                                 legacy_initial_header: str | None = None):
+        def _clean_up_progress_note():
+            if not progress_response:
+                return
+            try:
+                git_provider.edit_comment(
+                    progress_response,
+                    "Code suggestions published in the persistent thread above.",
+                )
+                git_provider.remove_comment(progress_response)
+            except Exception as cleanup_error:
+                get_logger().warning(
+                    "Failed to clean up progress note after persistent update, "
+                    f"leaving it in place: {cleanup_error}"
+                )
+
         if hasattr(git_provider, '_publish_check_run') and get_settings().github.publish_as_check_run:
             if git_provider._publish_check_run(pr_comment, name):
-                return
+                _clean_up_progress_note()
+                return progress_response
 
         def _extract_link(comment_text: str):
             match = re.search(r"<!--\s*([0-9a-fA-F]{7,40})\s*-->", comment_text)
@@ -416,21 +432,6 @@ class PRCodeSuggestions:
 
         def _with_identity(comment_text: str) -> str:
             return add_comment_identity(comment_text, identity_marker)
-
-        def _clean_up_progress_note():
-            if not progress_response:
-                return
-            try:
-                git_provider.edit_comment(
-                    progress_response,
-                    "Code suggestions published in the persistent thread above.",
-                )
-                git_provider.remove_comment(progress_response)
-            except Exception as cleanup_error:
-                get_logger().warning(
-                    "Failed to clean up progress note after persistent update, "
-                    f"leaving it in place: {cleanup_error}"
-                )
 
         history_header = f"#### Previous suggestions\n"
         last_commit_num = git_provider.get_latest_commit_url().split('/')[-1][:7]

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -376,9 +376,9 @@ class PRCodeSuggestions:
                                                 only_fold=False,
                                                 identity_marker: str | None = None,
                                                 legacy_initial_header: str | None = None):
-        def _clean_up_progress_note():
+        def _clean_up_progress_note() -> bool:
             if not progress_response:
-                return
+                return True
             try:
                 git_provider.edit_comment(
                     progress_response,
@@ -390,11 +390,12 @@ class PRCodeSuggestions:
                     "Failed to clean up progress note after persistent update, "
                     f"leaving it in place: {cleanup_error}"
                 )
+                return False
+            return True
 
         if hasattr(git_provider, '_publish_check_run') and get_settings().github.publish_as_check_run:
             if git_provider._publish_check_run(pr_comment, name):
-                _clean_up_progress_note()
-                return progress_response
+                return progress_response if _clean_up_progress_note() else None
 
         def _extract_link(comment_text: str):
             match = re.search(r"<!--\s*([0-9a-fA-F]{7,40})\s*-->", comment_text)

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -253,6 +253,7 @@ class PRCodeSuggestions:
                         )
                         if self.progress_response:
                             self.git_provider.edit_comment(self.progress_response, body=pr_body)
+                            self.progress_response = None
                         else:
                             self.git_provider.publish_comment(pr_body)
 
@@ -270,6 +271,16 @@ class PRCodeSuggestions:
                 return
         except asyncio.CancelledError:
             if self.progress_response is not None:
+                try:
+                    self.git_provider.edit_comment(
+                        self.progress_response,
+                        "Code suggestions generation cancelled.",
+                    )
+                except Exception as cleanup_error:
+                    get_logger().exception(
+                        f"Failed to update code suggestions progress comment after cancellation, "
+                        f"error: {cleanup_error}"
+                    )
                 try:
                     self.git_provider.remove_comment(self.progress_response)
                 except Exception as cleanup_error:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -246,7 +246,7 @@ class PRCodeSuggestions:
                             identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
                             legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
                         )
-                        if published_comment is self.progress_response:
+                        if published_comment is not None:
                             self.progress_response = None
                     else:
                         pr_body = add_comment_identity(

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -234,7 +234,7 @@ class PRCodeSuggestions:
 
                     # publish the PR comment
                     if get_settings().pr_code_suggestions.persistent_comment: # true by default
-                        self.publish_persistent_comment_with_history(
+                        published_comment = self.publish_persistent_comment_with_history(
                             self.git_provider,
                             pr_body,
                             initial_header=format_pr_code_suggestions_header(),
@@ -246,6 +246,8 @@ class PRCodeSuggestions:
                             identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
                             legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
                         )
+                        if published_comment is self.progress_response:
+                            self.progress_response = None
                     else:
                         pr_body = add_comment_identity(
                             pr_body,

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -17,6 +17,7 @@ _TRACKED_SETTINGS = (
     "pr_code_suggestions.commitable_code_suggestions",
     "pr_code_suggestions.dual_publishing_score_threshold",
     "pr_code_suggestions.persistent_comment",
+    "github.publish_as_check_run",
 )
 
 
@@ -178,5 +179,43 @@ async def test_run_preserves_cancellation_when_progress_cleanup_fails(monkeypatc
             progress_comment, "Code suggestions generation cancelled."
         )
         provider.remove_comment.assert_called_once_with(progress_comment)
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+async def test_run_cleans_up_progress_comment_on_check_run_publish(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        provider.get_latest_commit_url.return_value = "https://example.invalid/commit/abcdef1234567890"
+        provider._publish_check_run = MagicMock(return_value=True)
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+        tool.generate_summarized_suggestions = MagicMock(return_value="final summary")
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.github.publish_as_check_run = True
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.persistent_comment = True
+
+        await tool.run()
+
+        provider._publish_check_run.assert_called_once()
+        provider.edit_comment.assert_called_once_with(
+            progress_comment, "Code suggestions published in the persistent thread above."
+        )
+        provider.remove_comment.assert_called_once_with(progress_comment)
+        assert tool.progress_response is None
     finally:
         restore_settings(settings_snapshot)

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -1,0 +1,100 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.tools import pr_code_suggestions as pr_code_suggestions_module
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+
+_TRACKED_SETTINGS = (
+    "config.publish_output",
+    "config.publish_output_progress",
+    "config.is_auto_command",
+)
+
+
+def _make_tool(provider):
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.pr_url = "https://example.invalid/pull/1"
+    tool.progress_response = None
+    tool.incremental = SimpleNamespace(is_incremental=False)
+    return tool
+
+
+def _configure_published_run():
+    settings = get_settings()
+    settings.config.publish_output = True
+    settings.config.publish_output_progress = True
+    settings.config.is_auto_command = False
+
+
+@pytest.mark.parametrize(
+    ("supports_gfm", "progress_body", "progress_kwargs"),
+    [
+        (False, "Preparing suggestions...", {"is_temporary": True}),
+        (True, "progress body", {}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_removes_progress_comment_when_cancelled(
+    monkeypatch, supports_gfm, progress_body, progress_kwargs
+):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = supports_gfm
+        provider.publish_comment.return_value = progress_comment
+        tool = _make_tool(provider)
+        tool.progress = progress_body
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(side_effect=asyncio.CancelledError()),
+        )
+        _configure_published_run()
+
+        with pytest.raises(asyncio.CancelledError):
+            await tool.run()
+
+        provider.publish_comment.assert_called_once_with(
+            progress_body, **progress_kwargs
+        )
+        provider.remove_comment.assert_called_once_with(progress_comment)
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_cancellation_when_progress_cleanup_fails(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        provider.remove_comment.side_effect = RuntimeError("delete unavailable")
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(side_effect=asyncio.CancelledError()),
+        )
+        _configure_published_run()
+
+        with pytest.raises(asyncio.CancelledError):
+            await tool.run()
+
+        provider.remove_comment.assert_called_once_with(progress_comment)
+    finally:
+        restore_settings(settings_snapshot)

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -113,6 +113,45 @@ async def test_run_does_not_remove_final_summary_when_cancelled_during_dual_publ
 
 
 @pytest.mark.asyncio
+async def test_run_does_not_remove_persistent_summary_when_cancelled_during_dual_publishing(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        provider.get_issue_comments.return_value = []
+        provider.get_latest_commit_url.return_value = "https://example.invalid/commit/abcdef1234567890"
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+        tool.generate_summarized_suggestions = MagicMock(return_value="final summary")
+        tool.dual_publishing = AsyncMock(side_effect=asyncio.CancelledError())
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.dual_publishing_score_threshold = 1
+        settings.pr_code_suggestions.persistent_comment = True
+
+        with pytest.raises(asyncio.CancelledError):
+            await tool.run()
+
+        provider.edit_comment.assert_called_once()
+        assert provider.edit_comment.call_args.args[0] is progress_comment
+        assert "final summary" in provider.edit_comment.call_args.args[1]
+        provider.remove_comment.assert_not_called()
+        assert tool.progress_response is None
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
 async def test_run_preserves_cancellation_when_progress_cleanup_fails(monkeypatch):
     settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
     try:

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -14,6 +14,9 @@ _TRACKED_SETTINGS = (
     "config.publish_output",
     "config.publish_output_progress",
     "config.is_auto_command",
+    "pr_code_suggestions.commitable_code_suggestions",
+    "pr_code_suggestions.dual_publishing_score_threshold",
+    "pr_code_suggestions.persistent_comment",
 )
 
 
@@ -73,6 +76,43 @@ async def test_run_removes_progress_comment_when_cancelled(
 
 
 @pytest.mark.asyncio
+async def test_run_does_not_remove_final_summary_when_cancelled_during_dual_publishing(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+        tool.generate_summarized_suggestions = MagicMock(return_value="final summary")
+        tool.dual_publishing = AsyncMock(side_effect=asyncio.CancelledError())
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.dual_publishing_score_threshold = 1
+        settings.pr_code_suggestions.persistent_comment = False
+
+        with pytest.raises(asyncio.CancelledError):
+            await tool.run()
+
+        provider.edit_comment.assert_called_once()
+        assert provider.edit_comment.call_args.args[0] is progress_comment
+        assert "final summary" in provider.edit_comment.call_args.kwargs["body"]
+        provider.remove_comment.assert_not_called()
+        assert tool.progress_response is None
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
 async def test_run_preserves_cancellation_when_progress_cleanup_fails(monkeypatch):
     settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
     try:
@@ -95,6 +135,9 @@ async def test_run_preserves_cancellation_when_progress_cleanup_fails(monkeypatc
         with pytest.raises(asyncio.CancelledError):
             await tool.run()
 
+        provider.edit_comment.assert_called_once_with(
+            progress_comment, "Code suggestions generation cancelled."
+        )
         provider.remove_comment.assert_called_once_with(progress_comment)
     finally:
         restore_settings(settings_snapshot)

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -219,3 +219,43 @@ async def test_run_cleans_up_progress_comment_on_check_run_publish(monkeypatch):
         assert tool.progress_response is None
     finally:
         restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+async def test_run_retains_progress_handle_when_check_run_cleanup_fails(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        provider.get_latest_commit_url.return_value = "https://example.invalid/commit/abcdef1234567890"
+        provider._publish_check_run = MagicMock(return_value=True)
+        provider.remove_comment.side_effect = RuntimeError("delete unavailable")
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+        tool.generate_summarized_suggestions = MagicMock(return_value="final summary")
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.github.publish_as_check_run = True
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.persistent_comment = True
+
+        await tool.run()
+
+        provider._publish_check_run.assert_called_once()
+        provider.edit_comment.assert_called_once_with(
+            progress_comment, "Code suggestions published in the persistent thread above."
+        )
+        provider.remove_comment.assert_called_once_with(progress_comment)
+        # The handle is retained so a later cancellation or error handler can retry removal
+        assert tool.progress_response is progress_comment
+    finally:
+        restore_settings(settings_snapshot)


### PR DESCRIPTION
Fixes #2849

## What

Clean up the `/improve` progress comment when the command task is cancelled
after progress publication.

## Why

`asyncio.CancelledError` bypasses the existing `except Exception` cleanup path.
The cancellation correctly propagates, but the provider-owned progress comment
is left without a deletion attempt and can remain visible as stale status.

## Implementation

- Handle `asyncio.CancelledError` before the ordinary exception handler.
- Attempt `remove_comment()` only when this run has a progress handle.
- Log cleanup failures and re-raise the original cancellation.
- Add fake-provider coverage for GFM and temporary progress comments and for a
  cleanup failure that must not mask cancellation.

## Tests

- `pytest -q tests/unittest/test_pr_code_suggestions_lifecycle.py tests/unittest/test_pr_code_suggestions_core.py` — 71 passed
- `pytest -q tests/unittest` — 2576 passed, 1 skipped, 1 xfailed, 89 warnings
- `python -m py_compile pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_lifecycle.py`
- `git diff --check`

No real model, token, external provider, or production deployment was used.
