### PR TITLE
fix(skills): respect per-command settings in request-scoped cache

### DIFF
--- a/pr_agent/algo/skills_loader.py
+++ b/pr_agent/algo/skills_loader.py
@@ -56,6 +56,7 @@ _DEFAULT_MAX_SKILLS_TOKENS = 8000
 # matching the agent-skills standard's executable/binary conventions.
 _EXCLUDED_RESOURCE_DIRS = frozenset({"scripts", "assets"})
 _CONTEXT_CACHE_KEY = "skills_context"
+_CONTEXT_CACHE_SETTINGS_KEY = "skills_context_settings"
 # Per-resource-file size cap. Defence-in-depth against pathological skill
 # directories (large markdown dumps, accidental inclusion of generated docs,
 # or a misconfigured paths entry pointing at a directory with huge files).
@@ -277,8 +278,10 @@ def format_skills_context(skills: List[Skill], max_tokens: int) -> str:
     return separator.join(pieces).strip()
 
 
-def _get_cached_context() -> Optional[str]:
+def _get_cached_context(cache_settings: Tuple[bool, Tuple[object, ...], Optional[int]]) -> Optional[str]:
     try:
+        if context.get(_CONTEXT_CACHE_SETTINGS_KEY, None) != cache_settings:
+            return None
         return context.get(_CONTEXT_CACHE_KEY, None)
     except ContextDoesNotExistError:
         # No request-scoped context (e.g. CLI runs): nothing is memoised, so
@@ -286,8 +289,9 @@ def _get_cached_context() -> Optional[str]:
         return None
 
 
-def _set_cached_context(value: str) -> None:
+def _set_cached_context(cache_settings: Tuple[bool, Tuple[object, ...], Optional[int]], value: str) -> None:
     try:
+        context[_CONTEXT_CACHE_SETTINGS_KEY] = cache_settings
         context[_CONTEXT_CACHE_KEY] = value
     except ContextDoesNotExistError:
         # No request-scoped context (e.g. CLI runs): skip memoisation. The value
@@ -298,29 +302,41 @@ def _set_cached_context(value: str) -> None:
 def get_skills_context() -> str:
     """Read settings, discover skills, and format them for prompt injection.
 
-    Memoised per request via ``starlette_context`` so the three tools that
-    inject ``skills_context`` (review, improve, describe) share a single
-    discovery + parse + format. Returns ``''`` when skills are disabled, no
-    paths are configured, or no skills are found.
+    Memoised per request and effective Skills settings via ``starlette_context``
+    so the three tools that inject ``skills_context`` (review, improve, describe)
+    share a single discovery + parse + format. Returns ``''`` when skills are
+    disabled, no paths are configured, or no skills are found.
     """
-    cached = _get_cached_context()
-    if cached is not None:
-        return cached
-
     settings = get_settings()
-    if not settings.skills.enabled:
-        _set_cached_context("")
-        return ""
+    enabled = bool(settings.skills.enabled)
     paths = list(settings.skills.paths or [])
+
+    if not enabled:
+        cache_settings = (False, tuple(paths), None)
+        cached = _get_cached_context(cache_settings)
+        if cached is not None:
+            return cached
+        _set_cached_context(cache_settings, "")
+        return ""
+
     raw_max = settings.skills.max_skills_tokens
+    invalid_max = False
     try:
         max_tokens = int(raw_max)
     except (TypeError, ValueError):
+        invalid_max = True
+        max_tokens = _DEFAULT_MAX_SKILLS_TOKENS
+
+    cache_settings = (True, tuple(paths), max_tokens)
+    cached = _get_cached_context(cache_settings)
+    if cached is not None:
+        return cached
+    if invalid_max:
         get_logger().warning(
             f"Invalid skills.max_skills_tokens={raw_max!r}; falling back to {_DEFAULT_MAX_SKILLS_TOKENS}"
         )
-        max_tokens = _DEFAULT_MAX_SKILLS_TOKENS
+
     skills = discover_skills(paths)
     out = format_skills_context(skills, max_tokens) if skills else ""
-    _set_cached_context(out)
+    _set_cached_context(cache_settings, out)
     return out

--- a/pr_agent/algo/skills_loader.py
+++ b/pr_agent/algo/skills_loader.py
@@ -78,6 +78,22 @@ class Skill:
     resources: Tuple[SkillResource, ...] = field(default_factory=tuple)
 
 
+def _expand_skill_path(raw_path: object) -> Optional[str]:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    return os.path.expanduser(os.path.expandvars(raw_path.strip()))
+
+
+def _expanded_skill_paths(paths: List[str]) -> Tuple[str, ...]:
+    """Return the normalized path values used by discovery and cache keys."""
+    expanded_paths = []
+    for raw_path in paths or []:
+        expanded = _expand_skill_path(raw_path)
+        if expanded is not None:
+            expanded_paths.append(expanded)
+    return tuple(expanded_paths)
+
+
 def _count_tokens(text: str) -> int:
     return len(TokenEncoder.get_token_encoder().encode(text))
 
@@ -190,9 +206,9 @@ def discover_skills(paths: List[str]) -> List[Skill]:
     seen: set = set()
 
     for raw_path in paths or []:
-        if not isinstance(raw_path, str) or not raw_path.strip():
+        expanded = _expand_skill_path(raw_path)
+        if expanded is None:
             continue
-        expanded = os.path.expanduser(os.path.expandvars(raw_path.strip()))
         if not os.path.exists(expanded):
             get_logger().warning(f"Skills path does not exist: {expanded}")
             continue
@@ -310,9 +326,10 @@ def get_skills_context() -> str:
     settings = get_settings()
     enabled = bool(settings.skills.enabled)
     paths = list(settings.skills.paths or [])
+    expanded_paths = _expanded_skill_paths(paths)
 
     if not enabled:
-        cache_settings = (False, tuple(paths), None)
+        cache_settings = (False, expanded_paths, None)
         cached = _get_cached_context(cache_settings)
         if cached is not None:
             return cached
@@ -327,7 +344,7 @@ def get_skills_context() -> str:
         invalid_max = True
         max_tokens = _DEFAULT_MAX_SKILLS_TOKENS
 
-    cache_settings = (True, tuple(paths), max_tokens)
+    cache_settings = (True, expanded_paths, max_tokens)
     cached = _get_cached_context(cache_settings)
     if cached is not None:
         return cached

--- a/tests/unittest/test_skills_loader.py
+++ b/tests/unittest/test_skills_loader.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from jinja2 import Environment, StrictUndefined
 from starlette_context import request_cycle_context
 
-import pr_agent.algo.skills_loader as skills_loader
+from pr_agent.algo import skills_loader
 from pr_agent.algo.skills_loader import (
     Skill,
     _parse_skill_file,
@@ -222,6 +222,9 @@ class TestGetSkillsContext:
             settings.skills.max_skills_tokens = 1000
             assert get_skills_context() == "budget=1000"
 
+            settings.skills.paths = ["/other/skills"]
+            assert get_skills_context() == "budget=1000"
+
             settings.skills.enabled = False
             assert get_skills_context() == ""
 
@@ -229,7 +232,39 @@ class TestGetSkillsContext:
             settings.skills.max_skills_tokens = 200
             assert get_skills_context() == "budget=200"
 
-        assert discover_calls == [["/host/skills"], ["/host/skills"], ["/host/skills"]]
+        assert discover_calls == [
+            ["/host/skills"],
+            ["/host/skills"],
+            ["/other/skills"],
+            ["/other/skills"],
+        ]
+
+    def test_request_cache_respects_expanded_path_changes(self, tmp_path, monkeypatch):
+        first_dir = tmp_path / "first"
+        second_dir = tmp_path / "second"
+        _write_skill(first_dir, "first-skill")
+        _write_skill(second_dir, "second-skill")
+        settings = SimpleNamespace(
+            skills=SimpleNamespace(
+                enabled=True,
+                paths=["$SKILLS_TEST_DIR"],
+                max_skills_tokens=8000,
+            )
+        )
+
+        monkeypatch.setenv("SKILLS_TEST_DIR", str(first_dir))
+        monkeypatch.setattr(skills_loader, "get_settings", lambda: settings)
+        monkeypatch.setattr(
+            skills_loader,
+            "format_skills_context",
+            lambda skills, max_tokens: ",".join(skill.name for skill in skills),
+        )
+
+        with request_cycle_context({}):
+            assert get_skills_context() == "first-skill"
+
+            monkeypatch.setenv("SKILLS_TEST_DIR", str(second_dir))
+            assert get_skills_context() == "second-skill"
 
 
 class TestJinjaSafety:

--- a/tests/unittest/test_skills_loader.py
+++ b/tests/unittest/test_skills_loader.py
@@ -2,13 +2,19 @@
 import os
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 from jinja2 import Environment, StrictUndefined
+from starlette_context import request_cycle_context
 
-from pr_agent.algo.skills_loader import (Skill, _parse_skill_file,
-                                         discover_skills,
-                                         format_skills_context,
-                                         get_skills_context)
+import pr_agent.algo.skills_loader as skills_loader
+from pr_agent.algo.skills_loader import (
+    Skill,
+    _parse_skill_file,
+    discover_skills,
+    format_skills_context,
+    get_skills_context,
+)
 
 
 def _write_skill(directory: Path, name: str, body: str = "Body content."):
@@ -186,6 +192,44 @@ class TestGetSkillsContext:
         # Should not raise; should still produce skills_context using the default budget.
         out = get_skills_context()
         assert "Skill: demo" in out
+
+    def test_request_cache_respects_effective_settings_changes(self, monkeypatch):
+        settings = SimpleNamespace(
+            skills=SimpleNamespace(
+                enabled=True,
+                paths=["/host/skills"],
+                max_skills_tokens=8000,
+            )
+        )
+        discover_calls = []
+
+        def fake_discover(paths):
+            discover_calls.append(list(paths))
+            return [Skill(name="demo", description="Use for tests", body="test guidance")]
+
+        monkeypatch.setattr(skills_loader, "get_settings", lambda: settings)
+        monkeypatch.setattr(skills_loader, "discover_skills", fake_discover)
+        monkeypatch.setattr(
+            skills_loader,
+            "format_skills_context",
+            lambda skills, max_tokens: f"budget={max_tokens}",
+        )
+
+        with request_cycle_context({}):
+            assert get_skills_context() == "budget=8000"
+            assert get_skills_context() == "budget=8000"
+
+            settings.skills.max_skills_tokens = 1000
+            assert get_skills_context() == "budget=1000"
+
+            settings.skills.enabled = False
+            assert get_skills_context() == ""
+
+            settings.skills.enabled = True
+            settings.skills.max_skills_tokens = 200
+            assert get_skills_context() == "budget=200"
+
+        assert discover_calls == [["/host/skills"], ["/host/skills"], ["/host/skills"]]
 
 
 class TestJinjaSafety:


### PR DESCRIPTION
## Summary

- Scope the request-scoped Skills context cache by effective settings.
- Recompute Skills context when `skills.enabled`, `skills.max_skills_tokens`, or skill paths change.
- Preserve cache reuse when the effective settings are unchanged.

Fixes #2854

## Validation

- `PYTHONPATH=. /tmp/pr-agent-2781-venv/bin/pytest -q -p no:cacheprovider tests/unittest/test_skills_loader.py tests/unittest/test_skills_context_budget.py`
- 47 tests passed.
- Ruff checks passed.
