### PR TITLE
fix: skip non-UTF-8 files in Local Git and Gerrit diffs

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -272,17 +272,20 @@ class GerritProvider(GitProvider):
 
         diff_files = []
         for diff_item in diffs:
-            if diff_item.a_blob is not None:
-                original_file_content_str = (
-                    diff_item.a_blob.data_stream.read().decode('utf-8')
-                )
-            else:
-                original_file_content_str = ""  # empty file
-            if diff_item.b_blob is not None:
-                new_file_content_str = diff_item.b_blob.data_stream.read(). \
-                    decode('utf-8')
-            else:
-                new_file_content_str = ""  # empty file
+            filename = diff_item.b_path or diff_item.a_path
+            try:
+                if diff_item.a_blob is not None:
+                    original_file_content_str = diff_item.a_blob.data_stream.read().decode("utf-8")
+                else:
+                    original_file_content_str = ""  # empty file
+                if diff_item.b_blob is not None:
+                    new_file_content_str = diff_item.b_blob.data_stream.read().decode("utf-8")
+                else:
+                    new_file_content_str = ""  # empty file
+                patch = diff_item.diff.decode("utf-8")
+            except UnicodeDecodeError as e:
+                get_logger().warning(f"Skipping non-UTF-8 file in Gerrit diff: {filename!r} ({e})")
+                continue
             edit_type = EDIT_TYPE.MODIFIED
             if diff_item.new_file:
                 edit_type = EDIT_TYPE.ADDED
@@ -294,8 +297,8 @@ class GerritProvider(GitProvider):
                 FilePatchInfo(
                     original_file_content_str,
                     new_file_content_str,
-                    diff_item.diff.decode('utf-8'),
-                    diff_item.b_path or diff_item.a_path,
+                    patch,
+                    filename,
                     edit_type=edit_type,
                     old_filename=None
                     if diff_item.a_path == diff_item.b_path

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -81,14 +81,20 @@ class LocalGitProvider(GitProvider):
         )
         diff_files = []
         for diff_item in diffs:
-            if diff_item.a_blob is not None:
-                original_file_content_str = diff_item.a_blob.data_stream.read().decode('utf-8')
-            else:
-                original_file_content_str = ""  # empty file
-            if diff_item.b_blob is not None:
-                new_file_content_str = diff_item.b_blob.data_stream.read().decode('utf-8')
-            else:
-                new_file_content_str = ""  # empty file
+            filename = diff_item.b_path or diff_item.a_path
+            try:
+                if diff_item.a_blob is not None:
+                    original_file_content_str = diff_item.a_blob.data_stream.read().decode("utf-8")
+                else:
+                    original_file_content_str = ""  # empty file
+                if diff_item.b_blob is not None:
+                    new_file_content_str = diff_item.b_blob.data_stream.read().decode("utf-8")
+                else:
+                    new_file_content_str = ""  # empty file
+                patch = diff_item.diff.decode("utf-8")
+            except UnicodeDecodeError as e:
+                get_logger().warning(f"Skipping non-UTF-8 file in local diff: {filename!r} ({e})")
+                continue
             edit_type = EDIT_TYPE.MODIFIED
             if diff_item.new_file:
                 edit_type = EDIT_TYPE.ADDED
@@ -99,8 +105,8 @@ class LocalGitProvider(GitProvider):
             diff_files.append(
                 FilePatchInfo(original_file_content_str,
                               new_file_content_str,
-                              diff_item.diff.decode('utf-8'),
-                              diff_item.b_path or diff_item.a_path,
+                              patch,
+                              filename,
                               edit_type=edit_type,
                               old_filename=None if diff_item.a_path == diff_item.b_path else diff_item.a_path
                               )

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -1,4 +1,5 @@
 import git
+import pytest
 
 from pr_agent.algo.language_handler import sort_files_by_main_languages
 from pr_agent.algo.types import EDIT_TYPE
@@ -32,6 +33,46 @@ def test_get_diff_files_preserves_deleted_filename(tmp_path):
     deleted = [file for file in diff_files if file.edit_type == EDIT_TYPE.DELETED]
     assert len(deleted) == 1
     assert deleted[0].filename == "gone.py"
+
+
+@pytest.mark.parametrize("change_type", ["added", "modified", "deleted"])
+def test_get_diff_files_skips_non_utf8_file_and_keeps_utf8_sibling(tmp_path, change_type):
+    repo = git.Repo.init(tmp_path)
+    good_file = tmp_path / "good.py"
+    non_utf8_file = tmp_path / "non_utf8.py"
+    good_file.write_text("before\n", encoding="utf-8")
+    files_to_add = ["good.py"]
+    if change_type in {"modified", "deleted"}:
+        non_utf8_file.write_bytes(b"\xffbefore\n")
+        files_to_add.append("non_utf8.py")
+    repo.index.add(files_to_add)
+    repo.index.commit("base")
+
+    good_file.write_text("after\n", encoding="utf-8")
+    repo.index.add(["good.py"])
+    if change_type == "added":
+        non_utf8_file.write_bytes(b"\xffafter\n")
+        repo.index.add(["non_utf8.py"])
+    elif change_type == "modified":
+        non_utf8_file.write_bytes(b"\xfeafter\n")
+        repo.index.add(["non_utf8.py"])
+    else:
+        non_utf8_file.unlink()
+        repo.index.remove(["non_utf8.py"])
+    repo.index.commit(f"{change_type} non-UTF-8 file")
+
+    provider = object.__new__(GerritProvider)
+    provider.repo = repo
+
+    diff_files = provider.get_diff_files()
+
+    assert [file.filename for file in diff_files] == ["good.py"]
+    assert diff_files[0].base_file == "before\n"
+    assert diff_files[0].head_file == "after\n"
+    assert "-before" in diff_files[0].patch
+    assert "+after" in diff_files[0].patch
+    assert diff_files[0].edit_type == EDIT_TYPE.MODIFIED
+    assert provider.diff_files is diff_files
 
 
 def test_get_languages_returns_names_used_for_hunk_prioritization(tmp_path):

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -88,6 +88,52 @@ def test_get_diff_files_deleted_file_falls_back_to_old_path(tmp_path):
     assert all(f.filename is not None for f in diff_files)
 
 
+@pytest.mark.parametrize("change_type", ["added", "modified", "deleted"])
+def test_get_diff_files_skips_non_utf8_file_and_keeps_utf8_sibling(tmp_path, monkeypatch, change_type):
+    repo = git.Repo.init(tmp_path)
+    good_file = tmp_path / "good.py"
+    non_utf8_file = tmp_path / "non_utf8.py"
+    good_file.write_text("before\n", encoding="utf-8")
+    files_to_add = ["good.py"]
+    if change_type in {"modified", "deleted"}:
+        non_utf8_file.write_bytes(b"\xffbefore\n")
+        files_to_add.append("non_utf8.py")
+    repo.index.add(files_to_add)
+    repo.index.commit("base")
+    target_branch_name = repo.active_branch.name
+
+    repo.git.checkout("-b", "feature")
+    good_file.write_text("after\n", encoding="utf-8")
+    repo.index.add(["good.py"])
+    if change_type == "added":
+        non_utf8_file.write_bytes(b"\xffafter\n")
+        repo.index.add(["non_utf8.py"])
+    elif change_type == "modified":
+        non_utf8_file.write_bytes(b"\xfeafter\n")
+        repo.index.add(["non_utf8.py"])
+    else:
+        non_utf8_file.unlink()
+        repo.index.remove(["non_utf8.py"])
+    repo.index.commit(f"{change_type} non-UTF-8 file")
+
+    snapshot = snapshot_settings(["pr_reviewer.inline_code_comments"])
+    try:
+        monkeypatch.chdir(tmp_path)
+        provider = LocalGitProvider(target_branch_name)
+    finally:
+        restore_settings(snapshot)
+
+    diff_files = provider.pr.diff_files
+
+    assert [file.filename for file in diff_files] == ["good.py"]
+    assert diff_files[0].base_file == "before\n"
+    assert diff_files[0].head_file == "after\n"
+    assert "-before" in diff_files[0].patch
+    assert "+after" in diff_files[0].patch
+    assert diff_files[0].edit_type == EDIT_TYPE.MODIFIED
+    assert provider.diff_files is diff_files
+
+
 def test_publish_code_suggestions_writes_improve_file(tmp_path):
     # /improve has no hosted PR to attach inline comments to, so the suggestions
     # built for inline publishing are rendered to improve.md, mirroring how


### PR DESCRIPTION
Fixes #2852

Skip changed Local Git and Gerrit files whose blob or generated patch cannot be decoded as UTF-8. Other UTF-8 changes in the same comparison are still included.

Coverage includes added, modified, and deleted non-UTF-8 files alongside a changed UTF-8 file in both providers.

Validation:
- `PYTHONPATH=. .venv/bin/pytest tests/unittest/test_local_git_provider.py tests/unittest/test_gerrit_provider.py -q` (23 passed)
- `PYTHONPATH=. .venv/bin/pytest tests/unittest -q` (2598 passed, 1 skipped, 1 xfailed)
- `ruff check --select I pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py` (passed)
- `git diff --check upstream/main...HEAD` (passed)
