### PR TITLE
fix(mosaico): preserve request errors around Langfuse spans

### DIFF
--- a/pr_agent/mosaico/observability.py
+++ b/pr_agent/mosaico/observability.py
@@ -56,10 +56,13 @@ def langfuse_span(meta, context_id):
     mosaico-root-task-id with the four UUIDv4 hyphens removed -> trace_id (32 hex),
     last 16 hex digits of the de-hyphenated mosaico-super-task-id -> parent observation
     (parent_span_id, 16 hex), context_id -> session, mosaico-root-task-name -> trace_name.
-    All wrapped in try/except -> degrade to untraced. No-op when meta is empty."""
+    Setup and teardown failures are logged and degrade to untraced without changing
+    the wrapped request result. No-op when meta is empty."""
     if not meta:
         yield
         return
+
+    stack = contextlib.ExitStack()
     try:
         from langfuse import get_client, propagate_attributes
         lf = get_client()
@@ -70,10 +73,37 @@ def langfuse_span(meta, context_id):
         if meta.get("mosaico-super-task-id"):
             # W3C parent-id: last 16 hex digits (spec §observability lines 49-51).
             trace_ctx["parent_span_id"] = meta["mosaico-super-task-id"].replace("-", "")[-16:]
-        with propagate_attributes(session_id=context_id, trace_name=meta.get("mosaico-root-task-name")):
-            with lf.start_as_current_observation(as_type="span", name=AGENT_NAME,
-                                                 **({"trace_context": trace_ctx} if trace_ctx else {})):
-                yield
+        stack.enter_context(
+            propagate_attributes(session_id=context_id, trace_name=meta.get("mosaico-root-task-name"))
+        )
+        stack.enter_context(
+            lf.start_as_current_observation(
+                as_type="span",
+                name=AGENT_NAME,
+                **({"trace_context": trace_ctx} if trace_ctx else {}),
+            )
+        )
     except Exception as e:
+        try:
+            stack.close()
+        except Exception as close_error:
+            get_logger().warning(f"MOSAICO: Langfuse span cleanup failed: {close_error}")
         get_logger().warning(f"MOSAICO: Langfuse span setup failed: {e}")
         yield
+        return
+
+    try:
+        yield
+    except BaseException as error:
+        try:
+            suppressed = stack.__exit__(type(error), error, error.__traceback__)
+        except Exception as cleanup_error:
+            get_logger().warning(f"MOSAICO: Langfuse span cleanup failed: {cleanup_error}")
+            suppressed = False
+        if not suppressed:
+            raise
+    else:
+        try:
+            stack.close()
+        except Exception as e:
+            get_logger().warning(f"MOSAICO: Langfuse span cleanup failed: {e}")

--- a/tests/unittest/test_mosaico_observability_lifecycle.py
+++ b/tests/unittest/test_mosaico_observability_lifecycle.py
@@ -16,9 +16,11 @@ def _install_fake_langfuse(monkeypatch, *, teardown_failure=False):
     class FakeClient:
         @contextlib.contextmanager
         def start_as_current_observation(self, **kwargs):
-            yield
-            if teardown_failure:
-                raise RuntimeError("span flush failed")
+            try:
+                yield
+            finally:
+                if teardown_failure:
+                    raise RuntimeError("span flush failed")
 
     fake_langfuse = types.ModuleType("langfuse")
     fake_langfuse.get_client = lambda: FakeClient()

--- a/tests/unittest/test_mosaico_observability_lifecycle.py
+++ b/tests/unittest/test_mosaico_observability_lifecycle.py
@@ -1,0 +1,57 @@
+import asyncio
+import contextlib
+import sys
+import types
+
+import pytest
+
+from pr_agent.mosaico.observability import langfuse_span
+
+
+def _install_fake_langfuse(monkeypatch, *, teardown_failure=False):
+    @contextlib.contextmanager
+    def fake_propagate_attributes(**kwargs):
+        yield
+
+    class FakeClient:
+        @contextlib.contextmanager
+        def start_as_current_observation(self, **kwargs):
+            yield
+            if teardown_failure:
+                raise RuntimeError("span flush failed")
+
+    fake_langfuse = types.ModuleType("langfuse")
+    fake_langfuse.get_client = lambda: FakeClient()
+    fake_langfuse.propagate_attributes = fake_propagate_attributes
+    monkeypatch.setitem(sys.modules, "langfuse", fake_langfuse)
+
+
+def test_langfuse_span_preserves_body_exception(monkeypatch):
+    _install_fake_langfuse(monkeypatch)
+
+    with pytest.raises(ValueError, match="route failed"):
+        with langfuse_span({"mosaico-root-task-id": "root"}, "ctx"):
+            raise ValueError("route failed")
+
+
+def test_langfuse_span_preserves_body_exception_when_teardown_fails(monkeypatch):
+    _install_fake_langfuse(monkeypatch, teardown_failure=True)
+
+    with pytest.raises(ValueError, match="route failed"):
+        with langfuse_span({"mosaico-root-task-id": "root"}, "ctx"):
+            raise ValueError("route failed")
+
+
+def test_langfuse_span_preserves_cancellation(monkeypatch):
+    _install_fake_langfuse(monkeypatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        with langfuse_span({"mosaico-root-task-id": "root"}, "ctx"):
+            raise asyncio.CancelledError()
+
+
+def test_langfuse_span_does_not_mask_success_when_teardown_fails(monkeypatch):
+    _install_fake_langfuse(monkeypatch, teardown_failure=True)
+
+    with langfuse_span({"mosaico-root-task-id": "root"}, "ctx"):
+        pass


### PR DESCRIPTION
Fixes #2864

## Summary

- Preserve MOSAICO request errors and cancellation when Langfuse span setup/cleanup is involved.
- Prevent a tracing teardown failure from turning a successful A2A request into a failed task.
- Add provider-independent lifecycle regressions for body errors, cancellation, and teardown errors.

## Root cause

`langfuse_span()` placed the request `yield` inside the same broad `try/except Exception` used for Langfuse setup. An exception thrown into the generator body, or raised while an entered Langfuse context exited, was caught as if setup had failed. The fallback branch then yielded a second time, producing `RuntimeError: generator didn't stop after throw()` and masking the original request result.

## Fix

- Enter `propagate_attributes()` and `start_as_current_observation()` with `contextlib.ExitStack` before yielding to request execution.
- Handle body exceptions separately, pass their exception information to the entered context managers, and re-raise the original error or cancellation.
- Treat ordinary teardown failures as observability warnings so they do not alter the wrapped request result.

## Tests

- Baseline provider-independent harness on the unmodified source: `2 failed, 1 passed` for the initial body-error, cancellation, and teardown cases.
- `PYTHONPATH=. /Users/jacob.z/open-source/pr-agent-semantic-audit-20260828/.venv312/bin/python -m pytest -q tests/unittest/test_mosaico_observability_lifecycle.py tests/unittest/test_mosaico_metadata.py tests/unittest/test_mosaico_env_bridge.py` -> `31 passed`.
- `PYTHONPATH=. /Users/jacob.z/open-source/pr-agent-semantic-audit-20260828/.venv312/bin/python -m pytest -q tests/unittest/test_mosaico*.py` -> `165 passed, 1 skipped`.
- `PYTHONPATH=. /Users/jacob.z/open-source/pr-agent-semantic-audit-20260828/.venv312/bin/python -m pytest -q tests/unittest` -> `2581 passed, 1 skipped, 1 xfailed`.
- `/Users/jacob.z/open-source/pr-agent-semantic-audit-20260828/.venv312/bin/flake8 --max-line-length=120 pr_agent/mosaico/observability.py tests/unittest/test_mosaico_observability_lifecycle.py` -> passed.
- `/Users/jacob.z/open-source/pr-agent-semantic-audit-20260828/.venv312/bin/python -m pre_commit run --files pr_agent/mosaico/observability.py tests/unittest/test_mosaico_observability_lifecycle.py` -> passed, including isort and file checks.

## Scope and limits

The patch is limited to `pr_agent/mosaico/observability.py` and its lifecycle regression test. The fake Langfuse module verifies the context-manager contract without network or provider credentials. Real Langfuse exporter teardown frequency, deployment behavior, and external A2A acceptance were not tested.

## Note on cancellation coverage

As raised in review: cancellation already worked on `main`, because `asyncio.CancelledError` is not an `Exception` subclass and was never caught by the previous broad `except Exception` handler. `test_langfuse_span_preserves_cancellation` therefore passes against unmodified `main` and is included as a regression guard for the new `except BaseException` branch, not as part of the bug fix itself. The CodeQL `py/catch-base-exception` alert on `observability.py:97` is a false positive for the same reason (the handler re-raises unless a context manager suppresses, so `KeyboardInterrupt` and `CancelledError` reach the caller unchanged) and will be dismissed.
