### PR TITLE
fix: demote openrouter reasoning_effort warning to info for non-none values

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -936,7 +936,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 )
                             else:
                                 get_logger().info(
-                                    f"Using openrouter.reasoning_max_tokens over config.reasoning_effort='{openrouter_reasoning_effort}'."
+                                    "Using openrouter.reasoning_max_tokens over"
+                                    f" config.reasoning_effort='{openrouter_reasoning_effort}'."
                                 )
                         elif reasoning_max_tokens <= 0:
                             effective_reasoning_effort = openrouter_reasoning_effort or ""

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -929,10 +929,15 @@ class LiteLLMAIHandler(BaseAiHandler):
                             effective_reasoning_effort = ""
                     if not effective_reasoning_effort:
                         if reasoning_max_tokens > 0 and openrouter_reasoning_effort:
-                            get_logger().warning(
-                                f"Ignoring config.reasoning_effort='{openrouter_reasoning_effort}' because "
-                                "openrouter.reasoning_max_tokens takes precedence."
-                            )
+                            if openrouter_reasoning_effort == "none":
+                                get_logger().warning(
+                                    f"Ignoring config.reasoning_effort='{openrouter_reasoning_effort}' because "
+                                    "openrouter.reasoning_max_tokens takes precedence."
+                                )
+                            else:
+                                get_logger().info(
+                                    f"Using openrouter.reasoning_max_tokens over config.reasoning_effort='{openrouter_reasoning_effort}'."
+                                )
                         elif reasoning_max_tokens <= 0:
                             effective_reasoning_effort = openrouter_reasoning_effort or ""
 


### PR DESCRIPTION
## What

When only `reasoning_max_tokens` is set and `config.reasoning_effort` is the default `medium`, a warning fires on every request even though nothing contradictory was configured. Only `none` is a genuine contradiction (disabling reasoning while a token budget re-enables it). Demote the rest to info level.

## Why

The warning `Ignoring config.reasoning_effort='medium' because openrouter.reasoning_max_tokens takes precedence` fires on every request when the user only set a token budget. This is noise — the user didn't explicitly set reasoning_effort to contradict anything.

## How

In `pr_agent/algo/ai_handlers/litellm_ai_handler.py`, split the existing warning branch: keep `warning` level only for `openrouter_reasoning_effort == "none"`, demote everything else to `info`.

## Tests

Existing test `test_reasoning_budget_overrides_global_none` still passes (it asserts a warning for `none`). The 62 other reasoning tests are unaffected.

Resolves #2851