### PR TITLE
fix(suggestions): align fallback chunks after conversion failure

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -796,7 +796,7 @@ class PRCodeSuggestions:
 
         return data
 
-    async def push_inline_code_suggestions(self, data, include_coverage_footer: bool = True):
+    async def push_inline_code_suggestions(self, data, include_coverage_footer: bool = True) -> None:
         code_suggestions = []
         fallback_comments = []
         coverage_footer = self._get_suggestions_coverage_footer() if include_coverage_footer else ""
@@ -810,10 +810,10 @@ class PRCodeSuggestions:
                                       if empty_coverage_footer else "No suggestions found to improve this PR.")
             pr_body = no_suggestions_message + empty_coverage_footer
             if self.progress_response:
-                return self.git_provider.edit_comment(self.progress_response,
-                                                      body=pr_body)
+                self.git_provider.edit_comment(self.progress_response, body=pr_body)
             else:
-                return self.git_provider.publish_comment(pr_body)
+                self.git_provider.publish_comment(pr_body)
+            return
 
         for d in data['code_suggestions']:
             try:
@@ -876,6 +876,7 @@ class PRCodeSuggestions:
         if fallback_comments:
             self.git_provider.publish_comment("\n\n---\n\n".join(fallback_comments))
             self._output_published = True
+        return
 
     def _get_diff_file(self, relevant_file):
         diff_files = getattr(self.git_provider, "diff_files", None)
@@ -1212,6 +1213,15 @@ class PRCodeSuggestions:
                                                             model,
                                                             max_calls=get_settings().pr_code_suggestions.max_number_of_calls,
                                                             add_line_numbers=True)  # decouple hunk with line numbers
+                self.patches_diff_list_no_line_numbers = self.remove_line_numbers(self.patches_diff_list)
+
+        if len(self.patches_diff_list or []) != len(self.patches_diff_list_no_line_numbers or []):
+            get_logger().warning(
+                "Numbered and unnumbered PR chunks are misaligned; deriving both views from numbered chunks"
+            )
+            self.patches_diff_list_no_line_numbers = self.remove_line_numbers(self.patches_diff_list)
+            if len(self.patches_diff_list or []) != len(self.patches_diff_list_no_line_numbers or []):
+                raise ValueError("Failed to align numbered and unnumbered PR chunks")
 
         if self.patches_diff_list:
             get_logger().info(f"Number of PR chunk calls: {len(self.patches_diff_list)}")

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -1215,14 +1215,6 @@ class PRCodeSuggestions:
                                                             add_line_numbers=True)  # decouple hunk with line numbers
                 self.patches_diff_list_no_line_numbers = self.remove_line_numbers(self.patches_diff_list)
 
-        if len(self.patches_diff_list or []) != len(self.patches_diff_list_no_line_numbers or []):
-            get_logger().warning(
-                "Numbered and unnumbered PR chunks are misaligned; deriving both views from numbered chunks"
-            )
-            self.patches_diff_list_no_line_numbers = self.remove_line_numbers(self.patches_diff_list)
-            if len(self.patches_diff_list or []) != len(self.patches_diff_list_no_line_numbers or []):
-                raise ValueError("Failed to align numbered and unnumbered PR chunks")
-
         if self.patches_diff_list:
             get_logger().info(f"Number of PR chunk calls: {len(self.patches_diff_list)}")
             get_logger().debug("PR diff:", artifact=self.patches_diff_list)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -273,6 +273,42 @@ async def test_prepare_prediction_main_keeps_outer_fallback_when_all_chunks_fail
     assert tool.total_chunk_count == 2
 
 
+@pytest.mark.asyncio
+async def test_prepare_prediction_main_rebuilds_unnumbered_chunks_after_conversion_fallback():
+    settings = get_settings()
+    original_decouple_hunks = settings.pr_code_suggestions.decouple_hunks
+    original_parallel_calls = settings.pr_code_suggestions.parallel_calls
+    settings.pr_code_suggestions.decouple_hunks = False
+    settings.pr_code_suggestions.parallel_calls = False
+    tool = _make_tool()
+    tool.token_handler = MagicMock()
+    tool.convert_to_decoupled_with_line_numbers = AsyncMock(return_value=[])
+    chunk_pairs = []
+
+    async def fake_get_prediction(model, patches_diff, patches_diff_no_line_numbers):
+        chunk_pairs.append((patches_diff, patches_diff_no_line_numbers))
+        return {"code_suggestions": [_valid_suggestion(relevant_file=f"chunk-{len(chunk_pairs)}.py")]}
+
+    try:
+        with patch.object(pr_code_suggestions_module, "get_pr_multi_diffs", side_effect=[
+            ["stale unnumbered chunk"],
+            ["1 fallback-a", "2 fallback-b"],
+        ]):
+            tool._get_prediction = fake_get_prediction
+
+            data = await tool.prepare_prediction_main("primary-model")
+    finally:
+        settings.pr_code_suggestions.decouple_hunks = original_decouple_hunks
+        settings.pr_code_suggestions.parallel_calls = original_parallel_calls
+
+    assert chunk_pairs == [
+        ("1 fallback-a", "fallback-a"),
+        ("2 fallback-b", "fallback-b"),
+    ]
+    assert tool.total_chunk_count == 2
+    assert len(data["code_suggestions"]) == 2
+
+
 def test_suggestions_coverage_footer_reports_partial_runs_and_respects_flag():
     settings = get_settings()
     snapshot = snapshot_settings(["pr_code_suggestions.enable_suggestions_coverage_footer"])

--- a/tests/unittest/test_pr_code_suggestions_rendering.py
+++ b/tests/unittest/test_pr_code_suggestions_rendering.py
@@ -186,8 +186,9 @@ async def test_push_inline_publishes_no_suggestions_comment_when_empty():
     git_provider = MagicMock()
     tool = _make_tool(git_provider)
 
-    await tool.push_inline_code_suggestions({"code_suggestions": []})
+    result = await tool.push_inline_code_suggestions({"code_suggestions": []})
 
+    assert result is None
     git_provider.publish_comment.assert_called_once_with(
         "No suggestions found to improve this PR."
     )


### PR DESCRIPTION
## Summary
- rebuild unnumbered chunks from the final numbered fallback chunks so their membership and boundaries stay aligned
- make `push_inline_code_suggestions` return `None` explicitly on every path to satisfy CodeQL
- add regression coverage where fallback chunking changes from one chunk to two

## Testing
- `PYTHONPATH=. ./.venv/bin/pytest tests/unittest -q` (`2764 passed, 1 skipped, 1 xfailed`)
- `./.venv/bin/pre-commit run --files pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_rendering.py`

Follow-up to #2863.