### PR TITLE
Fix Azure diff fallback logging

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -664,7 +664,7 @@ class AzureDevopsProvider(GitProvider):
                     new_file_content_str = new_file_content_str.content
                 except Exception as error:
                     get_logger().error(
-                        "Failed to retrieve new file content of {file}",
+                        "Failed to retrieve new file content of {file} at version {version}",
                         file=file,
                         version=str(version),
                         error=error,
@@ -716,7 +716,7 @@ class AzureDevopsProvider(GitProvider):
                         original_file_content_str = base_original.content
                     except Exception as error:
                         get_logger().error(
-                            "Failed to retrieve original file content of {file}",
+                            "Failed to retrieve original file content of {file} at version {version}",
                             file=file,
                             version=str(base_version),
                             error=error,

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -257,7 +257,11 @@ class AzureDevopsProvider(GitProvider):
                     pull_request_id=self.pr_num
                 )
             except Exception as e:
-                get_logger().exception(f"Azure failed to publish code suggestion, error: {e}", suggestion=suggestion)
+                get_logger().exception(
+                    "Azure failed to publish code suggestion, error: {error}",
+                    error=e,
+                    suggestion=suggestion,
+                )
                 if fallback_to_pr_comment:
                     fallback_suggestions.append((suggestion, "could not be published as an inline comment"))
             else:
@@ -660,7 +664,7 @@ class AzureDevopsProvider(GitProvider):
                     new_file_content_str = new_file_content_str.content
                 except Exception as error:
                     get_logger().error(
-                        "Failed to retrieve new file content",
+                        "Failed to retrieve new file content of {file}",
                         file=file,
                         version=str(version),
                         error=error,
@@ -712,7 +716,7 @@ class AzureDevopsProvider(GitProvider):
                         original_file_content_str = base_original.content
                     except Exception as error:
                         get_logger().error(
-                            "Failed to retrieve original file content",
+                            "Failed to retrieve original file content of {file}",
                             file=file,
                             version=str(base_version),
                             error=error,

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -659,13 +659,12 @@ class AzureDevopsProvider(GitProvider):
 
                     new_file_content_str = new_file_content_str.content
                 except Exception as error:
-                    get_logger().error(f"Failed to retrieve new file content of {file} at version {version}", error=error)
-                    # get_logger().error(
-                    #     "Failed to retrieve new file content of %s at version %s. Error: %s",
-                    #     file,
-                    #     version,
-                    #     str(error),
-                    # )
+                    get_logger().error(
+                        "Failed to retrieve new file content",
+                        file=file,
+                        version=str(version),
+                        error=error,
+                    )
                     new_file_content_str = ""
 
                 edit_type = EDIT_TYPE.MODIFIED
@@ -713,7 +712,9 @@ class AzureDevopsProvider(GitProvider):
                         original_file_content_str = base_original.content
                     except Exception as error:
                         get_logger().error(
-                            f"Failed to retrieve original file content of {file} at version {base_version}",
+                            "Failed to retrieve original file content",
+                            file=file,
+                            version=str(base_version),
                             error=error,
                         )
                         original_file_content_str = ""

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -5,6 +5,7 @@ import pytest
 
 from pr_agent.algo.types import FilePatchInfo
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+from pr_agent.log import get_logger
 
 
 class TestAzureDevopsProviderRepoContext:
@@ -154,12 +155,18 @@ class TestAzureDevopsProviderFiles:
             SimpleNamespace(content="old content\n"),
         )
 
-        diff_files = provider.get_diff_files()
+        captured = []
+        sink_id = get_logger().add(lambda message: captured.append(str(message)), format="{message}")
+        try:
+            diff_files = provider.get_diff_files()
+        finally:
+            get_logger().remove(sink_id)
 
         assert len(diff_files) == 1
         assert diff_files[0].filename == "/src/app.py"
         assert diff_files[0].head_file == ""
         assert diff_files[0].base_file == "old content\n"
+        assert any("/src/app.py" in message and "head-sha" in message for message in captured)
 
     def test_get_diff_files_keeps_file_when_original_content_fetch_fails(self):
         provider = self._provider_with_pull_request_diff(
@@ -167,12 +174,18 @@ class TestAzureDevopsProviderFiles:
             Exception("base fetch failed"),
         )
 
-        diff_files = provider.get_diff_files()
+        captured = []
+        sink_id = get_logger().add(lambda message: captured.append(str(message)), format="{message}")
+        try:
+            diff_files = provider.get_diff_files()
+        finally:
+            get_logger().remove(sink_id)
 
         assert len(diff_files) == 1
         assert diff_files[0].filename == "/src/app.py"
         assert diff_files[0].head_file == "new content\n"
         assert diff_files[0].base_file == ""
+        assert any("/src/app.py" in message and "base-sha" in message for message in captured)
 
 
 def _provider_with_diff(*filenames):

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -430,6 +430,22 @@ class TestAzureDevopsProviderSuggestionAnchoring:
 
         assert provider.publish_code_suggestions([_suggestion("/src/Api/Controllers/SomeController.cs")]) is False
 
+    def test_braced_publish_error_does_not_stop_the_batch(self):
+        provider = _provider_with_diff("/src/first.py", "/src/second.py")
+        provider.azure_devops_client.create_thread.side_effect = [
+            RuntimeError("request {'reason': 'failed'}"),
+            MagicMock(),
+            MagicMock(),
+        ]
+
+        result = provider.publish_code_suggestions([
+            _suggestion("/src/first.py"),
+            _suggestion("/src/second.py"),
+        ])
+
+        assert result is True
+        assert provider.azure_devops_client.create_thread.call_count == 3
+
     def test_disabled_fallback_does_not_retry_a_failed_suggestion(self):
         provider = _provider_with_diff("/src/Api/Controllers/SomeController.cs")
         provider.azure_devops_client.create_thread.side_effect = RuntimeError("request failed")

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -119,6 +119,61 @@ class TestAzureDevopsProviderFiles:
 
         assert provider._get_files_full() == ["/src/app.py"]
 
+    @staticmethod
+    def _provider_with_pull_request_diff(*get_item_results):
+        provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+        provider.repo_slug = "my-repo"
+        provider.workspace_slug = "my-project"
+        provider.pr_num = 1
+        provider.pr = SimpleNamespace(
+            last_merge_target_commit=SimpleNamespace(commit_id="base-sha"),
+            last_merge_commit=SimpleNamespace(commit_id="head-sha"),
+        )
+        provider.azure_devops_client = MagicMock()
+        client = provider.azure_devops_client
+        client.get_pull_request_iterations.return_value = [SimpleNamespace(id=1)]
+        client.get_pull_request_iteration_changes.return_value = SimpleNamespace(
+            change_entries=[
+                SimpleNamespace(
+                    additional_properties={
+                        "item": {"path": "/src/app.py"},
+                        "changeType": "edit",
+                    }
+                )
+            ]
+        )
+        client.get_item.side_effect = get_item_results
+        provider.diff_files = None
+        provider.incremental = None
+        provider.unreviewed_files_map = {}
+        return provider
+
+    def test_get_diff_files_keeps_file_when_new_content_fetch_fails(self):
+        provider = self._provider_with_pull_request_diff(
+            Exception("head fetch failed"),
+            SimpleNamespace(content="old content\n"),
+        )
+
+        diff_files = provider.get_diff_files()
+
+        assert len(diff_files) == 1
+        assert diff_files[0].filename == "/src/app.py"
+        assert diff_files[0].head_file == ""
+        assert diff_files[0].base_file == "old content\n"
+
+    def test_get_diff_files_keeps_file_when_original_content_fetch_fails(self):
+        provider = self._provider_with_pull_request_diff(
+            SimpleNamespace(content="new content\n"),
+            Exception("base fetch failed"),
+        )
+
+        diff_files = provider.get_diff_files()
+
+        assert len(diff_files) == 1
+        assert diff_files[0].filename == "/src/app.py"
+        assert diff_files[0].head_file == "new content\n"
+        assert diff_files[0].base_file == ""
+
 
 def _provider_with_diff(*filenames):
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)


### PR DESCRIPTION
## Summary

- keep Azure DevOps head/base content-fetch filenames and versions visible in CONSOLE logs while retaining file, version, and error as structured fields
- preserve the existing per-file empty-content fallback instead of returning an empty diff for the whole PR
- parameterize the inline code-suggestion error path so brace-containing service errors cannot abort the remaining suggestion batch
- cover both content-fetch failures, rendered console context, and the braced suggestion-error continuation path with provider-level regressions

Fixes #2868.

## Validation

- `PYTHONPATH=. python -m pytest tests/unittest/test_azure_devops_provider.py -q` — 57 passed
- focused review regressions — 3 passed; the braced-error test and both rendered-log assertions failed before their respective fixes and pass afterward
- `PYTHONPATH=. python -m pytest tests/unittest -q` — 2,589 passed, 6 failed, 1 skipped, 1 xfailed on Windows; all six failures are within the seven previously recorded baseline-limited cases, with one previously flaky timing test passing on this final run
- `python -m compileall -q pr_agent tests` — passed (two existing invalid-escape SyntaxWarnings)
- `python -m flake8 ... --select E9,F63,F7,F82` and `git diff --check` — passed
- full-file Flake8/pre-commit remain baseline-limited by existing provider lint, import-order, and trailing-whitespace debt; no unrelated auto-edit is included

## Provenance

This pull request was prepared and submitted autonomously by OpenAI Codex through @LunaMeerkats. No human review or authorship is claimed.