### PR TITLE
feat(models): support Grok 4.5/4.6 on xAI and OpenRouter

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -184,14 +184,20 @@ To use xAI's models with PR-Agent, set:
 
 ```toml
 [config] # in configuration.toml
-model = "xai/grok-2-latest"
-fallback_models = ["xai/grok-2-latest"] # or any other model as fallback
+model = "xai/grok-4.6"
+fallback_models = ["xai/grok-4.6"] # or any other model as fallback
 
 [xai] # in .secrets.toml
 key = "..." # your xAI API key
 ```
 
 You can obtain an xAI API key from [xAI's console](https://console.x.ai/) by creating an account and navigating to the developer settings page.
+
+Grok 4.5 and Grok 4.6 are registered with a 500K token context window (`xai/grok-4.5`, `xai/grok-4.5-latest`, `xai/grok-build-latest`, `xai/grok-4.6`, `openrouter/x-ai/grok-4.5`, `openrouter/x-ai/grok-4.6`). xAI publishes `grok-4.5-latest` and `grok-build-latest` aliases for Grok 4.5; Grok 4.6 currently has no published alias.
+
+Grok 4.5 and Grok 4.6 are always-on reasoning models and honor `config.reasoning_effort` (`low`, `medium`, `high`; `"xhigh"` is supported on Grok 4.6 and later). PR-Agent sends `medium` by default; set `"high"` to restore xAI's native default. This setting is global, so changing it also affects other registered reasoning models. Unsupported values are clamped to the closest accepted level (`none`/`minimal` → `"low"`; `"max"`/`"xhigh"` on Grok 4.5 → `"high"`; `"max"` on Grok 4.6 → `"xhigh"`).
+
+OpenRouter routes (`openrouter/x-ai/grok-4.5`, `openrouter/x-ai/grok-4.6`) apply the same clamping after the OpenRouter effort value is resolved but before the none-versus-budget decision. An explicit `openrouter.reasoning_effort` overrides the global effort; a positive `openrouter.reasoning_max_tokens` remains budget-only and suppresses effort, including a clamped `"none"` value. Routing suffixes such as `:nitro` require `custom_model_max_tokens` because token lookup currently uses exact model IDs.
 
 ### Vertex AI
 
@@ -528,11 +534,11 @@ For `openrouter/...` models you can optionally restrict which upstream providers
 # provider_order = ["z-ai", "novita"]  # preferred order instead of an allowlist; ignored when provider_only is set
 # allow_fallbacks = true               # when provider_order is set, allow routing beyond the list
 # reasoning_effort = "low"             # override global effort: "none", "minimal", "low", "medium", "high", "xhigh" or "max"
-# reasoning_max_tokens = 2048          # explicit budget; takes precedence over effort unless effort is "none"
+# reasoning_max_tokens = 2048          # explicit budget; ignored only when final effort remains "none"
 # max_tokens = 16000                   # hard cap on completion tokens for the request
 ```
 
-`provider_only` and `reasoning_effort = "none"` are useful to pin a specific provider and to bound the cost of reasoning models. Because Openrouter treats effort and token budgets as mutually exclusive, an explicit Openrouter-specific `"none"` keeps reasoning disabled; otherwise a positive `reasoning_max_tokens` value takes precedence over the global effort and other Openrouter-specific values. Invalid Openrouter-specific effort values are warned about and treated as unset, so registered reasoning models fall back to `config.reasoning_effort`. Openrouter normalizes `"max"` to `"xhigh"` in this path to match LiteLLM 1.98.0. Supported effort values vary by model, and models whose metadata marks reasoning as mandatory reject `"none"`. For Anthropic models using a reasoning budget, set the effective output `max_tokens` higher than `reasoning_max_tokens` so the final answer has output headroom. See the Openrouter [provider routing](https://openrouter.ai/docs/guides/routing/provider-selection) and [reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens) docs.
+`provider_only` and `reasoning_effort = "none"` are useful to pin a specific provider and to bound the cost of reasoning models. Because Openrouter treats effort and token budgets as mutually exclusive, an explicit Openrouter-specific `"none"` keeps reasoning disabled when the model supports disabling it. Grok 4.5/4.6 clamp `"none"` before precedence is applied, so a positive budget wins there; otherwise a positive `reasoning_max_tokens` value takes precedence over the global effort and other Openrouter-specific values. Invalid Openrouter-specific effort values are warned about and treated as unset, so registered reasoning models fall back to `config.reasoning_effort`. Openrouter normalizes `"max"` to `"xhigh"` in this path to match LiteLLM 1.98.0. Supported effort values vary by model, and models whose metadata marks reasoning as mandatory reject `"none"`. For Anthropic models using a reasoning budget, set the effective output `max_tokens` higher than `reasoning_max_tokens` so the final answer has output headroom. See the Openrouter [provider routing](https://openrouter.ai/docs/guides/routing/provider-selection) and [reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens) docs.
 
 ### OrcaRouter
 

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -295,6 +295,12 @@ MAX_TOKENS = {
     'xai/grok-3-mini-beta': 131072,
     'xai/grok-3-mini-fast': 131072,
     'xai/grok-3-mini-fast-beta': 131072,
+    "xai/grok-4.5": 500000,  # 500K context, but may be limited by config.max_model_tokens
+    "xai/grok-4.5-latest": 500000,
+    "xai/grok-build-latest": 500000,
+    "xai/grok-4.6": 500000,  # 500K context, but may be limited by config.max_model_tokens
+    "openrouter/x-ai/grok-4.5": 500000,
+    "openrouter/x-ai/grok-4.6": 500000,
     'ollama/llama3': 4096,
     'watsonx/meta-llama/llama-3-8b-instruct': 4096,
     "watsonx/meta-llama/llama-3-70b-instruct": 4096,
@@ -401,7 +407,21 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     # LiteLLMAIHandler routes OpenRouter-prefixed forms through extra_body.reasoning.
     "gemini-2.5-pro",
     "gemini-2.5-flash",
+    # Register each published Grok id separately so provider-prefixed forms match
+    # and the allowlist below can clamp model-specific reasoning levels.
+    "grok-4.5",
+    "grok-4.5-latest",
+    "grok-build-latest",
+    "grok-4.6",
 ]
+
+# Clamp OpenAI-only levels for always-on Grok reasoning; allow xhigh on 4.6+.
+GROK_REASONING_EFFORT_LEVELS = {
+    "grok-4.5": {"low", "medium", "high"},
+    "grok-4.5-latest": {"low", "medium", "high"},
+    "grok-build-latest": {"low", "medium", "high"},
+    "grok-4.6": {"low", "medium", "high", "xhigh"},
+}
 
 # Claude models that support "extended thinking" through the manual
 # thinking={"type": "enabled", "budget_tokens": ...} request built by

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -12,6 +12,7 @@ from tenacity import retry, retry_if_exception_type, retry_if_not_exception_type
 
 from pr_agent.algo import (
     CLAUDE_EXTENDED_THINKING_MODELS,
+    GROK_REASONING_EFFORT_LEVELS,
     NO_SUPPORT_TEMPERATURE_MODELS,
     STREAMING_REQUIRED_MODELS,
     SUPPORT_REASONING_EFFORT_MODELS,
@@ -449,6 +450,33 @@ class LiteLLMAIHandler(BaseAiHandler):
             )
         )
 
+    @staticmethod
+    def _grok_reasoning_levels_for(model: str) -> set[str] | None:
+        """Return the reasoning-effort levels accepted by a registered Grok model."""
+        normalized_model = model.rsplit(":", 1)[0] if model.startswith("openrouter/") else model
+        return next(
+            (
+                levels
+                for grok_id, levels in GROK_REASONING_EFFORT_LEVELS.items()
+                if normalized_model == grok_id or normalized_model.endswith("/" + grok_id)
+            ),
+            None,
+        )
+
+    @classmethod
+    def _clamp_grok_reasoning_effort(cls, model: str, reasoning_effort: str) -> str:
+        """Clamp a configured reasoning effort to the closest supported Grok level."""
+        grok_levels = cls._grok_reasoning_levels_for(model)
+        if not grok_levels or reasoning_effort in grok_levels:
+            return reasoning_effort
+        try:
+            ReasoningEffort(reasoning_effort)
+        except (ValueError, TypeError):
+            return reasoning_effort
+        if reasoning_effort in ("max", "xhigh"):
+            return "xhigh" if "xhigh" in grok_levels else "high"
+        return "low"
+
     def _configure_claude_extended_thinking(self, model: str, kwargs: dict) -> dict:
         """
         Configure Claude extended thinking parameters if applicable.
@@ -753,6 +781,9 @@ class LiteLLMAIHandler(BaseAiHandler):
                     if 'temperature' in kwargs:
                         del kwargs['temperature']
 
+                custom_llm_provider = str(
+                    getattr(get_settings().litellm, "custom_llm_provider", "") or ""
+                ).strip().lower()
                 openrouter_reasoning_effort = None
                 reasoning_model = model.rsplit(":", 1)[0] if model.startswith("openrouter/") else model
                 # Add reasoning_effort if model supports it. Match the bare model
@@ -777,6 +808,14 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 f"Using default '{reasoning_effort}'. Valid values: {[e.value for e in ReasoningEffort]}"
                             )
 
+                    clamped_effort = self._clamp_grok_reasoning_effort(model, reasoning_effort)
+                    if clamped_effort != reasoning_effort:
+                        get_logger().info(
+                            f"Grok model {model} does not support reasoning_effort='{reasoning_effort}'; "
+                            f"using '{clamped_effort}' instead."
+                        )
+                        reasoning_effort = clamped_effort
+
                     if model.startswith("openrouter/"):
                         # LiteLLM 1.98.0 rejects top-level reasoning_effort for some
                         # OpenRouter model IDs it does not mark as reasoning-capable;
@@ -785,6 +824,18 @@ class LiteLLMAIHandler(BaseAiHandler):
                     else:
                         get_logger().info(f"Adding reasoning_effort with value {reasoning_effort} to model {model}.")
                         kwargs["reasoning_effort"] = reasoning_effort
+                        if self._grok_reasoning_levels_for(model):
+                            try:
+                                supported_params = litellm.get_supported_openai_params(
+                                    model=model,
+                                    custom_llm_provider=custom_llm_provider or None,
+                                ) or []
+                            except Exception:
+                                supported_params = []
+                            # LiteLLM 1.98.0 omits reasoning_effort for grok-build-latest
+                            # and OpenAI-compatible gateway-prefixed Grok IDs.
+                            if "reasoning_effort" not in supported_params:
+                                kwargs["allowed_openai_params"] = ["reasoning_effort"]
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
                 if (model in self.claude_extended_thinking_models) and get_settings().config.get("enable_claude_extended_thinking", False):
@@ -946,6 +997,15 @@ class LiteLLMAIHandler(BaseAiHandler):
                         elif reasoning_max_tokens <= 0:
                             effective_reasoning_effort = openrouter_reasoning_effort or ""
 
+                    if effective_reasoning_effort:
+                        clamped_effort = self._clamp_grok_reasoning_effort(model, effective_reasoning_effort)
+                        if clamped_effort != effective_reasoning_effort:
+                            get_logger().info(
+                                f"Grok model {model} does not support reasoning_effort="
+                                f"'{effective_reasoning_effort}'; using '{clamped_effort}' instead."
+                            )
+                            effective_reasoning_effort = clamped_effort
+
                     # Preserve explicit disablement; otherwise keep effort and
                     # max_tokens mutually exclusive by preferring the token budget.
                     if effective_reasoning_effort == "none":
@@ -1007,9 +1067,6 @@ class LiteLLMAIHandler(BaseAiHandler):
 
                 # Optional fixed provider override, so a raw hosted model id reaches the
                 # provider unchanged instead of being rewritten by LiteLLM's prefix inference.
-                custom_llm_provider = str(
-                    getattr(get_settings().litellm, "custom_llm_provider", "") or ""
-                ).strip().lower()
                 if custom_llm_provider:
                     kwargs["custom_llm_provider"] = custom_llm_provider
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -420,7 +420,9 @@ allow_fallbacks = true # when provider_order is set, allow routing beyond the li
 # Model-specific support varies; mandatory reasoning models reject "none".
 reasoning_effort = ""
 # A positive value overrides global effort and non-none OpenRouter-specific efforts.
-# Explicit openrouter.reasoning_effort = "none" keeps reasoning disabled.
+# Explicit openrouter.reasoning_effort = "none" keeps reasoning disabled, except on
+# Grok 4.5/4.6: there "none" is clamped to the lowest supported
+# effort first, so a positive budget wins over it.
 # Some providers require max_tokens to be greater than the reasoning budget.
 reasoning_max_tokens = 0
 max_tokens = 0 # hard cap on completion tokens for the request; 0 = unset

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -198,6 +198,26 @@ class TestGetMaxTokens:
 
         assert get_max_tokens("bedrock_mantle/xai.grok-4.3") == 1000000
 
+    @pytest.mark.parametrize("model", [
+        "xai/grok-4.5",
+        "xai/grok-4.5-latest",
+        "xai/grok-build-latest",
+        "xai/grok-4.6",
+        "openrouter/x-ai/grok-4.5",
+        "openrouter/x-ai/grok-4.6",
+    ])
+    def test_xai_and_openrouter_grok_4_5_and_4_6_models_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0,
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 500000
+
     @pytest.mark.parametrize(
         "model",
         [

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -1,6 +1,10 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
+import litellm.utils as litellm_utils
 import pytest
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+from litellm.utils import get_optional_params
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
@@ -930,3 +934,244 @@ class TestLiteLLMReasoningEffortGemini:
 
             call_kwargs = mock_completion.call_args[1]
             assert "reasoning_effort" not in call_kwargs
+
+
+class TestLiteLLMReasoningEffortGrok:
+    """Cover Grok-specific reasoning levels without duplicating generic OpenRouter tests."""
+
+    def _isolate_env(self, monkeypatch):
+        for variable in (
+            "AWS_USE_IMDS",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_REGION_NAME",
+            "OPENAI_API_KEY",
+        ):
+            monkeypatch.delenv(variable, raising=False)
+
+    async def _run(self, monkeypatch, model, global_effort="medium", openrouter=None, custom_llm_provider=""):
+        fake_settings = create_mock_settings(global_effort)
+        monkeypatch.setattr(
+            fake_settings.litellm,
+            "custom_llm_provider",
+            custom_llm_provider,
+            raising=False,
+        )
+        if openrouter is not None:
+            monkeypatch.setattr(
+                fake_settings,
+                "get",
+                lambda key, default=None: {"openrouter": openrouter}.get(key, default),
+            )
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        self._isolate_env(monkeypatch)
+
+        with patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_completion:
+            mock_completion.return_value = create_mock_acompletion_response()
+            handler = LiteLLMAIHandler()
+            await handler.chat_completion(model=model, system="test system", user="test user")
+            return mock_completion.call_args[1]
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("grok-4.5", {"low", "medium", "high"}),
+            ("xai/grok-4.5-latest", {"low", "medium", "high"}),
+            ("xai/grok-build-latest", {"low", "medium", "high"}),
+            ("xai/grok-4.6", {"low", "medium", "high", "xhigh"}),
+            ("openrouter/x-ai/grok-4.6:nitro", {"low", "medium", "high", "xhigh"}),
+            ("xai/grok-3-mini", None),
+        ],
+    )
+    def test_grok_reasoning_levels_for(self, model, expected):
+        assert LiteLLMAIHandler._grok_reasoning_levels_for(model) == expected
+
+    @pytest.mark.parametrize(
+        ("model", "configured", "expected"),
+        [
+            ("xai/grok-4.6", "none", "low"),
+            ("xai/grok-4.6", "minimal", "low"),
+            ("xai/grok-4.6", "max", "xhigh"),
+            ("xai/grok-4.6", "xhigh", "xhigh"),
+            ("xai/grok-4.5", "none", "low"),
+            ("xai/grok-4.5", "max", "high"),
+            ("xai/grok-4.5", "xhigh", "high"),
+            ("xai/grok-4.5", "extreme", "extreme"),
+            ("openrouter/google/gemini-2.5-pro", "xhigh", "xhigh"),
+        ],
+    )
+    def test_clamp_grok_reasoning_effort(self, model, configured, expected):
+        assert LiteLLMAIHandler._clamp_grok_reasoning_effort(model, configured) == expected
+
+    @pytest.mark.parametrize(
+        ("model", "effort", "requires_allowlist"),
+        [
+            ("grok-4.5", "low", False),
+            ("grok-4.5-latest", "low", False),
+            ("grok-build-latest", "low", True),
+            ("grok-4.6", "xhigh", False),
+        ],
+    )
+    def test_xai_grok_litellm_reasoning_param_support(self, monkeypatch, model, effort, requires_allowlist):
+        """Pin LiteLLM 1.98 capability gaps so upgrades expose removable workarounds."""
+        monkeypatch.setattr(litellm, "drop_params", False)
+        bundled_model_cost = GetModelCostMap.load_local_model_cost_map()
+        pinned_model_cost = dict(litellm.model_cost)
+        for model_key in (model, f"xai/{model}"):
+            if model_key in bundled_model_cost:
+                pinned_model_cost[model_key] = bundled_model_cost[model_key]
+            else:
+                pinned_model_cost.pop(model_key, None)
+        try:
+            with monkeypatch.context() as registry_patch:
+                registry_patch.setattr(litellm, "model_cost", pinned_model_cost)
+                litellm_utils._invalidate_model_cost_lowercase_map()
+                if requires_allowlist:
+                    with pytest.raises(litellm.UnsupportedParamsError):
+                        get_optional_params(
+                            model=model,
+                            custom_llm_provider="xai",
+                            reasoning_effort=effort,
+                        )
+
+                allowed = ["reasoning_effort"] if requires_allowlist else None
+                params = get_optional_params(
+                    model=model,
+                    custom_llm_provider="xai",
+                    reasoning_effort=effort,
+                    allowed_openai_params=allowed,
+                )
+                assert params["reasoning_effort"] == effort
+        finally:
+            litellm_utils._invalidate_model_cost_lowercase_map()
+
+    def test_openai_gateway_grok_litellm_reasoning_param_support(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        with pytest.raises(litellm.UnsupportedParamsError):
+            get_optional_params(
+                model="x-ai/grok-4.6",
+                custom_llm_provider="openai",
+                reasoning_effort="xhigh",
+            )
+
+        params = get_optional_params(
+            model="x-ai/grok-4.6",
+            custom_llm_provider="openai",
+            reasoning_effort="xhigh",
+            allowed_openai_params=["reasoning_effort"],
+        )
+        assert params["reasoning_effort"] == "xhigh"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "xai/grok-4.5",
+            "xai/grok-4.5-latest",
+            "xai/grok-build-latest",
+            "xai/grok-4.6",
+        ],
+    )
+    async def test_xai_grok_forwards_reasoning_effort(self, monkeypatch, mock_logger, model):
+        monkeypatch.setattr(
+            litellm,
+            "get_supported_openai_params",
+            lambda **kwargs: [] if kwargs["model"].endswith("grok-build-latest") else ["reasoning_effort"],
+        )
+        call_kwargs = await self._run(monkeypatch, model, global_effort="low")
+
+        assert call_kwargs["model"] == model
+        assert call_kwargs["reasoning_effort"] == "low"
+        if model.endswith("grok-build-latest"):
+            assert call_kwargs["allowed_openai_params"] == ["reasoning_effort"]
+        else:
+            assert "allowed_openai_params" not in call_kwargs
+        assert "temperature" in call_kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "configured", "expected"),
+        [
+            ("xai/grok-4.5", "xhigh", "high"),
+            ("xai/grok-4.6", "max", "xhigh"),
+        ],
+    )
+    async def test_xai_grok_clamps_reasoning_effort(self, monkeypatch, mock_logger, model, configured, expected):
+        monkeypatch.setattr(litellm, "get_supported_openai_params", lambda **kwargs: ["reasoning_effort"])
+        call_kwargs = await self._run(monkeypatch, model, global_effort=configured)
+
+        assert call_kwargs["reasoning_effort"] == expected
+
+    @pytest.mark.asyncio
+    async def test_openai_gateway_grok_allows_reasoning_effort(self, monkeypatch, mock_logger):
+        monkeypatch.setattr(litellm, "get_supported_openai_params", lambda **kwargs: [])
+        call_kwargs = await self._run(monkeypatch, "openai/x-ai/grok-4.6", global_effort="max")
+
+        assert call_kwargs["reasoning_effort"] == "xhigh"
+        assert call_kwargs["allowed_openai_params"] == ["reasoning_effort"]
+
+    @pytest.mark.asyncio
+    async def test_custom_openai_provider_grok_allows_reasoning_effort(self, monkeypatch, mock_logger):
+        probe = MagicMock(return_value=[])
+        monkeypatch.setattr(litellm, "get_supported_openai_params", probe)
+        call_kwargs = await self._run(
+            monkeypatch,
+            "grok-4.6",
+            global_effort="max",
+            custom_llm_provider="openai",
+        )
+
+        assert call_kwargs["reasoning_effort"] == "xhigh"
+        assert call_kwargs["allowed_openai_params"] == ["reasoning_effort"]
+        assert call_kwargs["custom_llm_provider"] == "openai"
+        probe.assert_called_once_with(model="grok-4.6", custom_llm_provider="openai")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "configured", "expected"),
+        [
+            ("openrouter/x-ai/grok-4.5", "xhigh", "high"),
+            ("openrouter/x-ai/grok-4.6", "xhigh", "xhigh"),
+            ("openrouter/x-ai/grok-4.6:nitro", "max", "xhigh"),
+            ("openrouter/x-ai/grok-4.6", "none", "low"),
+        ],
+    )
+    async def test_openrouter_grok_clamps_final_effort(
+        self, monkeypatch, mock_logger, model, configured, expected
+    ):
+        call_kwargs = await self._run(
+            monkeypatch,
+            model,
+            global_effort="medium",
+            openrouter={"reasoning_effort": configured},
+        )
+
+        assert call_kwargs["model"] == model
+        assert "reasoning_effort" not in call_kwargs
+        assert call_kwargs["extra_body"]["reasoning"] == {"effort": expected}
+
+    @pytest.mark.asyncio
+    async def test_openrouter_grok_budget_overrides_clamped_none(self, monkeypatch, mock_logger):
+        call_kwargs = await self._run(
+            monkeypatch,
+            "openrouter/x-ai/grok-4.6",
+            global_effort="high",
+            openrouter={"reasoning_effort": "none", "reasoning_max_tokens": 8000},
+        )
+
+        assert call_kwargs["extra_body"]["reasoning"] == {"max_tokens": 8000}
+
+    @pytest.mark.asyncio
+    async def test_openrouter_grok_invalid_override_falls_back_to_global(self, monkeypatch, mock_logger):
+        call_kwargs = await self._run(
+            monkeypatch,
+            "openrouter/x-ai/grok-4.6",
+            global_effort="high",
+            openrouter={"reasoning_effort": "extreme"},
+        )
+
+        assert call_kwargs["extra_body"]["reasoning"] == {"effort": "high"}


### PR DESCRIPTION
## Summary

- register published Grok 4.5 and 4.6 model IDs, aliases, and canonical OpenRouter routes with 500K context windows
- clamp always-on Grok reasoning effort to model-specific levels for native xAI and OpenRouter requests
- add a targeted compatibility workaround for the LiteLLM grok-build-latest registry gap
- update the xAI configuration guide with aliases, defaults, global effort impact, and routing limitations

## Behavior changes

- PR-Agent sends its configured reasoning effort, medium by default, to Grok 4.5 and 4.6; high restores the native xAI default but also affects other registered reasoning models
- none and minimal map to low because reasoning cannot be disabled
- max and xhigh map to high on Grok 4.5; Grok 4.6 retains xhigh and maps max to xhigh
- OpenRouter-specific precedence is resolved before the same Grok clamp is applied
- OpenRouter routing suffixes such as :nitro currently require custom_model_max_tokens

## Testing

- focused token, reasoning, OpenRouter, and handler suites: 239 passed
- Python compilation and git diff whitespace checks passed

## References

- https://docs.x.ai/developers/models/grok-4.5
- https://docs.x.ai/developers/models/grok-4.6
- https://docs.x.ai/developers/model-capabilities/text/reasoning
- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens