### PR TITLE
fix(polling): enforce process limit before spawning

### DIFF
--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -161,6 +161,24 @@ async def is_valid_notification(notification, headers, handled_ids, session, use
         return False, handled_ids
 
 
+def _start_queued_processes(task_queue, max_allowed_parallel_tasks):
+    """Start at most max_allowed_parallel_tasks queued jobs and clear the queue.
+
+    Do not join the started processes; let the polling loop move on to the next
+    iteration without waiting for them to complete.
+    """
+    processes = []
+    for i, (func, args) in enumerate(task_queue):
+        if i >= max_allowed_parallel_tasks:
+            get_logger().error(
+                f"Dropping {len(task_queue) - max_allowed_parallel_tasks} tasks from polling session")
+            break
+        process = multiprocessing.Process(target=func, args=args)
+        processes.append(process)
+        process.start()
+    task_queue.clear()
+    return processes
+
 
 async def polling_loop():
     """
@@ -235,20 +253,7 @@ async def polling_loop():
 
                         max_allowed_parallel_tasks = 10
                         if task_queue:
-                            processes = []
-                            for i, (func, args) in enumerate(task_queue):  # Create  parallel tasks
-                                p = multiprocessing.Process(target=func, args=args)
-                                processes.append(p)
-                                p.start()
-                                if i > max_allowed_parallel_tasks:
-                                    get_logger().error(
-                                        f"Dropping {len(task_queue) - max_allowed_parallel_tasks} tasks from polling session")
-                                    break
-                            task_queue.clear()
-
-                            # Don't wait for all processes to complete. Move on to the next iteration
-                            # for p in processes:
-                            #     p.join()
+                            _start_queued_processes(task_queue, max_allowed_parallel_tasks)
 
                     elif response.status != 304:
                         print(f"Failed to fetch notifications. Status code: {response.status}")

--- a/tests/unittest/test_github_polling.py
+++ b/tests/unittest/test_github_polling.py
@@ -1,0 +1,27 @@
+from collections import deque
+
+from pr_agent.servers import github_polling
+
+
+def test_start_queued_processes_respects_parallel_limit(monkeypatch):
+    created_processes = []
+
+    class FakeProcess:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+            self.started = False
+            created_processes.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(github_polling.multiprocessing, "Process", FakeProcess)
+
+    task_queue = deque((lambda: None, ()) for _ in range(12))
+    processes = github_polling._start_queued_processes(task_queue, 10)
+
+    assert len(created_processes) == 10
+    assert len(processes) == 10
+    assert all(process.started for process in processes)
+    assert not task_queue


### PR DESCRIPTION
## Problem

`github_polling.polling_loop()` intends to start at most 10 worker processes per polling batch, but the limit is checked only after `Process.start()` and uses `i > max_allowed_parallel_tasks`. A batch with 12 queued jobs can therefore start all 12 processes.

## Changes

- Check the per-batch limit before constructing or starting the next process.
- Extract the dispatch loop into a focused private helper.
- Preserve the existing behavior of dropping excess jobs and clearing the queue.
- Add a regression test covering 12 queued jobs with a limit of 10.

This intentionally does not introduce cross-iteration process tracking or change the existing overflow policy.

## Validation

- `PYTHONPATH=. pytest tests/unittest/test_github_polling.py -q` — 1 passed
- Flake8 and Ruff passed for the new test.
- `git diff --check` passed.
- Local and private exact-head reviews found no in-scope correctness issue.