### PR TITLE
perf(bitbucket): offload blocking HTTP from async handlers

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -305,6 +305,11 @@ Note that among other limitations, BitBucket provides relatively low rate-limits
 If you experience a lack of responses from PR-Agent, you might want to set: `bitbucket_app.avoid_full_files=true` in your configuration file.
 This will prevent PR-Agent from acquiring the full file content, and will only use the diff content. This will reduce the number of requests made to BitBucket, at the cost of small decrease in accuracy, as dynamic context will not be applicable.
 
+For self-hosted BitBucket App deployments, `bitbucket_app.request_timeout` sets both the connection timeout and
+response-read inactivity timeout, in positive seconds, for offloaded BitBucket HTTP requests. It defaults to `30` and
+is read from host-level configuration or the `BITBUCKET_APP__REQUEST_TIMEOUT` environment variable; repository
+`.pr_agent.toml` overrides do not apply to this host resource limit.
+
 #### BitBucket Self-Hosted App automatic tools
 
 To control which commands will run automatically when a new PR is opened, you can set the `pr_commands` parameter in the configuration file:

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -1,7 +1,9 @@
+import asyncio
 import base64
 import copy
 import hashlib
 import json
+import math
 import os
 import re
 import time
@@ -34,6 +36,20 @@ validate_secret_provider_setting()
 _secret_provider_state = {}
 
 
+def _get_request_timeout():
+    """Return the host-controlled timeout for offloaded Bitbucket App requests."""
+    timeout = global_settings.get("bitbucket_app.request_timeout")
+    if isinstance(timeout, bool):
+        raise ValueError("bitbucket_app.request_timeout must be a positive finite number")
+    try:
+        timeout = float(timeout)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError("bitbucket_app.request_timeout must be a positive finite number") from None
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("bitbucket_app.request_timeout must be a positive finite number")
+    return timeout
+
+
 def get_fork_safe_secret_provider():
     """Return this process's secret provider, building it on first use after a fork."""
     pid = os.getpid()
@@ -64,7 +80,14 @@ async def get_bearer_token(shared_secret: str, client_key: str):
             'Authorization': f'JWT {token}',
             'Content-Type': 'application/x-www-form-urlencoded'
         }
-        response = requests.request("POST", url, headers=headers, data=payload)
+        response = await asyncio.to_thread(
+            requests.request,
+            "POST",
+            url,
+            headers=headers,
+            data=payload,
+            timeout=_get_request_timeout(),
+        )
         bearer_token = response.json()["access_token"]
         return bearer_token
     except Exception as e:
@@ -114,7 +137,12 @@ async def _validate_time_from_last_commit_to_pr_update(data: dict) -> bool:
             'Authorization': f'Bearer {bearer_token}',
             'Accept': 'application/json'
         }
-        response = requests.get(commits_api, headers=headers)
+        response = await asyncio.to_thread(
+            requests.get,
+            commits_api,
+            headers=headers,
+            timeout=_get_request_timeout(),
+        )
         if response.status_code != 200:
             get_logger().warning(f"Bitbucket commits API returned {response.status_code} for {commits_api}")
             return False

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -355,6 +355,7 @@ pr_commands = [
     "/improve --pr_code_suggestions.commitable_code_suggestions=true",
 ]
 avoid_full_files = false
+request_timeout = 30 # positive seconds for connection and response-read inactivity timeouts
 
 [local]
 # LocalGitProvider settings - uncomment to use paths other than default

--- a/tests/unittest/test_bitbucket_app_offload.py
+++ b/tests/unittest/test_bitbucket_app_offload.py
@@ -1,0 +1,200 @@
+from types import SimpleNamespace
+
+import pytest
+
+from pr_agent.servers import bitbucket_app
+
+
+def _host_settings(request_timeout=30):
+    return SimpleNamespace(get=lambda *args: request_timeout)
+
+
+@pytest.mark.parametrize("request_timeout", [None, "", False, True, 0, -1, 10**400, float("inf"), float("nan")])
+def test_request_timeout_rejects_invalid_values(monkeypatch, request_timeout):
+    monkeypatch.setattr(bitbucket_app, "global_settings", _host_settings(request_timeout))
+
+    with pytest.raises(ValueError, match="must be a positive finite number"):
+        bitbucket_app._get_request_timeout()
+
+
+def test_request_timeout_accepts_positive_numeric_strings(monkeypatch):
+    monkeypatch.setattr(bitbucket_app, "global_settings", _host_settings("60"))
+
+    assert bitbucket_app._get_request_timeout() == 60
+
+
+def test_request_timeout_default_is_wired_to_configuration_toml():
+    """Pin the real key name and shipped default without mocking settings."""
+    from pr_agent.config_loader import global_settings
+
+    assert global_settings.get("bitbucket_app.request_timeout") == 30
+    assert bitbucket_app._get_request_timeout() == 30.0
+
+
+def test_request_timeout_ignores_request_scoped_settings(monkeypatch):
+    monkeypatch.setattr(bitbucket_app, "global_settings", _host_settings(30))
+    monkeypatch.setattr(bitbucket_app, "get_settings", lambda: _host_settings(900))
+
+    assert bitbucket_app._get_request_timeout() == 30
+
+
+@pytest.mark.asyncio
+async def test_get_bearer_token_offloads_blocking_request(monkeypatch):
+    response = SimpleNamespace(json=lambda: {"access_token": "access-token"})
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return response
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("Blocking request was called directly")
+
+    settings = SimpleNamespace(bitbucket=SimpleNamespace(app_key="app-key"))
+    monkeypatch.setattr(bitbucket_app, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        bitbucket_app,
+        "global_settings",
+        _host_settings(),
+    )
+    monkeypatch.setattr(bitbucket_app.jwt, "encode", lambda *args, **kwargs: "jwt-token")
+    monkeypatch.setattr(bitbucket_app.requests, "request", fail_if_called)
+    monkeypatch.setattr(bitbucket_app.asyncio, "to_thread", fake_to_thread)
+
+    token = await bitbucket_app.get_bearer_token("shared-secret", "client-key")
+
+    assert token == "access-token"
+    assert len(calls) == 1
+    func, args, kwargs = calls[0]
+    assert func is bitbucket_app.requests.request
+    assert args == ("POST", "https://bitbucket.org/site/oauth2/access_token")
+    assert kwargs["data"] == "grant_type=urn%3Abitbucket%3Aoauth2%3Ajwt"
+    assert kwargs["headers"]["Authorization"] == "JWT jwt-token"
+    assert kwargs["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_get_bearer_token_propagates_request_timeout(monkeypatch):
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        raise bitbucket_app.requests.exceptions.Timeout
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("Blocking request was called directly")
+
+    settings = SimpleNamespace(bitbucket=SimpleNamespace(app_key="app-key"))
+    monkeypatch.setattr(bitbucket_app, "get_settings", lambda: settings)
+    monkeypatch.setattr(bitbucket_app, "global_settings", _host_settings())
+    monkeypatch.setattr(bitbucket_app.jwt, "encode", lambda *args, **kwargs: "jwt-token")
+    monkeypatch.setattr(bitbucket_app.requests, "request", fail_if_called)
+    monkeypatch.setattr(bitbucket_app.asyncio, "to_thread", fake_to_thread)
+
+    with pytest.raises(bitbucket_app.requests.exceptions.Timeout):
+        await bitbucket_app.get_bearer_token("shared-secret", "client-key")
+
+    assert len(calls) == 1
+    func, _, kwargs = calls[0]
+    assert func is bitbucket_app.requests.request
+    assert kwargs["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_push_validation_offloads_blocking_request(monkeypatch):
+    commits_url = "https://api.bitbucket.org/2.0/repositories/acme/repo/pullrequests/1/commits"
+    response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "values": [
+                {
+                    "author": {"user": {"display_name": "alice"}},
+                    "date": "2026-08-27T12:00:00+00:00",
+                }
+            ]
+        },
+    )
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return response
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("Blocking request was called directly")
+
+    monkeypatch.setattr(
+        bitbucket_app,
+        "global_settings",
+        _host_settings(),
+    )
+    monkeypatch.setattr(bitbucket_app.requests, "get", fail_if_called)
+    monkeypatch.setattr(bitbucket_app.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        bitbucket_app,
+        "context",
+        SimpleNamespace(get=lambda key: "bearer-token"),
+    )
+
+    data = {
+        "data": {
+            "actor": {"username": "alice"},
+            "pullrequest": {
+                "links": {"commits": {"href": commits_url}},
+                "updated_on": "2026-08-27T12:00:10+00:00",
+            },
+        }
+    }
+
+    assert await bitbucket_app._validate_time_from_last_commit_to_pr_update(data) is True
+    assert len(calls) == 1
+    func, args, kwargs = calls[0]
+    assert func is bitbucket_app.requests.get
+    assert args == (commits_url,)
+    assert kwargs == {
+        "headers": {
+            "Authorization": "Bearer bearer-token",
+            "Accept": "application/json",
+        },
+        "timeout": 30,
+    }
+
+
+@pytest.mark.asyncio
+async def test_push_validation_handles_request_timeout(monkeypatch):
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        raise bitbucket_app.requests.exceptions.Timeout
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("Blocking request was called directly")
+
+    monkeypatch.setattr(
+        bitbucket_app,
+        "global_settings",
+        _host_settings(),
+    )
+    monkeypatch.setattr(bitbucket_app.requests, "get", fail_if_called)
+    monkeypatch.setattr(bitbucket_app.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        bitbucket_app,
+        "context",
+        SimpleNamespace(get=lambda key: "bearer-token"),
+    )
+
+    data = {
+        "data": {
+            "pullrequest": {
+                "links": {"commits": {"href": "https://api.bitbucket.org/commits"}},
+                "updated_on": "2026-08-27T12:00:10+00:00",
+            },
+        }
+    }
+
+    assert await bitbucket_app._validate_time_from_last_commit_to_pr_update(data) is False
+    assert len(calls) == 1
+    func, _, kwargs = calls[0]
+    assert func is bitbucket_app.requests.get
+    assert kwargs["timeout"] == 30


### PR DESCRIPTION
## Problem

Two Bitbucket App code paths are declared `async` but perform synchronous `requests` calls directly on the event-loop thread:

- `get_bearer_token()` calls `requests.request()` while exchanging the JWT for an OAuth access token.
- `_validate_time_from_last_commit_to_pr_update()` calls `requests.get()` while fetching the latest commits for push validation.

When Bitbucket is slow, these calls block the FastAPI event loop for the duration of the network request and can delay unrelated webhook work handled by the same worker. Moving an unbounded request to the shared executor would also allow a stalled endpoint to occupy a worker thread indefinitely.

## Changes

- Offload both blocking requests with `asyncio.to_thread()` while preserving method, URL, headers, payload, response handling, and exception behavior.
- Add `bitbucket_app.request_timeout`, defaulting to 30 seconds and requiring a positive finite host value.
- Keep the timeout in host-level settings so repository `.pr_agent.toml` cannot extend shared executor occupancy.
- Document the connection and response-read inactivity timeout semantics.
- Add focused tests for delegation, direct-call regression protection, timeout propagation, invalid values, host-versus-request-scoped settings, and timeout failure handling.

This intentionally does not introduce a new HTTP client/session, change retry policy, or modify other Bitbucket provider requests.

## Validation

- `PYTHONPATH=. pytest tests/unittest/test_bitbucket_app.py tests/unittest/test_bitbucket_fork_safe_secret_provider.py tests/unittest/test_bitbucket_provider.py -q` — 54 passed
- Flake8 and Ruff passed for the changed test file.
- TOML parsing and `git diff --check` passed.
- Local and private exact-head reviews found no in-scope correctness issue.