### PR TITLE
Fix: log dropped inline comments

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -11,27 +11,35 @@ from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from github.Issue import Issue
 from github import AppAuthentication, Auth, Github, GithubException
+from github.Issue import Issue
 from retry.api import retry_call
 from starlette_context import context
 
 from ..algo.file_filter import filter_ignored
 from ..algo.git_patch_processing import extract_hunk_headers
-from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
-                                         code_fingerprint,
-                                         get_inline_comment_store, has_marker)
+from ..algo.inline_comment_dedup import (
+    body_fingerprint,
+    body_with_markers,
+    code_fingerprint,
+    get_inline_comment_store,
+    has_marker,
+)
 from ..algo.language_handler import is_valid_file
 from ..algo.types import EDIT_TYPE
-from ..algo.utils import (Range, clip_tokens, comment_matches_any_identity,
-                          find_line_number_of_relevant_line_in_file,
-                          get_pr_review_comment_identifiers, load_large_diff,
-                          set_file_languages)
+from ..algo.utils import (
+    Range,
+    clip_tokens,
+    comment_matches_any_identity,
+    find_line_number_of_relevant_line_in_file,
+    get_pr_review_comment_identifiers,
+    load_large_diff,
+    set_file_languages,
+)
 from ..config_loader import get_settings
 from ..log import get_logger
 from ..servers.utils import RateLimitExceeded
-from .git_provider import (MAX_FILES_ALLOWED_FULL, FilePatchInfo, GitProvider,
-                           IncrementalPR, get_cached_global_settings)
+from .git_provider import MAX_FILES_ALLOWED_FULL, FilePatchInfo, GitProvider, IncrementalPR, get_cached_global_settings
 
 
 def _next_page_url(headers: dict) -> str:
@@ -53,8 +61,12 @@ class GithubProvider(GitProvider):
         except Exception:
             self.installation_id = None
         self.max_comment_chars = 65000
-        self.base_url = get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/") # "https://api.github.com"
-        self.base_url_html = self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
+        self.base_url = (
+            get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/")
+        )  # "https://api.github.com"
+        self.base_url_html = (
+            self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
+        )
         self.github_client = self._get_github_client()
         self.repo = None
         self.pr_num = None
@@ -65,14 +77,16 @@ class GithubProvider(GitProvider):
         self.git_files = None
         self.incremental = IncrementalPR(False)
         self._check_run_ids: dict = {}
-        if pr_url and 'pull' in pr_url:
+        if pr_url and "pull" in pr_url:
             self.set_pr(pr_url)
             self.pr_commits = list(self.pr.get_commits())
             self.last_commit_id = self.pr_commits[-1]
-            self.pr_url = self.get_pr_url() # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
-        elif pr_url and 'issue' in pr_url: #url is an issue
+            self.pr_url = (
+                self.get_pr_url()
+            )  # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
+        elif pr_url and "issue" in pr_url:  # url is an issue
             self.issue_main = self._get_issue_handle(pr_url)
-        else: #Instantiated the provider without a PR / Issue
+        else:  # Instantiated the provider without a PR / Issue
             self.pr_commits = None
 
     def _get_issue_handle(self, issue_url) -> Optional[Issue]:
@@ -84,13 +98,17 @@ class GithubProvider(GitProvider):
         try:
             repo_obj = self.github_client.get_repo(repo_name)
             if not repo_obj:
-                get_logger().error(f"Given url: {issue_url}, belonging to owner/repo: {repo_name} does "
-                                   f"not have a valid repository: {self.get_git_repo_url(issue_url)}")
+                get_logger().error(
+                    f"Given url: {issue_url}, belonging to owner/repo: {repo_name} does "
+                    f"not have a valid repository: {self.get_git_repo_url(issue_url)}"
+                )
                 return None
             # else: Valid repo handle:
             return repo_obj.get_issue(issue_number)
         except Exception as e:
-            get_logger().exception(f"Failed to get an issue object for issue: {issue_url}, belonging to owner/repo: {repo_name}")
+            get_logger().exception(
+                f"Failed to get an issue object for issue: {issue_url}, belonging to owner/repo: {repo_name}"
+            )
             return None
 
     def get_incremental_commits(self, incremental=IncrementalPR(False)):
@@ -107,15 +125,17 @@ class GithubProvider(GitProvider):
     def _get_owner_and_repo_path(self, given_url: str) -> str:
         try:
             repo_path = None
-            if 'issues' in given_url:
+            if "issues" in given_url:
                 repo_path, _ = self._parse_issue_url(given_url)
-            elif 'pull' in given_url:
+            elif "pull" in given_url:
                 repo_path, _ = self._parse_pr_url(given_url)
-            elif given_url.endswith('.git'):
+            elif given_url.endswith(".git"):
                 parsed_url = urlparse(given_url)
-                repo_path = (parsed_url.path.split('.git')[0])[1:] # /<owner>/<repo>.git -> <owner>/<repo>
+                repo_path = (parsed_url.path.split(".git")[0])[1:]  # /<owner>/<repo>.git -> <owner>/<repo>
             if not repo_path:
-                get_logger().error(f"url is neither an issues url nor a PR url nor a valid git url: {given_url}. Returning empty result.")
+                get_logger().error(
+                    f"url is neither an issues url nor a PR url nor a valid git url: {given_url}. Returning empty result."
+                )
                 return ""
             return repo_path
         except Exception as e:
@@ -123,37 +143,43 @@ class GithubProvider(GitProvider):
             return ""
 
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
-        repo_path = self._get_owner_and_repo_path(issues_or_pr_url) #Return: <OWNER>/<REPO>
+        repo_path = self._get_owner_and_repo_path(issues_or_pr_url)  # Return: <OWNER>/<REPO>
         if not repo_path or repo_path not in issues_or_pr_url:
             get_logger().error(f"Unable to retrieve owner/path from url: {issues_or_pr_url}")
             return ""
-        return f"{self.base_url_html}/{repo_path}.git" #https://github.com / <OWNER>/<REPO>.git
+        return f"{self.base_url_html}/{repo_path}.git"  # https://github.com / <OWNER>/<REPO>.git
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
     # Example: https://github.com/the-pr-agent/pr-agent.git and branch: v0.8 -> prefix: "https://github.com/the-pr-agent/pr-agent/blob/v0.8", suffix: ""
     # In case git url is not provided, provider will use PR context (which includes branch) to determine the prefix and suffix.
-    def get_canonical_url_parts(self, repo_git_url:str, desired_branch:str) -> Tuple[str, str]:
+    def get_canonical_url_parts(self, repo_git_url: str, desired_branch: str) -> Tuple[str, str]:
         owner = None
         repo = None
         scheme_and_netloc = None
 
-        if repo_git_url or self.issue_main: #Either user provided an external git url, which may be different than what this provider was initialized with, or an issue:
+        if (
+            repo_git_url or self.issue_main
+        ):  # Either user provided an external git url, which may be different than what this provider was initialized with, or an issue:
             desired_branch = desired_branch if repo_git_url else self.issue_main.repository.default_branch
             html_url = repo_git_url if repo_git_url else self.issue_main.html_url
             parsed_git_url = urlparse(html_url)
             scheme_and_netloc = parsed_git_url.scheme + "://" + parsed_git_url.netloc
             repo_path = self._get_owner_and_repo_path(html_url)
-            if repo_path.count('/') == 1: #Has to have the form <owner>/<repo>
-                owner, repo = repo_path.split('/')
+            if repo_path.count("/") == 1:  # Has to have the form <owner>/<repo>
+                owner, repo = repo_path.split("/")
             else:
                 get_logger().error(f"Invalid repo_path: {repo_path} from url: {html_url}")
                 return ("", "")
 
-        if (not owner or not repo) and self.repo: #"else" - User did not provide an external git url, or not an issue, use self.repo object
-            owner, repo = self.repo.split('/')
+        if (
+            not owner or not repo
+        ) and self.repo:  # "else" - User did not provide an external git url, or not an issue, use self.repo object
+            owner, repo = self.repo.split("/")
             scheme_and_netloc = self.base_url_html
             desired_branch = self.repo_obj.default_branch
-        if not all([scheme_and_netloc, owner, repo]): #"else": Not invoked from a PR context,but no provided git url for context
+        if not all(
+            [scheme_and_netloc, owner, repo]
+        ):  # "else": Not invoked from a PR context,but no provided git url for context
             get_logger().error(f"Unable to get canonical url parts since missing context (PR or explicit git url)")
             return ("", "")
 
@@ -216,7 +242,7 @@ class GithubProvider(GitProvider):
             git_files = context.get("git_files", None)
             if git_files:
                 return git_files
-            self.git_files = list(self.pr.get_files()) # 'list' to handle pagination
+            self.git_files = list(self.pr.get_files())  # 'list' to handle pagination
             context["git_files"] = self.git_files
             return self.git_files
         except Exception:
@@ -244,8 +270,14 @@ class GithubProvider(GitProvider):
         """
         # the retry settings are read at call time rather than in a decorator, so that importing this module
         # does not require a [github] settings section (issue #2427)
-        return retry_call(self._get_diff_files, exceptions=RateLimitExceeded,
-                          tries=get_settings().get("GITHUB.RATELIMIT_RETRIES", 5), delay=2, backoff=2, jitter=(1, 3))
+        return retry_call(
+            self._get_diff_files,
+            exceptions=RateLimitExceeded,
+            tries=get_settings().get("GITHUB.RATELIMIT_RETRIES", 5),
+            delay=2,
+            backoff=2,
+            jitter=(1, 3),
+        )
 
     def _get_diff_files(self) -> list[FilePatchInfo]:
         try:
@@ -266,9 +298,10 @@ class GithubProvider(GitProvider):
                 try:
                     names_original = [file.filename for file in files_original]
                     names_new = [file.filename for file in files]
-                    get_logger().info(f"Filtered out [ignore] files for pull request:", extra=
-                    {"files": names_original,
-                     "filtered_files": names_new})
+                    get_logger().info(
+                        f"Filtered out [ignore] files for pull request:",
+                        extra={"files": names_original, "filtered_files": names_new},
+                    )
                 except Exception:
                     pass
 
@@ -283,14 +316,13 @@ class GithubProvider(GitProvider):
             repo = self.repo_obj
             pr = self.pr
             try:
-                compare = repo.compare(pr.base.sha, pr.head.sha) # communication with GitHub
+                compare = repo.compare(pr.base.sha, pr.head.sha)  # communication with GitHub
                 merge_base_commit = compare.merge_base_commit
             except Exception as e:
                 get_logger().error(f"Failed to get merge base commit: {e}")
                 merge_base_commit = pr.base
             if merge_base_commit.sha != pr.base.sha:
-                get_logger().info(
-                    f"Using merge base commit {merge_base_commit.sha} instead of base commit ")
+                get_logger().info(f"Using merge base commit {merge_base_commit.sha} instead of base commit ")
 
             counter_valid = 0
             for file in files:
@@ -311,54 +343,65 @@ class GithubProvider(GitProvider):
                     if counter_valid >= MAX_FILES_ALLOWED_FULL and patch and not self.incremental.is_incremental:
                         avoid_load = True
                         if counter_valid == MAX_FILES_ALLOWED_FULL:
-                            get_logger().info(f"Too many files in PR, will avoid loading full content for rest of files")
+                            get_logger().info(
+                                f"Too many files in PR, will avoid loading full content for rest of files"
+                            )
 
                     if avoid_load:
                         new_file_content_str = ""
                     else:
-                        new_file_content_str = self._get_pr_file_content(file, self.pr.head.sha)  # communication with GitHub
+                        new_file_content_str = self._get_pr_file_content(
+                            file, self.pr.head.sha
+                        )  # communication with GitHub
 
                     if self.incremental.is_incremental and self.unreviewed_files_map:
                         original_file_content_str = self._get_pr_file_content(
-                            file, self.incremental.last_seen_commit_sha, path=old_filename)
+                            file, self.incremental.last_seen_commit_sha, path=old_filename
+                        )
                         patch = load_large_diff(file.filename, new_file_content_str, original_file_content_str)
                         self.unreviewed_files_map[file.filename] = patch
                     else:
                         if avoid_load:
                             original_file_content_str = ""
                         else:
-                            original_file_content_str = self._get_pr_file_content(file, merge_base_commit.sha, path=old_filename)
+                            original_file_content_str = self._get_pr_file_content(
+                                file, merge_base_commit.sha, path=old_filename
+                            )
                             # original_file_content_str = self._get_pr_file_content(file, self.pr.base.sha)
                         if not patch:
                             patch = load_large_diff(file.filename, new_file_content_str, original_file_content_str)
 
-
-                if file.status == 'added':
+                if file.status == "added":
                     edit_type = EDIT_TYPE.ADDED
-                elif file.status == 'removed':
+                elif file.status == "removed":
                     edit_type = EDIT_TYPE.DELETED
-                elif file.status == 'renamed':
+                elif file.status == "renamed":
                     edit_type = EDIT_TYPE.RENAMED
-                elif file.status == 'modified':
+                elif file.status == "modified":
                     edit_type = EDIT_TYPE.MODIFIED
                 else:
                     get_logger().error(f"Unknown edit type: {file.status}")
                     edit_type = EDIT_TYPE.UNKNOWN
 
                 # count number of lines added and removed
-                if hasattr(file, 'additions') and hasattr(file, 'deletions'):
+                if hasattr(file, "additions") and hasattr(file, "deletions"):
                     num_plus_lines = file.additions
                     num_minus_lines = file.deletions
                 else:
                     patch_lines = patch.splitlines(keepends=True)
-                    num_plus_lines = len([line for line in patch_lines if line.startswith('+')])
-                    num_minus_lines = len([line for line in patch_lines if line.startswith('-')])
+                    num_plus_lines = len([line for line in patch_lines if line.startswith("+")])
+                    num_minus_lines = len([line for line in patch_lines if line.startswith("-")])
 
-                file_patch_canonical_structure = FilePatchInfo(original_file_content_str, new_file_content_str, patch,
-                                                               file.filename, edit_type=edit_type,
-                                                               old_filename=old_filename,
-                                                               num_plus_lines=num_plus_lines,
-                                                               num_minus_lines=num_minus_lines,)
+                file_patch_canonical_structure = FilePatchInfo(
+                    original_file_content_str,
+                    new_file_content_str,
+                    patch,
+                    file.filename,
+                    edit_type=edit_type,
+                    old_filename=old_filename,
+                    num_plus_lines=num_plus_lines,
+                    num_minus_lines=num_minus_lines,
+                )
                 diff_files.append(file_patch_canonical_structure)
             if invalid_files_names:
                 get_logger().info(f"Filtered out files with invalid extensions: {invalid_files_names}")
@@ -372,8 +415,7 @@ class GithubProvider(GitProvider):
             return diff_files
 
         except Exception as e:
-            get_logger().error(f"Failing to get diff files: {e}",
-                               artifact={"traceback": traceback.format_exc()})
+            get_logger().error(f"Failing to get diff files: {e}", artifact={"traceback": traceback.format_exc()})
             raise RateLimitExceeded("Rate limit exceeded for GitHub API.") from e
 
     def publish_description(self, pr_title: str, pr_body: str):
@@ -388,13 +430,16 @@ class GithubProvider(GitProvider):
     def get_comment_url(self, comment) -> str:
         return comment.html_url
 
-    def publish_persistent_comment(self, pr_comment: str,
-                                   initial_header: str,
-                                   update_header: bool = True,
-                                   name='review',
-                                   final_update_message=True,
-                                   identity_marker: str | None = None,
-                                   legacy_initial_header: str | None = None):
+    def publish_persistent_comment(
+        self,
+        pr_comment: str,
+        initial_header: str,
+        update_header: bool = True,
+        name="review",
+        final_update_message=True,
+        identity_marker: str | None = None,
+        legacy_initial_header: str | None = None,
+    ):
         if get_settings().github.publish_as_check_run:
             if self._publish_check_run(pr_comment, name):
                 return
@@ -412,7 +457,7 @@ class GithubProvider(GitProvider):
         return True
 
     def _publish_check_run(self, text: str, name: str) -> bool:
-        if not getattr(self, 'last_commit_id', None):
+        if not getattr(self, "last_commit_id", None):
             get_logger().error("Cannot publish check run without a commit SHA")
             return False
         conclusion = "neutral"
@@ -470,7 +515,7 @@ class GithubProvider(GitProvider):
             return False
 
     def _find_existing_check_run(self, check_run_name: str, head_sha: str) -> Optional[int]:
-        pr = getattr(self, 'pr', None)
+        pr = getattr(self, "pr", None)
         if not pr:
             return None
         try:
@@ -503,23 +548,24 @@ class GithubProvider(GitProvider):
         if hasattr(response, "user") and hasattr(response.user, "login"):
             self.github_user_id = response.user.login
         response.is_temporary = is_temporary
-        if not hasattr(self.pr, 'comments_list'):
+        if not hasattr(self.pr, "comments_list"):
             self.pr.comments_list = []
         self.pr.comments_list.append(response)
         return response
 
-    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
+    def publish_inline_comment(
+        self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None
+    ):
         body = self.limit_output_characters(body, self.max_comment_chars)
         self.publish_inline_comments([self.create_inline_comment(body, relevant_file, relevant_line_in_file)])
 
-
-    def create_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str,
-                              absolute_position: int = None):
+    def create_inline_comment(
+        self, body: str, relevant_file: str, relevant_line_in_file: str, absolute_position: int = None
+    ):
         body = self.limit_output_characters(body, self.max_comment_chars)
-        position, absolute_position = find_line_number_of_relevant_line_in_file(self.diff_files,
-                                                                                relevant_file.strip('`'),
-                                                                                relevant_line_in_file,
-                                                                                absolute_position)
+        position, absolute_position = find_line_number_of_relevant_line_in_file(
+            self.diff_files, relevant_file.strip("`"), relevant_line_in_file, absolute_position
+        )
         if position == -1:
             get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
             subject_type = "FILE"
@@ -554,8 +600,11 @@ class GithubProvider(GitProvider):
                 # top-level call drops duplicates. The fallback still gets marked
                 # and recorded below so it dedups on later runs.
                 if not disable_fallback and (
-                        store.seen(body_fp) or store.seen(code_fp)
-                        or body_fp in local_seen or (code_fp and code_fp in local_seen)):
+                    store.seen(body_fp)
+                    or store.seen(code_fp)
+                    or body_fp in local_seen
+                    or (code_fp and code_fp in local_seen)
+                ):
                     skipped += 1
                     continue
                 marked = dict(comment)
@@ -563,8 +612,7 @@ class GithubProvider(GitProvider):
                 if has_marker(body):
                     pass  # already carries a marker from the first pass
                 else:
-                    marked["body"] = body_with_markers(
-                        body, body_fp, code_fp, getattr(self, "max_comment_chars", None))
+                    marked["body"] = body_with_markers(body, body_fp, code_fp, getattr(self, "max_comment_chars", None))
                 deduped.append(marked)
                 local_seen.add(body_fp)
                 if code_fp:
@@ -572,14 +620,13 @@ class GithubProvider(GitProvider):
                 pending_fingerprints.append((body_fp, code_fp))
             if skipped and not any(deduped):
                 get_logger().info(
-                    f"Persistent inline comments: all {skipped} suggestion(s) "
-                    f"already posted; nothing to publish")
+                    f"Persistent inline comments: all {skipped} suggestion(s) already posted; nothing to publish"
+                )
                 return
             comments = deduped
         else:
             comments = [
-                {key: value for key, value in comment.items() if key != dedup_code_fp_key}
-                if comment else comment
+                {key: value for key, value in comment.items() if key != dedup_code_fp_key} if comment else comment
                 for comment in comments
             ]
         try:
@@ -596,10 +643,10 @@ class GithubProvider(GitProvider):
         except Exception as e:
             get_logger().info(f"Initially failed to publish inline comments as committable")
 
-            if (getattr(e, "status", None) == 422 and not disable_fallback):
+            if getattr(e, "status", None) == 422 and not disable_fallback:
                 pass  # continue to try _publish_inline_comments_fallback_with_verification
             else:
-                raise e # will end up with publishing the comments one by one
+                raise e  # will end up with publishing the comments one by one
 
             try:
                 self._publish_inline_comments_fallback_with_verification(comments)
@@ -610,35 +657,38 @@ class GithubProvider(GitProvider):
     def get_review_thread_comments(self, comment_id: int) -> list[dict]:
         """
         Retrieves all comments in the same thread as the given comment.
-        
+
         Args:
             comment_id: Review comment ID
-                
+
         Returns:
             List of comments in the same thread
         """
         try:
             # Fetch all comments with a single API call
             all_comments = list(self.pr.get_comments())
-            
+
             # Find the target comment by ID
             target_comment = next((c for c in all_comments if c.id == comment_id), None)
             if not target_comment:
                 return []
-        
+
             # Get root comment id
             root_comment_id = target_comment.raw_data.get("in_reply_to_id", target_comment.id)
             # Build the thread - include the root comment and all replies to it
             thread_comments = [
-                c for c in all_comments if
-                c.id == root_comment_id or c.raw_data.get("in_reply_to_id") == root_comment_id
+                c
+                for c in all_comments
+                if c.id == root_comment_id or c.raw_data.get("in_reply_to_id") == root_comment_id
             ]
-        
-        
+
             return thread_comments
-                
+
         except Exception as e:
-            get_logger().exception(f"Failed to get review comments for an inline ask command", artifact={"comment_id": comment_id, "error": e})
+            get_logger().exception(
+                f"Failed to get review comments for an inline ask command",
+                artifact={"comment_id": comment_id, "error": e},
+            )
             return []
 
     def supports_thread_resolution(self) -> bool:
@@ -694,12 +744,11 @@ class GithubProvider(GitProvider):
                 response_json = json.loads(response_tuple[2])
                 errors = response_json.get("errors")
                 if errors:
-                    get_logger().error(
-                        f"GraphQL errors querying review threads: {errors}"
-                    )
+                    get_logger().error(f"GraphQL errors querying review threads: {errors}")
                     return False
-                review_threads = (response_json.get("data", {}).get("repository", {})
-                                  .get("pullRequest", {}).get("reviewThreads", {}))
+                review_threads = (
+                    response_json.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewThreads", {})
+                )
                 threads = review_threads.get("nodes", [])
 
                 for thread in threads:
@@ -747,12 +796,12 @@ class GithubProvider(GitProvider):
             if errors:
                 get_logger().error(f"GraphQL errors resolving thread {thread_id}: {errors}")
                 return False
-            is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
-                           .get("thread", {}).get("isResolved", False))
+            is_resolved = (
+                resolve_json.get("data", {}).get("resolveReviewThread", {}).get("thread", {}).get("isResolved", False)
+            )
             if not is_resolved:
                 get_logger().warning(
-                    f"Resolve mutation returned isResolved=false for thread "
-                    f"{thread_id} — possible permission issue"
+                    f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue"
                 )
                 return False
             get_logger().info(f"Resolved review thread {thread_id}")
@@ -783,17 +832,23 @@ class GithubProvider(GitProvider):
                     get_logger().info(f"Published invalid comment as a single line comment: {comment}")
                 except:
                     get_logger().error(f"Failed to publish invalid comment as a single line comment: {comment}")
-            
+
             dropped_count = len(invalid_comments) - len(fixed_comments_as_one_liner)
             if dropped_count > 0:
-                dropped_paths = [
-                    c.get("path") for c, _ in invalid_comments 
-                    if not ("```suggestion" in c.get("body", "") or "start_line" in c or "start_side" in c)
-                ]
-                get_logger().warning(f"Dropped {dropped_count} invalid comments that could not be fixed. Paths: {dropped_paths}")
+                dropped_paths = [c.get("path") for c, _ in invalid_comments]
+                for fixed_c in fixed_comments_as_one_liner:
+                    fixed_path = fixed_c.get("path")
+                    if fixed_path in dropped_paths:
+                        dropped_paths.remove(fixed_path)
+                get_logger().warning(
+                    f"Dropped {dropped_count} invalid comments that could not be fixed. Paths: {dropped_paths}"
+                )
         elif invalid_comments:
             dropped_paths = [c.get("path") for c, _ in invalid_comments]
-            get_logger().warning(f"Dropped {len(invalid_comments)} invalid comments (try_fix_invalid_inline_comments is off). Paths: {dropped_paths}")
+            get_logger().warning(
+                f"Dropped {len(invalid_comments)} invalid comments "
+                f"(try_fix_invalid_inline_comments is off). Paths: {dropped_paths}"
+            )
 
     def _verify_code_comment(self, comment: dict):
         is_verified = False
@@ -801,8 +856,7 @@ class GithubProvider(GitProvider):
         try:
             # event ="" # By leaving this blank, you set the review action state to PENDING
             input = dict(commit_id=self.last_commit_id.sha, comments=[comment])
-            headers, data = self.pr._requester.requestJsonAndCheck(
-                "POST", f"{self.pr.url}/reviews", input=input)
+            headers, data = self.pr._requester.requestJsonAndCheck("POST", f"{self.pr.url}/reviews", input=input)
             pending_review_id = data["id"]
             is_verified = True
         except Exception as err:
@@ -836,6 +890,7 @@ class GithubProvider(GitProvider):
         This is a best-effort attempt to fix invalid comments, and should be verified accordingly.
         """
         import copy
+
         fixed_comments = []
         for comment in invalid_comments:
             try:
@@ -863,24 +918,28 @@ class GithubProvider(GitProvider):
         code_suggestions_with_fingerprints = copy.deepcopy(code_suggestions)
         for suggestion in code_suggestions_with_fingerprints:
             suggestion["_dedup_code_fp"] = code_fingerprint(
-                suggestion.get("relevant_file", ""), None, suggestion.get("body", ""))
+                suggestion.get("relevant_file", ""), None, suggestion.get("body", "")
+            )
         code_suggestions_validated = self.validate_comments_inside_hunks(code_suggestions_with_fingerprints)
 
         for suggestion in code_suggestions_validated:
-            body = suggestion['body']
-            relevant_file = suggestion['relevant_file']
-            relevant_lines_start = suggestion['relevant_lines_start']
-            relevant_lines_end = suggestion['relevant_lines_end']
+            body = suggestion["body"]
+            relevant_file = suggestion["relevant_file"]
+            relevant_lines_start = suggestion["relevant_lines_start"]
+            relevant_lines_end = suggestion["relevant_lines_end"]
 
             if not relevant_lines_start or relevant_lines_start == -1:
                 get_logger().exception(
-                    f"Failed to publish code suggestion, relevant_lines_start is {relevant_lines_start}")
+                    f"Failed to publish code suggestion, relevant_lines_start is {relevant_lines_start}"
+                )
                 continue
 
             if relevant_lines_end < relevant_lines_start:
-                get_logger().exception(f"Failed to publish code suggestion, "
-                                  f"relevant_lines_end is {relevant_lines_end} and "
-                                  f"relevant_lines_start is {relevant_lines_start}")
+                get_logger().exception(
+                    f"Failed to publish code suggestion, "
+                    f"relevant_lines_end is {relevant_lines_end} and "
+                    f"relevant_lines_start is {relevant_lines_start}"
+                )
                 continue
 
             if relevant_lines_end > relevant_lines_start:
@@ -917,8 +976,8 @@ class GithubProvider(GitProvider):
             if hasattr(e, "status") and e.status == 403:
                 # Log as warning for permission-related issues (usually due to polling)
                 get_logger().warning(
-                    "Failed to edit github comment due to permission restrictions",
-                    artifact={"error": e})
+                    "Failed to edit github comment due to permission restrictions", artifact={"error": e}
+                )
             else:
                 get_logger().exception(f"Failed to edit github comment", artifact={"error": e})
 
@@ -927,8 +986,7 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(comment_id).edit(body)
             body = self.limit_output_characters(body, self.max_comment_chars)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "PATCH", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}",
-                input={"body": body}
+                "PATCH", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}", input={"body": body}
             )
         except Exception as e:
             get_logger().exception(f"Failed to edit comment, error: {e}")
@@ -938,8 +996,9 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(comment_id).edit(body)
             body = self.limit_output_characters(body, self.max_comment_chars)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "POST", f"{self.base_url}/repos/{self.repo}/pulls/{self.pr_num}/comments/{comment_id}/replies",
-                input={"body": body}
+                "POST",
+                f"{self.base_url}/repos/{self.repo}/pulls/{self.pr_num}/comments/{comment_id}/replies",
+                input={"body": body},
             )
         except Exception as e:
             get_logger().exception(f"Failed to reply comment, error: {e}")
@@ -950,33 +1009,36 @@ class GithubProvider(GitProvider):
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
                 "GET", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}"
             )
-            return data_patch.get("body","")
+            return data_patch.get("body", "")
         except Exception as e:
             get_logger().exception(f"Failed to edit comment, error: {e}")
             return None
 
     def publish_file_comments(self, file_comments: list) -> bool:
         try:
-            headers, existing_comments = self.pr._requester.requestJsonAndCheck(
-                "GET", f"{self.pr.url}/comments"
-            )
+            headers, existing_comments = self.pr._requester.requestJsonAndCheck("GET", f"{self.pr.url}/comments")
             for comment in file_comments:
-                comment['commit_id'] = self.last_commit_id.sha
-                comment['body'] = self.limit_output_characters(comment['body'], self.max_comment_chars)
+                comment["commit_id"] = self.last_commit_id.sha
+                comment["body"] = self.limit_output_characters(comment["body"], self.max_comment_chars)
 
                 found = False
                 for existing_comment in existing_comments:
-                    comment['commit_id'] = self.last_commit_id.sha
+                    comment["commit_id"] = self.last_commit_id.sha
                     our_app_name = get_settings().get("GITHUB.APP_NAME", "")
                     same_comment_creator = False
-                    if self.deployment_type == 'app':
-                        same_comment_creator = our_app_name.lower() in existing_comment['user']['login'].lower()
-                    elif self.deployment_type == 'user':
-                        same_comment_creator = self.github_user_id == existing_comment['user']['login']
-                    if existing_comment['subject_type'] == 'file' and comment['path'] == existing_comment['path'] and same_comment_creator:
-
+                    if self.deployment_type == "app":
+                        same_comment_creator = our_app_name.lower() in existing_comment["user"]["login"].lower()
+                    elif self.deployment_type == "user":
+                        same_comment_creator = self.github_user_id == existing_comment["user"]["login"]
+                    if (
+                        existing_comment["subject_type"] == "file"
+                        and comment["path"] == existing_comment["path"]
+                        and same_comment_creator
+                    ):
                         headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                            "PATCH", f"{self.base_url}/repos/{self.repo}/pulls/comments/{existing_comment['id']}", input={"body":comment['body']}
+                            "PATCH",
+                            f"{self.base_url}/repos/{self.repo}/pulls/comments/{existing_comment['id']}",
+                            input={"body": comment["body"]},
                         )
                         found = True
                         break
@@ -991,7 +1053,7 @@ class GithubProvider(GitProvider):
 
     def remove_initial_comment(self):
         try:
-            for comment in getattr(self.pr, 'comments_list', []):
+            for comment in getattr(self.pr, "comments_list", []):
                 if comment.is_temporary:
                     self.remove_comment(comment)
         except Exception as e:
@@ -1016,7 +1078,7 @@ class GithubProvider(GitProvider):
     def get_pr_owner_id(self) -> str | None:
         if not self.repo:
             return None
-        return self.repo.split('/')[0]
+        return self.repo.split("/")[0]
 
     def get_pr_description_full(self):
         return self.pr.body
@@ -1024,7 +1086,7 @@ class GithubProvider(GitProvider):
     def get_user_id(self):
         if not self.github_user_id:
             try:
-                self.github_user_id = self.github_client.get_user().raw_data['login']
+                self.github_user_id = self.github_client.get_user().raw_data["login"]
             except Exception as e:
                 self.github_user_id = ""
                 # logging.exception(f"Failed to get user id, error: {e}")
@@ -1033,7 +1095,7 @@ class GithubProvider(GitProvider):
     def get_notifications(self, since: datetime):
         deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
 
-        if deployment_type != 'user':
+        if deployment_type != "user":
             raise ValueError("Deployment mode must be set to 'user' to get notifications")
 
         notifications = self.github_client.get_user().get_notifications(since=since)
@@ -1070,8 +1132,7 @@ class GithubProvider(GitProvider):
                 # fallback that could apply unintended settings.
                 if e.status != 404:
                     raise
-                get_logger().debug(
-                    f"No .pr_agent.toml on branch '{config_branch}', falling back to default branch")
+                get_logger().debug(f"No .pr_agent.toml on branch '{config_branch}', falling back to default branch")
         try:
             # more logical to take 'pr_agent.toml' from the default branch
             contents = self.repo_obj.get_contents(".pr_agent.toml").decoded_content
@@ -1105,8 +1166,8 @@ class GithubProvider(GitProvider):
         # Cache per org: global settings change rarely, so avoid a lookup (and repeated 403/404
         # fallbacks) on every webhook event.
         return get_cached_global_settings(
-            f"github:{getattr(self, 'base_url', '')}:{repo_owner}",
-            lambda: self._fetch_global_repo_settings(repo_owner))
+            f"github:{getattr(self, 'base_url', '')}:{repo_owner}", lambda: self._fetch_global_repo_settings(repo_owner)
+        )
 
     def _fetch_global_repo_settings(self, repo_owner):
         try:
@@ -1118,7 +1179,8 @@ class GithubProvider(GitProvider):
             if e.status in (403, 404):
                 get_logger().debug(
                     "No accessible organization global .pr_agent.toml; using local settings only",
-                    artifact={"status": e.status})
+                    artifact={"status": e.status},
+                )
                 return ""
             # Transient/unexpected errors propagate so the caller does not cache the failure.
             raise
@@ -1149,15 +1211,16 @@ class GithubProvider(GitProvider):
             raise
 
     def get_workspace_name(self):
-        return self.repo.split('/')[0]
+        return self.repo.split("/")[0]
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         if disable_eyes:
             return None
         try:
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "POST", f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions",
-                input={"content": "eyes"}
+                "POST",
+                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions",
+                input={"content": "eyes"},
             )
             return data_patch.get("id", None)
         except Exception as e:
@@ -1169,7 +1232,7 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(issue_comment_id).delete_reaction(reaction_id)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
                 "DELETE",
-                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions/{reaction_id}"
+                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions/{reaction_id}",
             )
             return True
         except Exception as e:
@@ -1179,24 +1242,24 @@ class GithubProvider(GitProvider):
     def _parse_pr_url(self, pr_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(pr_url)
 
-        if parsed_url.path.startswith('/api/v3'):
+        if parsed_url.path.startswith("/api/v3"):
             parsed_url = urlparse(pr_url.replace("/api/v3", ""))
 
-        path_parts = parsed_url.path.strip('/').split('/')
-        if 'api.github.com' in parsed_url.netloc or '/api/v3' in pr_url:
-            if len(path_parts) < 5 or path_parts[3] != 'pulls':
+        path_parts = parsed_url.path.strip("/").split("/")
+        if "api.github.com" in parsed_url.netloc or "/api/v3" in pr_url:
+            if len(path_parts) < 5 or path_parts[3] != "pulls":
                 raise ValueError("The provided URL does not appear to be a GitHub PR URL")
-            repo_name = '/'.join(path_parts[1:3])
+            repo_name = "/".join(path_parts[1:3])
             try:
                 pr_number = int(path_parts[4])
             except ValueError as e:
                 raise ValueError("Unable to convert PR number to integer") from e
             return repo_name, pr_number
 
-        if len(path_parts) < 4 or path_parts[2] != 'pull':
+        if len(path_parts) < 4 or path_parts[2] != "pull":
             raise ValueError("The provided URL does not appear to be a GitHub PR URL")
 
-        repo_name = '/'.join(path_parts[:2])
+        repo_name = "/".join(path_parts[:2])
         try:
             pr_number = int(path_parts[3])
         except ValueError as e:
@@ -1207,24 +1270,24 @@ class GithubProvider(GitProvider):
     def _parse_issue_url(self, issue_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(issue_url)
 
-        if parsed_url.path.startswith('/api/v3'): #Check if came from github app
+        if parsed_url.path.startswith("/api/v3"):  # Check if came from github app
             parsed_url = urlparse(issue_url.replace("/api/v3", ""))
 
-        path_parts = parsed_url.path.strip('/').split('/')
-        if 'api.github.com' in parsed_url.netloc or '/api/v3' in issue_url: #Check if came from github app
-            if len(path_parts) < 5 or path_parts[3] != 'issues':
+        path_parts = parsed_url.path.strip("/").split("/")
+        if "api.github.com" in parsed_url.netloc or "/api/v3" in issue_url:  # Check if came from github app
+            if len(path_parts) < 5 or path_parts[3] != "issues":
                 raise ValueError("The provided URL does not appear to be a GitHub ISSUE URL")
-            repo_name = '/'.join(path_parts[1:3])
+            repo_name = "/".join(path_parts[1:3])
             try:
                 issue_number = int(path_parts[4])
             except ValueError as e:
                 raise ValueError("Unable to convert issue number to integer") from e
             return repo_name, issue_number
 
-        if len(path_parts) < 4 or path_parts[2] != 'issues':
+        if len(path_parts) < 4 or path_parts[2] != "issues":
             raise ValueError("The provided URL does not appear to be a GitHub PR issue")
 
-        repo_name = '/'.join(path_parts[:2])
+        repo_name = "/".join(path_parts[:2])
         try:
             issue_number = int(path_parts[3])
         except ValueError as e:
@@ -1235,7 +1298,7 @@ class GithubProvider(GitProvider):
     def _get_github_client(self):
         self.deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
         self.auth = None
-        if self.deployment_type == 'app':
+        if self.deployment_type == "app":
             try:
                 private_key = get_settings().github.private_key
                 app_id = get_settings().github.app_id
@@ -1243,16 +1306,16 @@ class GithubProvider(GitProvider):
                 raise ValueError("GitHub app ID and private key are required when using GitHub app deployment") from e
             if not self.installation_id:
                 raise ValueError("GitHub app installation ID is required when using GitHub app deployment")
-            auth = AppAuthentication(app_id=app_id, private_key=private_key,
-                                     installation_id=self.installation_id)
+            auth = AppAuthentication(app_id=app_id, private_key=private_key, installation_id=self.installation_id)
             self.auth = auth
-        elif self.deployment_type == 'user':
+        elif self.deployment_type == "user":
             try:
                 token = get_settings().github.user_token
             except AttributeError as e:
                 raise ValueError(
                     "GitHub token is required when using user deployment. See: "
-                    "https://github.com/Codium-ai/pr-agent#method-2-run-from-source") from e
+                    "https://github.com/Codium-ai/pr-agent#method-2-run-from-source"
+                ) from e
             self.auth = Auth.Token(token)
         if self.auth:
             return Github(auth=self.auth, base_url=self.base_url)
@@ -1260,37 +1323,28 @@ class GithubProvider(GitProvider):
             raise ValueError("Could not authenticate to GitHub")
 
     def _get_repo(self):
-        if hasattr(self, 'repo_obj') and \
-                hasattr(self.repo_obj, 'full_name') and \
-                self.repo_obj.full_name == self.repo:
+        if hasattr(self, "repo_obj") and hasattr(self.repo_obj, "full_name") and self.repo_obj.full_name == self.repo:
             return self.repo_obj
         else:
             self.repo_obj = self.github_client.get_repo(self.repo)
             return self.repo_obj
-
 
     def _get_pr(self):
         return self._get_repo().get_pull(self.pr_num)
 
     def get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:
-            file_content_str = str(
-                self._get_repo()
-                .get_contents(file_path, ref=branch)
-                .decoded_content.decode()
-            )
+            file_content_str = str(self._get_repo().get_contents(file_path, ref=branch).decoded_content.decode())
         except Exception:
             file_content_str = ""
         return file_content_str
 
-    def create_or_update_pr_file(
-        self, file_path: str, branch: str, contents="", message=""
-    ) -> None:
+    def create_or_update_pr_file(self, file_path: str, branch: str, contents="", message="") -> None:
         try:
             file_obj = self._get_repo().get_contents(file_path, ref=branch)
-            sha1=file_obj.sha
+            sha1 = file_obj.sha
         except Exception:
-            sha1=""
+            sha1 = ""
         self.repo_obj.update_file(
             path=file_path,
             message=message,
@@ -1304,9 +1358,14 @@ class GithubProvider(GitProvider):
 
     def publish_labels(self, pr_types):
         try:
-            label_color_map = {"Bug fix": "1d76db", "Tests": "e99695", "Bug fix with tests": "c5def5",
-                               "Enhancement": "bfd4f2", "Documentation": "d4c5f9",
-                               "Other": "d1bcf9"}
+            label_color_map = {
+                "Bug fix": "1d76db",
+                "Tests": "e99695",
+                "Bug fix with tests": "c5def5",
+                "Enhancement": "bfd4f2",
+                "Documentation": "d4c5f9",
+                "Other": "d1bcf9",
+            }
             post_parameters = []
             for p in pr_types:
                 color = label_color_map.get(p, "d1bcf9")  # default to "Other" color
@@ -1320,12 +1379,11 @@ class GithubProvider(GitProvider):
     def get_pr_labels(self, update=False):
         try:
             if not update:
-                labels =self.pr.labels
+                labels = self.pr.labels
                 return [label.name for label in labels]
-            else: # obtain the latest labels. Maybe they changed while the AI was running
-                headers, labels = self.pr._requester.requestJsonAndCheck(
-                    "GET", f"{self.pr.issue_url}/labels")
-                return [label['name'] for label in labels]
+            else:  # obtain the latest labels. Maybe they changed while the AI was running
+                headers, labels = self.pr._requester.requestJsonAndCheck("GET", f"{self.pr.issue_url}/labels")
+                return [label["name"] for label in labels]
 
         except Exception as e:
             get_logger().exception(f"Failed to get labels, error: {e}")
@@ -1355,13 +1413,14 @@ class GithubProvider(GitProvider):
 
     def generate_link_to_relevant_line_number(self, suggestion) -> str:
         try:
-            relevant_file = suggestion['relevant_file'].strip('`').strip("'").strip('\n')
-            relevant_line_str = suggestion['relevant_line'].strip('\n')
+            relevant_file = suggestion["relevant_file"].strip("`").strip("'").strip("\n")
+            relevant_line_str = suggestion["relevant_line"].strip("\n")
             if not relevant_line_str:
                 return ""
 
-            position, absolute_position = find_line_number_of_relevant_line_in_file \
-                (self.diff_files, relevant_file, relevant_line_str)
+            position, absolute_position = find_line_number_of_relevant_line_in_file(
+                self.diff_files, relevant_file, relevant_line_str
+            )
 
             if absolute_position != -1:
                 # # link to right file only
@@ -1369,7 +1428,7 @@ class GithubProvider(GitProvider):
                 #        + "#" + f"L{absolute_position}"
 
                 # link to diff
-                sha_file = hashlib.sha256(relevant_file.encode('utf-8')).hexdigest()
+                sha_file = hashlib.sha256(relevant_file.encode("utf-8")).hexdigest()
                 link = f"{self.base_url_html}/{self.repo}/pull/{self.pr_num}/files#diff-{sha_file}R{absolute_position}"
                 return link
         except Exception as e:
@@ -1378,7 +1437,7 @@ class GithubProvider(GitProvider):
         return ""
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
-        sha_file = hashlib.sha256(relevant_file.encode('utf-8')).hexdigest()
+        sha_file = hashlib.sha256(relevant_file.encode("utf-8")).hexdigest()
         if relevant_line_end is not None and relevant_line_start is not None:
             try:
                 if int(relevant_line_end) < int(relevant_line_start):
@@ -1415,8 +1474,7 @@ class GithubProvider(GitProvider):
         line_end = component_range.line_end + 1
         # link = (f"https://github.com/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
         #         f"#L{line_start}-L{line_end}")
-        link = (f"{self.base_url_html}/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
-                f"#L{line_start}-L{line_end}")
+        link = f"{self.base_url_html}/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/#L{line_start}-L{line_end}"
 
         return link
 
@@ -1448,8 +1506,9 @@ class GithubProvider(GitProvider):
                 }}
             }}
             """
-            response_tuple = self.github_client._Github__requester.requestJson("POST", "/graphql",
-                                                                               input={"query": query})
+            response_tuple = self.github_client._Github__requester.requestJson(
+                "POST", "/graphql", input={"query": query}
+            )
 
             # Extract the JSON response from the tuple and parses it
             if isinstance(response_tuple, tuple) and len(response_tuple) == 3:
@@ -1458,10 +1517,7 @@ class GithubProvider(GitProvider):
                 get_logger().error(f"Unexpected response format: {response_tuple}")
                 return sub_issues
 
-
-            issue_id = (((response_json.get("data") or {})
-                        .get("repository") or {})
-                        .get("issue") or {}).get("id")
+            issue_id = (((response_json.get("data") or {}).get("repository") or {}).get("issue") or {}).get("id")
 
             if not issue_id:
                 get_logger().warning(f"Issue ID not found for {issue_url}")
@@ -1481,19 +1537,20 @@ class GithubProvider(GitProvider):
                 }}
             }}
             """
-            sub_issues_response_tuple = self.github_client._Github__requester.requestJson("POST", "/graphql", input={
-                "query": sub_issues_query})
+            sub_issues_response_tuple = self.github_client._Github__requester.requestJson(
+                "POST", "/graphql", input={"query": sub_issues_query}
+            )
 
             # Extract the JSON response from the tuple and parses it
             if isinstance(sub_issues_response_tuple, tuple) and len(sub_issues_response_tuple) == 3:
                 sub_issues_response_json = json.loads(sub_issues_response_tuple[2])
             else:
-                get_logger().error("Unexpected sub-issues response format", artifact={"response": sub_issues_response_tuple})
+                get_logger().error(
+                    "Unexpected sub-issues response format", artifact={"response": sub_issues_response_tuple}
+                )
                 return sub_issues
 
-            sub_issues_data = (((sub_issues_response_json.get("data") or {})
-                                .get("node") or {})
-                                .get("subIssues") or {})
+            sub_issues_data = ((sub_issues_response_json.get("data") or {}).get("node") or {}).get("subIssues") or {}
             if not sub_issues_data:
                 get_logger().error("Invalid sub-issues response structure")
                 return sub_issues
@@ -1523,7 +1580,7 @@ class GithubProvider(GitProvider):
             return False
 
     def calc_pr_statistics(self, pull_request_data: dict):
-            return {}
+        return {}
 
     def validate_comments_inside_hunks(self, code_suggestions):
         """
@@ -1531,45 +1588,43 @@ class GithubProvider(GitProvider):
         """
         code_suggestions_copy = copy.deepcopy(code_suggestions)
         diff_files = self.get_diff_files()
-        RE_HUNK_HEADER = re.compile(
-            r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
+        RE_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
 
         diff_files = set_file_languages(diff_files)
 
         for suggestion in code_suggestions_copy:
             try:
-                relevant_file_path = suggestion['relevant_file']
+                relevant_file_path = suggestion["relevant_file"]
                 for file in diff_files:
                     if file.filename == relevant_file_path:
-
                         # generate on-demand the patches range for the relevant file
                         patch_str = file.patch
-                        if not hasattr(file, 'patches_range'):
+                        if not hasattr(file, "patches_range"):
                             file.patches_range = []
                             patch_lines = patch_str.splitlines()
                             for i, line in enumerate(patch_lines):
-                                if line.startswith('@@'):
+                                if line.startswith("@@"):
                                     match = RE_HUNK_HEADER.match(line)
                                     # identify hunk header
                                     if match:
                                         section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
-                                        file.patches_range.append({'start': start2, 'end': start2 + size2 - 1})
+                                        file.patches_range.append({"start": start2, "end": start2 + size2 - 1})
 
                         patches_range = file.patches_range
-                        comment_start_line = suggestion.get('relevant_lines_start', None)
-                        comment_end_line = suggestion.get('relevant_lines_end', None)
-                        original_suggestion = suggestion.get('original_suggestion', None) # needed for diff code
+                        comment_start_line = suggestion.get("relevant_lines_start", None)
+                        comment_end_line = suggestion.get("relevant_lines_end", None)
+                        original_suggestion = suggestion.get("original_suggestion", None)  # needed for diff code
                         if not comment_start_line or not comment_end_line or not original_suggestion:
                             continue
 
                         # check if the comment is inside a valid hunk
                         is_valid_hunk = False
-                        min_distance = float('inf')
+                        min_distance = float("inf")
                         patch_range_min = None
                         # find the hunk that contains the comment, or the closest one
                         for i, patch_range in enumerate(patches_range):
-                            d1 = comment_start_line - patch_range['start']
-                            d2 = patch_range['end'] - comment_end_line
+                            d1 = comment_start_line - patch_range["start"]
+                            d2 = patch_range["end"] - comment_end_line
                             if d1 >= 0 and d2 >= 0:  # found a valid hunk
                                 is_valid_hunk = True
                                 min_distance = 0
@@ -1583,41 +1638,50 @@ class GithubProvider(GitProvider):
                                     patch_range_min = patch_range
                                     min_distance = min(min_distance, d)
                         if not is_valid_hunk:
-                            if min_distance < 10:  # 10 lines - a reasonable distance to consider the comment inside the hunk
+                            if (
+                                min_distance < 10
+                            ):  # 10 lines - a reasonable distance to consider the comment inside the hunk
                                 # make the suggestion non-committable, yet multi line
-                                suggestion['relevant_lines_start'] = max(suggestion['relevant_lines_start'], patch_range_min['start'])
-                                suggestion['relevant_lines_end'] = min(suggestion['relevant_lines_end'], patch_range_min['end'])
-                                body = suggestion['body'].strip()
+                                suggestion["relevant_lines_start"] = max(
+                                    suggestion["relevant_lines_start"], patch_range_min["start"]
+                                )
+                                suggestion["relevant_lines_end"] = min(
+                                    suggestion["relevant_lines_end"], patch_range_min["end"]
+                                )
+                                body = suggestion["body"].strip()
 
                                 # present new diff code in collapsible
-                                existing_code = original_suggestion['existing_code'].rstrip() + "\n"
-                                improved_code = original_suggestion['improved_code'].rstrip() + "\n"
-                                diff = difflib.unified_diff(existing_code.split('\n'),
-                                                            improved_code.split('\n'), n=999)
+                                existing_code = original_suggestion["existing_code"].rstrip() + "\n"
+                                improved_code = original_suggestion["improved_code"].rstrip() + "\n"
+                                diff = difflib.unified_diff(existing_code.split("\n"), improved_code.split("\n"), n=999)
                                 patch_orig = "\n".join(diff)
-                                patch = "\n".join(patch_orig.splitlines()[5:]).strip('\n')
+                                patch = "\n".join(patch_orig.splitlines()[5:]).strip("\n")
                                 diff_code = f"\n\n<details><summary>New proposed code:</summary>\n\n```diff\n{patch.rstrip()}\n```"
                                 # replace ```suggestion ... ``` with diff_code, using regex:
-                                body = re.sub(r'```suggestion.*?```', diff_code, body, flags=re.DOTALL)
+                                body = re.sub(r"```suggestion.*?```", diff_code, body, flags=re.DOTALL)
                                 body += "\n\n</details>"
-                                suggestion['body'] = body
-                                get_logger().info(f"Comment was moved to a valid hunk, "
-                                                  f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}")
+                                suggestion["body"] = body
+                                get_logger().info(
+                                    f"Comment was moved to a valid hunk, "
+                                    f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}"
+                                )
                             else:
-                                get_logger().error(f"Comment is not inside a valid hunk, "
-                                                   f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}")
+                                get_logger().error(
+                                    f"Comment is not inside a valid hunk, "
+                                    f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}"
+                                )
             except Exception as e:
                 get_logger().error(f"Failed to process patch for committable comment, error: {e}")
         return code_suggestions_copy
 
-    #Clone related
+    # Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
         scheme = "https://"
 
-        #For example, to clone:
-        #https://github.com/Codium-ai/pr-agent-pro.git
-        #Need to embed inside the github token:
-        #https://<token>@github.com/Codium-ai/pr-agent-pro.git
+        # For example, to clone:
+        # https://github.com/Codium-ai/pr-agent-pro.git
+        # Need to embed inside the github token:
+        # https://<token>@github.com/Codium-ai/pr-agent-pro.git
 
         github_token = self.auth.token
         github_base_url = self.base_url_html
@@ -1640,7 +1704,7 @@ class GithubProvider(GitProvider):
             return None
 
         clone_url = scheme
-        if self.deployment_type == 'app':
+        if self.deployment_type == "app":
             clone_url += "git:"
         clone_url += f"{github_token}@{github_com}{repo_full_name}"
         return clone_url

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -11,35 +11,27 @@ from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from github import AppAuthentication, Auth, Github, GithubException
 from github.Issue import Issue
+from github import AppAuthentication, Auth, Github, GithubException
 from retry.api import retry_call
 from starlette_context import context
 
 from ..algo.file_filter import filter_ignored
 from ..algo.git_patch_processing import extract_hunk_headers
-from ..algo.inline_comment_dedup import (
-    body_fingerprint,
-    body_with_markers,
-    code_fingerprint,
-    get_inline_comment_store,
-    has_marker,
-)
+from ..algo.inline_comment_dedup import (body_fingerprint, body_with_markers,
+                                         code_fingerprint,
+                                         get_inline_comment_store, has_marker)
 from ..algo.language_handler import is_valid_file
 from ..algo.types import EDIT_TYPE
-from ..algo.utils import (
-    Range,
-    clip_tokens,
-    comment_matches_any_identity,
-    find_line_number_of_relevant_line_in_file,
-    get_pr_review_comment_identifiers,
-    load_large_diff,
-    set_file_languages,
-)
+from ..algo.utils import (Range, clip_tokens, comment_matches_any_identity,
+                          find_line_number_of_relevant_line_in_file,
+                          get_pr_review_comment_identifiers, load_large_diff,
+                          set_file_languages)
 from ..config_loader import get_settings
 from ..log import get_logger
 from ..servers.utils import RateLimitExceeded
-from .git_provider import MAX_FILES_ALLOWED_FULL, FilePatchInfo, GitProvider, IncrementalPR, get_cached_global_settings
+from .git_provider import (MAX_FILES_ALLOWED_FULL, FilePatchInfo, GitProvider,
+                           IncrementalPR, get_cached_global_settings)
 
 
 def _next_page_url(headers: dict) -> str:
@@ -61,12 +53,8 @@ class GithubProvider(GitProvider):
         except Exception:
             self.installation_id = None
         self.max_comment_chars = 65000
-        self.base_url = (
-            get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/")
-        )  # "https://api.github.com"
-        self.base_url_html = (
-            self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
-        )
+        self.base_url = get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/") # "https://api.github.com"
+        self.base_url_html = self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
         self.github_client = self._get_github_client()
         self.repo = None
         self.pr_num = None
@@ -77,16 +65,14 @@ class GithubProvider(GitProvider):
         self.git_files = None
         self.incremental = IncrementalPR(False)
         self._check_run_ids: dict = {}
-        if pr_url and "pull" in pr_url:
+        if pr_url and 'pull' in pr_url:
             self.set_pr(pr_url)
             self.pr_commits = list(self.pr.get_commits())
             self.last_commit_id = self.pr_commits[-1]
-            self.pr_url = (
-                self.get_pr_url()
-            )  # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
-        elif pr_url and "issue" in pr_url:  # url is an issue
+            self.pr_url = self.get_pr_url() # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
+        elif pr_url and 'issue' in pr_url: #url is an issue
             self.issue_main = self._get_issue_handle(pr_url)
-        else:  # Instantiated the provider without a PR / Issue
+        else: #Instantiated the provider without a PR / Issue
             self.pr_commits = None
 
     def _get_issue_handle(self, issue_url) -> Optional[Issue]:
@@ -98,17 +84,13 @@ class GithubProvider(GitProvider):
         try:
             repo_obj = self.github_client.get_repo(repo_name)
             if not repo_obj:
-                get_logger().error(
-                    f"Given url: {issue_url}, belonging to owner/repo: {repo_name} does "
-                    f"not have a valid repository: {self.get_git_repo_url(issue_url)}"
-                )
+                get_logger().error(f"Given url: {issue_url}, belonging to owner/repo: {repo_name} does "
+                                   f"not have a valid repository: {self.get_git_repo_url(issue_url)}")
                 return None
             # else: Valid repo handle:
             return repo_obj.get_issue(issue_number)
         except Exception as e:
-            get_logger().exception(
-                f"Failed to get an issue object for issue: {issue_url}, belonging to owner/repo: {repo_name}"
-            )
+            get_logger().exception(f"Failed to get an issue object for issue: {issue_url}, belonging to owner/repo: {repo_name}")
             return None
 
     def get_incremental_commits(self, incremental=IncrementalPR(False)):
@@ -125,17 +107,15 @@ class GithubProvider(GitProvider):
     def _get_owner_and_repo_path(self, given_url: str) -> str:
         try:
             repo_path = None
-            if "issues" in given_url:
+            if 'issues' in given_url:
                 repo_path, _ = self._parse_issue_url(given_url)
-            elif "pull" in given_url:
+            elif 'pull' in given_url:
                 repo_path, _ = self._parse_pr_url(given_url)
-            elif given_url.endswith(".git"):
+            elif given_url.endswith('.git'):
                 parsed_url = urlparse(given_url)
-                repo_path = (parsed_url.path.split(".git")[0])[1:]  # /<owner>/<repo>.git -> <owner>/<repo>
+                repo_path = (parsed_url.path.split('.git')[0])[1:] # /<owner>/<repo>.git -> <owner>/<repo>
             if not repo_path:
-                get_logger().error(
-                    f"url is neither an issues url nor a PR url nor a valid git url: {given_url}. Returning empty result."
-                )
+                get_logger().error(f"url is neither an issues url nor a PR url nor a valid git url: {given_url}. Returning empty result.")
                 return ""
             return repo_path
         except Exception as e:
@@ -143,43 +123,37 @@ class GithubProvider(GitProvider):
             return ""
 
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
-        repo_path = self._get_owner_and_repo_path(issues_or_pr_url)  # Return: <OWNER>/<REPO>
+        repo_path = self._get_owner_and_repo_path(issues_or_pr_url) #Return: <OWNER>/<REPO>
         if not repo_path or repo_path not in issues_or_pr_url:
             get_logger().error(f"Unable to retrieve owner/path from url: {issues_or_pr_url}")
             return ""
-        return f"{self.base_url_html}/{repo_path}.git"  # https://github.com / <OWNER>/<REPO>.git
+        return f"{self.base_url_html}/{repo_path}.git" #https://github.com / <OWNER>/<REPO>.git
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
     # Example: https://github.com/the-pr-agent/pr-agent.git and branch: v0.8 -> prefix: "https://github.com/the-pr-agent/pr-agent/blob/v0.8", suffix: ""
     # In case git url is not provided, provider will use PR context (which includes branch) to determine the prefix and suffix.
-    def get_canonical_url_parts(self, repo_git_url: str, desired_branch: str) -> Tuple[str, str]:
+    def get_canonical_url_parts(self, repo_git_url:str, desired_branch:str) -> Tuple[str, str]:
         owner = None
         repo = None
         scheme_and_netloc = None
 
-        if (
-            repo_git_url or self.issue_main
-        ):  # Either user provided an external git url, which may be different than what this provider was initialized with, or an issue:
+        if repo_git_url or self.issue_main: #Either user provided an external git url, which may be different than what this provider was initialized with, or an issue:
             desired_branch = desired_branch if repo_git_url else self.issue_main.repository.default_branch
             html_url = repo_git_url if repo_git_url else self.issue_main.html_url
             parsed_git_url = urlparse(html_url)
             scheme_and_netloc = parsed_git_url.scheme + "://" + parsed_git_url.netloc
             repo_path = self._get_owner_and_repo_path(html_url)
-            if repo_path.count("/") == 1:  # Has to have the form <owner>/<repo>
-                owner, repo = repo_path.split("/")
+            if repo_path.count('/') == 1: #Has to have the form <owner>/<repo>
+                owner, repo = repo_path.split('/')
             else:
                 get_logger().error(f"Invalid repo_path: {repo_path} from url: {html_url}")
                 return ("", "")
 
-        if (
-            not owner or not repo
-        ) and self.repo:  # "else" - User did not provide an external git url, or not an issue, use self.repo object
-            owner, repo = self.repo.split("/")
+        if (not owner or not repo) and self.repo: #"else" - User did not provide an external git url, or not an issue, use self.repo object
+            owner, repo = self.repo.split('/')
             scheme_and_netloc = self.base_url_html
             desired_branch = self.repo_obj.default_branch
-        if not all(
-            [scheme_and_netloc, owner, repo]
-        ):  # "else": Not invoked from a PR context,but no provided git url for context
+        if not all([scheme_and_netloc, owner, repo]): #"else": Not invoked from a PR context,but no provided git url for context
             get_logger().error(f"Unable to get canonical url parts since missing context (PR or explicit git url)")
             return ("", "")
 
@@ -242,7 +216,7 @@ class GithubProvider(GitProvider):
             git_files = context.get("git_files", None)
             if git_files:
                 return git_files
-            self.git_files = list(self.pr.get_files())  # 'list' to handle pagination
+            self.git_files = list(self.pr.get_files()) # 'list' to handle pagination
             context["git_files"] = self.git_files
             return self.git_files
         except Exception:
@@ -270,14 +244,8 @@ class GithubProvider(GitProvider):
         """
         # the retry settings are read at call time rather than in a decorator, so that importing this module
         # does not require a [github] settings section (issue #2427)
-        return retry_call(
-            self._get_diff_files,
-            exceptions=RateLimitExceeded,
-            tries=get_settings().get("GITHUB.RATELIMIT_RETRIES", 5),
-            delay=2,
-            backoff=2,
-            jitter=(1, 3),
-        )
+        return retry_call(self._get_diff_files, exceptions=RateLimitExceeded,
+                          tries=get_settings().get("GITHUB.RATELIMIT_RETRIES", 5), delay=2, backoff=2, jitter=(1, 3))
 
     def _get_diff_files(self) -> list[FilePatchInfo]:
         try:
@@ -298,10 +266,9 @@ class GithubProvider(GitProvider):
                 try:
                     names_original = [file.filename for file in files_original]
                     names_new = [file.filename for file in files]
-                    get_logger().info(
-                        f"Filtered out [ignore] files for pull request:",
-                        extra={"files": names_original, "filtered_files": names_new},
-                    )
+                    get_logger().info(f"Filtered out [ignore] files for pull request:", extra=
+                    {"files": names_original,
+                     "filtered_files": names_new})
                 except Exception:
                     pass
 
@@ -316,13 +283,14 @@ class GithubProvider(GitProvider):
             repo = self.repo_obj
             pr = self.pr
             try:
-                compare = repo.compare(pr.base.sha, pr.head.sha)  # communication with GitHub
+                compare = repo.compare(pr.base.sha, pr.head.sha) # communication with GitHub
                 merge_base_commit = compare.merge_base_commit
             except Exception as e:
                 get_logger().error(f"Failed to get merge base commit: {e}")
                 merge_base_commit = pr.base
             if merge_base_commit.sha != pr.base.sha:
-                get_logger().info(f"Using merge base commit {merge_base_commit.sha} instead of base commit ")
+                get_logger().info(
+                    f"Using merge base commit {merge_base_commit.sha} instead of base commit ")
 
             counter_valid = 0
             for file in files:
@@ -343,65 +311,54 @@ class GithubProvider(GitProvider):
                     if counter_valid >= MAX_FILES_ALLOWED_FULL and patch and not self.incremental.is_incremental:
                         avoid_load = True
                         if counter_valid == MAX_FILES_ALLOWED_FULL:
-                            get_logger().info(
-                                f"Too many files in PR, will avoid loading full content for rest of files"
-                            )
+                            get_logger().info(f"Too many files in PR, will avoid loading full content for rest of files")
 
                     if avoid_load:
                         new_file_content_str = ""
                     else:
-                        new_file_content_str = self._get_pr_file_content(
-                            file, self.pr.head.sha
-                        )  # communication with GitHub
+                        new_file_content_str = self._get_pr_file_content(file, self.pr.head.sha)  # communication with GitHub
 
                     if self.incremental.is_incremental and self.unreviewed_files_map:
                         original_file_content_str = self._get_pr_file_content(
-                            file, self.incremental.last_seen_commit_sha, path=old_filename
-                        )
+                            file, self.incremental.last_seen_commit_sha, path=old_filename)
                         patch = load_large_diff(file.filename, new_file_content_str, original_file_content_str)
                         self.unreviewed_files_map[file.filename] = patch
                     else:
                         if avoid_load:
                             original_file_content_str = ""
                         else:
-                            original_file_content_str = self._get_pr_file_content(
-                                file, merge_base_commit.sha, path=old_filename
-                            )
+                            original_file_content_str = self._get_pr_file_content(file, merge_base_commit.sha, path=old_filename)
                             # original_file_content_str = self._get_pr_file_content(file, self.pr.base.sha)
                         if not patch:
                             patch = load_large_diff(file.filename, new_file_content_str, original_file_content_str)
 
-                if file.status == "added":
+
+                if file.status == 'added':
                     edit_type = EDIT_TYPE.ADDED
-                elif file.status == "removed":
+                elif file.status == 'removed':
                     edit_type = EDIT_TYPE.DELETED
-                elif file.status == "renamed":
+                elif file.status == 'renamed':
                     edit_type = EDIT_TYPE.RENAMED
-                elif file.status == "modified":
+                elif file.status == 'modified':
                     edit_type = EDIT_TYPE.MODIFIED
                 else:
                     get_logger().error(f"Unknown edit type: {file.status}")
                     edit_type = EDIT_TYPE.UNKNOWN
 
                 # count number of lines added and removed
-                if hasattr(file, "additions") and hasattr(file, "deletions"):
+                if hasattr(file, 'additions') and hasattr(file, 'deletions'):
                     num_plus_lines = file.additions
                     num_minus_lines = file.deletions
                 else:
                     patch_lines = patch.splitlines(keepends=True)
-                    num_plus_lines = len([line for line in patch_lines if line.startswith("+")])
-                    num_minus_lines = len([line for line in patch_lines if line.startswith("-")])
+                    num_plus_lines = len([line for line in patch_lines if line.startswith('+')])
+                    num_minus_lines = len([line for line in patch_lines if line.startswith('-')])
 
-                file_patch_canonical_structure = FilePatchInfo(
-                    original_file_content_str,
-                    new_file_content_str,
-                    patch,
-                    file.filename,
-                    edit_type=edit_type,
-                    old_filename=old_filename,
-                    num_plus_lines=num_plus_lines,
-                    num_minus_lines=num_minus_lines,
-                )
+                file_patch_canonical_structure = FilePatchInfo(original_file_content_str, new_file_content_str, patch,
+                                                               file.filename, edit_type=edit_type,
+                                                               old_filename=old_filename,
+                                                               num_plus_lines=num_plus_lines,
+                                                               num_minus_lines=num_minus_lines,)
                 diff_files.append(file_patch_canonical_structure)
             if invalid_files_names:
                 get_logger().info(f"Filtered out files with invalid extensions: {invalid_files_names}")
@@ -415,7 +372,8 @@ class GithubProvider(GitProvider):
             return diff_files
 
         except Exception as e:
-            get_logger().error(f"Failing to get diff files: {e}", artifact={"traceback": traceback.format_exc()})
+            get_logger().error(f"Failing to get diff files: {e}",
+                               artifact={"traceback": traceback.format_exc()})
             raise RateLimitExceeded("Rate limit exceeded for GitHub API.") from e
 
     def publish_description(self, pr_title: str, pr_body: str):
@@ -430,16 +388,13 @@ class GithubProvider(GitProvider):
     def get_comment_url(self, comment) -> str:
         return comment.html_url
 
-    def publish_persistent_comment(
-        self,
-        pr_comment: str,
-        initial_header: str,
-        update_header: bool = True,
-        name="review",
-        final_update_message=True,
-        identity_marker: str | None = None,
-        legacy_initial_header: str | None = None,
-    ):
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_header: str,
+                                   update_header: bool = True,
+                                   name='review',
+                                   final_update_message=True,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
         if get_settings().github.publish_as_check_run:
             if self._publish_check_run(pr_comment, name):
                 return
@@ -457,7 +412,7 @@ class GithubProvider(GitProvider):
         return True
 
     def _publish_check_run(self, text: str, name: str) -> bool:
-        if not getattr(self, "last_commit_id", None):
+        if not getattr(self, 'last_commit_id', None):
             get_logger().error("Cannot publish check run without a commit SHA")
             return False
         conclusion = "neutral"
@@ -515,7 +470,7 @@ class GithubProvider(GitProvider):
             return False
 
     def _find_existing_check_run(self, check_run_name: str, head_sha: str) -> Optional[int]:
-        pr = getattr(self, "pr", None)
+        pr = getattr(self, 'pr', None)
         if not pr:
             return None
         try:
@@ -548,24 +503,23 @@ class GithubProvider(GitProvider):
         if hasattr(response, "user") and hasattr(response.user, "login"):
             self.github_user_id = response.user.login
         response.is_temporary = is_temporary
-        if not hasattr(self.pr, "comments_list"):
+        if not hasattr(self.pr, 'comments_list'):
             self.pr.comments_list = []
         self.pr.comments_list.append(response)
         return response
 
-    def publish_inline_comment(
-        self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None
-    ):
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
         body = self.limit_output_characters(body, self.max_comment_chars)
         self.publish_inline_comments([self.create_inline_comment(body, relevant_file, relevant_line_in_file)])
 
-    def create_inline_comment(
-        self, body: str, relevant_file: str, relevant_line_in_file: str, absolute_position: int = None
-    ):
+
+    def create_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str,
+                              absolute_position: int = None):
         body = self.limit_output_characters(body, self.max_comment_chars)
-        position, absolute_position = find_line_number_of_relevant_line_in_file(
-            self.diff_files, relevant_file.strip("`"), relevant_line_in_file, absolute_position
-        )
+        position, absolute_position = find_line_number_of_relevant_line_in_file(self.diff_files,
+                                                                                relevant_file.strip('`'),
+                                                                                relevant_line_in_file,
+                                                                                absolute_position)
         if position == -1:
             get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
             subject_type = "FILE"
@@ -600,11 +554,8 @@ class GithubProvider(GitProvider):
                 # top-level call drops duplicates. The fallback still gets marked
                 # and recorded below so it dedups on later runs.
                 if not disable_fallback and (
-                    store.seen(body_fp)
-                    or store.seen(code_fp)
-                    or body_fp in local_seen
-                    or (code_fp and code_fp in local_seen)
-                ):
+                        store.seen(body_fp) or store.seen(code_fp)
+                        or body_fp in local_seen or (code_fp and code_fp in local_seen)):
                     skipped += 1
                     continue
                 marked = dict(comment)
@@ -612,7 +563,8 @@ class GithubProvider(GitProvider):
                 if has_marker(body):
                     pass  # already carries a marker from the first pass
                 else:
-                    marked["body"] = body_with_markers(body, body_fp, code_fp, getattr(self, "max_comment_chars", None))
+                    marked["body"] = body_with_markers(
+                        body, body_fp, code_fp, getattr(self, "max_comment_chars", None))
                 deduped.append(marked)
                 local_seen.add(body_fp)
                 if code_fp:
@@ -620,13 +572,14 @@ class GithubProvider(GitProvider):
                 pending_fingerprints.append((body_fp, code_fp))
             if skipped and not any(deduped):
                 get_logger().info(
-                    f"Persistent inline comments: all {skipped} suggestion(s) already posted; nothing to publish"
-                )
+                    f"Persistent inline comments: all {skipped} suggestion(s) "
+                    f"already posted; nothing to publish")
                 return
             comments = deduped
         else:
             comments = [
-                {key: value for key, value in comment.items() if key != dedup_code_fp_key} if comment else comment
+                {key: value for key, value in comment.items() if key != dedup_code_fp_key}
+                if comment else comment
                 for comment in comments
             ]
         try:
@@ -643,10 +596,10 @@ class GithubProvider(GitProvider):
         except Exception as e:
             get_logger().info(f"Initially failed to publish inline comments as committable")
 
-            if getattr(e, "status", None) == 422 and not disable_fallback:
+            if (getattr(e, "status", None) == 422 and not disable_fallback):
                 pass  # continue to try _publish_inline_comments_fallback_with_verification
             else:
-                raise e  # will end up with publishing the comments one by one
+                raise e # will end up with publishing the comments one by one
 
             try:
                 self._publish_inline_comments_fallback_with_verification(comments)
@@ -657,38 +610,35 @@ class GithubProvider(GitProvider):
     def get_review_thread_comments(self, comment_id: int) -> list[dict]:
         """
         Retrieves all comments in the same thread as the given comment.
-
+        
         Args:
             comment_id: Review comment ID
-
+                
         Returns:
             List of comments in the same thread
         """
         try:
             # Fetch all comments with a single API call
             all_comments = list(self.pr.get_comments())
-
+            
             # Find the target comment by ID
             target_comment = next((c for c in all_comments if c.id == comment_id), None)
             if not target_comment:
                 return []
-
+        
             # Get root comment id
             root_comment_id = target_comment.raw_data.get("in_reply_to_id", target_comment.id)
             # Build the thread - include the root comment and all replies to it
             thread_comments = [
-                c
-                for c in all_comments
-                if c.id == root_comment_id or c.raw_data.get("in_reply_to_id") == root_comment_id
+                c for c in all_comments if
+                c.id == root_comment_id or c.raw_data.get("in_reply_to_id") == root_comment_id
             ]
-
+        
+        
             return thread_comments
-
+                
         except Exception as e:
-            get_logger().exception(
-                f"Failed to get review comments for an inline ask command",
-                artifact={"comment_id": comment_id, "error": e},
-            )
+            get_logger().exception(f"Failed to get review comments for an inline ask command", artifact={"comment_id": comment_id, "error": e})
             return []
 
     def supports_thread_resolution(self) -> bool:
@@ -744,11 +694,12 @@ class GithubProvider(GitProvider):
                 response_json = json.loads(response_tuple[2])
                 errors = response_json.get("errors")
                 if errors:
-                    get_logger().error(f"GraphQL errors querying review threads: {errors}")
+                    get_logger().error(
+                        f"GraphQL errors querying review threads: {errors}"
+                    )
                     return False
-                review_threads = (
-                    response_json.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewThreads", {})
-                )
+                review_threads = (response_json.get("data", {}).get("repository", {})
+                                  .get("pullRequest", {}).get("reviewThreads", {}))
                 threads = review_threads.get("nodes", [])
 
                 for thread in threads:
@@ -796,12 +747,12 @@ class GithubProvider(GitProvider):
             if errors:
                 get_logger().error(f"GraphQL errors resolving thread {thread_id}: {errors}")
                 return False
-            is_resolved = (
-                resolve_json.get("data", {}).get("resolveReviewThread", {}).get("thread", {}).get("isResolved", False)
-            )
+            is_resolved = (resolve_json.get("data", {}).get("resolveReviewThread", {})
+                           .get("thread", {}).get("isResolved", False))
             if not is_resolved:
                 get_logger().warning(
-                    f"Resolve mutation returned isResolved=false for thread {thread_id} — possible permission issue"
+                    f"Resolve mutation returned isResolved=false for thread "
+                    f"{thread_id} — possible permission issue"
                 )
                 return False
             get_logger().info(f"Resolved review thread {thread_id}")
@@ -832,7 +783,7 @@ class GithubProvider(GitProvider):
                     get_logger().info(f"Published invalid comment as a single line comment: {comment}")
                 except:
                     get_logger().error(f"Failed to publish invalid comment as a single line comment: {comment}")
-
+            
             dropped_count = len(invalid_comments) - len(fixed_comments_as_one_liner)
             if dropped_count > 0:
                 dropped_paths = [c.get("path") for c, _ in invalid_comments]
@@ -856,7 +807,8 @@ class GithubProvider(GitProvider):
         try:
             # event ="" # By leaving this blank, you set the review action state to PENDING
             input = dict(commit_id=self.last_commit_id.sha, comments=[comment])
-            headers, data = self.pr._requester.requestJsonAndCheck("POST", f"{self.pr.url}/reviews", input=input)
+            headers, data = self.pr._requester.requestJsonAndCheck(
+                "POST", f"{self.pr.url}/reviews", input=input)
             pending_review_id = data["id"]
             is_verified = True
         except Exception as err:
@@ -890,7 +842,6 @@ class GithubProvider(GitProvider):
         This is a best-effort attempt to fix invalid comments, and should be verified accordingly.
         """
         import copy
-
         fixed_comments = []
         for comment in invalid_comments:
             try:
@@ -918,28 +869,24 @@ class GithubProvider(GitProvider):
         code_suggestions_with_fingerprints = copy.deepcopy(code_suggestions)
         for suggestion in code_suggestions_with_fingerprints:
             suggestion["_dedup_code_fp"] = code_fingerprint(
-                suggestion.get("relevant_file", ""), None, suggestion.get("body", "")
-            )
+                suggestion.get("relevant_file", ""), None, suggestion.get("body", ""))
         code_suggestions_validated = self.validate_comments_inside_hunks(code_suggestions_with_fingerprints)
 
         for suggestion in code_suggestions_validated:
-            body = suggestion["body"]
-            relevant_file = suggestion["relevant_file"]
-            relevant_lines_start = suggestion["relevant_lines_start"]
-            relevant_lines_end = suggestion["relevant_lines_end"]
+            body = suggestion['body']
+            relevant_file = suggestion['relevant_file']
+            relevant_lines_start = suggestion['relevant_lines_start']
+            relevant_lines_end = suggestion['relevant_lines_end']
 
             if not relevant_lines_start or relevant_lines_start == -1:
                 get_logger().exception(
-                    f"Failed to publish code suggestion, relevant_lines_start is {relevant_lines_start}"
-                )
+                    f"Failed to publish code suggestion, relevant_lines_start is {relevant_lines_start}")
                 continue
 
             if relevant_lines_end < relevant_lines_start:
-                get_logger().exception(
-                    f"Failed to publish code suggestion, "
-                    f"relevant_lines_end is {relevant_lines_end} and "
-                    f"relevant_lines_start is {relevant_lines_start}"
-                )
+                get_logger().exception(f"Failed to publish code suggestion, "
+                                  f"relevant_lines_end is {relevant_lines_end} and "
+                                  f"relevant_lines_start is {relevant_lines_start}")
                 continue
 
             if relevant_lines_end > relevant_lines_start:
@@ -976,8 +923,8 @@ class GithubProvider(GitProvider):
             if hasattr(e, "status") and e.status == 403:
                 # Log as warning for permission-related issues (usually due to polling)
                 get_logger().warning(
-                    "Failed to edit github comment due to permission restrictions", artifact={"error": e}
-                )
+                    "Failed to edit github comment due to permission restrictions",
+                    artifact={"error": e})
             else:
                 get_logger().exception(f"Failed to edit github comment", artifact={"error": e})
 
@@ -986,7 +933,8 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(comment_id).edit(body)
             body = self.limit_output_characters(body, self.max_comment_chars)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "PATCH", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}", input={"body": body}
+                "PATCH", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}",
+                input={"body": body}
             )
         except Exception as e:
             get_logger().exception(f"Failed to edit comment, error: {e}")
@@ -996,9 +944,8 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(comment_id).edit(body)
             body = self.limit_output_characters(body, self.max_comment_chars)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "POST",
-                f"{self.base_url}/repos/{self.repo}/pulls/{self.pr_num}/comments/{comment_id}/replies",
-                input={"body": body},
+                "POST", f"{self.base_url}/repos/{self.repo}/pulls/{self.pr_num}/comments/{comment_id}/replies",
+                input={"body": body}
             )
         except Exception as e:
             get_logger().exception(f"Failed to reply comment, error: {e}")
@@ -1009,36 +956,33 @@ class GithubProvider(GitProvider):
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
                 "GET", f"{self.base_url}/repos/{self.repo}/issues/comments/{comment_id}"
             )
-            return data_patch.get("body", "")
+            return data_patch.get("body","")
         except Exception as e:
             get_logger().exception(f"Failed to edit comment, error: {e}")
             return None
 
     def publish_file_comments(self, file_comments: list) -> bool:
         try:
-            headers, existing_comments = self.pr._requester.requestJsonAndCheck("GET", f"{self.pr.url}/comments")
+            headers, existing_comments = self.pr._requester.requestJsonAndCheck(
+                "GET", f"{self.pr.url}/comments"
+            )
             for comment in file_comments:
-                comment["commit_id"] = self.last_commit_id.sha
-                comment["body"] = self.limit_output_characters(comment["body"], self.max_comment_chars)
+                comment['commit_id'] = self.last_commit_id.sha
+                comment['body'] = self.limit_output_characters(comment['body'], self.max_comment_chars)
 
                 found = False
                 for existing_comment in existing_comments:
-                    comment["commit_id"] = self.last_commit_id.sha
+                    comment['commit_id'] = self.last_commit_id.sha
                     our_app_name = get_settings().get("GITHUB.APP_NAME", "")
                     same_comment_creator = False
-                    if self.deployment_type == "app":
-                        same_comment_creator = our_app_name.lower() in existing_comment["user"]["login"].lower()
-                    elif self.deployment_type == "user":
-                        same_comment_creator = self.github_user_id == existing_comment["user"]["login"]
-                    if (
-                        existing_comment["subject_type"] == "file"
-                        and comment["path"] == existing_comment["path"]
-                        and same_comment_creator
-                    ):
+                    if self.deployment_type == 'app':
+                        same_comment_creator = our_app_name.lower() in existing_comment['user']['login'].lower()
+                    elif self.deployment_type == 'user':
+                        same_comment_creator = self.github_user_id == existing_comment['user']['login']
+                    if existing_comment['subject_type'] == 'file' and comment['path'] == existing_comment['path'] and same_comment_creator:
+
                         headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                            "PATCH",
-                            f"{self.base_url}/repos/{self.repo}/pulls/comments/{existing_comment['id']}",
-                            input={"body": comment["body"]},
+                            "PATCH", f"{self.base_url}/repos/{self.repo}/pulls/comments/{existing_comment['id']}", input={"body":comment['body']}
                         )
                         found = True
                         break
@@ -1053,7 +997,7 @@ class GithubProvider(GitProvider):
 
     def remove_initial_comment(self):
         try:
-            for comment in getattr(self.pr, "comments_list", []):
+            for comment in getattr(self.pr, 'comments_list', []):
                 if comment.is_temporary:
                     self.remove_comment(comment)
         except Exception as e:
@@ -1078,7 +1022,7 @@ class GithubProvider(GitProvider):
     def get_pr_owner_id(self) -> str | None:
         if not self.repo:
             return None
-        return self.repo.split("/")[0]
+        return self.repo.split('/')[0]
 
     def get_pr_description_full(self):
         return self.pr.body
@@ -1086,7 +1030,7 @@ class GithubProvider(GitProvider):
     def get_user_id(self):
         if not self.github_user_id:
             try:
-                self.github_user_id = self.github_client.get_user().raw_data["login"]
+                self.github_user_id = self.github_client.get_user().raw_data['login']
             except Exception as e:
                 self.github_user_id = ""
                 # logging.exception(f"Failed to get user id, error: {e}")
@@ -1095,7 +1039,7 @@ class GithubProvider(GitProvider):
     def get_notifications(self, since: datetime):
         deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
 
-        if deployment_type != "user":
+        if deployment_type != 'user':
             raise ValueError("Deployment mode must be set to 'user' to get notifications")
 
         notifications = self.github_client.get_user().get_notifications(since=since)
@@ -1132,7 +1076,8 @@ class GithubProvider(GitProvider):
                 # fallback that could apply unintended settings.
                 if e.status != 404:
                     raise
-                get_logger().debug(f"No .pr_agent.toml on branch '{config_branch}', falling back to default branch")
+                get_logger().debug(
+                    f"No .pr_agent.toml on branch '{config_branch}', falling back to default branch")
         try:
             # more logical to take 'pr_agent.toml' from the default branch
             contents = self.repo_obj.get_contents(".pr_agent.toml").decoded_content
@@ -1166,8 +1111,8 @@ class GithubProvider(GitProvider):
         # Cache per org: global settings change rarely, so avoid a lookup (and repeated 403/404
         # fallbacks) on every webhook event.
         return get_cached_global_settings(
-            f"github:{getattr(self, 'base_url', '')}:{repo_owner}", lambda: self._fetch_global_repo_settings(repo_owner)
-        )
+            f"github:{getattr(self, 'base_url', '')}:{repo_owner}",
+            lambda: self._fetch_global_repo_settings(repo_owner))
 
     def _fetch_global_repo_settings(self, repo_owner):
         try:
@@ -1179,8 +1124,7 @@ class GithubProvider(GitProvider):
             if e.status in (403, 404):
                 get_logger().debug(
                     "No accessible organization global .pr_agent.toml; using local settings only",
-                    artifact={"status": e.status},
-                )
+                    artifact={"status": e.status})
                 return ""
             # Transient/unexpected errors propagate so the caller does not cache the failure.
             raise
@@ -1211,16 +1155,15 @@ class GithubProvider(GitProvider):
             raise
 
     def get_workspace_name(self):
-        return self.repo.split("/")[0]
+        return self.repo.split('/')[0]
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         if disable_eyes:
             return None
         try:
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
-                "POST",
-                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions",
-                input={"content": "eyes"},
+                "POST", f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions",
+                input={"content": "eyes"}
             )
             return data_patch.get("id", None)
         except Exception as e:
@@ -1232,7 +1175,7 @@ class GithubProvider(GitProvider):
             # self.pr.get_issue_comment(issue_comment_id).delete_reaction(reaction_id)
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
                 "DELETE",
-                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions/{reaction_id}",
+                f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions/{reaction_id}"
             )
             return True
         except Exception as e:
@@ -1242,24 +1185,24 @@ class GithubProvider(GitProvider):
     def _parse_pr_url(self, pr_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(pr_url)
 
-        if parsed_url.path.startswith("/api/v3"):
+        if parsed_url.path.startswith('/api/v3'):
             parsed_url = urlparse(pr_url.replace("/api/v3", ""))
 
-        path_parts = parsed_url.path.strip("/").split("/")
-        if "api.github.com" in parsed_url.netloc or "/api/v3" in pr_url:
-            if len(path_parts) < 5 or path_parts[3] != "pulls":
+        path_parts = parsed_url.path.strip('/').split('/')
+        if 'api.github.com' in parsed_url.netloc or '/api/v3' in pr_url:
+            if len(path_parts) < 5 or path_parts[3] != 'pulls':
                 raise ValueError("The provided URL does not appear to be a GitHub PR URL")
-            repo_name = "/".join(path_parts[1:3])
+            repo_name = '/'.join(path_parts[1:3])
             try:
                 pr_number = int(path_parts[4])
             except ValueError as e:
                 raise ValueError("Unable to convert PR number to integer") from e
             return repo_name, pr_number
 
-        if len(path_parts) < 4 or path_parts[2] != "pull":
+        if len(path_parts) < 4 or path_parts[2] != 'pull':
             raise ValueError("The provided URL does not appear to be a GitHub PR URL")
 
-        repo_name = "/".join(path_parts[:2])
+        repo_name = '/'.join(path_parts[:2])
         try:
             pr_number = int(path_parts[3])
         except ValueError as e:
@@ -1270,24 +1213,24 @@ class GithubProvider(GitProvider):
     def _parse_issue_url(self, issue_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(issue_url)
 
-        if parsed_url.path.startswith("/api/v3"):  # Check if came from github app
+        if parsed_url.path.startswith('/api/v3'): #Check if came from github app
             parsed_url = urlparse(issue_url.replace("/api/v3", ""))
 
-        path_parts = parsed_url.path.strip("/").split("/")
-        if "api.github.com" in parsed_url.netloc or "/api/v3" in issue_url:  # Check if came from github app
-            if len(path_parts) < 5 or path_parts[3] != "issues":
+        path_parts = parsed_url.path.strip('/').split('/')
+        if 'api.github.com' in parsed_url.netloc or '/api/v3' in issue_url: #Check if came from github app
+            if len(path_parts) < 5 or path_parts[3] != 'issues':
                 raise ValueError("The provided URL does not appear to be a GitHub ISSUE URL")
-            repo_name = "/".join(path_parts[1:3])
+            repo_name = '/'.join(path_parts[1:3])
             try:
                 issue_number = int(path_parts[4])
             except ValueError as e:
                 raise ValueError("Unable to convert issue number to integer") from e
             return repo_name, issue_number
 
-        if len(path_parts) < 4 or path_parts[2] != "issues":
+        if len(path_parts) < 4 or path_parts[2] != 'issues':
             raise ValueError("The provided URL does not appear to be a GitHub PR issue")
 
-        repo_name = "/".join(path_parts[:2])
+        repo_name = '/'.join(path_parts[:2])
         try:
             issue_number = int(path_parts[3])
         except ValueError as e:
@@ -1298,7 +1241,7 @@ class GithubProvider(GitProvider):
     def _get_github_client(self):
         self.deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
         self.auth = None
-        if self.deployment_type == "app":
+        if self.deployment_type == 'app':
             try:
                 private_key = get_settings().github.private_key
                 app_id = get_settings().github.app_id
@@ -1306,16 +1249,16 @@ class GithubProvider(GitProvider):
                 raise ValueError("GitHub app ID and private key are required when using GitHub app deployment") from e
             if not self.installation_id:
                 raise ValueError("GitHub app installation ID is required when using GitHub app deployment")
-            auth = AppAuthentication(app_id=app_id, private_key=private_key, installation_id=self.installation_id)
+            auth = AppAuthentication(app_id=app_id, private_key=private_key,
+                                     installation_id=self.installation_id)
             self.auth = auth
-        elif self.deployment_type == "user":
+        elif self.deployment_type == 'user':
             try:
                 token = get_settings().github.user_token
             except AttributeError as e:
                 raise ValueError(
                     "GitHub token is required when using user deployment. See: "
-                    "https://github.com/Codium-ai/pr-agent#method-2-run-from-source"
-                ) from e
+                    "https://github.com/Codium-ai/pr-agent#method-2-run-from-source") from e
             self.auth = Auth.Token(token)
         if self.auth:
             return Github(auth=self.auth, base_url=self.base_url)
@@ -1323,28 +1266,37 @@ class GithubProvider(GitProvider):
             raise ValueError("Could not authenticate to GitHub")
 
     def _get_repo(self):
-        if hasattr(self, "repo_obj") and hasattr(self.repo_obj, "full_name") and self.repo_obj.full_name == self.repo:
+        if hasattr(self, 'repo_obj') and \
+                hasattr(self.repo_obj, 'full_name') and \
+                self.repo_obj.full_name == self.repo:
             return self.repo_obj
         else:
             self.repo_obj = self.github_client.get_repo(self.repo)
             return self.repo_obj
+
 
     def _get_pr(self):
         return self._get_repo().get_pull(self.pr_num)
 
     def get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:
-            file_content_str = str(self._get_repo().get_contents(file_path, ref=branch).decoded_content.decode())
+            file_content_str = str(
+                self._get_repo()
+                .get_contents(file_path, ref=branch)
+                .decoded_content.decode()
+            )
         except Exception:
             file_content_str = ""
         return file_content_str
 
-    def create_or_update_pr_file(self, file_path: str, branch: str, contents="", message="") -> None:
+    def create_or_update_pr_file(
+        self, file_path: str, branch: str, contents="", message=""
+    ) -> None:
         try:
             file_obj = self._get_repo().get_contents(file_path, ref=branch)
-            sha1 = file_obj.sha
+            sha1=file_obj.sha
         except Exception:
-            sha1 = ""
+            sha1=""
         self.repo_obj.update_file(
             path=file_path,
             message=message,
@@ -1358,14 +1310,9 @@ class GithubProvider(GitProvider):
 
     def publish_labels(self, pr_types):
         try:
-            label_color_map = {
-                "Bug fix": "1d76db",
-                "Tests": "e99695",
-                "Bug fix with tests": "c5def5",
-                "Enhancement": "bfd4f2",
-                "Documentation": "d4c5f9",
-                "Other": "d1bcf9",
-            }
+            label_color_map = {"Bug fix": "1d76db", "Tests": "e99695", "Bug fix with tests": "c5def5",
+                               "Enhancement": "bfd4f2", "Documentation": "d4c5f9",
+                               "Other": "d1bcf9"}
             post_parameters = []
             for p in pr_types:
                 color = label_color_map.get(p, "d1bcf9")  # default to "Other" color
@@ -1379,11 +1326,12 @@ class GithubProvider(GitProvider):
     def get_pr_labels(self, update=False):
         try:
             if not update:
-                labels = self.pr.labels
+                labels =self.pr.labels
                 return [label.name for label in labels]
-            else:  # obtain the latest labels. Maybe they changed while the AI was running
-                headers, labels = self.pr._requester.requestJsonAndCheck("GET", f"{self.pr.issue_url}/labels")
-                return [label["name"] for label in labels]
+            else: # obtain the latest labels. Maybe they changed while the AI was running
+                headers, labels = self.pr._requester.requestJsonAndCheck(
+                    "GET", f"{self.pr.issue_url}/labels")
+                return [label['name'] for label in labels]
 
         except Exception as e:
             get_logger().exception(f"Failed to get labels, error: {e}")
@@ -1413,14 +1361,13 @@ class GithubProvider(GitProvider):
 
     def generate_link_to_relevant_line_number(self, suggestion) -> str:
         try:
-            relevant_file = suggestion["relevant_file"].strip("`").strip("'").strip("\n")
-            relevant_line_str = suggestion["relevant_line"].strip("\n")
+            relevant_file = suggestion['relevant_file'].strip('`').strip("'").strip('\n')
+            relevant_line_str = suggestion['relevant_line'].strip('\n')
             if not relevant_line_str:
                 return ""
 
-            position, absolute_position = find_line_number_of_relevant_line_in_file(
-                self.diff_files, relevant_file, relevant_line_str
-            )
+            position, absolute_position = find_line_number_of_relevant_line_in_file \
+                (self.diff_files, relevant_file, relevant_line_str)
 
             if absolute_position != -1:
                 # # link to right file only
@@ -1428,7 +1375,7 @@ class GithubProvider(GitProvider):
                 #        + "#" + f"L{absolute_position}"
 
                 # link to diff
-                sha_file = hashlib.sha256(relevant_file.encode("utf-8")).hexdigest()
+                sha_file = hashlib.sha256(relevant_file.encode('utf-8')).hexdigest()
                 link = f"{self.base_url_html}/{self.repo}/pull/{self.pr_num}/files#diff-{sha_file}R{absolute_position}"
                 return link
         except Exception as e:
@@ -1437,7 +1384,7 @@ class GithubProvider(GitProvider):
         return ""
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
-        sha_file = hashlib.sha256(relevant_file.encode("utf-8")).hexdigest()
+        sha_file = hashlib.sha256(relevant_file.encode('utf-8')).hexdigest()
         if relevant_line_end is not None and relevant_line_start is not None:
             try:
                 if int(relevant_line_end) < int(relevant_line_start):
@@ -1474,7 +1421,8 @@ class GithubProvider(GitProvider):
         line_end = component_range.line_end + 1
         # link = (f"https://github.com/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
         #         f"#L{line_start}-L{line_end}")
-        link = f"{self.base_url_html}/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/#L{line_start}-L{line_end}"
+        link = (f"{self.base_url_html}/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
+                f"#L{line_start}-L{line_end}")
 
         return link
 
@@ -1506,9 +1454,8 @@ class GithubProvider(GitProvider):
                 }}
             }}
             """
-            response_tuple = self.github_client._Github__requester.requestJson(
-                "POST", "/graphql", input={"query": query}
-            )
+            response_tuple = self.github_client._Github__requester.requestJson("POST", "/graphql",
+                                                                               input={"query": query})
 
             # Extract the JSON response from the tuple and parses it
             if isinstance(response_tuple, tuple) and len(response_tuple) == 3:
@@ -1517,7 +1464,10 @@ class GithubProvider(GitProvider):
                 get_logger().error(f"Unexpected response format: {response_tuple}")
                 return sub_issues
 
-            issue_id = (((response_json.get("data") or {}).get("repository") or {}).get("issue") or {}).get("id")
+
+            issue_id = (((response_json.get("data") or {})
+                        .get("repository") or {})
+                        .get("issue") or {}).get("id")
 
             if not issue_id:
                 get_logger().warning(f"Issue ID not found for {issue_url}")
@@ -1537,20 +1487,19 @@ class GithubProvider(GitProvider):
                 }}
             }}
             """
-            sub_issues_response_tuple = self.github_client._Github__requester.requestJson(
-                "POST", "/graphql", input={"query": sub_issues_query}
-            )
+            sub_issues_response_tuple = self.github_client._Github__requester.requestJson("POST", "/graphql", input={
+                "query": sub_issues_query})
 
             # Extract the JSON response from the tuple and parses it
             if isinstance(sub_issues_response_tuple, tuple) and len(sub_issues_response_tuple) == 3:
                 sub_issues_response_json = json.loads(sub_issues_response_tuple[2])
             else:
-                get_logger().error(
-                    "Unexpected sub-issues response format", artifact={"response": sub_issues_response_tuple}
-                )
+                get_logger().error("Unexpected sub-issues response format", artifact={"response": sub_issues_response_tuple})
                 return sub_issues
 
-            sub_issues_data = ((sub_issues_response_json.get("data") or {}).get("node") or {}).get("subIssues") or {}
+            sub_issues_data = (((sub_issues_response_json.get("data") or {})
+                                .get("node") or {})
+                                .get("subIssues") or {})
             if not sub_issues_data:
                 get_logger().error("Invalid sub-issues response structure")
                 return sub_issues
@@ -1580,7 +1529,7 @@ class GithubProvider(GitProvider):
             return False
 
     def calc_pr_statistics(self, pull_request_data: dict):
-        return {}
+            return {}
 
     def validate_comments_inside_hunks(self, code_suggestions):
         """
@@ -1588,43 +1537,45 @@ class GithubProvider(GitProvider):
         """
         code_suggestions_copy = copy.deepcopy(code_suggestions)
         diff_files = self.get_diff_files()
-        RE_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
+        RE_HUNK_HEADER = re.compile(
+            r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
 
         diff_files = set_file_languages(diff_files)
 
         for suggestion in code_suggestions_copy:
             try:
-                relevant_file_path = suggestion["relevant_file"]
+                relevant_file_path = suggestion['relevant_file']
                 for file in diff_files:
                     if file.filename == relevant_file_path:
+
                         # generate on-demand the patches range for the relevant file
                         patch_str = file.patch
-                        if not hasattr(file, "patches_range"):
+                        if not hasattr(file, 'patches_range'):
                             file.patches_range = []
                             patch_lines = patch_str.splitlines()
                             for i, line in enumerate(patch_lines):
-                                if line.startswith("@@"):
+                                if line.startswith('@@'):
                                     match = RE_HUNK_HEADER.match(line)
                                     # identify hunk header
                                     if match:
                                         section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
-                                        file.patches_range.append({"start": start2, "end": start2 + size2 - 1})
+                                        file.patches_range.append({'start': start2, 'end': start2 + size2 - 1})
 
                         patches_range = file.patches_range
-                        comment_start_line = suggestion.get("relevant_lines_start", None)
-                        comment_end_line = suggestion.get("relevant_lines_end", None)
-                        original_suggestion = suggestion.get("original_suggestion", None)  # needed for diff code
+                        comment_start_line = suggestion.get('relevant_lines_start', None)
+                        comment_end_line = suggestion.get('relevant_lines_end', None)
+                        original_suggestion = suggestion.get('original_suggestion', None) # needed for diff code
                         if not comment_start_line or not comment_end_line or not original_suggestion:
                             continue
 
                         # check if the comment is inside a valid hunk
                         is_valid_hunk = False
-                        min_distance = float("inf")
+                        min_distance = float('inf')
                         patch_range_min = None
                         # find the hunk that contains the comment, or the closest one
                         for i, patch_range in enumerate(patches_range):
-                            d1 = comment_start_line - patch_range["start"]
-                            d2 = patch_range["end"] - comment_end_line
+                            d1 = comment_start_line - patch_range['start']
+                            d2 = patch_range['end'] - comment_end_line
                             if d1 >= 0 and d2 >= 0:  # found a valid hunk
                                 is_valid_hunk = True
                                 min_distance = 0
@@ -1638,50 +1589,41 @@ class GithubProvider(GitProvider):
                                     patch_range_min = patch_range
                                     min_distance = min(min_distance, d)
                         if not is_valid_hunk:
-                            if (
-                                min_distance < 10
-                            ):  # 10 lines - a reasonable distance to consider the comment inside the hunk
+                            if min_distance < 10:  # 10 lines - a reasonable distance to consider the comment inside the hunk
                                 # make the suggestion non-committable, yet multi line
-                                suggestion["relevant_lines_start"] = max(
-                                    suggestion["relevant_lines_start"], patch_range_min["start"]
-                                )
-                                suggestion["relevant_lines_end"] = min(
-                                    suggestion["relevant_lines_end"], patch_range_min["end"]
-                                )
-                                body = suggestion["body"].strip()
+                                suggestion['relevant_lines_start'] = max(suggestion['relevant_lines_start'], patch_range_min['start'])
+                                suggestion['relevant_lines_end'] = min(suggestion['relevant_lines_end'], patch_range_min['end'])
+                                body = suggestion['body'].strip()
 
                                 # present new diff code in collapsible
-                                existing_code = original_suggestion["existing_code"].rstrip() + "\n"
-                                improved_code = original_suggestion["improved_code"].rstrip() + "\n"
-                                diff = difflib.unified_diff(existing_code.split("\n"), improved_code.split("\n"), n=999)
+                                existing_code = original_suggestion['existing_code'].rstrip() + "\n"
+                                improved_code = original_suggestion['improved_code'].rstrip() + "\n"
+                                diff = difflib.unified_diff(existing_code.split('\n'),
+                                                            improved_code.split('\n'), n=999)
                                 patch_orig = "\n".join(diff)
-                                patch = "\n".join(patch_orig.splitlines()[5:]).strip("\n")
+                                patch = "\n".join(patch_orig.splitlines()[5:]).strip('\n')
                                 diff_code = f"\n\n<details><summary>New proposed code:</summary>\n\n```diff\n{patch.rstrip()}\n```"
                                 # replace ```suggestion ... ``` with diff_code, using regex:
-                                body = re.sub(r"```suggestion.*?```", diff_code, body, flags=re.DOTALL)
+                                body = re.sub(r'```suggestion.*?```', diff_code, body, flags=re.DOTALL)
                                 body += "\n\n</details>"
-                                suggestion["body"] = body
-                                get_logger().info(
-                                    f"Comment was moved to a valid hunk, "
-                                    f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}"
-                                )
+                                suggestion['body'] = body
+                                get_logger().info(f"Comment was moved to a valid hunk, "
+                                                  f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}")
                             else:
-                                get_logger().error(
-                                    f"Comment is not inside a valid hunk, "
-                                    f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}"
-                                )
+                                get_logger().error(f"Comment is not inside a valid hunk, "
+                                                   f"start_line={suggestion['relevant_lines_start']}, end_line={suggestion['relevant_lines_end']}, file={file.filename}")
             except Exception as e:
                 get_logger().error(f"Failed to process patch for committable comment, error: {e}")
         return code_suggestions_copy
 
-    # Clone related
+    #Clone related
     def _prepare_clone_url_with_token(self, repo_url_to_clone: str) -> str | None:
         scheme = "https://"
 
-        # For example, to clone:
-        # https://github.com/Codium-ai/pr-agent-pro.git
-        # Need to embed inside the github token:
-        # https://<token>@github.com/Codium-ai/pr-agent-pro.git
+        #For example, to clone:
+        #https://github.com/Codium-ai/pr-agent-pro.git
+        #Need to embed inside the github token:
+        #https://<token>@github.com/Codium-ai/pr-agent-pro.git
 
         github_token = self.auth.token
         github_base_url = self.base_url_html
@@ -1704,7 +1646,7 @@ class GithubProvider(GitProvider):
             return None
 
         clone_url = scheme
-        if self.deployment_type == "app":
+        if self.deployment_type == 'app':
             clone_url += "git:"
         clone_url += f"{github_token}@{github_com}{repo_full_name}"
         return clone_url

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -775,14 +775,25 @@ class GithubProvider(GitProvider):
 
         # try to publish one by one the invalid comments as a one-line code comment
         if invalid_comments and get_settings().github.try_fix_invalid_inline_comments:
-            fixed_comments_as_one_liner = self._try_fix_invalid_inline_comments(
-                [comment for comment, _ in invalid_comments])
+            invalid_comments_list = [comment for comment, _ in invalid_comments]
+            fixed_comments_as_one_liner = self._try_fix_invalid_inline_comments(invalid_comments_list)
             for comment in fixed_comments_as_one_liner:
                 try:
                     self.publish_inline_comments([comment], disable_fallback=True)
                     get_logger().info(f"Published invalid comment as a single line comment: {comment}")
                 except:
                     get_logger().error(f"Failed to publish invalid comment as a single line comment: {comment}")
+            
+            dropped_count = len(invalid_comments) - len(fixed_comments_as_one_liner)
+            if dropped_count > 0:
+                dropped_paths = [
+                    c.get("path") for c, _ in invalid_comments 
+                    if not ("```suggestion" in c.get("body", "") or "start_line" in c or "start_side" in c)
+                ]
+                get_logger().warning(f"Dropped {dropped_count} invalid comments that could not be fixed. Paths: {dropped_paths}")
+        elif invalid_comments:
+            dropped_paths = [c.get("path") for c, _ in invalid_comments]
+            get_logger().warning(f"Dropped {len(invalid_comments)} invalid comments (try_fix_invalid_inline_comments is off). Paths: {dropped_paths}")
 
     def _verify_code_comment(self, comment: dict):
         is_verified = False

--- a/tests/unittest/test_github_provider_fallback_verification.py
+++ b/tests/unittest/test_github_provider_fallback_verification.py
@@ -1,7 +1,10 @@
-import pytest
-from pr_agent.git_providers.github_provider import GithubProvider
-from pr_agent.config_loader import get_settings
 from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.github_provider import GithubProvider
+
 
 def test_fallback_logs_dropped_comments_when_fix_fails():
     provider = GithubProvider.__new__(GithubProvider)
@@ -13,20 +16,26 @@ def test_fallback_logs_dropped_comments_when_fix_fails():
     comment_2 = {"path": "f2.py", "body": "invalid"}
 
     # Mock verify to return 0 verified, 2 invalid
-    provider._verify_code_comments = MagicMock(return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))]))
-    
+    provider._verify_code_comments = MagicMock(
+        return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))])
+    )
+
     # Mock fix to return only the first one
     fixed_1 = {"path": "f1.py", "body": "fixed"}
     provider._try_fix_invalid_inline_comments = MagicMock(return_value=[fixed_1])
 
-    with patch('pr_agent.git_providers.github_provider.get_logger') as mock_logger, \
-         patch('pr_agent.git_providers.github_provider.get_settings') as mock_settings:
+    with (
+        patch("pr_agent.git_providers.github_provider.get_logger") as mock_logger,
+        patch("pr_agent.git_providers.github_provider.get_settings") as mock_settings,
+    ):
         mock_settings.return_value.github.try_fix_invalid_inline_comments = True
-        
+
         provider._publish_inline_comments_fallback_with_verification([comment_1, comment_2])
-        
-        # Should have warned about 1 dropped comment
-        mock_logger.return_value.warning.assert_called_with("Dropped 1 invalid comments that could not be fixed. Paths: ['f2.py']")
+
+        # Verify one dropped-comment warning.
+        mock_logger.return_value.warning.assert_called_with(
+            "Dropped 1 invalid comments that could not be fixed. Paths: ['f2.py']"
+        )
 
 
 def test_fallback_logs_dropped_comments_when_fix_disabled():
@@ -39,14 +48,20 @@ def test_fallback_logs_dropped_comments_when_fix_disabled():
     comment_2 = {"path": "f2.py", "body": "invalid"}
 
     # Mock verify to return 0 verified, 2 invalid
-    provider._verify_code_comments = MagicMock(return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))]))
-    
-    with patch('pr_agent.git_providers.github_provider.get_logger') as mock_logger, \
-         patch('pr_agent.git_providers.github_provider.get_settings') as mock_settings:
-        mock_settings.return_value.github.try_fix_invalid_inline_comments = False
-        
-        provider._publish_inline_comments_fallback_with_verification([comment_1, comment_2])
-        
-        # Should have warned about 2 dropped comments
-        mock_logger.return_value.warning.assert_called_with("Dropped 2 invalid comments (try_fix_invalid_inline_comments is off). Paths: ['f1.py', 'f2.py']")
+    provider._verify_code_comments = MagicMock(
+        return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))])
+    )
 
+    with (
+        patch("pr_agent.git_providers.github_provider.get_logger") as mock_logger,
+        patch("pr_agent.git_providers.github_provider.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.github.try_fix_invalid_inline_comments = False
+
+        provider._publish_inline_comments_fallback_with_verification([comment_1, comment_2])
+
+        # Verify two dropped-comment warnings.
+        mock_logger.return_value.warning.assert_called_with(
+            "Dropped 2 invalid comments "
+            "(try_fix_invalid_inline_comments is off). Paths: ['f1.py', 'f2.py']"
+        )

--- a/tests/unittest/test_github_provider_fallback_verification.py
+++ b/tests/unittest/test_github_provider_fallback_verification.py
@@ -1,0 +1,52 @@
+import pytest
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.config_loader import get_settings
+from unittest.mock import MagicMock, patch
+
+def test_fallback_logs_dropped_comments_when_fix_fails():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.publish_inline_comments = MagicMock()
+    provider.pr = MagicMock()
+    provider.last_commit_id = "abc"
+
+    comment_1 = {"path": "f1.py", "body": "```suggestion\nfixed\n```"}
+    comment_2 = {"path": "f2.py", "body": "invalid"}
+
+    # Mock verify to return 0 verified, 2 invalid
+    provider._verify_code_comments = MagicMock(return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))]))
+    
+    # Mock fix to return only the first one
+    fixed_1 = {"path": "f1.py", "body": "fixed"}
+    provider._try_fix_invalid_inline_comments = MagicMock(return_value=[fixed_1])
+
+    with patch('pr_agent.git_providers.github_provider.get_logger') as mock_logger, \
+         patch('pr_agent.git_providers.github_provider.get_settings') as mock_settings:
+        mock_settings.return_value.github.try_fix_invalid_inline_comments = True
+        
+        provider._publish_inline_comments_fallback_with_verification([comment_1, comment_2])
+        
+        # Should have warned about 1 dropped comment
+        mock_logger.return_value.warning.assert_called_with("Dropped 1 invalid comments that could not be fixed. Paths: ['f2.py']")
+
+
+def test_fallback_logs_dropped_comments_when_fix_disabled():
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.publish_inline_comments = MagicMock()
+    provider.pr = MagicMock()
+    provider.last_commit_id = "abc"
+
+    comment_1 = {"path": "f1.py", "body": "invalid"}
+    comment_2 = {"path": "f2.py", "body": "invalid"}
+
+    # Mock verify to return 0 verified, 2 invalid
+    provider._verify_code_comments = MagicMock(return_value=([], [(comment_1, Exception("e1")), (comment_2, Exception("e2"))]))
+    
+    with patch('pr_agent.git_providers.github_provider.get_logger') as mock_logger, \
+         patch('pr_agent.git_providers.github_provider.get_settings') as mock_settings:
+        mock_settings.return_value.github.try_fix_invalid_inline_comments = False
+        
+        provider._publish_inline_comments_fallback_with_verification([comment_1, comment_2])
+        
+        # Should have warned about 2 dropped comments
+        mock_logger.return_value.warning.assert_called_with("Dropped 2 invalid comments (try_fix_invalid_inline_comments is off). Paths: ['f1.py', 'f2.py']")
+


### PR DESCRIPTION
Fixes #2874\n\nLogs paths of invalid inline comments that are dropped because they could not be converted to a one-line comment or because try_fix_invalid_inline_comments is off.