### PR TITLE
fix(gitea): report success/failure and submit reviews, not drafts

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -415,7 +415,8 @@ class GiteaProvider(GitProvider):
 
     def publish_code_suggestions(self, suggestions: List[Dict[str, Any]]) -> bool:
         """Publish code suggestions"""
-        all_successful = True
+        publishable_count = 0
+        published_count = 0
         for suggestion in suggestions:
             body = suggestion.get("body","")
             if not body:
@@ -427,12 +428,18 @@ class GiteaProvider(GitProvider):
             old_position = suggestion.get("relevant_lines_start",0) if "original_suggestion" not in suggestion else suggestion["original_suggestion"].get("relevant_lines_start",0)
             title_body = suggestion["original_suggestion"].get("suggestion_content","") if "original_suggestion" in suggestion else ""
             payload = dict(body=body, path=path, old_position=old_position,new_position = new_position)
+            publishable_count += 1
             if title_body:
                 title_body = f"**Suggestion:** {title_body}"
-                all_successful &= self.publish_inline_comments([payload],title_body)
+                published = self.publish_inline_comments([payload],title_body)
             else:
-                all_successful &= self.publish_inline_comments([payload])
-        return all_successful
+                published = self.publish_inline_comments([payload])
+            if published:
+                published_count += 1
+
+        # A partial failure must not report failure: the caller republishes the whole
+        # list, which would post the already-accepted suggestions a second time.
+        return published_count > 0 or publishable_count == 0
 
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -396,7 +396,7 @@ class GiteaProvider(GitProvider):
         self.publish_inline_comments([payload])
 
 
-    def publish_inline_comments(self, comments: List[Dict[str, Any]],body : str = "Inline comment") -> None:
+    def publish_inline_comments(self, comments: List[Dict[str, Any]],body : str = "Inline comment") -> bool:
         response = self.repo_api.create_inline_comment(
             owner=self.owner,
             repo=self.repo,
@@ -408,12 +408,14 @@ class GiteaProvider(GitProvider):
 
         if not response:
             self.logger.error("Failed to publish inline comment")
-            return
+            return False
 
         self.logger.info("Inline comment published")
+        return True
 
-    def publish_code_suggestions(self, suggestions: List[Dict[str, Any]]):
+    def publish_code_suggestions(self, suggestions: List[Dict[str, Any]]) -> bool:
         """Publish code suggestions"""
+        all_successful = True
         for suggestion in suggestions:
             body = suggestion.get("body","")
             if not body:
@@ -427,9 +429,11 @@ class GiteaProvider(GitProvider):
             payload = dict(body=body, path=path, old_position=old_position,new_position = new_position)
             if title_body:
                 title_body = f"**Suggestion:** {title_body}"
-                self.publish_inline_comments([payload],title_body)
+                all_successful &= self.publish_inline_comments([payload],title_body)
             else:
-                self.publish_inline_comments([payload])
+                all_successful &= self.publish_inline_comments([payload])
+        return all_successful
+
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         """Add eyes reaction to a comment"""
@@ -881,6 +885,12 @@ class RepoApi(giteapy.RepositoryApi):
             "body": body,
             "comments": comments,
             "commit_id": commit_id,
+            # Gitea/Forgejo defaults an event-less review to a draft (state
+            # PENDING), invisible to everyone but the review's author until
+            # someone manually submits it from the web UI. There is no such
+            # "submit" step in this flow, so the review must be submitted as
+            # a real event up front.
+            "event": "COMMENT",
         }
         return self.api_client.call_api(
             '/repos/{owner}/{repo}/pulls/{pr_number}/reviews',

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -796,3 +796,80 @@ class TestGiteaProviderUrlParsing:
         assert provider._parse_issue_url("https://gitea.example.com/owner/repo/issues/5") == ("owner", "repo", 5)
         assert provider._parse_issue_url(
             "https://gitea.example.com/api/v1/repos/owner/repo/issues/5") == ("owner", "repo", 5)
+
+
+class TestGiteaProviderInlineCommentStatus:
+    """Regression tests for the ``/improve`` inline-comment path:
+
+    1. ``publish_inline_comments``/``publish_code_suggestions`` never reported
+       success or failure, so ``PRCodeSuggestions.push_inline_code_suggestions``
+       always treated the call as failed and republished every suggestion a
+       second time, duplicating each one.
+    2. ``RepoApi.create_inline_comment`` posted to ``pulls/{id}/reviews``
+       without an ``event``, which Gitea/Forgejo defaults to a draft review
+       (state ``PENDING``) invisible to everyone but its author - there is no
+       later step in this flow that submits it.
+    """
+
+    @staticmethod
+    def _provider(create_inline_comment_result=True):
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.pr_number = 4
+        provider.enabled_pr = True
+        provider.last_commit = MagicMock(sha="head-sha")
+        provider.diff_files = []
+        provider.repo_api = MagicMock()
+        provider.repo_api.create_inline_comment.return_value = (
+            MagicMock() if create_inline_comment_result else None
+        )
+        return provider
+
+    def test_publish_inline_comments_reports_success(self):
+        provider = self._provider(create_inline_comment_result=True)
+
+        assert provider.publish_inline_comments([{"path": "a.py", "body": "x"}]) is True
+
+    def test_publish_inline_comments_reports_failure(self):
+        provider = self._provider(create_inline_comment_result=False)
+
+        assert provider.publish_inline_comments([{"path": "a.py", "body": "x"}]) is False
+
+    def test_publish_code_suggestions_does_not_republish_on_success(self):
+        # Before the fix, a truthy result here was still treated as failure by
+        # PRCodeSuggestions.push_inline_code_suggestions, which republished
+        # every suggestion a second time.
+        provider = self._provider(create_inline_comment_result=True)
+        suggestions = [{"body": "**Suggestion:** fix it", "relevant_file": "a.py",
+                        "relevant_lines_start": 3}]
+
+        result = provider.publish_code_suggestions(suggestions)
+
+        assert result is True
+        assert provider.repo_api.create_inline_comment.call_count == 1
+
+    def test_publish_code_suggestions_reports_failure(self):
+        provider = self._provider(create_inline_comment_result=False)
+        suggestions = [{"body": "**Suggestion:** fix it", "relevant_file": "a.py",
+                        "relevant_lines_start": 3}]
+
+        assert provider.publish_code_suggestions(suggestions) is False
+
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
+    def test_create_inline_comment_submits_as_comment_not_pending(self, mock_api_client_cls):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        client = mock_api_client_cls.return_value
+        client.call_api.return_value = MagicMock()
+        repo_api = RepoApi(client)
+
+        repo_api.create_inline_comment(
+            owner="owner", repo="repo", pr_number=4,
+            body="Inline comment", commit_id="head-sha",
+            comments=[{"path": "a.py", "body": "x"}],
+        )
+
+        _, kwargs = client.call_api.call_args
+        assert kwargs["body"]["event"] == "COMMENT"

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -857,6 +857,25 @@ class TestGiteaProviderInlineCommentStatus:
 
         assert provider.publish_code_suggestions(suggestions) is False
 
+    def test_publish_code_suggestions_reports_success_on_partial_failure(self):
+        # A partial failure must not report failure overall: the caller
+        # (PRCodeSuggestions.push_inline_code_suggestions) republishes the whole
+        # list on any falsy result, which would post the two already-accepted
+        # suggestions a second time. Exactly one create_inline_comment call per
+        # suggestion, no retries.
+        provider = self._provider()
+        provider.repo_api.create_inline_comment.side_effect = [MagicMock(), None, MagicMock()]
+        suggestions = [
+            {"body": "**Suggestion:** one", "relevant_file": "a.py", "relevant_lines_start": 1},
+            {"body": "**Suggestion:** two", "relevant_file": "a.py", "relevant_lines_start": 2},
+            {"body": "**Suggestion:** three", "relevant_file": "a.py", "relevant_lines_start": 3},
+        ]
+
+        result = provider.publish_code_suggestions(suggestions)
+
+        assert result is True
+        assert provider.repo_api.create_inline_comment.call_count == 3
+
     @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
     def test_create_inline_comment_submits_as_comment_not_pending(self, mock_api_client_cls):
         from pr_agent.git_providers.gitea_provider import RepoApi


### PR DESCRIPTION
## Problem

With `pr_code_suggestions.commitable_code_suggestions = true`, `/improve` on a Gitea/Forgejo provider produces two bugs:

1. **Every suggestion gets duplicated.** `GiteaProvider.publish_inline_comments`/`publish_code_suggestions` never returned a value (implicit `None`). `PRCodeSuggestions.push_inline_code_suggestions` checks the return of `publish_code_suggestions` and, on falsy, republishes every suggestion individually as a fallback - so a fully successful publish is always treated as a failure and every suggestion is posted twice.
2. **The review is invisible.** `RepoApi.create_inline_comment` POSTs to `/pulls/{id}/reviews` without an `event` field. Per the Gitea/Forgejo API, an event-less review defaults to a draft (`PENDING`), visible only to its author until someone manually submits it - and nothing in this flow ever does.

## Fix

- `publish_inline_comments` and `publish_code_suggestions` now return `bool`, reflecting whether the underlying API call actually succeeded.
- `create_inline_comment` submits `"event": "COMMENT"` so the review lands as a normal, visible comment instead of a stuck draft.

## Verification

- Added `TestGiteaProviderInlineCommentStatus` (5 tests) covering both failure modes. Confirmed each fails against the pre-fix code and passes against the fix.
- `pytest tests/unittest/test_gitea_provider.py`: 44 passed.
- Also verified against a live Forgejo instance (not just mocks): before the fix, one `/improve` call left a `PENDING` review with a duplicated inline comment; after the fix, exactly one `COMMENT`-state review with exactly one comment.

Both bugs are gated behind `commitable_code_suggestions = true` (default `false`), which explains why they haven't surfaced before - the default `/improve` path uses a different, single-comment publish method untouched by this change.
