### PR TITLE
fix(improve): avoid false failure after successful publish

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -162,6 +162,7 @@ class PRCodeSuggestions:
 
     async def run(self):
         init_run_details()
+        output_published = False
         try:
             if getattr(self, "_incremental_empty_scope", False):
                 # Set by `__init__` when incremental anchored cleanly but no files changed
@@ -258,6 +259,7 @@ class PRCodeSuggestions:
                         )
                         if published_comment is not None:
                             self.progress_response = None
+                        output_published = True
                     else:
                         pr_body = add_comment_identity(
                             pr_body,
@@ -268,6 +270,7 @@ class PRCodeSuggestions:
                             self.progress_response = None
                         else:
                             self.git_provider.publish_comment(pr_body)
+                        output_published = True
 
                     # dual publishing mode
                     if int(get_settings().pr_code_suggestions.dual_publishing_score_threshold) > 0:
@@ -308,7 +311,7 @@ class PRCodeSuggestions:
             if get_settings().config.publish_output:
                 if self.progress_response:
                     self.git_provider.remove_comment(self.progress_response)
-                else:
+                elif not output_published:
                     try:
                         self.git_provider.remove_initial_comment()
                         self.git_provider.publish_comment("Failed to generate code suggestions for PR")

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -113,6 +113,45 @@ async def test_run_does_not_remove_final_summary_when_cancelled_during_dual_publ
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("persistent_comment", [False, True])
+async def test_run_does_not_publish_failure_after_successful_summary(monkeypatch, persistent_comment):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = True
+        provider.publish_comment.return_value = progress_comment
+        provider.get_latest_commit_url.return_value = "https://example.invalid/commit/abcdef1234567890"
+        tool = _make_tool(provider)
+        tool.progress = "progress body"
+        tool.generate_summarized_suggestions = MagicMock(return_value="final summary")
+
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.dual_publishing_score_threshold = "invalid"
+        settings.pr_code_suggestions.persistent_comment = persistent_comment
+
+        await tool.run()
+
+        provider.edit_comment.assert_called_once()
+        if "body" in provider.edit_comment.call_args.kwargs:
+            published_body = provider.edit_comment.call_args.kwargs["body"]
+        else:
+            published_body = provider.edit_comment.call_args.args[1]
+        assert "final summary" in published_body
+        provider.publish_comment.assert_called_once_with("progress body")
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
 async def test_run_does_not_remove_persistent_summary_when_cancelled_during_dual_publishing(monkeypatch):
     settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
     try:


### PR DESCRIPTION
Fixes #2879

## What

- track when the suggestions summary has already been published
- suppress the generic failure comment when a later step raises
- cover both persistent and non-persistent summary publication

## Why

After the final summary replaces or consumes the progress comment, `progress_response` is cleared. If a later operation in the same `try` block raises, the exception handler currently interprets that cleared handle as meaning no output was published and posts a misleading failure comment next to the successful summary.

## Tests

- `PYTHONPATH=. .venv/bin/pytest tests/unittest/test_pr_code_suggestions_lifecycle.py tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_filtering.py tests/unittest/test_pr_code_suggestions_rendering.py tests/unittest/test_code_suggestions_comment_identity.py -q`
- `.venv/bin/ruff check pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_lifecycle.py`
- `git diff --check`