### PR TITLE
fix(improve): avoid false failure after inline publish

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -162,7 +162,7 @@ class PRCodeSuggestions:
 
     async def run(self):
         init_run_details()
-        output_published = False
+        self._output_published = False
         try:
             if getattr(self, "_incremental_empty_scope", False):
                 # Set by `__init__` when incremental anchored cleanly but no files changed
@@ -259,7 +259,7 @@ class PRCodeSuggestions:
                         )
                         if published_comment is not None:
                             self.progress_response = None
-                        output_published = True
+                        self._output_published = True
                     else:
                         pr_body = add_comment_identity(
                             pr_body,
@@ -270,7 +270,7 @@ class PRCodeSuggestions:
                             self.progress_response = None
                         else:
                             self.git_provider.publish_comment(pr_body)
-                        output_published = True
+                        self._output_published = True
 
                     # dual publishing mode
                     if int(get_settings().pr_code_suggestions.dual_publishing_score_threshold) > 0:
@@ -311,7 +311,7 @@ class PRCodeSuggestions:
             if get_settings().config.publish_output:
                 if self.progress_response:
                     self.git_provider.remove_comment(self.progress_response)
-                elif not output_published:
+                elif not self._output_published:
                     try:
                         self.git_provider.remove_initial_comment()
                         self.git_provider.publish_comment("Failed to generate code suggestions for PR")
@@ -864,14 +864,18 @@ class PRCodeSuggestions:
                     code_suggestions, artifact_footer=coverage_footer)
             else:
                 is_successful = self.git_provider.publish_code_suggestions(code_suggestions)
+            if is_successful:
+                self._output_published = True
             if not is_successful:
                 get_logger().info("Failed to publish code suggestions, trying to publish each suggestion separately")
                 for code_suggestion in code_suggestions:
-                    self.git_provider.publish_code_suggestions([code_suggestion])
+                    if self.git_provider.publish_code_suggestions([code_suggestion]):
+                        self._output_published = True
         if coverage_footer and not supports_suggestions_artifact:
             fallback_comments.append(coverage_footer.strip())
         if fallback_comments:
             self.git_provider.publish_comment("\n\n---\n\n".join(fallback_comments))
+            self._output_published = True
 
     def _get_diff_file(self, relevant_file):
         diff_files = getattr(self.git_provider, "diff_files", None)

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -152,6 +152,98 @@ async def test_run_does_not_publish_failure_after_successful_summary(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_run_does_not_publish_failure_after_successful_inline_suggestions(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.get_files.return_value = [object()]
+        provider.supports_code_suggestions_artifact.return_value = False
+        provider.publish_code_suggestions.return_value = True
+
+        def publish_comment(body, **_kwargs):
+            if body == "Failed to generate code suggestions for PR":
+                return MagicMock()
+            raise RuntimeError("fallback comment rejected")
+
+        provider.publish_comment.side_effect = publish_comment
+        tool = _make_tool(provider)
+        tool._validate_suggestion = MagicMock(
+            side_effect=[
+                (True, "", True),
+                (False, "the target range is outside the diff", False),
+            ]
+        )
+        tool.dedent_code = MagicMock(side_effect=lambda _file, _line, code: code)
+        fallback_suggestion = {
+            "relevant_file": "src/missing.py",
+            "relevant_lines_start": 5,
+            "relevant_lines_end": 5,
+            "suggestion_content": "Keep the fallback visible.",
+            "existing_code": "old_value",
+            "improved_code": "new_value",
+            "label": "bug",
+        }
+        suggestions = [
+            {
+                **fallback_suggestion,
+                "relevant_file": "src/example.py",
+                "relevant_lines_start": 1,
+                "relevant_lines_end": 1,
+            },
+            fallback_suggestion,
+        ]
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": suggestions}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.config.is_auto_command = True
+        settings.pr_code_suggestions.commitable_code_suggestions = True
+        settings.pr_code_suggestions.dual_publishing_score_threshold = 0
+
+        await tool.run()
+
+        provider.publish_code_suggestions.assert_called_once()
+        published_comments = [call.args[0] for call in provider.publish_comment.call_args_list]
+        assert published_comments == [
+            "**Suggestion:** Keep the fallback visible. [bug]\n\n"
+            "Proposed code (not offered as a committable change because the target range is outside the diff):\n"
+            "```\nnew_value\n```\n\nLocation: `src/missing.py:5-5`"
+        ]
+        provider.remove_initial_comment.assert_called_once()
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_failure_when_inline_suggestions_never_publish(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.get_files.return_value = [object()]
+        tool = _make_tool(provider)
+        tool.push_inline_code_suggestions = AsyncMock(side_effect=RuntimeError("inline publish failed"))
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [{"score": 1}]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.config.is_auto_command = True
+        settings.pr_code_suggestions.commitable_code_suggestions = True
+
+        await tool.run()
+
+        provider.publish_comment.assert_called_once_with("Failed to generate code suggestions for PR")
+        assert provider.remove_initial_comment.call_count == 2
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
 async def test_run_does_not_remove_persistent_summary_when_cancelled_during_dual_publishing(monkeypatch):
     settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
     try:


### PR DESCRIPTION
Closes #2883

## What

- record successful inline suggestion publications before publishing fallback comments
- suppress the generic failure comment only when at least one output already landed
- cover both partial-success and no-output error paths

## Why

On automatic committable runs, inline suggestions can publish successfully before an unanchored fallback comment is rejected. The outer error handler previously had no record of the successful inline output and posted a misleading failure comment beside it.

## Tests

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_code_suggestions_lifecycle.py tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_filtering.py tests/unittest/test_pr_code_suggestions_rendering.py tests/unittest/test_code_suggestions_comment_identity.py -q`
- `uv run ruff check pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_lifecycle.py`
- `git diff --check`