### PR TITLE
fix(github): handle pull requests without commits

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -76,7 +76,10 @@ class GithubProvider(GitProvider):
         if pr_url and 'pull' in pr_url:
             self.set_pr(pr_url)
             self.pr_commits = list(self.pr.get_commits())
-            self.last_commit_id = self.pr_commits[-1]
+            if self.pr_commits:
+                self.last_commit_id = self.pr_commits[-1]
+            else:
+                self.last_commit_id = self._get_repo().get_commit(self.pr.head.sha)
             self.pr_url = self.get_pr_url() # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
         elif pr_url and 'issue' in pr_url: #url is an issue
             self.issue_main = self._get_issue_handle(pr_url)

--- a/tests/unittest/test_github_provider_empty_commits.py
+++ b/tests/unittest/test_github_provider_empty_commits.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+from github.Commit import Commit
+
+from pr_agent.git_providers.github_provider import GithubProvider
+
+
+def _commit(sha: str) -> Commit:
+    return Commit(
+        requester=MagicMock(),
+        headers={},
+        attributes={
+            "sha": sha,
+            "url": f"https://api.github.com/repos/owner/repo/commits/{sha}",
+            "html_url": f"https://github.com/owner/repo/commit/{sha}",
+        },
+        completed=True,
+    )
+
+
+def _provider(pr, repo) -> GithubProvider:
+    def set_pr(provider, _):
+        provider.repo = "owner/repo"
+        provider.pr_num = 1
+        provider.pr = pr
+
+    with (
+        patch("pr_agent.git_providers.github_provider.get_settings") as get_settings,
+        patch.object(GithubProvider, "_get_github_client", return_value=MagicMock()),
+        patch.object(GithubProvider, "set_pr", autospec=True, side_effect=set_pr),
+        patch.object(GithubProvider, "_get_repo", autospec=True, return_value=repo),
+    ):
+        get_settings.return_value.get.side_effect = lambda _key, default=None: default
+        return GithubProvider("https://github.com/owner/repo/pull/1")
+
+
+def test_empty_commit_list_falls_back_to_pull_request_head():
+    head_sha = "a" * 40
+    fallback_commit = _commit(head_sha)
+    pr = MagicMock()
+    pr.get_commits.return_value = []
+    pr.head.sha = head_sha
+    pr.html_url = "https://github.com/owner/repo/pull/1"
+    repo = MagicMock()
+    repo.get_commit.return_value = fallback_commit
+
+    provider = _provider(pr, repo)
+
+    assert provider.pr_commits == []
+    assert provider.last_commit_id is fallback_commit
+    assert provider.get_latest_commit_url() == fallback_commit.html_url
+    repo.get_commit.assert_called_once_with(head_sha)
+
+
+def test_non_empty_commit_list_keeps_latest_commit_without_fallback():
+    latest_commit = _commit("b" * 40)
+    pr = MagicMock()
+    pr.get_commits.return_value = [latest_commit]
+    pr.html_url = "https://github.com/owner/repo/pull/1"
+    repo = MagicMock()
+
+    provider = _provider(pr, repo)
+
+    assert provider.last_commit_id is latest_commit
+    repo.get_commit.assert_not_called()


### PR DESCRIPTION
Fixes #2887

## What

- fall back to the pull request head commit when GitHub returns an empty commit list
- preserve the existing latest-commit behavior for normal pull requests
- cover both empty and non-empty commit lists with focused unit tests

## Why

A pull request whose head is reset onto its base can report zero commits. The provider previously indexed the empty list during construction, so CLI and Action runs against that pull request crashed before a tool could start. Resolving the head SHA to a PyGithub Commit keeps the object contract used by review publishing, check runs, links, and descriptions.

## Tests

- `PYTHONPATH=. uv run pytest --color=no tests/unittest/test_github_provider_*.py tests/unittest/test_github_inline_comment_fallback.py tests/unittest/test_github_line_link_range.py tests/unittest/test_inline_comment_dedup.py tests/unittest/test_pr_description*.py -q`
- `uv run ruff check pr_agent/git_providers/github_provider.py tests/unittest/test_github_provider_empty_commits.py`
- `uv run pre-commit run --files pr_agent/git_providers/github_provider.py tests/unittest/test_github_provider_empty_commits.py`
- `git diff --check`