### PR TITLE
feat(models): add OpenRouter router model support

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -523,6 +523,21 @@ key = "..." # your openrouter api key
 
 (you can obtain an Openrouter API key from [here](https://openrouter.ai/settings/keys))
 
+OpenRouter's router models can be selected directly without setting `custom_model_max_tokens`:
+
+```toml
+[config]
+model = "openrouter/auto"
+fallback_models = ["openrouter/free"]
+```
+
+PR-Agent also registers `openrouter/fusion` and `openrouter/pareto-code`. Provider routing, reasoning, and output-cap
+settings are optional for all four router models; omit them to use OpenRouter's defaults. See OpenRouter's documentation
+for the [Auto](https://openrouter.ai/docs/guides/routing/routers/auto-router),
+[Free](https://openrouter.ai/docs/guides/routing/routers/free-router),
+[Fusion](https://openrouter.ai/docs/guides/routing/routers/fusion-router), and
+[Pareto](https://openrouter.ai/docs/guides/routing/routers/pareto-router) routers.
+
 #### Openrouter provider routing, reasoning and output cap
 
 For `openrouter/...` models you can optionally restrict which upstream providers Openrouter uses, control reasoning, and cap the completion length. All keys live in the `[openrouter]` section of `configuration.toml`. Models listed in [`SUPPORT_REASONING_EFFORT_MODELS`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py) inherit `config.reasoning_effort` unless an Openrouter-specific effort or token budget is set.

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -77,6 +77,10 @@ MAX_TOKENS = {
     'zai/glm-5.2': 200000,  # 200K, matching the Z.AI GLM-5/5.1 lineage, but may be limited by config.max_model_tokens
     'moonshot/kimi-k3': 262144,  # 256K, matching the Moonshot Kimi-k2.5/k2.6 lineage, but may be limited by config.max_model_tokens
     'openai/qwq-plus': 131072,  # 131K context length, but may be limited by config.max_model_tokens
+    "openrouter/auto": 2000000,  # 2M context length, but may be limited by config.max_model_tokens
+    "openrouter/free": 200000,  # 200K context length, but may be limited by config.max_model_tokens
+    "openrouter/fusion": 1000000,  # 1M context length, but may be limited by config.max_model_tokens
+    "openrouter/pareto-code": 2000000,  # 2M context length, but may be limited by config.max_model_tokens
     'replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1': 4096,
     'meta-llama/Llama-2-7b-chat-hf': 4096,
     'vertex_ai/codechat-bison': 6144,
@@ -328,6 +332,20 @@ MAX_TOKENS = {
     'xiaomi_mimo/mimo-v2.5': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5, xiaomi_mimo/ is the native LiteLLM Xiaomi provider, but may be limited by config.max_model_tokens
     'xiaomi_mimo/mimo-v2.5-pro': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5-pro, but may be limited by config.max_model_tokens
 }
+
+OPENROUTER_ROUTER_MODEL_ALIASES = {
+    "openrouter/auto": "openrouter/openrouter/auto",
+    "openrouter/free": "openrouter/openrouter/free",
+    "openrouter/fusion": "openrouter/openrouter/fusion",
+    "openrouter/pareto-code": "openrouter/openrouter/pareto-code",
+}
+
+
+def normalize_litellm_model(model: str, custom_llm_provider: str = "") -> str:
+    if custom_llm_provider.strip().lower() not in ("", "openrouter"):
+        return model
+    return OPENROUTER_ROUTER_MODEL_ALIASES.get(model, model)
+
 
 USER_MESSAGE_ONLY_MODELS = [
     "deepseek/deepseek-reasoner",

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -18,6 +18,7 @@ from pr_agent.algo import (
     STREAMING_REQUIRED_MODELS,
     SUPPORT_REASONING_EFFORT_MODELS,
     USER_MESSAGE_ONLY_MODELS,
+    normalize_litellm_model,
 )
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_helpers import (
@@ -1162,6 +1163,9 @@ class LiteLLMAIHandler(BaseAiHandler):
         """
         model = kwargs["model"]
         custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
+        # Double the prefix so LiteLLM strips its provider prefix but preserves
+        # OpenRouter's native router ID; leave other explicit providers unchanged.
+        kwargs["model"] = normalize_litellm_model(model, custom_llm_provider)
         api_base_value = kwargs.get("api_base")
         api_base = api_base_value.strip().lower() if isinstance(api_base_value, str) else ""
         force_streaming = (

--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -24,6 +24,7 @@ from a2a.server.tasks import TaskUpdater
 from a2a.types import Part
 from starlette_context import context as sctx
 
+from pr_agent.algo import normalize_litellm_model
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.log import get_logger
 from pr_agent.mosaico.dispatch import route_and_run_result
@@ -100,12 +101,17 @@ async def health_check() -> str:
         if not model:
             return "Unhealthy: no model configured"
 
+        custom_llm_provider = str(
+            getattr(get_settings().litellm, "custom_llm_provider", "") or ""
+        ).strip().lower()
         kwargs = {
-            "model": model,
+            "model": normalize_litellm_model(model, custom_llm_provider),
             "messages": [{"role": "system", "content": "Say ping"}],
             "max_tokens": 10,
             "timeout": 10,
         }
+        if custom_llm_provider:
+            kwargs["custom_llm_provider"] = custom_llm_provider
         if getattr(handler, "api_base", None):
             kwargs["api_base"] = handler.api_base
 

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -87,6 +87,27 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == 1050000
 
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("openrouter/auto", 2000000),
+            ("openrouter/free", 200000),
+            ("openrouter/fusion", 1000000),
+            ("openrouter/pareto-code", 2000000),
+        ],
+    )
+    def test_openrouter_router_model_max_tokens(self, monkeypatch, model, expected):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0,
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == expected
+
     # Test situations where the model is not registered and exists as a custom model
     def test_model_has_custom(self, monkeypatch):
         fake_settings = type('', (), {

--- a/tests/unittest/test_litellm_openrouter_controls.py
+++ b/tests/unittest/test_litellm_openrouter_controls.py
@@ -14,7 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import litellm
 import openai
 import pytest
-from litellm.utils import get_optional_params
+from litellm.llms.openrouter.chat.transformation import OpenrouterConfig
+from litellm.utils import get_llm_provider, get_optional_params
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
 
@@ -59,7 +60,7 @@ def _restore_litellm_globals():
                 os.environ[name] = value
 
 
-def _make_settings(openrouter=None, reasoning_effort="medium"):
+def _make_settings(openrouter=None, reasoning_effort="medium", custom_llm_provider=""):
     """Minimal settings whose `.get("openrouter", ...)` returns the given dict."""
     openrouter = openrouter or {}
     return type("Settings", (), {
@@ -73,6 +74,7 @@ def _make_settings(openrouter=None, reasoning_effort="medium"):
             "get": lambda self, key, default=None: default,
         })(),
         "litellm": type("LiteLLM", (), {
+            "custom_llm_provider": custom_llm_provider,
             "get": lambda self, key, default=None: default,
         })(),
         "get": lambda self, key, default=None: (openrouter if key == "openrouter" else default),
@@ -87,11 +89,11 @@ def _mock_response():
     return mock
 
 
-async def _run(monkeypatch, model, openrouter, reasoning_effort="medium"):
+async def _run(monkeypatch, model, openrouter, reasoning_effort="medium", custom_llm_provider=""):
     monkeypatch.setattr(
         litellm_handler,
         "get_settings",
-        lambda: _make_settings(openrouter, reasoning_effort),
+        lambda: _make_settings(openrouter, reasoning_effort, custom_llm_provider),
     )
     with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                new_callable=AsyncMock) as mock_call:
@@ -148,6 +150,69 @@ class TestOpenRouterControls:
         kwargs = await _run(monkeypatch, "openrouter/z-ai/glm-5.2", {})
         assert "extra_body" not in kwargs
         assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "routed_model"),
+        [
+            ("openrouter/auto", "openrouter/openrouter/auto"),
+            ("openrouter/free", "openrouter/openrouter/free"),
+            ("openrouter/fusion", "openrouter/openrouter/fusion"),
+            ("openrouter/pareto-code", "openrouter/openrouter/pareto-code"),
+        ],
+    )
+    async def test_router_model_uses_openrouter_defaults(self, monkeypatch, model, routed_model):
+        kwargs = await _run(monkeypatch, model, {})
+        assert kwargs["model"] == routed_model
+        assert "extra_body" not in kwargs
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("custom_llm_provider", "expected_model", "expected_provider"),
+        [
+            (" OpenRouter ", "openrouter/openrouter/auto", "openrouter"),
+            (" OpenAI ", "openrouter/auto", "openai"),
+        ],
+    )
+    async def test_router_model_respects_custom_llm_provider(
+        self,
+        monkeypatch,
+        custom_llm_provider,
+        expected_model,
+        expected_provider,
+    ):
+        kwargs = await _run(monkeypatch, "openrouter/auto", {}, custom_llm_provider=custom_llm_provider)
+        assert kwargs["model"] == expected_model
+        assert kwargs["custom_llm_provider"] == expected_provider
+
+    @pytest.mark.parametrize(
+        ("model", "routed_model"),
+        [
+            ("openrouter/auto", "openrouter/openrouter/auto"),
+            ("openrouter/free", "openrouter/openrouter/free"),
+            ("openrouter/fusion", "openrouter/openrouter/fusion"),
+            ("openrouter/pareto-code", "openrouter/openrouter/pareto-code"),
+        ],
+    )
+    def test_router_model_preserves_openrouter_slug(self, model, routed_model):
+        resolved_model, provider, _, _ = get_llm_provider(routed_model)
+        assert resolved_model == model
+        assert provider == "openrouter"
+        explicit_model, explicit_provider, _, _ = get_llm_provider(
+            routed_model,
+            custom_llm_provider="openrouter",
+        )
+        assert explicit_model == model
+        assert explicit_provider == "openrouter"
+        request = OpenrouterConfig().transform_request(
+            model=resolved_model,
+            messages=[{"role": "user", "content": "test"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert request["model"] == model
 
     @pytest.mark.asyncio
     async def test_non_openrouter_model_unaffected(self, monkeypatch):

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -53,19 +53,24 @@ _MODEL_WITHOUT_STOP = "gpt-5.6"
 
 @pytest.fixture
 def restore_config_model():
-    """Snapshot/restore CONFIG.MODEL on the shared settings (no request scope here, so
+    """Snapshot/restore LLM settings on the shared settings (no request scope here, so
     get_settings() resolves to global_settings). Mirrors the snapshot/restore convention
     in test_mosaico_isolation.py."""
     settings = get_settings()
     sentinel = object()
-    before = settings.get("CONFIG.MODEL", sentinel)
+    model_before = settings.get("CONFIG.MODEL", sentinel)
+    provider_before = settings.get("LITELLM.CUSTOM_LLM_PROVIDER", sentinel)
     yield settings
-    if before is sentinel:
+    if model_before is sentinel:
         # Best-effort removal of a key we introduced; dynaconf has no public delete, so
         # blank it out rather than leak a fake model into sibling tests.
         settings.set("CONFIG.MODEL", "")
     else:
-        settings.set("CONFIG.MODEL", before)
+        settings.set("CONFIG.MODEL", model_before)
+    if provider_before is sentinel:
+        settings.set("LITELLM.CUSTOM_LLM_PROVIDER", "")
+    else:
+        settings.set("LITELLM.CUSTOM_LLM_PROVIDER", provider_before)
 
 
 class TestHealthCheckGate:
@@ -106,6 +111,38 @@ class TestHealthCheckGate:
         result = await health_check()
         assert result.startswith("Unhealthy:")
         assert "connection refused" in result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("custom_llm_provider", "expected_model", "expected_provider"),
+        [
+            ("", "openrouter/openrouter/auto", ""),
+            (" OpenRouter ", "openrouter/openrouter/auto", "openrouter"),
+            (" OpenAI ", "openrouter/auto", "openai"),
+        ],
+    )
+    async def test_openrouter_router_model_preserves_provider_routing(
+        self, monkeypatch, restore_config_model, custom_llm_provider, expected_model, expected_provider
+    ):
+        restore_config_model.set("CONFIG.MODEL", "openrouter/auto")
+        restore_config_model.set("LITELLM.CUSTOM_LLM_PROVIDER", custom_llm_provider)
+
+        called = {}
+
+        async def fake_acompletion(**kwargs):
+            called.update(kwargs)
+            return {"choices": [{"message": {"content": "pong"}}]}
+
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+        result = await health_check()
+
+        assert result == "OK"
+        assert called.get("model") == expected_model
+        if expected_provider:
+            assert called.get("custom_llm_provider") == expected_provider
+        else:
+            assert "custom_llm_provider" not in called
 
     @pytest.mark.asyncio
     async def test_no_model_configured_returns_unhealthy(


### PR DESCRIPTION
Register Auto, Free, Fusion, and Pareto Code router aliases with their context limits so they work without custom token settings.

Preserve each native OpenRouter model ID across LiteLLM provider prefix handling, including explicit providers and MOSAICO health checks, and document the default router behavior.

## GitHub Copilot PR Summary

This pull request adds robust support for OpenRouter router models in PR-Agent, ensuring correct model selection, provider routing, and context length handling. It introduces normalization logic to resolve OpenRouter router model names, updates health checks and AI handler logic to use this normalization, and adds comprehensive tests to verify correct behavior. Documentation has also been updated to clarify usage.

**OpenRouter router model support and normalization:**

* Added `OPENROUTER_ROUTER_MODEL_ALIASES` and `normalize_litellm_model()` in `pr_agent/algo/__init__.py` to map user-friendly router model names (e.g., `openrouter/auto`) to the required fully qualified names for LiteLLM, ensuring correct routing and provider behavior.
* Updated `pr_agent/algo/ai_handlers/litellm_ai_handler.py` and `pr_agent/mosaico/executor.py` to use `normalize_litellm_model()` when invoking completions and during health checks, preserving or overriding provider routing as appropriate. [[1]](diffhunk://#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfeR1166-R1168) [[2]](diffhunk://#diff-3798012ed14f9c702d4dcee964ac07d6105a48df5741dc9d5c319ae25430778fR104-R114)

**Model context length and configuration:**

* Registered OpenRouter router models with their correct context lengths in `SUPPORT_MODEL_MAX_TOKENS` for accurate token limit handling.
* Updated documentation to clarify that router models can be selected directly and to link to OpenRouter router documentation.

**Testing improvements:**

* Added and expanded tests for OpenRouter router model normalization, provider routing, and context length handling in `tests/unittest/test_get_max_tokens.py`, `tests/unittest/test_litellm_openrouter_controls.py`, and `tests/unittest/test_mosaico_health.py`. These tests cover both default and custom provider scenarios. [[1]](diffhunk://#diff-542a4562a15acee3cee1c8a0b4c7b69b0ff7149939d9f85ff12d272dc2fd0817R90-R110) [[2]](diffhunk://#diff-295bc2fa976804e777d9258120d31b3289b89a4a60358c0d4922f773b8feb4caR154-R216) [[3]](diffhunk://#diff-a94c26a5883906a895931a923c65455f70efb5778e5a2134dc20ad8aea4e17c4R115-R146)

**Test and code hygiene:**

* Improved test fixtures and helper functions to snapshot and restore both model and provider settings, ensuring test isolation.
* Refactored test helpers for clarity and expanded parameterization for coverage. [[1]](diffhunk://#diff-295bc2fa976804e777d9258120d31b3289b89a4a60358c0d4922f773b8feb4caL62-R63) [[2]](diffhunk://#diff-295bc2fa976804e777d9258120d31b3289b89a4a60358c0d4922f773b8feb4caR77) [[3]](diffhunk://#diff-295bc2fa976804e777d9258120d31b3289b89a4a60358c0d4922f773b8feb4caL90-R96)

These changes make it easier and safer to use OpenRouter router models with PR-Agent, while providing guarantees around correct provider routing and context handling.