### PR TITLE
fix: share language matcher with plain diff provider

### DIFF
--- a/pr_agent/git_providers/plain_diff_provider.py
+++ b/pr_agent/git_providers/plain_diff_provider.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from unidiff.errors import UnidiffParseError
 
+from pr_agent.algo.language_handler import build_language_file_matcher
 from pr_agent.algo.types import FilePatchInfo
 from pr_agent.config_loader import _find_repository_root, get_settings
 from pr_agent.git_providers.diff_parsing import parse_unified_diff, reconstruct_base_file, to_hunk_only_patch
@@ -145,20 +146,16 @@ class PlainDiffGitProvider(GitProvider):
         # sort_files_by_main_languages() keys on language NAMES (it maps each
         # name back to its extensions), so returning raw extensions here would
         # drop every file into the "Other" bucket and disable language-based
-        # hunk prioritization. Invert the settings map (name -> [extensions])
-        # into an extension -> name lookup; files with unknown extensions are
-        # left out and fall through to "Other" downstream.
-        ext_to_lang = {}
+        # hunk prioritization. Use the shared filename matcher so full names,
+        # multipart suffixes, and case-sensitive extensions behave consistently.
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
-        for language, extensions in lang_map.items():
-            for ext in extensions:
-                ext_to_lang.setdefault(ext.lower().lstrip("*"), language)
+        get_language = build_language_file_matcher(lang_map)
 
         lang_count = Counter()
         for f in self.get_diff_files():
             if not f.filename:
                 continue
-            language = ext_to_lang.get(os.path.splitext(f.filename)[1].lower())
+            language = get_language(f.filename)
             if language:
                 lang_count[language] += 1
 

--- a/tests/unittest/test_plain_diff_provider.py
+++ b/tests/unittest/test_plain_diff_provider.py
@@ -84,6 +84,20 @@ diff --git a/weird.zzz b/weird.zzz
 +q
 """
 
+_FILENAME_MATCHING_DIFF = """diff --git a/upper.C b/upper.C
+--- a/upper.C
++++ b/upper.C
+@@ -1 +1,2 @@
+ a
++b
+diff --git a/Dockerfile b/Dockerfile
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -1 +1,2 @@
+ x
++y
+"""
+
 
 def test_get_languages_returns_language_names(cfg):
     # get_languages() must key on language NAMES (e.g. "Python"), not raw
@@ -103,6 +117,14 @@ def test_get_languages_returns_language_names(cfg):
     assert buckets["Python"] == {"foo.py"}
     assert buckets["JavaScript"] == {"app.js"}
     assert buckets["Other"] == {"weird.zzz"}  # unknown extension falls through
+
+
+def test_get_languages_matches_case_sensitive_and_full_filenames(cfg):
+    cfg("plain_diff.content", _FILENAME_MATCHING_DIFF)
+    cfg("plain_diff.output_path", None)
+    provider = PlainDiffGitProvider(None)
+
+    assert provider.get_languages() == {"C++": 50.0, "Dockerfile": 50.0}
 
 
 def test_get_diff_files_patch_is_hunk_only(cfg):


### PR DESCRIPTION
## Summary

- replace `PlainDiffGitProvider`'s private extension inversion with the shared `build_language_file_matcher`
- preserve case-sensitive extensions, full filename rules, and multipart suffix matching in plain-diff mode
- add regression coverage for `.C` and `Dockerfile`, as requested in the issue

## Why

The private implementation lowercased extensions and relied on `os.path.splitext()`. That classified `.C` as C instead of C++, dropped full filenames such as `Dockerfile`, and truncated multipart suffixes. Reusing the shared matcher keeps plain-diff behavior aligned with the other local providers.

Fixes #2894

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest -q` — 2,758 passed, 1 skipped, 1 xfailed
- `uv run pre-commit run --files pr_agent/git_providers/plain_diff_provider.py tests/unittest/test_plain_diff_provider.py` — passed
- `uv run ruff check --fix pr_agent/git_providers/plain_diff_provider.py tests/unittest/test_plain_diff_provider.py` — passed
