### PR TITLE
fix(pr_agent/tools/pr_code_suggestions.py): reporting no suggestions when the key is missing

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -751,6 +751,11 @@ class PRCodeSuggestions:
                          first_key="code_suggestions", last_key="label")
         if isinstance(data, list):
             data = {'code_suggestions': data}
+        if not isinstance(data, dict) or not isinstance(data.get('code_suggestions'), list):
+            get_logger().warning("The model did not return a code_suggestions list; "
+                                 "reporting no suggestions for this call",
+                                 artifact={'predictions': predictions})
+            return {'code_suggestions': []}
 
         # remove or edit invalid suggestions
         suggestion_list = []

--- a/tests/unittest/test_improve_missing_suggestions_key.py
+++ b/tests/unittest/test_improve_missing_suggestions_key.py
@@ -1,0 +1,52 @@
+"""Parse an /improve response that does not carry the documented code_suggestions list."""
+import pytest
+
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+
+DOCUMENTED = """code_suggestions:
+- relevant_file: |
+    src/app.py
+  suggestion_content: |
+    do x
+  existing_code: |
+    a = 1
+  improved_code: |
+    a = 2
+  one_sentence_summary: |
+    fix a
+  relevant_lines_start: 1
+  relevant_lines_end: 1
+  label: |
+    best practice
+"""
+
+
+def parse(prediction):
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    return tool._prepare_pr_code_suggestions(prediction)
+
+
+def test_parse_the_documented_response():
+    """Keep the documented response parsing exactly as before."""
+    assert len(parse(DOCUMENTED)["code_suggestions"]) == 1
+
+
+@pytest.mark.parametrize("prediction, reason", [
+    ("No suggestions found for this PR.\n", "the model answered in prose"),
+    ("suggestions:\n- relevant_file: src/app.py\n", "the model renamed the key"),
+    ("code_suggestions:\n", "the model emitted the key with no value"),
+    ("code_suggestions: |\n  none\n", "the model wrote a string instead of a list"),
+    ("::: not : valid : yaml :::\n\t- [", "the response could not be parsed at all"),
+])
+def test_return_an_empty_suggestion_list(prediction, reason):
+    """Report no suggestions instead of failing the whole /improve run."""
+    assert parse(prediction) == {"code_suggestions": []}, reason
+
+
+def test_a_bare_list_response_is_still_wrapped():
+    """Keep accepting a top-level list, which the parser already normalises."""
+    prediction = ("- relevant_file: |\n    src/app.py\n  suggestion_content: |\n    do x\n"
+                  "  existing_code: |\n    a = 1\n  improved_code: |\n    a = 2\n"
+                  "  one_sentence_summary: |\n    fix a\n  label: |\n    best practice\n")
+
+    assert len(parse(prediction)["code_suggestions"]) == 1


### PR DESCRIPTION

Closes #2902.

## Description

`_prepare_pr_code_suggestions` iterates `data['code_suggestions']` without checking that the key exists or holds a list.

### Root cause

Answering in prose when there is nothing to suggest is the behaviour of a helpful assistant, and it is
exactly the case the tool should report cleanly. Instead it is the case that loses the run.

### The fix

Validate the parsed payload once, before the loop: anything that is not a dict carrying a `code_suggestions` list is logged with the raw prediction and reported as an empty suggestion list.

## Behaviour change

| | |
|---|---|
| **Before** | A prose answer fails the whole `/improve` run |
| **After** | A prose answer reports no suggestions; a well-formed response is unchanged |

## Files changed

```
pr_agent/tools/pr_code_suggestions.py | 5 +++++
 1 file changed, 5 insertions(+)
```

## Testing

Written test-first: the test was committed red, then the fix turned it green.

New regression coverage in `tests/unittest/test_improve_missing_suggestions_key.py` — **7 tests**:

```
$ PYTHONPATH=. pytest tests/unittest/test_improve_missing_suggestions_key.py
7 passed
```

Proven to be a genuine regression test: with every changed `pr_agent/` file reverted to its `739ea8a6`
version and the new test file left in place, the suite **fails**. It only passes with the fix applied.

Full unit suite on this branch:

```
$ PYTHONPATH=. pytest tests/unittest
3 failed, 2767 passed, 1 skipped, 1 xfailed, 89 warnings in 27.88s
```

The 3 failures are `tests/unittest/test_extra_config_url.py`, which fail identically on unmodified `main` in this
sandbox because they need outbound network; they pass in CI.

Also checked:

- `ruff` — no new findings vs `main`; `isort` — clean on every file touched
- No new code comments authored

## Risk / compatibility

The existing normalisation of a top-level list is preserved and still tested. Only inputs that used to raise now return an empty list.
