### PR TITLE
fix(pr_agent/config_loader.py): coercing verbosity_level to int

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -29,7 +29,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
 )
 from pr_agent.algo.run_details import _as_decimal_cost, record_ai_call
 from pr_agent.algo.utils import ReasoningEffort, get_version
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.log import get_logger
 
 MODEL_RETRIES = 2
@@ -505,12 +505,12 @@ class LiteLLMAIHandler(BaseAiHandler):
             "type": "enabled",
             "budget_tokens": extended_thinking_budget_tokens
         }
-        if get_settings().config.verbosity_level >= 2:
+        if get_verbosity_level() >= 2:
             get_logger().info(f"Adding max output tokens {extended_thinking_max_output_tokens} to model {model}, extended thinking budget tokens: {extended_thinking_budget_tokens}")
         kwargs["max_tokens"] = extended_thinking_max_output_tokens
 
         # temperature may only be set to 1 when thinking is enabled
-        if get_settings().config.verbosity_level >= 2:
+        if get_verbosity_level() >= 2:
             get_logger().info("Temperature may only be set to 1 when thinking is enabled with claude models.")
         kwargs["temperature"] = 1
 
@@ -1097,7 +1097,7 @@ class LiteLLMAIHandler(BaseAiHandler):
 
                 get_logger().debug("Prompts", artifact={"system": system, "user": user})
 
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"\nSystem prompt:\n{system}")
                     get_logger().info(f"\nUser prompt:\n{user}")
 
@@ -1150,7 +1150,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         get_logger().debug("Full_response", artifact=response_log)
 
         # for CLI debugging
-        if get_settings().config.verbosity_level >= 2:
+        if get_verbosity_level() >= 2:
             get_logger().info(f"\nAI response:\n{resp}")
 
         self._record_completion_metadata(response_obj, model=model, display_model=user_model)

--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -4,7 +4,7 @@ import re
 import traceback
 
 from pr_agent.algo.types import EDIT_TYPE
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.log import get_logger
 
 # Optimized: Pre-compile the hunk header regex at the module level to avoid redundant compilation
@@ -284,14 +284,14 @@ def handle_patch_deletions(patch: str, original_file_content_str: str,
     """
     if not new_file_content_str and (edit_type == EDIT_TYPE.DELETED or edit_type == EDIT_TYPE.UNKNOWN):
         # logic for handling deleted files - don't show patch, just show that the file was deleted
-        if get_settings().config.verbosity_level > 0:
+        if get_verbosity_level() > 0:
             get_logger().info(f"Processing file: {file_name}, minimizing deletion file")
         patch = None # file was deleted
     else:
         patch_lines = patch.splitlines()
         patch_new = omit_deletion_hunks(patch_lines)
         if patch != patch_new:
-            if get_settings().config.verbosity_level > 0:
+            if get_verbosity_level() > 0:
                 get_logger().info(f"Processing file: {file_name}, hunks were deleted")
             patch = patch_new
     return patch

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -15,7 +15,7 @@ from pr_agent.algo.run_details import record_model_used
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.algo.utils import ModelType, clip_tokens, get_max_tokens, get_model
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.log import get_logger
 
@@ -313,7 +313,7 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
             # Current logic is to skip the patch if it's too large
             # TODO: Option for alternative logic to remove hunks from the patch to reduce the number of tokens
             #  until we meet the requirements
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().warning(f"Patch too large, skipping it: '{filename}'")
             remaining_files_list_new.append(filename)
             continue
@@ -326,7 +326,7 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
             patches.append(patch_final)
             total_tokens += token_handler.count_tokens(patch_final)
             files_in_patch_list.append(filename)
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Tokens: {total_tokens}, last filename: {filename}")
     return total_tokens, patches, remaining_files_list_new, files_in_patch_list
 
@@ -444,7 +444,7 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     call_number = 1
     for file in sorted_files:
         if call_number > max_calls:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Reached max calls ({max_calls})")
             break
 
@@ -497,16 +497,16 @@ def get_pr_multi_diffs(git_provider: GitProvider,
             total_tokens = token_handler.prompt_tokens
             call_number += 1
             if call_number > max_calls: # avoid creating new patches
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"Reached max calls ({max_calls})")
                 break
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Call number: {call_number}")
 
         if patch:
             patches.append(patch)
             total_tokens += new_patch_tokens
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Tokens: {total_tokens}, last filename: {file.filename}")
 
     # Add the last chunk

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -29,7 +29,7 @@ from pr_agent.algo.git_patch_processing import extract_hunk_headers, extract_hun
 from pr_agent.algo.run_details import get_run_details
 from pr_agent.algo.token_handler import TokenEncoder
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level, global_settings
 from pr_agent.log import get_logger
 
 
@@ -827,7 +827,7 @@ def load_large_diff(filename, new_file_content_str: str, original_file_content_s
         new_file_content_str = (new_file_content_str or "").rstrip() + "\n"
         diff = difflib.unified_diff(original_file_content_str.splitlines(keepends=True),
                                     new_file_content_str.splitlines(keepends=True))
-        if get_settings().config.verbosity_level >= 2 and show_warning:
+        if get_verbosity_level() >= 2 and show_warning:
             get_logger().info(f"File was modified, but no patch was found. Manually creating patch: {filename}.")
         patch = ''.join(diff)
         return patch

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -60,6 +60,21 @@ def get_settings(use_context=False):
         return global_settings
 
 
+def get_verbosity_level() -> int:
+    """Return config.verbosity_level as an int, falling back to the quietest level.
+
+    The value is compared with >= at many call sites, so a quoted number in a settings file
+    would otherwise raise in the middle of a command.
+    """
+    value = get_settings().config.get("verbosity_level", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        from pr_agent.log import get_logger
+        get_logger().warning(f"verbosity_level is not a number ({value!r}), using 0")
+        return 0
+
+
 # Add local configuration from pyproject.toml of the project being reviewed
 def _find_repository_root() -> Optional[Path]:
     """

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -17,7 +17,7 @@ from ..algo.utils import (
     get_pr_review_comment_identifiers,
     load_large_diff,
 )
-from ..config_loader import get_settings
+from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
 from .git_provider import GitProvider, IncrementalPR
 
@@ -510,7 +510,7 @@ class AzureDevopsProvider(GitProvider):
             )
             return b"".join(list(contents))
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().error(f"Failed to get repo settings, error: {e}")
             return ""
 
@@ -534,7 +534,7 @@ class AzureDevopsProvider(GitProvider):
             )
             return item.content or ""
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().warning(f"Failed to load repo file: {file_path}, error: {e}")
             if _is_not_found_error(e):
                 return ""
@@ -861,7 +861,7 @@ class AzureDevopsProvider(GitProvider):
                                                                                 relevant_line_in_file,
                                                                                 absolute_position)
         if position == -1:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
             subject_type = "FILE"
         else:
@@ -904,12 +904,12 @@ class AzureDevopsProvider(GitProvider):
                         body = (f"`{relevant_file}` - could not be anchored to a file in the PR diff\n\n"
                                 f"{comment_body}")
                     self.publish_comment(body, thread_context=thread_context)
-                    if get_settings().config.verbosity_level >= 2:
+                    if get_verbosity_level() >= 2:
                         get_logger().info(
                             f"Published code suggestion on {self.pr_num} at {relevant_file}"
                         )
                 except Exception as e:
-                    if get_settings().config.verbosity_level >= 2:
+                    if get_verbosity_level() >= 2:
                         get_logger().error(f"Failed to publish code suggestion, error: {e}")
                     overall_success = False
             return overall_success
@@ -1103,7 +1103,7 @@ class AzureDevopsProvider(GitProvider):
             pr_id = f"{self.workspace_slug}/{self.repo_slug}/{self.pr_num}"
             return pr_id
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Failed to get PR id, error: {e}")
             return ""
 

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -13,7 +13,7 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from ..algo.file_filter import filter_ignored
 from ..algo.language_handler import is_valid_file
 from ..algo.utils import add_pr_review_identity, comment_matches_identity, find_line_number_of_relevant_line_in_file
-from ..config_loader import get_settings
+from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
 from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, get_cached_global_settings
 
@@ -494,7 +494,7 @@ class BitbucketProvider(GitProvider):
                                                                                 relevant_line_in_file,
                                                                                 absolute_position)
         if position == -1:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
             subject_type = "FILE"
         else:
@@ -540,7 +540,7 @@ class BitbucketProvider(GitProvider):
                 link = f"{self.pr_url}/#L{relevant_file}T{absolute_position}"
                 return link
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Failed adding line link, error: {e}")
 
         return ""

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -14,7 +14,7 @@ from ..algo.git_patch_processing import decode_if_bytes
 from ..algo.language_handler import is_valid_file
 from ..algo.types import EDIT_TYPE, FilePatchInfo
 from ..algo.utils import find_line_number_of_relevant_line_in_file, load_large_diff
-from ..config_loader import get_settings
+from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
 from .git_provider import GitProvider, get_git_ssl_env
 
@@ -193,7 +193,7 @@ class BitbucketServerProvider(GitProvider):
             self.publish_inline_comments(post_parameters_list)
             return True
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().error(f"Failed to publish code suggestion, error: {e}")
             return False
 
@@ -354,7 +354,7 @@ class BitbucketServerProvider(GitProvider):
             absolute_position
         )
         if position == -1:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
             subject_type = "FILE"
         else:
@@ -404,17 +404,17 @@ class BitbucketServerProvider(GitProvider):
                     link = f"{self.pr_url}/diff#{quote_plus(relevant_file)}?t={absolute_position}"
                     return link
                 else:
-                    if get_settings().config.verbosity_level >= 2:
+                    if get_verbosity_level() >= 2:
                         get_logger().info(f"Failed adding line link to '{relevant_file}' since PR not set")
             else:
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"Failed adding line link to '{relevant_file}' since position not found")
 
             if absolute_position != -1 and self.pr_url:
                 link = f"{self.pr_url}/diff#{quote_plus(relevant_file)}?t={absolute_position}"
                 return link
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Failed adding line link to '{relevant_file}', error: {e}")
 
         return ""

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -31,7 +31,7 @@ from ..algo.utils import (
     get_pr_review_comment_identifiers,
     load_large_diff,
 )
-from ..config_loader import get_settings
+from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
 from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, IncrementalPR, get_cached_global_settings
 
@@ -1689,7 +1689,7 @@ class GitLabProvider(GitProvider):
                 # link = f"{self.pr.web_url}/diffs#{sha_file}_{absolute_position}_{absolute_position}"
                 return link
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Failed adding line link, error: {e}")
 
         return ""

--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -10,7 +10,7 @@ from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import load_yaml
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.log import get_logger
@@ -86,7 +86,7 @@ class PRAddDocs:
         environment = Environment(undefined=StrictUndefined)
         system_prompt = environment.from_string(get_settings().pr_add_docs_prompt.system).render(variables)
         user_prompt = environment.from_string(get_settings().pr_add_docs_prompt.user).render(variables)
-        if get_settings().config.verbosity_level >= 2:
+        if get_verbosity_level() >= 2:
             get_logger().info(f"\nSystem prompt:\n{system_prompt}")
             get_logger().info(f"\nUser prompt:\n{user_prompt}")
         response, finish_reason = await self.ai_handler.chat_completion(
@@ -109,7 +109,7 @@ class PRAddDocs:
 
         for d in data['Code Documentation']:
             try:
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"add_docs: {d}")
                 relevant_file = d['relevant file'].strip()
                 relevant_line = int(d['relevant line'])  # absolute position
@@ -124,7 +124,7 @@ class PRAddDocs:
                                              'relevant_lines_start': relevant_line,
                                              'relevant_lines_end': relevant_line})
             except Exception:
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"Could not parse code docs: {d}")
 
         is_successful = self.git_provider.publish_code_suggestions(docs)
@@ -169,7 +169,7 @@ class PRAddDocs:
                     else:
                         new_code_snippet = new_code_snippet.rstrip() + "\n" + original_initial_line
         except Exception as e:
-            if get_settings().config.verbosity_level >= 2:
+            if get_verbosity_level() >= 2:
                 get_logger().info(f"Could not dedent code snippet for file {relevant_file}, error: {e}")
 
         return new_code_snippet

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -40,7 +40,7 @@ from pr_agent.algo.utils import (
     show_relevant_configurations,
     show_run_details,
 )
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.git_providers import (
     GithubProvider,
     get_git_provider_with_context,
@@ -817,7 +817,7 @@ class PRCodeSuggestions:
 
         for d in data['code_suggestions']:
             try:
-                if get_settings().config.verbosity_level >= 2:
+                if get_verbosity_level() >= 2:
                     get_logger().info(f"suggestion: {d}")
                 relevant_file = d['relevant_file'].strip()
                 relevant_lines_start = int(d['relevant_lines_start'])  # absolute position

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -10,7 +10,7 @@ from pr_agent.algo.git_patch_processing import extract_hunk_lines_from_patch
 from pr_agent.algo.pr_processing import OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD, retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenEncoder, TokenHandler
 from pr_agent.algo.utils import ModelType, get_max_tokens
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.git_providers.github_provider import GithubProvider
@@ -191,7 +191,7 @@ class PR_LineQuestions:
         variables["selected_lines"] = self.selected_lines
         variables["conversation_history"] = self._fit_conversation_history(variables, model)
         system_prompt, user_prompt = self._render_prompts(variables)
-        if get_settings().config.verbosity_level >= 2:
+        if get_verbosity_level() >= 2:
             # get_logger().info(f"\nSystem prompt:\n{system_prompt}")
             # get_logger().info(f"\nUser prompt:\n{user_prompt}")
             print(f"\nSystem prompt:\n{system_prompt}")

--- a/tests/unittest/test_verbosity_level_coercion.py
+++ b/tests/unittest/test_verbosity_level_coercion.py
@@ -1,0 +1,55 @@
+"""Read config.verbosity_level whatever numeric form the settings file uses."""
+import pytest
+
+from pr_agent.algo.pr_processing import get_pr_diff
+from pr_agent.algo.token_handler import TokenHandler
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.config_loader import get_settings, get_verbosity_level
+
+
+class BigPRProvider:
+    def get_diff_files(self):
+        patch = "@@ -0,0 +1,4000 @@\n" + "\n".join(f"+line {i} " + "x" * 200 for i in range(4000))
+        return [FilePatchInfo(base_file="", head_file="", patch=patch, filename="big.py",
+                              edit_type=EDIT_TYPE.ADDED)]
+
+    def get_languages(self):
+        return {"Python": 100}
+
+    def get_files(self):
+        return ["big.py"]
+
+    def is_supported(self, capability):
+        return True
+
+
+@pytest.fixture
+def restore_verbosity():
+    settings = get_settings(use_context=False)
+    original = settings.get("config.verbosity_level", 0)
+    yield settings
+    settings.set("config.verbosity_level", original)
+
+
+@pytest.mark.parametrize("value, expected", [(2, 2), ("2", 2), (0, 0), ("0", 0), (" 3 ", 3)])
+def test_read_a_numeric_verbosity_level(restore_verbosity, value, expected):
+    """A quoted number is what TOML yields for verbosity_level = "2"."""
+    restore_verbosity.set("config.verbosity_level", value)
+
+    assert get_verbosity_level() == expected
+
+
+@pytest.mark.parametrize("value", ["chatty", None, [2]])
+def test_fall_back_to_silent_for_an_unusable_verbosity_level(restore_verbosity, value):
+    """Fall back to the quietest level rather than raising mid-command."""
+    restore_verbosity.set("config.verbosity_level", value)
+
+    assert get_verbosity_level() == 0
+
+
+def test_build_a_large_pr_diff_with_a_quoted_verbosity_level(restore_verbosity):
+    """The diff pipeline compares verbosity_level, so a quoted value used to break /review."""
+    restore_verbosity.set("config.verbosity_level", "2")
+    token_handler = TokenHandler(type("PR", (), {"title": "t"})(), {}, "system", "user")
+
+    assert get_pr_diff(BigPRProvider(), token_handler, "gpt-4o") is not None


### PR DESCRIPTION


Closes #2908.

## Description

`config.verbosity_level` is compared with `>=` at more than twenty call sites and never coerced, so a quoted value in `.pr_agent.toml` raises mid-command.

### Root cause

The same TOML quoting slip whose siblings were already fixed and merged for `patch_extra_lines_*`,
`max_model_tokens` and `model_token_count_estimate_factor`. `verbosity_level` was not covered.

### The fix

A `get_verbosity_level()` accessor in `config_loader` coerces the value to `int`, logging a warning and
falling back to the quietest level when it cannot. Every one of the 20+ raw comparisons across
`algo/`, `tools/` and `git_providers/` now goes through it.

## Behaviour change

| | |
|---|---|
| **Before** | A quoted number raises `TypeError` on every large PR |
| **After** | A quoted number is coerced; an unusable value logs a warning and runs silently |

## Files changed

```
pr_agent/algo/ai_handlers/litellm_ai_handler.py     | 10 +++++-----
 pr_agent/algo/git_patch_processing.py               |  6 +++---
 pr_agent/algo/pr_processing.py                      | 14 +++++++-------
 pr_agent/algo/utils.py                              |  4 ++--
 pr_agent/config_loader.py                           | 15 +++++++++++++++
 pr_agent/git_providers/azuredevops_provider.py      | 14 +++++++-------
 pr_agent/git_providers/bitbucket_provider.py        |  6 +++---
 pr_agent/git_providers/bitbucket_server_provider.py | 12 ++++++------
 pr_agent/git_providers/gitlab_provider.py           |  4 ++--
 pr_agent/tools/pr_add_docs.py                       | 10 +++++-----
 pr_agent/tools/pr_code_suggestions.py               |  4 ++--
 pr_agent/tools/pr_line_questions.py                 |  4 ++--
 12 files changed, 59 insertions(+), 44 deletions(-)
```

## Testing

Written test-first: the test was committed red, then the fix turned it green.

New regression coverage in `tests/unittest/test_verbosity_level_coercion.py` — **9 tests**:

```
$ PYTHONPATH=. pytest tests/unittest/test_verbosity_level_coercion.py
9 passed
```

Proven to be a genuine regression test: with every changed `pr_agent/` file reverted to its `739ea8a6`
version and the new test file left in place, the suite **fails**. It only passes with the fix applied.

Full unit suite on this branch:

```
$ PYTHONPATH=. pytest tests/unittest
3 failed, 2769 passed, 1 skipped, 1 xfailed, 89 warnings in 28.12s
```

The 3 failures are `tests/unittest/test_extra_config_url.py`, which fail identically on unmodified `main` in this
sandbox because they need outbound network; they pass in CI.

Also checked:

- `ruff` — no new findings vs `main`; `isort` — clean on every file touched
- No new code comments authored

## Risk / compatibility

The helper lives in `config_loader`, the lowest-level module, so no import cycle is introduced —
`algo/utils.py` and `algo/git_patch_processing.py` can both import it. Numeric values behave exactly as before.
