### PR TITLE
fix(add_docs): clear the progress comment and report when no documentation was produced

### DIFF
--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -104,6 +104,10 @@ class PRAddDocs:
         data = load_yaml(docs)
         if isinstance(data, list):
             data = {'Code Documentation': data}
+        if not isinstance(data, dict) or not isinstance(data.get('Code Documentation'), list):
+            get_logger().warning("The model did not return a Code Documentation list",
+                                 artifact={'prediction': docs})
+            return {'Code Documentation': []}
         return data
 
     def push_inline_docs(self, data):

--- a/tests/unittest/test_add_docs_missing_key.py
+++ b/tests/unittest/test_add_docs_missing_key.py
@@ -1,0 +1,59 @@
+"""Report an /add_docs response that carries no documentation, instead of going silent."""
+import pytest
+
+from pr_agent.tools.pr_add_docs import PRAddDocs
+
+DOCUMENTED = """Code Documentation:
+- relevant file: |
+    src/app.py
+  relevant line: 1
+  doc placement: |
+    before
+  documentation: |
+    \"\"\"Do the thing.\"\"\"
+"""
+
+
+class FakeGitProvider:
+    def __init__(self):
+        self.comments = []
+        self.suggestions = []
+
+    def publish_comment(self, body, **kwargs):
+        self.comments.append(body)
+        return "comment"
+
+    def publish_code_suggestions(self, suggestions):
+        self.suggestions.append(suggestions)
+        return True
+
+    def get_diff_files(self):
+        return []
+
+
+def run(prediction):
+    tool = PRAddDocs.__new__(PRAddDocs)
+    tool.git_provider = FakeGitProvider()
+    tool.prediction = prediction
+    tool.push_inline_docs(tool._prepare_pr_code_docs())
+    return tool.git_provider
+
+
+def test_publish_the_documented_response():
+    """Keep publishing suggestions for a well-formed response."""
+    provider = run(DOCUMENTED)
+
+    assert provider.suggestions and provider.suggestions[0]
+
+
+@pytest.mark.parametrize("prediction, reason", [
+    ("No documentation needed for this PR.\n", "the model answered in prose"),
+    ("documentation:\n- relevant file: src/app.py\n", "the model renamed the key"),
+    ("Code Documentation:\n", "the model emitted the key with no value"),
+    ("::: not : valid : yaml :::\n\t- [", "the response could not be parsed at all"),
+])
+def test_tell_the_user_that_nothing_was_produced(prediction, reason):
+    """A command that ran must leave a comment, never silence."""
+    provider = run(prediction)
+
+    assert provider.comments, reason

--- a/tests/unittest/test_add_docs_missing_key.py
+++ b/tests/unittest/test_add_docs_missing_key.py
@@ -1,6 +1,10 @@
-"""Report an /add_docs response that carries no documentation, instead of going silent."""
+"""Clear the progress comment when an /add_docs response carries no documentation."""
+import asyncio
+
 import pytest
 
+import pr_agent.tools.pr_add_docs as pr_add_docs
+from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_add_docs import PRAddDocs
 
 DOCUMENTED = """Code Documentation:
@@ -18,32 +22,55 @@ class FakeGitProvider:
     def __init__(self):
         self.comments = []
         self.suggestions = []
+        self.initial_comment_removed = False
+        self.diff_files = []
 
     def publish_comment(self, body, **kwargs):
         self.comments.append(body)
         return "comment"
+
+    def remove_initial_comment(self):
+        self.initial_comment_removed = True
 
     def publish_code_suggestions(self, suggestions):
         self.suggestions.append(suggestions)
         return True
 
     def get_diff_files(self):
-        return []
+        return self.diff_files
 
 
-def run(prediction):
+@pytest.fixture
+def publish_output():
+    settings = get_settings(use_context=False)
+    original = settings.get("config.publish_output", True)
+    settings.set("config.publish_output", True)
+    yield settings
+    settings.set("config.publish_output", original)
+
+
+def run(prediction, monkeypatch):
+    async def fake_retry(fn=None, model_type=None):
+        return prediction
+
+    monkeypatch.setattr(pr_add_docs, "retry_with_fallback_models", fake_retry)
     tool = PRAddDocs.__new__(PRAddDocs)
     tool.git_provider = FakeGitProvider()
     tool.prediction = prediction
-    tool.push_inline_docs(tool._prepare_pr_code_docs())
+    asyncio.run(tool.run())
     return tool.git_provider
 
 
-def test_publish_the_documented_response():
+def results(provider):
+    return [c for c in provider.comments if "Generating Documentation" not in c]
+
+
+def test_publish_the_documented_response(publish_output, monkeypatch):
     """Keep publishing suggestions for a well-formed response."""
-    provider = run(DOCUMENTED)
+    provider = run(DOCUMENTED, monkeypatch)
 
     assert provider.suggestions and provider.suggestions[0]
+    assert provider.initial_comment_removed
 
 
 @pytest.mark.parametrize("prediction, reason", [
@@ -52,8 +79,22 @@ def test_publish_the_documented_response():
     ("Code Documentation:\n", "the model emitted the key with no value"),
     ("::: not : valid : yaml :::\n\t- [", "the response could not be parsed at all"),
 ])
-def test_tell_the_user_that_nothing_was_produced(prediction, reason):
-    """A command that ran must leave a comment, never silence."""
-    provider = run(prediction)
+def test_clear_the_progress_comment_when_nothing_was_produced(publish_output, monkeypatch,
+                                                              prediction, reason):
+    """The 'Generating Documentation...' placeholder must not be left behind."""
+    provider = run(prediction, monkeypatch)
 
-    assert provider.comments, reason
+    assert provider.initial_comment_removed, reason
+
+
+@pytest.mark.parametrize("prediction", [
+    "No documentation needed for this PR.\n",
+    "documentation:\n- relevant file: src/app.py\n",
+    "Code Documentation:\n",
+    "::: not : valid : yaml :::\n\t- [",
+])
+def test_tell_the_user_that_nothing_was_produced(publish_output, monkeypatch, prediction):
+    """A command that ran must leave a result, never just a stale placeholder."""
+    provider = run(prediction, monkeypatch)
+
+    assert results(provider) == ["No code documentation found to improve this PR."]


### PR DESCRIPTION
Closes #2914.

When the model answers `/add_docs` with prose, renames the key, or returns unparseable YAML, `run()` takes the early return at `pr_add_docs.py:64` and skips `remove_initial_comment()`, so the "Generating Documentation..." placeholder is left behind and nothing tells the user the command finished.

`_prepare_pr_code_docs` now normalises any response without a `Code Documentation` list to an empty one (with a warning carrying the raw prediction), so `run()` continues into `push_inline_docs`, clears the placeholder and posts the existing "No code documentation found to improve this PR." comment. Well-formed responses are unchanged.

Tests: `tests/unittest/test_add_docs_missing_key.py` drives `run()` end to end for four malformed shapes and one documented response, nine cases; six go red with main's `pr_add_docs.py`.

Carried by the maintainer on 16 Sep: the two 7 Sep suggestions applied, `fake_retry` accepts the `git_provider` keyword #3104 added, description rewritten to the placeholder story.
