### PR TITLE
fix(gitlab): handle null webhook labels

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -271,7 +271,7 @@ def should_process_pr_logic(data) -> bool:
                 return False
 
         if ignore_mr_labels:
-            labels = [label['title'] for label in data['object_attributes'].get('labels', [])]
+            labels = [label['title'] for label in data['object_attributes'].get('labels') or []]
             if any(label in ignore_mr_labels for label in labels):
                 labels_str = ", ".join(labels)
                 get_logger().info(f"Ignoring MR with labels '{labels_str}' due to gitlab.ignore_mr_labels settings")

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -207,6 +207,12 @@ def test_gitlab_should_process_pr_logic_ignores_labels_and_branches(gitlab_webho
         assert gitlab_webhook_module.should_process_pr_logic(
             _gitlab_payload(target_branch="legacy")
         ) is False
+
+        settings.set("CONFIG.IGNORE_PR_TITLE", ["^Auto:"])
+        for nullable_field in ("source_branch", "target_branch", "labels"):
+            assert gitlab_webhook_module.should_process_pr_logic(
+                _gitlab_payload(title="Auto: bump deps", **{nullable_field: None})
+            ) is False
     finally:
         settings.set("CONFIG.IGNORE_REPOSITORIES", original["ignore_repositories"])
         settings.set("CONFIG.IGNORE_PR_AUTHORS", original["ignore_pr_authors"])


### PR DESCRIPTION
## What

- treat a present-but-null GitLab `labels` field as an empty list
- add regression coverage showing that null `source_branch`, `target_branch`, or `labels` values cannot bypass the later title-ignore rule

## Why

GitLab can send `"labels": null`. The previous default only covered a missing key, so iterating the explicit null raised `TypeError`. Because `should_process_pr_logic` catches the exception and falls through to `True`, later ignore rules were skipped and the MR could be processed unexpectedly.

Fixes #2896.

## Verification

- focused webhook logic suite: **37 passed**
- Ruff on the touched files: **passed**
- repository-wide Ruff check: **passed**
- repository pre-commit hooks: **passed**
- full unit suite: **2,759 passed, 18 failed, 1 skipped, 1 xfailed**; the remaining failures were outside this two-file scope and Windows/environment-dependent (artifact path expectations, local Git newline/encoding behavior, cancellation timing, and discovery of user-local skills), so I am not reporting the full suite as green
- diff whitespace check: **passed**

Not verified against a live GitLab webhook delivery.

## AI-assisted disclosure

This change was developed with AI assistance. I reproduced the failure before the fix, reviewed the final two-file diff, ran the checks above, and audited the patch for unrelated or sensitive content.