### PR TITLE
fix(gerrit): clean up failed repository setup

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -107,9 +107,19 @@ def prepare_repo(url: urllib3.util.Url, project, refspec):
     repo_url = (f"{url.scheme}://{url.auth}@{url.host}:{url.port}/{project}")
 
     directory = pathlib.Path(mkdtemp())
-    clone(repo_url, directory)
-    fetch(repo_url, refspec, cwd=directory)
-    checkout(cwd=directory)
+    try:
+        clone(repo_url, directory)
+        fetch(repo_url, refspec, cwd=directory)
+        checkout(cwd=directory)
+    except BaseException:
+        try:
+            shutil.rmtree(directory)
+        except OSError as cleanup_error:
+            get_logger().warning(
+                "Failed to clean up temp repo at {} after setup failed: {}",
+                directory, cleanup_error
+            )
+        raise
     return directory
 
 

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -1,9 +1,11 @@
 import git
 import pytest
+import urllib3.util
 
 from pr_agent.algo.language_handler import sort_files_by_main_languages
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import gerrit_provider
 from pr_agent.git_providers.gerrit_provider import GerritProvider
 from tests.unittest import _settings_helpers as settings_helpers
 
@@ -223,6 +225,33 @@ def _capture_logs():
     captured = []
     sink_id = loguru_logger.add(lambda msg: captured.append(str(msg)), level="DEBUG")
     return captured, sink_id
+
+
+@pytest.mark.parametrize("failing_step", ["clone", "fetch", "checkout"])
+def test_prepare_repo_removes_temp_directory_when_setup_fails(tmp_path, monkeypatch, failing_step):
+    repo_path = tmp_path / "clone"
+
+    def make_temp_directory():
+        repo_path.mkdir()
+        return str(repo_path)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError(f"{failing_step} failed")
+
+    monkeypatch.setattr(gerrit_provider, "mkdtemp", make_temp_directory)
+    monkeypatch.setattr(gerrit_provider, "clone", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gerrit_provider, "fetch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gerrit_provider, "checkout", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gerrit_provider, failing_step, fail)
+
+    with pytest.raises(RuntimeError, match=f"{failing_step} failed"):
+        gerrit_provider.prepare_repo(
+            urllib3.util.parse_url("https://user@example.com:443"),
+            "project",
+            "refs/changes/01/1/1",
+        )
+
+    assert not repo_path.exists()
 
 
 def test_cleanup_removes_the_temp_repo_and_names_it_in_the_log(tmp_path):

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -254,6 +254,45 @@ def test_prepare_repo_removes_temp_directory_when_setup_fails(tmp_path, monkeypa
     assert not repo_path.exists()
 
 
+def test_prepare_repo_reports_a_failed_cleanup_and_keeps_the_setup_error(tmp_path, monkeypatch):
+    """A cleanup that cannot remove the directory must not replace the original setup error."""
+    from loguru import logger as loguru_logger
+
+    repo_path = tmp_path / "clone"
+
+    def make_temp_directory():
+        repo_path.mkdir()
+        return str(repo_path)
+
+    def failing_checkout(*args, **kwargs):
+        raise RuntimeError("checkout failed")
+
+    def failing_rmtree(path, **kwargs):
+        raise OSError("device busy")
+
+    monkeypatch.setattr(gerrit_provider, "mkdtemp", make_temp_directory)
+    monkeypatch.setattr(gerrit_provider, "clone", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gerrit_provider, "fetch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gerrit_provider, "checkout", failing_checkout)
+    monkeypatch.setattr("pr_agent.git_providers.gerrit_provider.shutil.rmtree", failing_rmtree)
+
+    captured, sink_id = _capture_logs()
+    try:
+        with pytest.raises(RuntimeError, match="checkout failed"):
+            gerrit_provider.prepare_repo(
+                urllib3.util.parse_url("https://user@example.com:443"),
+                "project",
+                "refs/changes/01/1/1",
+            )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    combined = "\n".join(captured)
+    assert repo_path.exists()
+    assert "after setup failed" in combined
+    assert str(repo_path) in combined
+
+
 def test_cleanup_removes_the_temp_repo_and_names_it_in_the_log(tmp_path):
     from loguru import logger as loguru_logger
 


### PR DESCRIPTION
## Summary
- remove the temporary Gerrit checkout when clone, fetch, or checkout fails
- preserve the original setup exception if cleanup itself fails
- cover each setup stage with a regression test

## Tests
- `PYTHONPATH=. uv run pytest tests/unittest/test_gerrit_provider.py -q`
- `uv run ruff check pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py`
- `uv run pre-commit run --files pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py`

Closes #2897