### PR TITLE
fix(similar-issue): scope optional vector imports

### DIFF
--- a/pr_agent/tools/pr_similar_issue.py
+++ b/pr_agent/tools/pr_similar_issue.py
@@ -320,6 +320,8 @@ class PRSimilarIssue:
         score_list = []
 
         if get_settings().pr_similar_issue.vectordb == "pinecone":
+            import pinecone
+
             pinecone_index = pinecone.Index(index_name=self.index_name)
             res = pinecone_index.query(embeds[0],
                                     top_k=5,
@@ -431,6 +433,10 @@ class PRSimilarIssue:
         return issue_str, comments, number
 
     def _update_index_with_issues(self, issues_list, repo_name_for_index, upsert=False):
+        import pandas as pd
+        import pinecone
+        from pinecone_datasets import Dataset, DatasetMetadata
+
         get_logger().info('Processing issues...')
         corpus = Corpus()
         example_issue_record = Record(
@@ -514,6 +520,8 @@ class PRSimilarIssue:
         get_logger().info('Done')
 
     def _update_table_with_issues(self, issues_list, repo_name_for_index, ingest=False):
+        import pandas as pd
+
         get_logger().info('Processing issues...')
 
         corpus = Corpus()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,10 +177,6 @@ lint.ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore import-position and unused-import in __init__.py (re-export modules).
 "__init__.py" = ["E402", "F401"]
-# The 'similar issue' tool imports its optional deps (pinecone, pandas,
-# pinecone-datasets) lazily at runtime; ruff can't see them at module scope.
-"pr_agent/tools/pr_similar_issue.py" = ["F821"]
-
 [tool.bandit]
 exclude_dirs = ["tests"]
 skips = ["B101"]

--- a/tests/unittest/test_similar_issue_embeddings.py
+++ b/tests/unittest/test_similar_issue_embeddings.py
@@ -103,8 +103,11 @@ def test_the_client_is_reused_across_calls(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_pinecone_query_import_is_available_in_run(monkeypatch):
+    queried = []
+
     class FakeIndex:
         def query(self, *args, **kwargs):
+            queried.append(kwargs)
             return SimpleNamespace(to_dict=lambda: {"matches": []})
 
     monkeypatch.setitem(sys.modules, "pinecone", SimpleNamespace(Index=lambda **kwargs: FakeIndex()))
@@ -130,3 +133,4 @@ async def test_pinecone_query_import_is_available_in_run(monkeypatch):
     )
 
     assert await tool.run() is None
+    assert queried, "run() never entered the pinecone branch"

--- a/tests/unittest/test_similar_issue_embeddings.py
+++ b/tests/unittest/test_similar_issue_embeddings.py
@@ -1,5 +1,7 @@
 """Embed with the openai>=1.0 client that requirements.txt pins."""
 import inspect
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -97,3 +99,34 @@ def test_the_client_is_reused_across_calls(monkeypatch):
     psi._embed(["c"])
 
     assert built == ["unit-test-key"]
+
+
+@pytest.mark.asyncio
+async def test_pinecone_query_import_is_available_in_run(monkeypatch):
+    class FakeIndex:
+        def query(self, *args, **kwargs):
+            return SimpleNamespace(to_dict=lambda: {"matches": []})
+
+    monkeypatch.setitem(sys.modules, "pinecone", SimpleNamespace(Index=lambda **kwargs: FakeIndex()))
+    monkeypatch.setattr(psi, "_embed", lambda texts: [[0.5]])
+    monkeypatch.setattr(
+        psi,
+        "get_settings",
+        lambda: SimpleNamespace(
+            config=SimpleNamespace(publish_output=False),
+            pr_similar_issue=SimpleNamespace(vectordb="pinecone", skip_comments=True),
+        ),
+    )
+
+    issue = SimpleNamespace(title="Issue", body="Body", number=1, get_comments=lambda: [])
+    tool = psi.PRSimilarIssue.__new__(psi.PRSimilarIssue)
+    tool.supported = True
+    tool.issue_url = "https://github.com/example/repo/issues/1"
+    tool.index_name = "issues"
+    tool.repo_name_for_index = "example-repo"
+    tool.git_provider = SimpleNamespace(
+        _parse_issue_url=lambda url: ("example/repo", 1),
+        repo_obj=SimpleNamespace(get_issue=lambda number: issue),
+    )
+
+    assert await tool.run() is None


### PR DESCRIPTION
## Summary

- import Pinecone in the query path where it is used
- import pandas and pinecone-datasets in their indexing methods
- remove the file-wide F821 exemption now that all names are bound
- add a regression test for the Pinecone query path

Fixes #2924.

## Validation

- `uv run --frozen pytest -q tests/unittest/test_similar_issue_embeddings.py` (7 passed)
- `uv run --frozen ruff check --isolated --select F821 pr_agent/tools/pr_similar_issue.py`
- `uv run --frozen ruff check pr_agent/tools/pr_similar_issue.py tests/unittest/test_similar_issue_embeddings.py`

## Risk boundary

This only changes lazy import scope for existing optional vector database dependencies. The mocked Pinecone query path is covered locally; live Pinecone and LanceDB services were not exercised because they require external service configuration.