### PR TITLE
fix(fallback): restore deployment after model retries

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -334,25 +334,29 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
 async def retry_with_fallback_models(f: Callable, model_type: ModelType = ModelType.REGULAR):
     all_models = _get_all_models(model_type)
     all_deployments = _get_all_deployments(all_models)
-    # try each (model, deployment_id) pair until one is successful, otherwise raise exception
-    for i, (model, deployment_id) in enumerate(zip(all_models, all_deployments)):
-        try:
-            get_logger().debug(
-                f"Generating prediction with {model}"
-                f"{(' from deployment ' + deployment_id) if deployment_id else ''}"
-            )
-            get_settings().set("openai.deployment_id", deployment_id)
-            result = await f(model)
-        except Exception as e:
-            get_logger().warning(
-                f"Failed to generate prediction with {model}",
-                artifact={"error": e},
-            )
-            if i == len(all_models) - 1:  # If it's the last iteration
-                raise Exception(f"Failed to generate prediction with any model of {all_models}") from e
-        else:
-            record_model_used(model, is_fallback=i > 0)
-            return result
+    original_deployment_id = get_settings().get("openai.deployment_id", None)
+    try:
+        # try each (model, deployment_id) pair until one is successful, otherwise raise exception
+        for i, (model, deployment_id) in enumerate(zip(all_models, all_deployments)):
+            try:
+                get_logger().debug(
+                    f"Generating prediction with {model}"
+                    f"{(' from deployment ' + deployment_id) if deployment_id else ''}"
+                )
+                get_settings().set("openai.deployment_id", deployment_id)
+                result = await f(model)
+            except Exception as e:
+                get_logger().warning(
+                    f"Failed to generate prediction with {model}",
+                    artifact={"error": e},
+                )
+                if i == len(all_models) - 1:  # If it's the last iteration
+                    raise Exception(f"Failed to generate prediction with any model of {all_models}") from e
+            else:
+                record_model_used(model, is_fallback=i > 0)
+                return result
+    finally:
+        get_settings().set("openai.deployment_id", original_deployment_id)
 
 
 def _get_all_models(model_type: ModelType = ModelType.REGULAR) -> List[str]:

--- a/tests/unittest/test_retry_with_fallback_models.py
+++ b/tests/unittest/test_retry_with_fallback_models.py
@@ -132,6 +132,55 @@ def test_deployment_id_updated_per_attempt():
         _restore_settings(snapshot)
 
 
+def test_fallback_deployment_does_not_poison_the_next_retry():
+    snapshot = _snapshot_settings()
+    try:
+        get_settings().set("config.model", "primary-model")
+        get_settings().set("config.fallback_models", ["fallback-1"])
+        get_settings().set("openai.deployment_id", "deployment-primary")
+        get_settings().set("openai.fallback_deployments", ["deployment-fallback"])
+
+        observed = []
+
+        async def fake_f(model):
+            observed.append((model, get_settings().get("openai.deployment_id", None)))
+            if model == "primary-model":
+                raise RuntimeError("primary failed")
+            return "fallback-ok"
+
+        assert asyncio.run(retry_with_fallback_models(fake_f)) == "fallback-ok"
+        assert get_settings().get("openai.deployment_id") == "deployment-primary"
+        assert asyncio.run(retry_with_fallback_models(fake_f)) == "fallback-ok"
+
+        assert observed == [
+            ("primary-model", "deployment-primary"),
+            ("fallback-1", "deployment-fallback"),
+            ("primary-model", "deployment-primary"),
+            ("fallback-1", "deployment-fallback"),
+        ]
+    finally:
+        _restore_settings(snapshot)
+
+
+def test_deployment_id_is_restored_when_retry_is_cancelled():
+    snapshot = _snapshot_settings()
+    try:
+        get_settings().set("config.model", "primary-model")
+        get_settings().set("config.fallback_models", ["fallback-1"])
+        get_settings().set("openai.deployment_id", "deployment-primary")
+        get_settings().set("openai.fallback_deployments", ["deployment-fallback"])
+
+        async def fake_f(model):
+            raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(retry_with_fallback_models(fake_f))
+
+        assert get_settings().get("openai.deployment_id") == "deployment-primary"
+    finally:
+        _restore_settings(snapshot)
+
+
 def test_weak_model_type_uses_weak_setting_and_forwards_identifier():
     snapshot = _snapshot_settings()
     try:

--- a/tests/unittest/test_retry_with_fallback_models.py
+++ b/tests/unittest/test_retry_with_fallback_models.py
@@ -171,6 +171,8 @@ def test_deployment_id_is_restored_when_retry_is_cancelled():
         get_settings().set("openai.fallback_deployments", ["deployment-fallback"])
 
         async def fake_f(model):
+            if model == "primary-model":
+                raise RuntimeError("primary failed")
             raise asyncio.CancelledError
 
         with pytest.raises(asyncio.CancelledError):


### PR DESCRIPTION
## Problem

`retry_with_fallback_models()` mutates the global `openai.deployment_id` setting for each `(model, deployment)` attempt but leaves the last attempted deployment active.

If the primary model fails and a fallback succeeds, the next independent retry reads the fallback deployment as its primary deployment. This breaks the configured model/deployment pairing.

## Fix

- Capture the deployment active at the start of `retry_with_fallback_models()`.
- Restore it in `finally`.
- Preserve the existing per-attempt deployment selection.
- Ensure restoration also happens on terminal failure and `asyncio.CancelledError`.

## Tests

Added provider-independent regressions covering:

- fallback success followed by a second retry;
- deployment restoration after cancellation.

Executed:

- `tests/unittest/test_retry_with_fallback_models.py`: 13 passed
- focused retry/core suites: 252 passed
- full `tests/unittest`: 2796 passed, 1 skipped, 1 xfailed
- Ruff check: passed
- pre-commit non-Ruff hooks: passed
- `git diff --check`: passed

## Boundaries

The tests use a fake async callable and do not contact real model providers or deployments. The patch fixes sequential retry state leakage; it does not redesign concurrent access to the process-global Dynaconf settings.

Fixes #2928
