### PR TITLE
fix(docker): restore the pr-agent console script in the cli image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,4 +53,5 @@ ADD docker/mosaico docker/mosaico
 
 FROM base AS cli
 ADD pr_agent pr_agent
+RUN uv sync --frozen --no-dev && ln -s /app/.venv/bin/pr-agent /usr/local/bin/pr-agent
 ENTRYPOINT ["python", "pr_agent/cli.py"]


### PR DESCRIPTION
`pr-agent` is missing from the published Docker image since v0.44.0. Reproduced against the published image rather than the Dockerfile:

```
$ docker run --rm --entrypoint sh pragent/pr-agent:0.44.0 -c 'pr-agent --help'
sh: 1: pr-agent: not found              (exit 127)

$ docker run --rm --entrypoint bash pragent/pr-agent:0.43.0 -c 'command -v pr-agent'
/usr/local/bin/pr-agent
```

`:latest` and `:0.44.0` share the same digest, so anyone following the Bitbucket and Azure install docs is hit today.

Cause is 41c738ec (#2509), which replaced `pip install .` with `uv sync --frozen --no-install-project --no-dev` in the `base` stage. The project is never installed, so the `pr-agent = "pr_agent.cli:run"` console script declared in `pyproject.toml` is not created. The Action and Lambda images are unaffected because they invoke Python paths directly.

The symlink is load-bearing rather than tidiness: Debian's `/etc/profile` resets `PATH`, so a login shell drops `/app/.venv/bin` and `uv sync` alone leaves the binary present but unreachable. v0.43.0 was immune only because pip wrote to `/usr/local/bin`.

Verified on the rebuilt image: `pr-agent --help` exits 0 under `sh`, login `bash` and non-login `bash`, and from a foreign working directory. `ENTRYPOINT` is unchanged, `pr_agent.__file__` still resolves to `/app/pr_agent/__init__.py` so there is no duplicated source, image size is unchanged and the dependency layer still caches.

Closes #2931
