### PR TITLE
fix(review): guard label updates by provider capability

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -627,8 +627,9 @@ class PRReviewer:
         if not get_settings().pr_reviewer.require_security_review:
             get_settings().pr_reviewer.enable_review_labels_security = False # we did not generate this output
 
-        if (get_settings().pr_reviewer.enable_review_labels_security or
-                get_settings().pr_reviewer.enable_review_labels_effort):
+        if ((get_settings().pr_reviewer.enable_review_labels_security or
+                get_settings().pr_reviewer.enable_review_labels_effort) and
+                self.git_provider.is_supported("get_labels")):
             try:
                 review_labels = []
                 if get_settings().pr_reviewer.enable_review_labels_effort:

--- a/tests/unittest/test_effort_bar_clamp.py
+++ b/tests/unittest/test_effort_bar_clamp.py
@@ -50,6 +50,7 @@ def test_the_review_label_matches_the_rendered_bar(score, expected):
     reviewer.git_provider = type("P", (), {
         "publish_labels": lambda _self, labels: published.append(labels) or True,
         "get_pr_labels": lambda _self, update=False: [],
+        "is_supported": lambda _self, feature: feature == "get_labels",
     })()
 
     settings = get_settings(use_context=False)

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -932,6 +932,43 @@ def test_set_review_labels_replaces_stale_review_labels_and_keeps_user_labels():
         settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
 
 
+def test_set_review_labels_skips_providers_without_label_support():
+    settings = get_settings()
+    original = {
+        "publish_output": settings.config.publish_output,
+        "require_estimate_effort_to_review": settings.pr_reviewer.require_estimate_effort_to_review,
+        "require_security_review": settings.pr_reviewer.require_security_review,
+        "enable_review_labels_effort": settings.pr_reviewer.enable_review_labels_effort,
+        "enable_review_labels_security": settings.pr_reviewer.enable_review_labels_security,
+    }
+    settings.config.publish_output = True
+    settings.pr_reviewer.require_estimate_effort_to_review = True
+    settings.pr_reviewer.require_security_review = True
+    settings.pr_reviewer.enable_review_labels_effort = True
+    settings.pr_reviewer.enable_review_labels_security = True
+    git_provider = MagicMock()
+    git_provider.is_supported.return_value = False
+    reviewer = _make_reviewer(git_provider)
+    data = {
+        "review": {
+            "estimated_effort_to_review_[1-5]": "3, moderate",
+            "security_concerns": "yes",
+        }
+    }
+
+    try:
+        reviewer.set_review_labels(data)
+
+        git_provider.get_pr_labels.assert_not_called()
+        git_provider.publish_labels.assert_not_called()
+    finally:
+        settings.config.publish_output = original["publish_output"]
+        settings.pr_reviewer.require_estimate_effort_to_review = original["require_estimate_effort_to_review"]
+        settings.pr_reviewer.require_security_review = original["require_security_review"]
+        settings.pr_reviewer.enable_review_labels_effort = original["enable_review_labels_effort"]
+        settings.pr_reviewer.enable_review_labels_security = original["enable_review_labels_security"]
+
+
 def test_get_user_answers_collects_question_and_answer_from_issue_comments():
     git_provider = MagicMock()
     git_provider.get_issue_comments.return_value = [


### PR DESCRIPTION
## Summary

Guard `/review` label reads and writes with the provider's `get_labels` capability.

## Problem

Providers that do not support labels still reached `get_pr_labels()` and `publish_labels()`. Depending on the provider, this either logged a caught `NotImplementedError` or silently discarded computed review labels.

## Solution

- require `is_supported("get_labels")` before entering the review-label update path
- add a regression test proving unsupported providers call neither label method
- update the existing minimal provider test double to declare label support

## Tests

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_reviewer_core.py -q` — 63 passed
- `PYTHONPATH=. uv run pytest tests/unittest/test_effort_bar_clamp.py tests/unittest/test_pr_reviewer_core.py -q` — 72 passed
- `uv run ruff check pr_agent/tools/pr_reviewer.py tests/unittest/test_pr_reviewer_core.py tests/unittest/test_effort_bar_clamp.py`
- `uv run pre-commit run --files pr_agent/tools/pr_reviewer.py tests/unittest/test_pr_reviewer_core.py tests/unittest/test_effort_bar_clamp.py`

The full Windows unit run reached 649 passed before stopping on the existing CRLF-sensitive assertion in `tests/unittest/test_gerrit_provider.py` (`before\r\n` vs `before\n`).

Fixes #2932