### PR TITLE
fix(providers): normalize inverted line ranges

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -389,6 +389,17 @@ class GitProvider(ABC):
     def get_pr_id(self):
         return ""
 
+    @staticmethod
+    def _normalize_line_range(relevant_line_start: int, relevant_line_end: int = None) -> tuple[int, int | None]:
+        """Clamp inverted ranges and discard malformed end lines before building an anchor."""
+        if relevant_line_end is not None and relevant_line_start is not None:
+            try:
+                if int(relevant_line_end) < int(relevant_line_start):
+                    relevant_line_end = relevant_line_start
+            except (TypeError, ValueError):
+                relevant_line_end = None
+        return relevant_line_start, relevant_line_end
+
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         return ""
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -609,6 +609,9 @@ class GiteaProvider(GitProvider):
 
     def get_line_link(self, relevant_file, relevant_line_start, relevant_line_end = None) -> str:
         link = f"{self.base_url_html}/{self.owner}/{self.repo}/src/branch/{self.get_pr_branch()}/{relevant_file}"
+        relevant_line_start, relevant_line_end = self._normalize_line_range(
+            relevant_line_start, relevant_line_end
+        )
         if relevant_line_start == -1:
             pass
         elif relevant_line_end:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1403,12 +1403,9 @@ class GithubProvider(GitProvider):
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         sha_file = hashlib.sha256(relevant_file.encode('utf-8')).hexdigest()
-        if relevant_line_end is not None and relevant_line_start is not None:
-            try:
-                if int(relevant_line_end) < int(relevant_line_start):
-                    relevant_line_end = relevant_line_start
-            except (TypeError, ValueError):
-                relevant_line_end = None
+        relevant_line_start, relevant_line_end = self._normalize_line_range(
+            relevant_line_start, relevant_line_end
+        )
         if relevant_line_start == -1:
             link = f"{self.base_url_html}/{self.repo}/pull/{self.pr_num}/files#diff-{sha_file}"
         elif relevant_line_end:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1681,6 +1681,9 @@ class GitLabProvider(GitProvider):
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         project_web_url = self._get_project_web_url()
+        relevant_line_start, relevant_line_end = self._normalize_line_range(
+            relevant_line_start, relevant_line_end
+        )
         if relevant_line_start == -1:
             link = f"{project_web_url}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads"
         elif relevant_line_end:

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -744,6 +744,8 @@ class TestGiteaProviderUserFacingLinks:
         prefix = "https://git.example.com/forgejo/owner/repo/src/branch/feat/retry/app/storage.py"
         assert provider.get_line_link("app/storage.py", 24) == f"{prefix}#L24"
         assert provider.get_line_link("app/storage.py", 24, 30) == f"{prefix}#L24-L30"
+        assert provider.get_line_link("app/storage.py", 24, 20) == f"{prefix}#L24-L24"
+        assert provider.get_line_link("app/storage.py", 24, "not-a-number") == f"{prefix}#L24"
         assert provider.get_line_link("app/storage.py", -1) == prefix
 
     @patch("pr_agent.git_providers.gitea_provider.get_settings")

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -339,6 +339,12 @@ class TestGitLabProvider:
         assert gitlab_provider.get_line_link("src/app.py", 10, 12) == (
             "https://gitlab.com/group/repo/-/blob/feature/cache/src/app.py?ref_type=heads#L10-12"
         )
+        assert gitlab_provider.get_line_link("src/app.py", 10, 5) == (
+            "https://gitlab.com/group/repo/-/blob/feature/cache/src/app.py?ref_type=heads#L10-10"
+        )
+        assert gitlab_provider.get_line_link("src/app.py", 10, "not-a-number") == (
+            "https://gitlab.com/group/repo/-/blob/feature/cache/src/app.py?ref_type=heads#L10"
+        )
 
     def test_publish_description_with_none_title_leaves_title_unchanged(self, gitlab_provider):
         gitlab_provider.mr = MagicMock()


### PR DESCRIPTION
## What

- centralize the existing GitHub inverted-range guard in `GitProvider._normalize_line_range`
- apply the guard consistently to GitHub, GitLab, and Gitea link builders
- add regression coverage for inverted and malformed end-line values

## Why

The `/review` focus-areas path can pass model-supplied line ranges straight to a provider. When the end precedes the start, GitLab produced anchors such as `#L10-5` and Gitea produced `#L24-L20`, which do not point to the intended line.

Fixes #2935.

## Verification

- reproduced the regression before the fix: the new GitLab and Gitea assertions failed with the inverted anchors above
- `uv run ruff check --fix <touched files>` — passed
- `uv run pre-commit run --files <touched files>` — passed
- `PYTHONPATH=. uv run pytest tests/unittest/test_github_line_link_range.py tests/unittest/test_gitlab_provider.py tests/unittest/test_gitea_provider.py -q` — 208 passed
- `PYTHONPATH=. uv run pytest tests/unittest -q` — 2805 passed, 17 failed, 1 skipped, 1 xfailed; the 17 failures are outside the changed files and are limited to Windows/environment-sensitive path-root behavior, CRLF expectations, default GBK decoding, cancellation timing, and HOME expansion

## Boundaries

- no live GitLab or Gitea service was used; generated anchors were verified through provider unit tests
- Bitbucket providers remain unchanged, matching the issue scope

## AI-assisted disclosure

This change was completed with AI assistance. I reproduced the bug, reviewed the final diff, and ran the checks listed above.