### PR TITLE
fix: guard against empty commit list in Azure DevOps get_latest_commit_url

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1118,6 +1118,9 @@ class AzureDevopsProvider(GitProvider):
 
     def get_latest_commit_url(self) -> str:
         commits = self.azure_devops_client.get_pull_request_commits(self.repo_slug, self.pr_num, self.workspace_slug)
+        if not commits:
+            # a PR force-pushed back onto its base has zero commits; fall back to the base-class contract
+            return ""
         last = commits[0]
         # workspace/repo slugs are stored decoded (e.g. "Dev Project") for the REST API,
         # so re-encode them when building a web URL to avoid raw spaces in markdown output

--- a/tests/unittest/test_azure_devops_comment.py
+++ b/tests/unittest/test_azure_devops_comment.py
@@ -81,3 +81,16 @@ class TestAzureDevopsProviderCommitUrl(unittest.TestCase):
 
             assert url == "https://dev.azure.com/org/Dev%20Project/_git/repo%20name/commit/abc123"
             assert " " not in url
+
+    def test_get_latest_commit_url_empty_commit_list(self):
+        # a PR force-pushed back onto its base has zero commits; the provider must not
+        # index an empty list, and should fall back to the base-class empty-string contract
+        with patch.object(AzureDevopsProvider, "_get_azure_devops_client", return_value=(MagicMock(), MagicMock())):
+            provider = AzureDevopsProvider()
+            provider.workspace_slug = "ws"
+            provider.repo_slug = "repo"
+            provider.pr_num = 1234
+
+            provider.azure_devops_client.get_pull_request_commits.return_value = []
+
+            assert provider.get_latest_commit_url() == ""


### PR DESCRIPTION
## Problem

`AzureDevopsProvider.get_latest_commit_url` indexes the commit list without checking it is non-empty:

```python
def get_latest_commit_url(self) -> str:
    commits = self.azure_devops_client.get_pull_request_commits(self.repo_slug, self.pr_num, self.workspace_slug)
    last = commits[0]
```

A pull request whose head has been force-pushed back onto its base has zero commits, and `commits[0]` then raises `IndexError`.

This is the Azure sibling of #2887, which was the same defect on GitHub (`github_provider.py`) and was fixed in #2888. Azure was not in scope there.

## Fix

Guard the empty list and return `""`, which is what `GitProvider.get_latest_commit_url` returns by default (`git_provider.py`), so the behaviour matches the contract the other providers hold to. The index (`commits[0]`) is left unchanged since Azure returns commits newest-first.

## Test

Added `test_get_latest_commit_url_empty_commit_list` to `tests/unittest/test_azure_devops_comment.py`. It fails with `IndexError` on `main` and passes with this change. Full Azure DevOps unit suite (81 tests) passes; `ruff check` clean on both touched files.

Closes #2934
