### PR TITLE
fix issue #2933

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -435,7 +435,7 @@ class BitbucketServerProvider(GitProvider):
         return self.pr.title
 
     def get_languages(self):
-        return {"yaml": 0}  # devops LOL
+        return {}  # devops LOL
 
     def get_pr_branch(self):
         return self.pr.fromRef['displayId']


### PR DESCRIPTION
Fix BitbucketServerProvider.get_languages returning a hardcoded YAML placeholder
Problem

BitbucketServerProvider.get_languages always returns a hardcoded, meaningless value instead of an honest result:

python
def get_languages(self):
return {"yaml": 0} # devops LOL

This return value feeds sort_files_by_main_languages in pr_agent/algo/language_handler.py, which every PR-Agent tool uses to rank and prioritize files during review. Because {"yaml": 0} is a non-empty (truthy) dict, the function never takes its if not languages fallback path that would honestly treat the diff as unclassified ("Other"). Instead it builds files_by_language = {"yaml": []}, so every file in the PR — regardless of actual language (.py, .js, etc.) — falls through to the leftover bucket while the code silently pretends language data exists. This breaks language-based hunk prioritization for every Bitbucket Server pull request, with no error or warning to indicate anything is wrong.


This routes sort_files_by_main_languages into the existing, correct "no language data / treat as Other" path rather than introducing new logic. It's a strict improvement over the current behavior — a proper implementation that queries the Bitbucket Server API for real language stats would be even better, but returning {} is the correct floor and fixes the silent misclassification.

Fixes https://github.com/The-PR-Agent/pr-agent/issues/2933