### PR TITLE
fix(azure): handle pull requests without commits

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1118,6 +1118,8 @@ class AzureDevopsProvider(GitProvider):
 
     def get_latest_commit_url(self) -> str:
         commits = self.azure_devops_client.get_pull_request_commits(self.repo_slug, self.pr_num, self.workspace_slug)
+        if not commits:
+            return ""
         last = commits[0]
         # workspace/repo slugs are stored decoded (e.g. "Dev Project") for the REST API,
         # so re-encode them when building a web URL to avoid raw spaces in markdown output

--- a/tests/unittest/test_azure_devops_comment.py
+++ b/tests/unittest/test_azure_devops_comment.py
@@ -62,6 +62,20 @@ class TestAzureDevopsProviderPublishComment(unittest.TestCase):
 
 
 class TestAzureDevopsProviderCommitUrl(unittest.TestCase):
+    def test_get_latest_commit_url_returns_empty_string_without_commits(self):
+        with patch.object(AzureDevopsProvider, "_get_azure_devops_client", return_value=(MagicMock(), MagicMock())):
+            provider = AzureDevopsProvider()
+            provider.workspace_slug = "Dev Project"
+            provider.repo_slug = "repo name"
+            provider.pr_num = 1234
+
+            client = provider.azure_devops_client
+            client.get_pull_request_commits.return_value = []
+
+            url = provider.get_latest_commit_url()
+
+            assert url == ""
+
     def test_get_latest_commit_url_reencodes_spaces(self):
         # workspace/repo slugs are stored decoded for the REST API; the web URL must
         # re-encode them so project/repo names with spaces don't emit raw spaces


### PR DESCRIPTION
## Summary

- return an empty string when Azure DevOps reports no commits for a pull request, matching the base provider contract
- preserve the existing commit URL behavior for non-empty commit lists
- add regression coverage for the empty-commit case

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_azure_devops_comment.py -q` — 5 passed
- `uv run ruff check pr_agent/git_providers/azuredevops_provider.py tests/unittest/test_azure_devops_comment.py` — passed
- `git diff --check origin/main...HEAD` — passed

Closes #2934

Related: #2937 was opened while this fix was being prepared. This version keeps the diff scoped to the Azure provider and its unit test, and includes regression coverage.