### PR TITLE
test: run ASGI unit tests without TestClient

### DIFF
--- a/tests/unittest/test_azure_devops_webhook_auth.py
+++ b/tests/unittest/test_azure_devops_webhook_auth.py
@@ -1,15 +1,11 @@
+import httpx
 import pytest
 from fastapi import APIRouter, Depends, FastAPI
-from starlette.testclient import TestClient
 
 import pr_agent.servers.azuredevops_server_webhook as azure_webhook
 
 
-@pytest.fixture
-def client(monkeypatch):
-    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", "admin")
-    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", "s3cret")
-
+def _build_app():
     router = APIRouter()
 
     @router.post("/", dependencies=[Depends(azure_webhook.authorize)])
@@ -18,41 +14,51 @@ def client(monkeypatch):
 
     app = FastAPI()
     app.include_router(router)
-    return TestClient(app, raise_server_exceptions=False)
+    return app
 
 
-def test_missing_authorization_header_is_rejected_with_401(client):
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", "admin")
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", "s3cret")
+    return _build_app()
+
+
+async def _post(app, **kwargs):
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.post("/", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header_is_rejected_with_401(app):
     """Reject a request that carries no Authorization header with 401, since
     HTTPBasic(auto_error=False) yields None rather than raising."""
-    response = client.post("/")
+    response = await _post(app)
 
     assert response.status_code == 401
     assert response.headers.get("WWW-Authenticate") == "Basic"
 
 
-def test_wrong_credentials_are_rejected_with_401(client):
-    response = client.post("/", auth=("admin", "wrong"))
+@pytest.mark.asyncio
+async def test_wrong_credentials_are_rejected_with_401(app):
+    response = await _post(app, auth=("admin", "wrong"))
 
     assert response.status_code == 401
 
 
-def test_correct_credentials_are_accepted(client):
-    response = client.post("/", auth=("admin", "s3cret"))
+@pytest.mark.asyncio
+async def test_correct_credentials_are_accepted(app):
+    response = await _post(app, auth=("admin", "s3cret"))
 
     assert response.status_code == 200
 
 
-def test_auth_is_skipped_when_no_credentials_are_configured(monkeypatch):
+@pytest.mark.asyncio
+async def test_auth_is_skipped_when_no_credentials_are_configured(monkeypatch):
     monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", None)
     monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", None)
 
-    router = APIRouter()
+    response = await _post(_build_app())
 
-    @router.post("/", dependencies=[Depends(azure_webhook.authorize)])
-    async def _hook():
-        return {"ok": True}
-
-    app = FastAPI()
-    app.include_router(router)
-
-    assert TestClient(app, raise_server_exceptions=False).post("/").status_code == 200
+    assert response.status_code == 200

--- a/tests/unittest/test_gitlab_webhook_secret_provider.py
+++ b/tests/unittest/test_gitlab_webhook_secret_provider.py
@@ -1,5 +1,6 @@
 import os
 
+import httpx
 import pytest
 
 os.environ.setdefault("GITLAB__URL", "https://gitlab.example.com")
@@ -87,36 +88,42 @@ def gitlab_webhook_settings():
         settings.set("GITLAB", original)
 
 
-def _post_webhook(token=None):
+async def _post_webhook(token=None):
     from fastapi import FastAPI
     from starlette.middleware import Middleware
-    from starlette.testclient import TestClient
     from starlette_context.middleware import RawContextMiddleware
 
     app = FastAPI(middleware=[Middleware(RawContextMiddleware)])
     app.include_router(gitlab_webhook.router)
     headers = {"X-Gitlab-Token": token} if token is not None else {}
-    return TestClient(app, raise_server_exceptions=False).post(
-        "/webhook", json={"object_kind": "note", "event_type": "note"}, headers=headers)
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.post(
+            "/webhook", json={"object_kind": "note", "event_type": "note"}, headers=headers
+        )
 
 
-def test_answer_a_wrong_shared_secret_with_401(gitlab_webhook_settings):
+@pytest.mark.asyncio
+async def test_answer_a_wrong_shared_secret_with_401(gitlab_webhook_settings):
     """Answer a rejected delivery with 401 instead of the unconditional 200 that made a
     misconfigured token look healthy."""
-    assert _post_webhook("wrong-secret").status_code == 401
+    assert (await _post_webhook("wrong-secret")).status_code == 401
 
 
-def test_answer_a_missing_token_with_401(gitlab_webhook_settings):
+@pytest.mark.asyncio
+async def test_answer_a_missing_token_with_401(gitlab_webhook_settings):
     """Answer a delivery that carries no token at all with 401."""
-    assert _post_webhook().status_code == 401
+    assert (await _post_webhook()).status_code == 401
 
 
-def test_accept_the_correct_shared_secret(gitlab_webhook_settings):
+@pytest.mark.asyncio
+async def test_accept_the_correct_shared_secret(gitlab_webhook_settings):
     """Accept a correctly authenticated delivery and dispatch it as before."""
-    assert _post_webhook("topsecret").status_code == 200
+    assert (await _post_webhook("topsecret")).status_code == 200
 
 
-def test_compare_the_shared_secret_in_constant_time(monkeypatch, gitlab_webhook_settings):
+@pytest.mark.asyncio
+async def test_compare_the_shared_secret_in_constant_time(monkeypatch, gitlab_webhook_settings):
     """Compare the shared secret with a constant-time primitive, as every other webhook
     auth path in the project already does."""
     calls = []
@@ -128,19 +135,20 @@ def test_compare_the_shared_secret_in_constant_time(monkeypatch, gitlab_webhook_
 
     monkeypatch.setattr(gitlab_webhook.hmac, "compare_digest", recording_compare)
 
-    _post_webhook("wrong-secret")
+    await _post_webhook("wrong-secret")
 
     assert calls, "hmac.compare_digest was not used to compare the shared secret"
 
 
-def test_keep_the_webhook_token_out_of_the_logs(gitlab_webhook_settings):
+@pytest.mark.asyncio
+async def test_keep_the_webhook_token_out_of_the_logs(gitlab_webhook_settings):
     """Keep a rejected token out of the logs, where it would otherwise be shipped to a log
     aggregator in cleartext."""
     records = []
     handler_id = gitlab_webhook.get_logger().add(lambda m: records.append(str(m)))
     secret_token = "super-secret-webhook-token"
     try:
-        _post_webhook(secret_token)
+        await _post_webhook(secret_token)
     finally:
         gitlab_webhook.get_logger().remove(handler_id)
 

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -15,6 +15,7 @@ import pr_agent.mosaico.server as server_mod
 from pr_agent.config_loader import get_settings
 from pr_agent.mosaico.executor import health_check
 from pr_agent.mosaico.server import build_app
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
 
 
 def _app(monkeypatch, health_value):
@@ -60,24 +61,12 @@ _MODEL_WITHOUT_STOP = "gpt-5.6"
 
 @pytest.fixture
 def restore_config_model():
-    """Snapshot/restore LLM settings on the shared settings (no request scope here, so
-    get_settings() resolves to global_settings). Mirrors the snapshot/restore convention
-    in test_mosaico_isolation.py."""
-    settings = get_settings()
-    sentinel = object()
-    model_before = settings.get("CONFIG.MODEL", sentinel)
-    provider_before = settings.get("LITELLM.CUSTOM_LLM_PROVIDER", sentinel)
-    yield settings
-    if model_before is sentinel:
-        # Best-effort removal of a key we introduced; dynaconf has no public delete, so
-        # blank it out rather than leak a fake model into sibling tests.
-        settings.set("CONFIG.MODEL", "")
-    else:
-        settings.set("CONFIG.MODEL", model_before)
-    if provider_before is sentinel:
-        settings.set("LITELLM.CUSTOM_LLM_PROVIDER", "")
-    else:
-        settings.set("LITELLM.CUSTOM_LLM_PROVIDER", provider_before)
+    """Restore LLM settings exactly, including originally-absent state."""
+    snapshot = snapshot_settings(
+        ["CONFIG.MODEL", "LITELLM.CUSTOM_LLM_PROVIDER"]
+    )
+    yield get_settings()
+    restore_settings(snapshot)
 
 
 class TestHealthCheckGate:

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -1,14 +1,15 @@
 """HTTP /health route tests.
 
-Uses Starlette TestClient against build_app(); monkeypatches health_check (the no-retry
-behavior itself was proven in 2c). Verifies the route + 200/503 response shape.
+Exercise build_app() directly through an in-process ASGI transport and monkeypatch
+health_check (the no-retry behavior itself was proven in 2c). Verify the route and
+200/503 response shape without relying on Starlette's thread-backed TestClient.
 
 Also exercises the REAL health_check() (no stub) to lock in Fix A: the removed
 'stop'-param gate must NOT short-circuit /health for models that lack 'stop' (e.g. the
 shipped gpt-5.x defaults), since PR-Agent's LiteLLMAIHandler never sends 'stop'."""
+import httpx
 import litellm
 import pytest
-from starlette.testclient import TestClient
 
 import pr_agent.mosaico.server as server_mod
 from pr_agent.config_loader import get_settings
@@ -16,27 +17,33 @@ from pr_agent.mosaico.executor import health_check
 from pr_agent.mosaico.server import build_app
 
 
-def _client(monkeypatch, health_value):
+def _app(monkeypatch, health_value):
     async def fake_health_check():
         return health_value
 
     # health_check is imported into server_mod's namespace and called by _HealthApp._health.
     monkeypatch.setattr(server_mod, "health_check", fake_health_check)
-    return TestClient(build_app())
+    return build_app()
+
+
+async def _get_health(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.get("/health")
 
 
 class TestHealthRoute:
-    def test_healthy_returns_200(self, monkeypatch):
-        client = _client(monkeypatch, "OK")
-        resp = client.get("/health")
+    @pytest.mark.asyncio
+    async def test_healthy_returns_200(self, monkeypatch):
+        resp = await _get_health(_app(monkeypatch, "OK"))
         assert resp.status_code == 200
         body = resp.json()
         assert body["is_healthy"] is True
         assert body["status"] == "OK"
 
-    def test_unhealthy_returns_503(self, monkeypatch):
-        client = _client(monkeypatch, "Unhealthy: connection refused")
-        resp = client.get("/health")
+    @pytest.mark.asyncio
+    async def test_unhealthy_returns_503(self, monkeypatch):
+        resp = await _get_health(_app(monkeypatch, "Unhealthy: connection refused"))
         assert resp.status_code == 503
         body = resp.json()
         assert body["is_healthy"] is False

--- a/tests/unittest/test_mosaico_smoke.py
+++ b/tests/unittest/test_mosaico_smoke.py
@@ -1,7 +1,7 @@
 """Full-path smoke test (A2A 1.0).
 
-Drives ONE message/send through the SDK via Starlette TestClient against build_app()
-(REAL RawContextMiddleware mounted), proving the full path:
+Drive message/send requests through the SDK via an in-process ASGI HTTP transport against
+build_app() (REAL RawContextMiddleware mounted), proving the full path:
   HTTP POST / -> RawContextMiddleware -> DefaultRequestHandler -> PRAgentExecutor.execute
   -> request-scoped settings deepcopy -> route_and_run -> DiffInputProvider -> render.
 
@@ -13,10 +13,10 @@ This test passing is the end-to-end proof that the middleware->executor->dispatc
 provider->render chain works through the wire."""
 import uuid
 
+import httpx
 import pytest
 from a2a.types import Message, Part, Role, SendMessageRequest
 from google.protobuf.json_format import MessageToDict
-from starlette.testclient import TestClient
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_mod
 from pr_agent.mosaico.server import build_app
@@ -88,16 +88,21 @@ def _extract_text(result: dict) -> str:
     return "\n".join(chunks)
 
 
+async def _post_message(text: str):
+    transport = httpx.ASGITransport(app=build_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.post("/", json=_send_message_payload(text), headers=_A2A_HEADERS)
+
+
 class TestSmokeFullPath:
-    def test_review_diff_round_trip(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_review_diff_round_trip(self, monkeypatch):
         async def fake_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
             return CANNED_REVIEW_YAML, "stop"
 
         monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", fake_chat_completion)
 
-        client = TestClient(build_app())
-        resp = client.post("/", json=_send_message_payload(f"review this\n{REVIEW_DIFF}"),
-                           headers=_A2A_HEADERS)
+        resp = await _post_message(f"review this\n{REVIEW_DIFF}")
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert "error" not in body, body
@@ -117,7 +122,8 @@ class TestSmokeFullPath:
         # Must NOT be the executor's exception placeholder.
         assert not text.startswith("Error:"), text
 
-    def test_empty_diff_yields_fallback_no_exception(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_empty_diff_yields_fallback_no_exception(self, monkeypatch):
         # No LLM call should be needed (parse yields nothing -> empty fallback), but mock
         # anyway so any accidental call is harmless.
         async def fake_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
@@ -125,10 +131,8 @@ class TestSmokeFullPath:
 
         monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", fake_chat_completion)
 
-        client = TestClient(build_app())
         empty = "```diff\nnot actually a diff\n```"
-        resp = client.post("/", json=_send_message_payload(f"review\n{empty}"),
-                           headers=_A2A_HEADERS)
+        resp = await _post_message(f"review\n{empty}")
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert "error" not in body, body
@@ -145,8 +149,9 @@ class TestSmokeFullPath:
         assert "no output produced" in text, text
         assert not text.startswith("Error:"), text
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("verb", ["review", "improve", "describe", "ask"])
-    def test_llm_outage_yields_failed_not_completed(self, monkeypatch, verb):
+    async def test_llm_outage_yields_failed_not_completed(self, monkeypatch, verb):
         """A total model outage must reach the caller as TASK_STATE_FAILED. review/improve/
         describe used to swallow it and report success with 'no output produced'; 'ask' was
         already correct and is pinned here so the fix does not regress it."""
@@ -155,9 +160,7 @@ class TestSmokeFullPath:
 
         monkeypatch.setattr(litellm_mod.LiteLLMAIHandler, "chat_completion", failing_chat_completion)
 
-        client = TestClient(build_app())
-        resp = client.post("/", json=_send_message_payload(f"{verb} this\n{REVIEW_DIFF}"),
-                           headers=_A2A_HEADERS)
+        resp = await _post_message(f"{verb} this\n{REVIEW_DIFF}")
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert "error" not in body, body

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -3,9 +3,9 @@ import importlib
 import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from starlette.background import BackgroundTasks
-from starlette.testclient import TestClient
 from starlette_context import request_cycle_context
 
 from pr_agent.config_loader import get_settings
@@ -113,6 +113,14 @@ def _gitlab_payload(**object_attributes):
         "project": {"path_with_namespace": "org/repo"},
         "user": {"username": "alice", "name": "Alice"},
     }
+
+
+async def _post_gitlab_webhook(app, data):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.post(
+            "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
+        )
 
 
 def test_bitbucket_server_should_process_pr_logic_ignores_author_title_and_branch():
@@ -374,7 +382,7 @@ async def test_gitea_automatic_feedback_continues_after_invalid_command(monkeypa
     assert agent.commands == [["/review"]]
 
 
-def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="open"):
+async def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="open"):
     settings = get_settings()
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
     settings.set("GITLAB.PR_COMMANDS", ["/review"])
@@ -411,10 +419,7 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="ope
     if event == "draft_ready":
         data["changes"] = {"draft": {"previous": True, "current": False}}
     try:
-        with TestClient(module.app) as client:
-            response = client.post(
-                "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
-            )
+        response = await _post_gitlab_webhook(module.app, data)
     finally:
         settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
 
@@ -422,6 +427,7 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="ope
     return agent.commands, repo_settings_calls
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("event", "draft", "feedback_on_draft_pr", "expected_commands"),
     [
@@ -436,7 +442,7 @@ def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, event="ope
         ("draft_ready", False, True, []),
     ],
 )
-def test_gitlab_automatic_feedback_follows_draft_setting(
+async def test_gitlab_automatic_feedback_follows_draft_setting(
     gitlab_webhook_module,
     monkeypatch,
     event,
@@ -444,7 +450,7 @@ def test_gitlab_automatic_feedback_follows_draft_setting(
     feedback_on_draft_pr,
     expected_commands,
 ):
-    commands, repo_settings_calls = _run_gitlab_pr_commands(
+    commands, repo_settings_calls = await _run_gitlab_pr_commands(
         gitlab_webhook_module, monkeypatch, draft, feedback_on_draft_pr, event
     )
 
@@ -452,7 +458,8 @@ def test_gitlab_automatic_feedback_follows_draft_setting(
     assert repo_settings_calls == 1
 
 
-def test_gitlab_manual_feedback_on_draft_is_unaffected(gitlab_webhook_module, monkeypatch):
+@pytest.mark.asyncio
+async def test_gitlab_manual_feedback_on_draft_is_unaffected(gitlab_webhook_module, monkeypatch):
     settings = get_settings()
     settings.set("GITLAB.FEEDBACK_ON_DRAFT_PR", False)
 
@@ -480,10 +487,7 @@ def test_gitlab_manual_feedback_on_draft_is_unaffected(gitlab_webhook_module, mo
         }
     )
 
-    with TestClient(gitlab_webhook_module.app) as client:
-        response = client.post(
-            "/webhook", headers={"X-Gitlab-Token": "secret-id"}, json=data
-        )
+    response = await _post_gitlab_webhook(gitlab_webhook_module.app, data)
 
     assert response.status_code == 200
     assert agent.commands == ["/review"]


### PR DESCRIPTION
## Summary

Replace thread-backed Starlette `TestClient` requests in the Azure DevOps, GitLab, and Mosaico HTTP tests with `AsyncClient` and `ASGITransport`. These tests exercise in-process ASGI routes without requiring a second event-loop thread, while preserving authentication, middleware, dependency, background-task, exception, and response assertions.

The Mosaico health fixture now uses shared snapshot helpers to restore both `CONFIG.MODEL` and `LITELLM.CUSTOM_LLM_PROVIDER` exactly.

## Commit structure

1. Migrate the five HTTP-facing test modules to direct ASGI transport.
2. Replace local sentinel cleanup with shared settings snapshot helpers.

## Validation

- Focused five-file pytest run: 65 passed
- Ruff 0.16.5 passed
- Pre-commit passed
- `git diff --check` passed
