### PR TITLE
test: cover the pr_review_prompt user-half variable contract

### DIFF
--- a/tests/unittest/test_pr_reviewer_prompt_contract.py
+++ b/tests/unittest/test_pr_reviewer_prompt_contract.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from jinja2 import Environment, StrictUndefined, meta
+from jinja2 import Environment, StrictUndefined, meta, select_autoescape
 
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -46,8 +46,13 @@ def _build_reviewer(monkeypatch):
 def _referenced_variables(half):
     template = getattr(get_settings().pr_review_prompt, half)
     # Environment() here only needs to parse; production rendering happens in
-    # PRReviewer._get_prediction with the same StrictUndefined setting.
-    return meta.find_undeclared_variables(Environment(undefined=StrictUndefined).parse(template))
+    # PRReviewer._get_prediction with the same StrictUndefined setting. autoescape
+    # mirrors pr_line_questions._render_prompts and is irrelevant to parsing.
+    environment = Environment(
+        autoescape=select_autoescape(default_for_string=False),
+        undefined=StrictUndefined,
+    )
+    return meta.find_undeclared_variables(environment.parse(template))
 
 
 @pytest.mark.parametrize("half", ["system", "user"])

--- a/tests/unittest/test_pr_reviewer_prompt_contract.py
+++ b/tests/unittest/test_pr_reviewer_prompt_contract.py
@@ -1,0 +1,83 @@
+"""Contract tests for the variables ``pr_reviewer_prompts.toml`` depends on.
+
+``PRReviewer._get_prediction`` renders both the system and user halves of
+``pr_review_prompt`` with ``undefined=StrictUndefined`` against a copy of
+``PRReviewer.vars``. Under ``StrictUndefined`` a bare ``{%- if x %}`` raises
+``UndefinedError`` exactly like a direct reference, so every name either prompt
+mentions is a hard requirement on that dict. A missing name is not a degraded
+review, it is ``/review`` failing outright on every PR.
+
+These tests derive the requirement from the templates (via
+``jinja2.meta.find_undeclared_variables``) instead of restating it, and check it
+against the dict the tool actually builds by driving the real
+``PRReviewer.__init__``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from jinja2 import Environment, StrictUndefined, meta
+
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+
+def _build_reviewer(monkeypatch):
+    """Run the real ``PRReviewer.__init__`` so ``self.vars`` is the shipped dict."""
+    from pr_agent.tools import pr_reviewer as pr_reviewer_module
+
+    provider = MagicMock()
+    provider.is_supported.return_value = True
+    provider.get_languages.return_value = {}
+    provider.get_files.return_value = []
+    provider.get_pr_description.return_value = ("desc", [])
+
+    monkeypatch.setattr(pr_reviewer_module, "get_git_provider_with_context", lambda pr_url: provider)
+    monkeypatch.setattr(pr_reviewer_module, "get_main_pr_language", lambda languages, files: "Python")
+    monkeypatch.setattr(pr_reviewer_module, "TokenHandler", MagicMock())
+
+    return PRReviewer(
+        "https://example/pr/1",
+        ai_handler=lambda: SimpleNamespace(main_pr_language=None),
+    )
+
+
+def _referenced_variables(half):
+    template = getattr(get_settings().pr_review_prompt, half)
+    # Environment() here only needs to parse; production rendering happens in
+    # PRReviewer._get_prediction with the same StrictUndefined setting.
+    return meta.find_undeclared_variables(Environment(undefined=StrictUndefined).parse(template))
+
+
+@pytest.mark.parametrize("half", ["system", "user"])
+def test_pr_review_prompt_variables_are_all_supplied(monkeypatch, half):
+    reviewer = _build_reviewer(monkeypatch)
+    provided = set(reviewer.vars)
+
+    # Subset, not equality: vars legitimately carries keys the review prompts do
+    # not use (e.g. language, commit_messages_str, custom_labels).
+    missing = _referenced_variables(half) - provided
+    assert not missing, (
+        f"pr_reviewer_prompts.toml '{half}' prompt references {sorted(missing)}, "
+        f"but PRReviewer.vars does not supply them; /review would raise UndefinedError "
+        f"on every PR."
+    )
+
+
+def test_user_prompt_contributes_variables_of_its_own(monkeypatch):
+    """The user half references names the system half does not.
+
+    Before this file, only the system prompt was rendered under StrictUndefined in
+    the test suite, so those user-only names had no coverage. Keep an explicit check
+    that dropping one from ``vars`` is visible to the derived subset test above.
+    """
+    reviewer = _build_reviewer(monkeypatch)
+    user_referenced = _referenced_variables("user")
+    user_only = user_referenced - _referenced_variables("system")
+    assert user_only, "expected the user prompt to reference variables the system prompt does not"
+    assert user_only <= set(reviewer.vars)
+
+    # Dropping one such name from vars is what the subset test above would flag.
+    dropped = next(iter(user_only))
+    assert user_referenced - (set(reviewer.vars) - {dropped}) == {dropped}

--- a/tests/unittest/test_pr_reviewer_prompt_contract.py
+++ b/tests/unittest/test_pr_reviewer_prompt_contract.py
@@ -62,7 +62,9 @@ def test_pr_review_prompt_variables_are_all_supplied(monkeypatch, half):
 
     # Subset, not equality: vars legitimately carries keys the review prompts do
     # not use (e.g. language, commit_messages_str, custom_labels).
-    missing = _referenced_variables(half) - provided
+    referenced = _referenced_variables(half)
+    assert referenced, f"expected the '{half}' prompt to reference variables; it references none"
+    missing = referenced - provided
     assert not missing, (
         f"pr_reviewer_prompts.toml '{half}' prompt references {sorted(missing)}, "
         f"but PRReviewer.vars does not supply them; /review would raise UndefinedError "


### PR DESCRIPTION
### What

Adds a unit test for the variable contract between `pr_reviewer_prompts.toml` and `PRReviewer.vars`.

`PRReviewer._get_prediction` renders both the system and user halves of `pr_review_prompt` with `undefined=StrictUndefined` against a copy of `self.vars`. Under `StrictUndefined`, a bare `{%- if x %}` raises `UndefinedError` just like a direct reference, so every name either prompt mentions is a hard requirement on that dict.

The only existing coverage (`test_repo_context.py::test_prompt_templates_render_configured_repo_context`) renders **only the system prompt** and checks it against a hand-maintained `variables` dict. Seven names the **user prompt alone** references are covered by nothing:

```
answer_str, branch, date, description, diff, duplicate_prompt_examples, title
```

### Why it matters

A missing name is not a degraded review — it is `/review` failing outright. The render-time `UndefinedError` is caught in `_get_prediction`, retried across every fallback model, and finally re-raised as `Failed to generate prediction with any model of [...]`, which points suspicion at the provider / API key / model name rather than the template. Editing the TOML to reference a new variable, or dropping a key from `self.vars`, is enough to trigger it, and nothing in the suite would notice.

### The change

`tests/unittest/test_pr_reviewer_prompt_contract.py` (test-only, no runtime change):

1. Parses `pr_review_prompt.system` and `.user` with `jinja2.meta.find_undeclared_variables`.
2. Builds `PRReviewer.vars` by driving the real `PRReviewer.__init__` with the provider mocked, following the pattern already in `test_pr_reviewer_core.py`.
3. Asserts every referenced name is supplied — a subset check, since `vars` legitimately carries keys the review prompts do not use (`language`, `commit_messages_str`, `custom_labels`, `enable_custom_labels`).

### Testing

```
PYTHONPATH=. uv run pytest tests/unittest/test_pr_reviewer_prompt_contract.py -q   # 3 passed
PYTHONPATH=. uv run pytest tests/unittest/test_pr_reviewer_core.py tests/unittest/test_repo_context.py -q   # green
uv run ruff check tests/unittest/test_pr_reviewer_prompt_contract.py               # clean
uv run pre-commit run --files tests/unittest/test_pr_reviewer_prompt_contract.py   # pass
```

Removing any key from `self.vars` makes the parametrized test fail with a message naming the missing variable.

Closes #2814
