### PR TITLE
feat(automation): add opt-in fail-fast policy for automatic commands

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -169,6 +169,17 @@ For GitHub Action, settings fall back from `github_action_config.*` to `github_a
 
 This means that when new code is pushed to the PR, PR-Agent will run the `describe` and `review` tools, with the specified parameters.
 
+#### Handling failures in automatic command sequences
+
+By default, PR-Agent continues with the remaining configured automatic commands when one command fails. To stop the sequence after the first failed command, enable the opt-in setting below:
+
+```toml
+[config]
+auto_command_stop_on_failure = true
+```
+
+This setting applies to configured `pr_commands`, `push_commands`, and `reviewer_commands` in the GitHub App, GitHub Action synchronize flow, GitLab, Bitbucket, Azure DevOps Server, Gitea, and Bitbucket Server integrations. A command is considered failed when its `PRAgent.handle_request` call returns `False` or raises an exception. Commands that already completed are not retried or rolled back.
+
 ### GitHub Action
 
 `GitHub Action` is a different way to trigger PR-Agent tools, and uses a different configuration mechanism than `GitHub App`.<br>

--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -27,6 +27,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
+from pr_agent.servers.utils import should_stop_auto_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 security = HTTPBasic(auto_error=False)
@@ -109,14 +110,21 @@ async def _perform_commands_azure(commands_conf: str, agent: PRAgent, api_url: s
         return
 
     get_settings().set("config.is_auto_command", True)
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
-                await agent.handle_request(api_url, new_command)
+                handled = await agent.handle_request(api_url, new_command)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to perform command {command}: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
 
 
 async def handle_request_azure(data, log_context):

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -26,6 +26,7 @@ from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
+from pr_agent.servers.utils import should_stop_auto_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -197,14 +198,21 @@ async def _perform_commands_bitbucket(commands_conf: str, agent: PRAgent, api_ur
         if not is_valid_push:
             get_logger().info("Bitbucket skipping 'pullrequest:updated' for push commands")
             return
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
-                await agent.handle_request(api_url, new_command)
+                handled = await agent.handle_request(api_url, new_command)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to perform command {command}: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
 
 
 def is_bot_user(data) -> bool:

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -21,7 +21,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import verify_signature
+from pr_agent.servers.utils import should_stop_auto_commands, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -213,6 +213,7 @@ async def _run_commands_sequentially(commands: List[str], url: str, log_context:
     if commands is None:
         return
 
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             body = _process_command(command, url)
@@ -221,9 +222,15 @@ async def _run_commands_sequentially(commands: List[str], url: str, log_context:
             log_context["api_url"] = url
 
             with get_logger().contextualize(**log_context):
-                await PRAgent().handle_request(url, body)
+                handled = await PRAgent().handle_request(url, body)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping automatic commands after failed command for {url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to handle command: {command} , error: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping automatic commands after failed command for {url=}")
+                break
 
 def _process_command(command: str, url) -> list[str]:
     # don't think we need this

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -13,7 +13,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import verify_signature
+from pr_agent.servers.utils import should_stop_auto_commands, verify_signature
 
 # Setup logging and router
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
@@ -138,13 +138,20 @@ async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict
         get_logger().info("New PR, but no auto commands configured")
         return
     get_settings().set("config.is_auto_command", True)
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
-            await agent.handle_request(api_url, new_command)
+            handled = await agent.handle_request(api_url, new_command)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to perform command {command}: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
 
 def should_process_pr_logic(body) -> bool:
     try:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -14,6 +14,7 @@ from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import get_logger
 from pr_agent.servers.github_app import handle_line_comments
+from pr_agent.servers.utils import should_stop_auto_commands
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -211,8 +212,19 @@ async def run_action():
                 get_settings().config.is_auto_command = True
                 get_settings().pr_description.final_update_message = False
                 get_logger().info(f"Running push commands: {push_commands}")
+                stop_on_failure = should_stop_auto_commands()
                 for command in push_commands:
-                    await PRAgent().handle_request(pr_url, command)
+                    try:
+                        handled = await PRAgent().handle_request(pr_url, command)
+                        if not handled and stop_on_failure:
+                            get_logger().info(f"Stopping push commands after failed command for {pr_url=}")
+                            break
+                    except Exception as e:
+                        get_logger().error(f"Failed to perform push command {command}: {e}")
+                        if stop_on_failure:
+                            get_logger().info(f"Stopping push commands after failed command for {pr_url=}")
+                            break
+                        raise
                 return
         if action in pr_actions:
             pr_url = event_payload.get("pull_request", {}).get("url")

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -19,7 +19,7 @@ from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import DefaultDictWithTimeout, verify_signature
+from pr_agent.servers.utils import DefaultDictWithTimeout, should_stop_auto_commands, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -446,13 +446,20 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         get_logger().info("New PR, but no auto commands configured")
         return
     get_settings().set("config.is_auto_command", True)
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
-            await agent.handle_request(api_url, new_command)
+            handled = await agent.handle_request(api_url, new_command)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to perform command {command}: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
 
 
 @router.get("/")

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -22,6 +22,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
+from pr_agent.servers.utils import should_stop_auto_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -73,14 +74,21 @@ async def _perform_commands_gitlab(commands_conf: str, agent: PRAgent, api_url: 
         return
     commands = get_settings().get(f"gitlab.{commands_conf}", {})
     get_settings().set("config.is_auto_command", True)
+    stop_on_failure = should_stop_auto_commands()
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"Performing command: {new_command}")
             with get_logger().contextualize(**log_context):
-                await agent.handle_request(api_url, new_command)
+                handled = await agent.handle_request(api_url, new_command)
+            if not handled and stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
         except Exception as e:
             get_logger().error(f"Failed to perform command {command}: {e}")
+            if stop_on_failure:
+                get_logger().info(f"Stopping {commands_conf} after failed command for {api_url=}")
+                break
 
 
 def is_bot_user(data) -> bool:

--- a/pr_agent/servers/utils.py
+++ b/pr_agent/servers/utils.py
@@ -6,6 +6,16 @@ from typing import Any, Callable
 
 from fastapi import HTTPException
 
+from pr_agent.config_loader import get_settings
+
+
+def should_stop_auto_commands() -> bool:
+    """Return whether configured automatic commands should fail fast."""
+    value = get_settings().get("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE", False)
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
 
 def verify_signature(payload_body, secret_token, signature_header):
     """Verify that the payload was sent from GitHub by validating SHA256.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -74,6 +74,7 @@ bot_user_indicators = ["codium", "bot_", "bot-", "_bot", "-bot"]
 #
 restricted_mode = false # when true, skip operations that require elevated permissions (e.g. pushing code to the repository)
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
+auto_command_stop_on_failure = false # when true, stop a configured automatic command sequence after a command fails
 propagate_tool_errors = false # when true, a tool re-raises instead of swallowing an internal error, so a caller can tell a failed run from an empty one
 enable_ai_metadata = false # will enable adding ai metadata
 add_user_to_requests = false # send the current command and PR URL in the OpenAI-compatible "user" request field, for provider-side attribution of requests (e.g. OpenRouter "external_user")

--- a/tests/unittest/test_auto_command_failure_policy.py
+++ b/tests/unittest/test_auto_command_failure_policy.py
@@ -1,0 +1,89 @@
+"""Regression tests for the opt-in automatic command failure policy."""
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.servers import github_app
+
+
+class _FailingAgent:
+    def __init__(self):
+        self.commands = []
+
+    async def handle_request(self, _api_url, command):
+        self.commands.append(command)
+        return len(self.commands) > 1
+
+
+@pytest.mark.asyncio
+async def test_auto_commands_stop_after_a_failed_command_when_enabled(monkeypatch):
+    settings = get_settings()
+    original_github_app = settings.get("GITHUB_APP")
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    original_stop_on_failure = settings.get("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE")
+    settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", True)
+    settings.set("GITHUB_APP.PR_COMMANDS", ["/review", "/improve"])
+    settings.set("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE", True)
+
+    agent = _FailingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "should_process_pr_logic", lambda _body: True)
+
+    try:
+        await github_app._perform_auto_commands_github(
+            "pr_commands",
+            agent,
+            {
+                "action": "opened",
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": False,
+                },
+            },
+            "https://api.github.com/repos/org/repo/pulls/1",
+            {},
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+        settings.set("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE", original_stop_on_failure)
+
+    assert agent.commands == [["/review"]]
+
+
+@pytest.mark.asyncio
+async def test_auto_commands_continue_after_a_failed_command_by_default(monkeypatch):
+    settings = get_settings()
+    original_github_app = settings.get("GITHUB_APP")
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    original_stop_on_failure = settings.get("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE")
+    settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", True)
+    settings.set("GITHUB_APP.PR_COMMANDS", ["/review", "/improve"])
+    settings.set("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE", False)
+
+    agent = _FailingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "should_process_pr_logic", lambda _body: True)
+
+    try:
+        await github_app._perform_auto_commands_github(
+            "pr_commands",
+            agent,
+            {
+                "action": "opened",
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": False,
+                },
+            },
+            "https://api.github.com/repos/org/repo/pulls/1",
+            {},
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+        settings.set("CONFIG.AUTO_COMMAND_STOP_ON_FAILURE", original_stop_on_failure)
+
+    assert agent.commands == [["/review"], ["/improve"]]


### PR DESCRIPTION
## Summary

Add an opt-in fail-fast policy for configured automatic command sequences.

## Motivation

Automatic command loops currently ignore the boolean result of `PRAgent.handle_request()` and continue after a command fails. This can run later commands against an incomplete or failed workflow.

## Changes

- Add `[config].auto_command_stop_on_failure`, defaulting to `false`.
- Stop configured automatic command sequences after a command returns `False` when the option is enabled.
- Stop after command preparation or handling raises an exception when the option is enabled.
- Apply the policy consistently to GitHub App/Action synchronize, GitLab, Bitbucket App/Server, Azure DevOps Server, and Gitea paths.
- Document the configuration and compatibility behavior.
- Add fake-agent regressions covering opt-in fail-fast and default continue-on-failure behavior.

## Compatibility

The default remains `false`, preserving existing behavior. Completed commands are not retried or rolled back.

## Tests

- Focused webhook/action/feature tests: 58 passed.
- Full `tests/unittest`: 2846 passed, 1 skipped, 1 xfailed.
- Ruff: passed.
- Pre-commit: passed.
- Docker `test` target build: passed.

## Related issue

Fixes #2951
