### PR TITLE
feat(github-action): resolve fork PRs for workflow runs

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -89,6 +89,35 @@ jobs:
 !!! warning "Security considerations"
     Using `pull_request_target` gives the workflow access to repository secrets. Unlike the `pull_request` event, the PR code is not automatically checked out, which is a security feature. Avoid adding an `actions/checkout` step unless you have a specific need for the local files — if you do add one, review the [GitHub security guide on pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
 
+#### Using `workflow_run` after fork CI
+
+If a separate `pull_request` workflow must run first — for example, to produce test reports or Terraform plans — PR-Agent can optionally run after that workflow completes. GitHub may omit `workflow_run.pull_requests` for pull requests from forks, so enable the opt-in resolver to find the open base-repository PR by the triggering run's fork repository, branch, and head SHA:
+
+```yaml
+name: PR Agent after CI
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+jobs:
+  pr_agent_job:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: PR Agent action step
+        uses: the-pr-agent/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_action_config.workflow_run_resolve_fork_prs: "true"
+```
+
+The setting is disabled by default. PR-Agent only accepts one matching open PR and verifies both the fork repository and exact head SHA; if the metadata is incomplete, no matching PR exists, or the match is ambiguous, the action skips the run. PR-Agent uses the GitHub API and does not check out or execute the fork's code. Because `workflow_run` workflows can access repository secrets and write permissions, do not add a checkout or execute untrusted fork code in this privileged workflow. `workflow_run` is intended for orchestration after another workflow; use `pull_request_target` when you do not need a separate CI workflow first.
+
 ### Configuration Examples
 
 This section provides detailed, step-by-step examples for configuring PR-Agent with different models and advanced options in GitHub Actions.

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -91,6 +91,9 @@ jobs:
 
 #### Using `workflow_run` after fork CI
 
+!!! warning "Security considerations"
+    A `workflow_run` workflow runs with repository-level secrets and write permissions, and fork activity can trigger it. Do not add an `actions/checkout` step or execute scripts from the fork in this privileged workflow. Keep this workflow limited to API-based orchestration after the untrusted CI workflow; otherwise copies of this pattern can become `pull_request_target` vulnerabilities.
+
 If a separate `pull_request` workflow must run first — for example, to produce test reports or Terraform plans — PR-Agent can optionally run after that workflow completes. GitHub may omit `workflow_run.pull_requests` for pull requests from forks, so enable the opt-in resolver to find the open base-repository PR by the triggering run's fork repository, branch, and head SHA:
 
 ```yaml
@@ -116,7 +119,7 @@ jobs:
           github_action_config.workflow_run_resolve_fork_prs: "true"
 ```
 
-The setting is disabled by default. PR-Agent only accepts one matching open PR and verifies both the fork repository and exact head SHA; if the metadata is incomplete, no matching PR exists, or the match is ambiguous, the action skips the run. PR-Agent uses the GitHub API and does not check out or execute the fork's code. Because `workflow_run` workflows can access repository secrets and write permissions, do not add a checkout or execute untrusted fork code in this privileged workflow. `workflow_run` is intended for orchestration after another workflow; use `pull_request_target` when you do not need a separate CI workflow first.
+The setting is disabled by default. PR-Agent only accepts one matching open PR and verifies both the fork repository and exact head SHA; if the metadata is incomplete, no matching PR exists, or the match is ambiguous, the action skips the run. PR-Agent uses the GitHub API and does not check out or execute the fork's code. `workflow_run` is intended for orchestration after another workflow; use `pull_request_target` when you do not need a separate CI workflow first.
 
 ### Configuration Examples
 

--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -92,7 +92,7 @@ jobs:
 #### Using `workflow_run` after fork CI
 
 !!! warning "Security considerations"
-    A `workflow_run` workflow runs with repository-level secrets and write permissions, and fork activity can trigger it. Do not add an `actions/checkout` step or execute scripts from the fork in this privileged workflow. Keep this workflow limited to API-based orchestration after the untrusted CI workflow; otherwise copies of this pattern can become `pull_request_target` vulnerabilities.
+    A `workflow_run` workflow runs with repository-level secrets and write permissions, and fork activity can trigger it. Do not add an `actions/checkout` step or execute scripts from the fork in this privileged workflow. Keep this workflow limited to API-based orchestration after the untrusted CI workflow; otherwise copies of this pattern can become `pull_request_target` vulnerabilities. If `[artifacts]` is configured or wired into this workflow, treat every artifact produced by the fork as untrusted prompt input because its contents can reach the model; it is not trusted instructions or code. PR-Agent's output is advisory and must never be used as a required status, merge gate, or approval condition for a fork pull request.
 
 If a separate `pull_request` workflow must run first — for example, to produce test reports or Terraform plans — PR-Agent can optionally run after that workflow completes. GitHub may omit `workflow_run.pull_requests` for pull requests from forks, so enable the opt-in resolver to find the open base-repository PR by the triggering run's fork repository, branch, and head SHA:
 

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -203,6 +203,8 @@ Adding `"synchronize"` to this list enables auto tools on new commits pushed to 
 
 `github_action_config.push_trigger_ignore_bot_commits` (default `true`) skips processing when the push author is a bot, avoiding redundant runs on automated commits.
 
+`github_action_config.workflow_run_resolve_fork_prs` (default `false`) opts into resolving an open fork PR by the `workflow_run` head repository, branch, and SHA when GitHub does not include a pull-request URL. The resolver fails closed when metadata is incomplete, no unique open PR matches, or the match is ambiguous. See the [fork CI workflow example](../installation/github.md#using-workflow_run-after-fork-ci).
+
 `github_action_config.enable_output` are used to enable/disable github actions [output parameter](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions) (default is `true`).
 Review result is output as JSON to `steps.{step-id}.outputs.review` property.
 The JSON structure is equivalent to the yaml data structure defined in [pr_reviewer_prompts.toml](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml).

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -167,6 +167,12 @@ class GitProvider(ABC):
     def supports_line_question_history(self) -> bool:
         return False
 
+    def find_open_pr_url(
+            self, base_repo: str, head_repo: str, head_branch: str, head_sha: str
+    ) -> str:
+        """Return the unique open PR represented by repository and commit metadata."""
+        raise NotImplementedError("This git provider does not support PR lookup by commit metadata")
+
     #Given a url (issues or PR/MR) - get the .git repo url to which they belong. Needs to be implemented by the provider.
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
         get_logger().warning("Not implemented! Returning empty url")

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1301,6 +1301,49 @@ class GithubProvider(GitProvider):
     def _get_pr(self):
         return self._get_repo().get_pull(self.pr_num)
 
+    def resolve_workflow_run_pull_request_url(self, workflow_run: dict) -> str:
+        """Resolve the unique open fork PR represented by a workflow run."""
+        repository = workflow_run.get("repository", {})
+        head_repository = workflow_run.get("head_repository", {})
+        base_repo = repository.get("full_name") if isinstance(repository, dict) else ""
+        head_repo = head_repository.get("full_name") if isinstance(head_repository, dict) else ""
+        head_branch = workflow_run.get("head_branch")
+        head_sha = workflow_run.get("head_sha")
+
+        if not all(isinstance(value, str) and value for value in (base_repo, head_repo, head_branch, head_sha)):
+            get_logger().warning("Cannot resolve workflow_run PR: incomplete repository, branch, or SHA metadata")
+            return ""
+        if base_repo.casefold() == head_repo.casefold() or base_repo.count("/") != 1 or head_repo.count("/") != 1:
+            get_logger().warning("Cannot resolve workflow_run PR: head repository is not a valid fork repository")
+            return ""
+
+        head_owner = head_repo.split("/", 1)[0]
+        try:
+            pull_requests = self.github_client.get_repo(base_repo).get_pulls(
+                state="open", head=f"{head_owner}:{head_branch}"
+            )
+            matches = []
+            for pull_request in pull_requests:
+                head = getattr(pull_request, "head", None)
+                pull_request_head_repo = getattr(getattr(head, "repo", None), "full_name", "")
+                if (
+                    isinstance(pull_request_head_repo, str)
+                    and pull_request_head_repo.casefold() == head_repo.casefold()
+                    and getattr(head, "sha", "") == head_sha
+                ):
+                    matches.append(pull_request)
+        except Exception as e:
+            get_logger().warning(f"Failed to resolve workflow_run PR for {base_repo}: {e}")
+            return ""
+
+        if len(matches) != 1:
+            get_logger().info(
+                f"Skipping workflow_run PR resolution: expected one open PR for {head_repo}:{head_branch}@{head_sha}, "
+                f"found {len(matches)}"
+            )
+            return ""
+        return getattr(matches[0], "url", "") or ""
+
     def get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:
             file_content_str = str(

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1301,20 +1301,13 @@ class GithubProvider(GitProvider):
     def _get_pr(self):
         return self._get_repo().get_pull(self.pr_num)
 
-    def resolve_workflow_run_pull_request_url(self, workflow_run: dict) -> str:
-        """Resolve the unique open fork PR represented by a workflow run."""
-        repository = workflow_run.get("repository", {})
-        head_repository = workflow_run.get("head_repository", {})
-        base_repo = repository.get("full_name") if isinstance(repository, dict) else ""
-        head_repo = head_repository.get("full_name") if isinstance(head_repository, dict) else ""
-        head_branch = workflow_run.get("head_branch")
-        head_sha = workflow_run.get("head_sha")
-
+    def find_open_pr_url(self, base_repo: str, head_repo: str, head_branch: str, head_sha: str) -> str:
+        """Resolve the unique open fork PR represented by repository and commit metadata."""
         if not all(isinstance(value, str) and value for value in (base_repo, head_repo, head_branch, head_sha)):
-            get_logger().warning("Cannot resolve workflow_run PR: incomplete repository, branch, or SHA metadata")
+            get_logger().warning("Cannot resolve PR: incomplete repository, branch, or SHA metadata")
             return ""
         if base_repo.casefold() == head_repo.casefold() or base_repo.count("/") != 1 or head_repo.count("/") != 1:
-            get_logger().warning("Cannot resolve workflow_run PR: head repository is not a valid fork repository")
+            get_logger().warning("Cannot resolve PR: head repository is not a valid fork repository")
             return ""
 
         head_owner = head_repo.split("/", 1)[0]
@@ -1333,12 +1326,12 @@ class GithubProvider(GitProvider):
                 ):
                     matches.append(pull_request)
         except Exception as e:
-            get_logger().warning(f"Failed to resolve workflow_run PR for {base_repo}: {e}")
+            get_logger().warning(f"Failed to resolve PR for {base_repo}: {e}")
             return ""
 
         if len(matches) != 1:
             get_logger().info(
-                f"Skipping workflow_run PR resolution: expected one open PR for {head_repo}:{head_branch}@{head_sha}, "
+                f"Skipping PR resolution: expected one open PR for {head_repo}:{head_branch}@{head_sha}, "
                 f"found {len(matches)}"
             )
             return ""

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1382,6 +1382,46 @@ class GitLabProvider(GitProvider):
     def get_pr_branch(self):
         return self.mr.source_branch
 
+    def find_open_pr_url(self, base_repo: str, head_repo: str, head_branch: str, head_sha: str) -> str:
+        """Resolve the unique open merge request represented by project and commit metadata."""
+        if not all(isinstance(value, str) and value for value in (base_repo, head_repo, head_branch, head_sha)):
+            get_logger().warning("Cannot resolve MR: incomplete project, branch, or SHA metadata")
+            return ""
+
+        try:
+            base_project = self.gl.projects.get(base_repo)
+            head_project = self.gl.projects.get(head_repo)
+            head_project_id = getattr(head_project, "id", None)
+            if head_project_id is None:
+                get_logger().warning(f"Cannot resolve MR: source project '{head_repo}' has no ID")
+                return ""
+
+            merge_requests = base_project.mergerequests.list(
+                get_all=True, state="opened", source_branch=head_branch
+            )
+            matches = []
+            for merge_request in merge_requests:
+                source_project_id = getattr(merge_request, "source_project_id", None)
+                if (
+                    source_project_id is not None
+                    and str(source_project_id) == str(head_project_id)
+                    and getattr(merge_request, "source_branch", "") == head_branch
+                    and getattr(merge_request, "sha", "") == head_sha
+                    and getattr(merge_request, "state", "opened") == "opened"
+                ):
+                    matches.append(merge_request)
+        except Exception as e:
+            get_logger().warning(f"Failed to resolve MR for {base_repo}: {e}")
+            return ""
+
+        if len(matches) != 1:
+            get_logger().info(
+                f"Skipping MR resolution: expected one open MR for {head_repo}:{head_branch}@{head_sha}, "
+                f"found {len(matches)}"
+            )
+            return ""
+        return getattr(matches[0], "web_url", "") or ""
+
     def get_pr_owner_id(self) -> str | None:
         if not self.gitlab_url or 'gitlab.com' in self.gitlab_url:
             if not self.id_project:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -37,9 +37,21 @@ def get_setting_or_env(key: str, default: Union[str, bool] = None) -> Union[str,
 
 def _resolve_workflow_run_pull_request(workflow_run: dict) -> str:
     """Resolve a fork PR URL when GitHub omits it from a workflow_run payload."""
-    from pr_agent.git_providers.github_provider import GithubProvider
+    repository = workflow_run.get("repository", {})
+    head_repository = workflow_run.get("head_repository", {})
+    base_repo = repository.get("full_name", "") if isinstance(repository, dict) else ""
+    head_repo = head_repository.get("full_name", "") if isinstance(head_repository, dict) else ""
+    head_branch = workflow_run.get("head_branch", "")
+    head_sha = workflow_run.get("head_sha", "")
 
-    return GithubProvider().resolve_workflow_run_pull_request_url(workflow_run)
+    try:
+        return get_git_provider()().find_open_pr_url(base_repo, head_repo, head_branch, head_sha)
+    except NotImplementedError:
+        get_logger().warning("The configured git provider does not support PR lookup by workflow run metadata")
+        return ""
+    except Exception as e:
+        get_logger().warning(f"Failed to resolve workflow_run PR: {e}")
+        return ""
 
 
 def _inject_artifact_context():

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -35,6 +35,13 @@ def get_setting_or_env(key: str, default: Union[str, bool] = None) -> Union[str,
     return value
 
 
+def _resolve_workflow_run_pull_request(workflow_run: dict) -> str:
+    """Resolve a fork PR URL when GitHub omits it from a workflow_run payload."""
+    from pr_agent.git_providers.github_provider import GithubProvider
+
+    return GithubProvider().resolve_workflow_run_pull_request_url(workflow_run)
+
+
 def _inject_artifact_context():
     """Inject CI artifact content into extra_instructions for configured tools."""
     artifact_path_env = (
@@ -311,10 +318,22 @@ async def run_action():
 
         pull_requests = workflow_run.get("pull_requests", [])
         if not pull_requests:
-            get_logger().info("Skipping workflow_run: no pull_requests found in payload (fork PRs are not supported)")
-            return
+            resolve_fork_prs = get_setting_or_env(
+                "GITHUB_ACTION_CONFIG.WORKFLOW_RUN_RESOLVE_FORK_PRS", False
+            )
+            if not is_true(resolve_fork_prs):
+                get_logger().info(
+                    "Skipping workflow_run: no pull_requests found in payload "
+                    "(fork PR resolution is disabled)"
+                )
+                return
+            pr_url = _resolve_workflow_run_pull_request(workflow_run)
+            if not pr_url:
+                get_logger().info("Skipping workflow_run: no unique open fork PR matched the workflow run")
+                return
+        else:
+            pr_url = pull_requests[0].get("url")
 
-        pr_url = pull_requests[0].get("url")
         if not pr_url:
             get_logger().info("Skipping workflow_run: pull_requests[0] has no url")
             return

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -286,6 +286,9 @@ publish_as_check_run = false # when true, publish review/description/improve out
 # push_trigger_ignore_bot_commits = true
 # push_trigger_ignore_merge_commits = true
 # push_commands = ['/describe', '/review']  # defaults mirror github_app.push_commands
+# Resolve an open fork PR by its workflow_run head repository, branch, and SHA when
+# GitHub omits workflow_run.pull_requests (disabled by default).
+workflow_run_resolve_fork_prs = false
 
 [github_app]
 # these toggles allows running the github app from custom deployments

--- a/tests/unittest/test_git_provider_workflow_run.py
+++ b/tests/unittest/test_git_provider_workflow_run.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pr_agent.git_providers.git_provider import GitProvider
+
+
+def test_find_open_pr_url_is_not_implemented_by_default():
+    with pytest.raises(NotImplementedError):
+        GitProvider.find_open_pr_url(
+            object(), "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+        )

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -494,12 +494,14 @@ async def test_workflow_run_resolves_fork_pr_when_opted_in(monkeypatch, tmp_path
     )))
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     get_settings().set("GITHUB_ACTION_CONFIG.WORKFLOW_RUN_RESOLVE_FORK_PRS", True)
-    monkeypatch.setattr(
-        github_action_runner,
-        "_resolve_workflow_run_pull_request",
-        lambda workflow_run: "https://api.github.com/repos/org/repo/pulls/42",
-        raising=False,
-    )
+    resolved = []
+
+    class FakeProvider:
+        def find_open_pr_url(self, base_repo, head_repo, head_branch, head_sha):
+            resolved.append((base_repo, head_repo, head_branch, head_sha))
+            return "https://api.github.com/repos/org/repo/pulls/42"
+
+    monkeypatch.setattr(github_action_runner, "get_git_provider", lambda: FakeProvider)
 
     def fake_get_setting_or_env(key, default=None):
         values = {
@@ -519,6 +521,7 @@ async def test_workflow_run_resolves_fork_pr_when_opted_in(monkeypatch, tmp_path
         ("describe", "https://api.github.com/repos/org/repo/pulls/42"),
         ("review", "https://api.github.com/repos/org/repo/pulls/42"),
     ]
+    assert resolved == [("org/repo", "contributor/repo", "feature/fork-review", "abc123")]
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -375,7 +375,9 @@ async def test_issue_comment_from_user_is_processed(monkeypatch, tmp_path, resto
     assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]
 
 
-def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_requests=None, conclusion="success"):
+def _write_workflow_run_event(
+        tmp_path, originating_event="pull_request", pull_requests=None, conclusion="success", workflow_run_fields=None
+):
     if pull_requests is None:
         pull_requests = [{"url": "https://api.github.com/repos/org/repo/pulls/42", "number": 42}]
     workflow_run = {
@@ -383,6 +385,8 @@ def _write_workflow_run_event(tmp_path, originating_event="pull_request", pull_r
         "event": originating_event,
         "pull_requests": pull_requests,
     }
+    if workflow_run_fields:
+        workflow_run.update(workflow_run_fields)
     if conclusion is not None:
         workflow_run["conclusion"] = conclusion
     event_path = tmp_path / "event.json"
@@ -470,6 +474,51 @@ async def test_workflow_run_skips_when_pull_requests_empty(monkeypatch, tmp_path
     await github_action_runner.run_action()
 
     assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_resolves_fork_pr_when_opted_in(monkeypatch, tmp_path, restore_github_settings):
+    """An opted-in workflow_run can identify a fork PR when GitHub omits pull_requests."""
+    runs = []
+    _patch_workflow_run_deps(monkeypatch, runs)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_run")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_workflow_run_event(
+        tmp_path,
+        pull_requests=[],
+        workflow_run_fields={
+            "head_branch": "feature/fork-review",
+            "head_sha": "abc123",
+            "head_repository": {"full_name": "contributor/repo"},
+            "repository": {"full_name": "org/repo"},
+        },
+    )))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    get_settings().set("GITHUB_ACTION_CONFIG.WORKFLOW_RUN_RESOLVE_FORK_PRS", True)
+    monkeypatch.setattr(
+        github_action_runner,
+        "_resolve_workflow_run_pull_request",
+        lambda workflow_run: "https://api.github.com/repos/org/repo/pulls/42",
+        raising=False,
+    )
+
+    def fake_get_setting_or_env(key, default=None):
+        values = {
+            "GITHUB_ACTION.AUTO_DESCRIBE": True,
+            "GITHUB_ACTION.AUTO_REVIEW": True,
+            "GITHUB_ACTION.AUTO_IMPROVE": False,
+            "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            "GITHUB_ACTION_CONFIG.WORKFLOW_RUN_RESOLVE_FORK_PRS": True,
+        }
+        return values.get(key, default)
+
+    monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+    await github_action_runner.run_action()
+
+    assert runs == [
+        ("describe", "https://api.github.com/repos/org/repo/pulls/42"),
+        ("review", "https://api.github.com/repos/org/repo/pulls/42"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_github_provider_workflow_run.py
+++ b/tests/unittest/test_github_provider_workflow_run.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pr_agent.git_providers.github_provider import GithubProvider
+
+
+def _provider_with_pull_requests(pull_requests):
+    provider = GithubProvider.__new__(GithubProvider)
+    provider.github_client = MagicMock()
+    provider.github_client.get_repo.return_value.get_pulls.return_value = pull_requests
+    return provider
+
+
+def _workflow_run():
+    return {
+        "repository": {"full_name": "org/repo"},
+        "head_repository": {"full_name": "contributor/repo"},
+        "head_branch": "feature/fork-review",
+        "head_sha": "abc123",
+    }
+
+
+def test_resolve_workflow_run_pull_request_url_matches_fork_and_sha():
+    pull_request = SimpleNamespace(
+        url="https://api.github.com/repos/org/repo/pulls/42",
+        head=SimpleNamespace(
+            repo=SimpleNamespace(full_name="contributor/repo"),
+            sha="abc123",
+        ),
+    )
+    provider = _provider_with_pull_requests([pull_request])
+
+    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == pull_request.url
+    provider.github_client.get_repo.return_value.get_pulls.assert_called_once_with(
+        state="open", head="contributor:feature/fork-review"
+    )
+
+
+def test_resolve_workflow_run_pull_request_url_fails_closed_for_mismatched_sha():
+    pull_request = SimpleNamespace(
+        url="https://api.github.com/repos/org/repo/pulls/42",
+        head=SimpleNamespace(
+            repo=SimpleNamespace(full_name="contributor/repo"),
+            sha="different-sha",
+        ),
+    )
+    provider = _provider_with_pull_requests([pull_request])
+
+    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == ""
+
+
+def test_resolve_workflow_run_pull_request_url_fails_closed_for_ambiguous_matches():
+    pull_request = SimpleNamespace(
+        url="https://api.github.com/repos/org/repo/pulls/42",
+        head=SimpleNamespace(
+            repo=SimpleNamespace(full_name="contributor/repo"),
+            sha="abc123",
+        ),
+    )
+    provider = _provider_with_pull_requests([pull_request, pull_request])
+
+    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == ""

--- a/tests/unittest/test_github_provider_workflow_run.py
+++ b/tests/unittest/test_github_provider_workflow_run.py
@@ -11,16 +11,7 @@ def _provider_with_pull_requests(pull_requests):
     return provider
 
 
-def _workflow_run():
-    return {
-        "repository": {"full_name": "org/repo"},
-        "head_repository": {"full_name": "contributor/repo"},
-        "head_branch": "feature/fork-review",
-        "head_sha": "abc123",
-    }
-
-
-def test_resolve_workflow_run_pull_request_url_matches_fork_and_sha():
+def test_find_open_pr_url_matches_fork_and_sha():
     pull_request = SimpleNamespace(
         url="https://api.github.com/repos/org/repo/pulls/42",
         head=SimpleNamespace(
@@ -30,13 +21,15 @@ def test_resolve_workflow_run_pull_request_url_matches_fork_and_sha():
     )
     provider = _provider_with_pull_requests([pull_request])
 
-    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == pull_request.url
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == pull_request.url
     provider.github_client.get_repo.return_value.get_pulls.assert_called_once_with(
         state="open", head="contributor:feature/fork-review"
     )
 
 
-def test_resolve_workflow_run_pull_request_url_fails_closed_for_mismatched_sha():
+def test_find_open_pr_url_fails_closed_for_mismatched_sha():
     pull_request = SimpleNamespace(
         url="https://api.github.com/repos/org/repo/pulls/42",
         head=SimpleNamespace(
@@ -46,10 +39,12 @@ def test_resolve_workflow_run_pull_request_url_fails_closed_for_mismatched_sha()
     )
     provider = _provider_with_pull_requests([pull_request])
 
-    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == ""
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == ""
 
 
-def test_resolve_workflow_run_pull_request_url_fails_closed_for_ambiguous_matches():
+def test_find_open_pr_url_fails_closed_for_ambiguous_matches():
     pull_request = SimpleNamespace(
         url="https://api.github.com/repos/org/repo/pulls/42",
         head=SimpleNamespace(
@@ -59,4 +54,6 @@ def test_resolve_workflow_run_pull_request_url_fails_closed_for_ambiguous_matche
     )
     provider = _provider_with_pull_requests([pull_request, pull_request])
 
-    assert provider.resolve_workflow_run_pull_request_url(_workflow_run()) == ""
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == ""

--- a/tests/unittest/test_gitlab_provider_workflow_run.py
+++ b/tests/unittest/test_gitlab_provider_workflow_run.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+
+def _provider_with_merge_requests(merge_requests):
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.gl = MagicMock()
+    base_project = SimpleNamespace(
+        id=101,
+        path_with_namespace="org/repo",
+        mergerequests=MagicMock(),
+    )
+    source_project = SimpleNamespace(id=202, path_with_namespace="contributor/repo")
+    base_project.mergerequests.list.return_value = merge_requests
+    provider.gl.projects.get.side_effect = lambda project: {
+        "org/repo": base_project,
+        "contributor/repo": source_project,
+    }[project]
+    return provider, base_project
+
+
+def _merge_request(source_project_id=202, sha="abc123"):
+    return SimpleNamespace(
+        source_project_id=source_project_id,
+        source_branch="feature/fork-review",
+        sha=sha,
+        web_url="https://gitlab.com/org/repo/-/merge_requests/42",
+    )
+
+
+def test_find_open_pr_url_matches_source_project_branch_and_sha():
+    provider, base_project = _provider_with_merge_requests([_merge_request()])
+
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == "https://gitlab.com/org/repo/-/merge_requests/42"
+    base_project.mergerequests.list.assert_called_once_with(
+        get_all=True, state="opened", source_branch="feature/fork-review"
+    )
+
+
+def test_find_open_pr_url_fails_closed_for_mismatched_source_metadata():
+    provider, _ = _provider_with_merge_requests([
+        _merge_request(source_project_id=999),
+        _merge_request(sha="different-sha"),
+    ])
+
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == ""
+
+
+def test_find_open_pr_url_fails_closed_for_ambiguous_matches():
+    provider, _ = _provider_with_merge_requests([_merge_request(), _merge_request()])
+
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == ""
+
+
+def test_find_open_pr_url_fails_closed_when_gitlab_lookup_fails():
+    provider, base_project = _provider_with_merge_requests([])
+    base_project.mergerequests.list.side_effect = RuntimeError("GitLab unavailable")
+
+    assert provider.find_open_pr_url(
+        "org/repo", "contributor/repo", "feature/fork-review", "abc123"
+    ) == ""


### PR DESCRIPTION
## Summary

Add an opt-in resolver for GitHub Action `workflow_run` events whose payload does not contain a pull-request URL for a fork pull request.

## Motivation

PR-Agent already supports running after another workflow completes and can inject CI artifact context into its tools. The current runner depends on `workflow_run.pull_requests[0].url`, then skips when that array is empty. As a result, repositories that run CI for external fork contributions cannot use the existing post-CI review flow for those pull requests.

## Implementation

- Add `github_action_config.workflow_run_resolve_fork_prs`, defaulting to `false`.
- When enabled, resolve the pull request through the GitHub provider using the workflow run's base repository, fork repository, head branch, and exact head SHA.
- Query only open pull requests and require exactly one match with the same fork repository and SHA.
- Preserve the existing URL-based path for payloads that already include `pull_requests`.
- Fail closed for incomplete metadata, API errors, no match, or ambiguous matches.
- Document the workflow configuration and the `workflow_run` security boundary.

## Compatibility and security

The new lookup is disabled by default and is used only when the existing pull-request list is empty. No existing event path, provider output, prompt, model selection, or MCP/tool orchestration behavior changes. The resolver uses GitHub API metadata only; it does not check out or execute code from the fork. Users must still treat the privileged `workflow_run` workflow as untrusted-code sensitive and must not add a checkout or execute fork scripts in that workflow.

## Tests

- Added a baseline red webhook harness for an opted-in empty `pull_requests` payload.
- Added runner coverage for resolving a fork PR through the action path.
- Added provider coverage for exact fork/SHA matching and fail-closed mismatch/ambiguity behavior.
- Focused runner/provider tests: 23 passed.
- Full `tests/unittest`: 2848 passed, 1 skipped, 1 xfailed.
- Full Ruff and mounted-worktree pre-commit: passed.
- Docker test target and CI-equivalent `pytest -v tests/unittest`: passed.

Fixes #2953
