### PR TITLE
docs(usage-guide): add extension guide and fill contributor onboarding gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,17 @@ Thank you for your interest in contributing to the PR-Agent project!
    - For bug fixes: `git checkout -b fix/issue-description`
 5. Make your changes
 6. Write or update tests as needed
-7. Run tests locally to ensure everything passes
-8. Commit your changes using conventional commit messages
-9. Push to your fork and submit a pull request
+7. Run tests locally to ensure everything passes:
+   ```bash
+   PYTHONPATH=. uv run pytest tests/unittest
+   ```
+8. Lint the files you changed and run the pre-commit hooks on them:
+   ```bash
+   uv run ruff check --fix <changed files>
+   uv run pre-commit run --files <changed files>
+   ```
+9. Commit your changes using conventional commit messages
+10. Push to your fork and submit a pull request
 
 ## Development Guidelines
 

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -20,7 +20,7 @@ Here is a list of PR-Agent tools, each with a dedicated page that explains how t
 Each tool can be triggered in two ways:
 
 - **As a comment** — write the command (e.g. `/review`) as a comment, and PR-Agent replies. Most tools are commented on a PR; issue-scoped tools such as `similar_issue` are commented on an issue.
-- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`. Issue-scoped tools take `--issue_url=<ISSUE_URL>` instead of `--pr_url`.
+- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`. Issue-scoped tools take `--issue_url=<ISSUE_URL>` instead of `--pr_url`. The module form works only inside an environment with PR-Agent installed (for example the project venv created by `uv sync`); alternatively run `pr-agent` directly if available on your `PATH`.
 
 Both accept the same tool arguments and [configuration overrides](../usage-guide/configuration_options.md).
 

--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -1,0 +1,32 @@
+# Extending PR-Agent
+
+PR-Agent is made of replaceable pieces: the AI model behind the tools, the git provider it talks to, and the individual tools (such as `review` or `describe`) that form its command surface. This page explains where each piece lives and how to add a new one. It is aimed at contributors, not users — see the [Changing a Model](./changing_a_model.md) page for the operator-side configuration guide.
+
+## Adding a model
+
+All AI calls go through [LiteLLM](https://docs.litellm.ai/) (see `pr_agent/algo/ai_handlers/litellm_ai_handler.py`), so adding a model usually needs no code:
+
+1. Set `model` (and optionally `fallback_models`) in `pr_agent/settings/configuration.toml` to the LiteLLM model name.
+2. If the model needs special handling — no temperature support, extended thinking, streaming quirks — the relevant lists live in `pr_agent/algo/__init__.py` (for example `NO_SUPPORT_TEMPERATURE_MODELS` or `CLAUDE_EXTENDED_THINKING_MODELS`). Add the model name there and cover it with a unit test.
+
+Never hard-code model names in tool code; keep them in configuration.
+
+## Adding a git provider
+
+A git provider adapts PR-Agent to a specific git hosting platform:
+
+1. Implement a provider class in `pr_agent/git_providers/` that extends the `GitProvider` interface in `pr_agent/git_providers/git_provider.py` (see `gitlab_provider.py` for a reference).
+2. Register it in the `_GIT_PROVIDERS` map in `pr_agent/git_providers/__init__.py` under a short name.
+3. Set `git_provider` in `pr_agent/settings/configuration.toml` to that name.
+4. Add an `installation/<name>.md` page (see `installation/gitlab.md` for a reference) and register it in the Installation section of `docs/mkdocs.yml`.
+5. Gate provider-dependent behavior with capability checks like `provider.is_supported("feature")` instead of concrete provider-type checks, since providers can stub or override capabilities.
+
+## Adding a tool
+
+A tool is a class that consumes PR data from the git provider and produces a response (the `PRReviewer` from `review` and `PRDescription` from `describe` are the usual references):
+
+1. Implement the tool under `pr_agent/tools/`, following the existing conventions. Tool and prompt names normally correspond: `pr_reviewer.py` ↔ `pr_reviewer_prompts.toml` under `pr_agent/settings/`.
+2. Register any new prompt TOML in the `settings_files=[...]` list in `pr_agent/config_loader.py`, or it will not be loaded into settings.
+3. Register the tool in `command2class` in `pr_agent/agent/pr_agent.py` under a command name. That map is what makes the tool reachable from comment commands and the CLI.
+4. Add a `tools/<name>.md` page (see `tools/review.md`) with usage and command examples, and register it under Tools in `docs/mkdocs.yml`.
+5. Add unit tests under `tests/unittest/`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,6 +9,12 @@ nav:
   - Installation:
     - 'installation/index.md'
     - PR-Agent: 'installation/pr_agent.md'
+    - Self-Hosted Webhook Server: 'installation/locally.md'
+    - GitHub Action / App: 'installation/github.md'
+    - GitLab Pipeline: 'installation/gitlab.md'
+    - Azure DevOps Pipeline: 'installation/azure.md'
+    - Bitbucket Pipeline: 'installation/bitbucket.md'
+    - Gitea Webhook Server: 'installation/gitea.md'
   - Usage Guide:
     - 'usage-guide/index.md'
     - Introduction: 'usage-guide/introduction.md'
@@ -16,6 +22,7 @@ nav:
     - Usage and Automation: 'usage-guide/automations_and_usage.md'
     - Managing Mail Notifications: 'usage-guide/mail_notifications.md'
     - Changing a Model: 'usage-guide/changing_a_model.md'
+    - Extending PR-Agent: 'usage-guide/extending_pr_agent.md'
     - Additional Configurations: 'usage-guide/additional_configurations.md'
     - Plain-Diff Mode: 'usage-guide/plain_diff_mode.md'
     - Local Git Provider: 'usage-guide/local_git_provider.md'


### PR DESCRIPTION
What
- CONTRIBUTING.md: step 7 now gives the working test command (`PYTHONPATH=. uv run pytest tests/unittest`) and step 8 the required `ruff check --fix` and pre-commit steps.
- docs/mkdocs.yml: Installation sidebar now lists locally.md, github.md, gitlab.md, azure.md, bitbucket.md, gitea.md (previously reachable only through in-page links); new "Extending PR-Agent" entry under Usage Guide.
- docs/docs/tools/index.md: `python -m pr_agent.cli` examples clarify that the module form requires an installed environment (e.g. the project venv from `uv sync`), per issue note that it only worked inside an activated venv.
- New docs/docs/usage-guide/extending_pr_agent.md: contributor-facing reference for adding a model, a git provider, or a tool, pointing at the exact files to touch.

Why
Closes #2961. The reported gaps make the first contribution harder than it needs to be: no test command, no contributor-facing extension pages, hidden installation pages, and a CLI example that fails without a venv.

How (brief)
Docs-only changes; no runtime code touched. The extension guide was written against the existing architecture (litellm handler, `_GIT_PROVIDERS` map, `command2class`) and AGENTS.md.

Testing
- `uvx --with mkdocs-material --with mkdocs-glightbox mkdocs build -f docs/mkdocs.yml` — builds clean.
- `pre-commit run --files <changed files>` — all hooks pass.
- No unit tests touched (docs-only).

Risks/Impact
None; no behavior change. Anchor warnings reported during mkdocs build are pre-existing and unrelated to this diff.

Docs/Follow-ups
Docs themselves; the extension guide links to existing pages.

Closes #2961