### PR TITLE
fix: align CLI settings validation with repo allowlist

### DIFF
--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -10,6 +10,8 @@ class CliArgs:
         setting_name = arg.removeprefix('--').split('=', 1)[0].replace('__', '.')
         section, separator, key = setting_name.partition('.')
         if not separator:
+            if section in REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION:
+                return f'.{section}'
             return None
 
         allowed_keys = REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section)

--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -1,7 +1,22 @@
 from base64 import b64decode
 
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
+
 
 class CliArgs:
+    @staticmethod
+    def _host_only_setting_arg(arg: str) -> str | None:
+        """Return a protected setting token when a CLI arg targets a host-only key."""
+        setting_name = arg.removeprefix('--').split('=', 1)[0].replace('__', '.')
+        section, separator, key = setting_name.partition('.')
+        if not separator:
+            return None
+
+        allowed_keys = REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section)
+        if allowed_keys is not None and key not in allowed_keys:
+            return f'.{section}.{key}'
+        return None
+
     @staticmethod
     def validate_user_args(args: list) -> (bool, str):
         try:
@@ -50,6 +65,9 @@ class CliArgs:
                 if arg.startswith('--'):
                     arg_word = arg.lower()
                     arg_word = arg_word.replace('__', '.')  # replace double underscore with dot, e.g. --openai__key -> --openai.key
+                    host_only_arg = CliArgs._host_only_setting_arg(arg_word)
+                    if host_only_arg:
+                        return False, host_only_arg
                     for forbidden_arg_word in forbidden_cli_args:
                         if forbidden_arg_word in arg_word:
                             return False, forbidden_arg_word

--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -1,7 +1,22 @@
 from base64 import b64decode
 
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
+
 
 class CliArgs:
+    @staticmethod
+    def _host_only_setting_arg(arg: str) -> str | None:
+        """Return a protected setting token when a CLI arg targets a host-only key."""
+        setting_name = arg.removeprefix('--').split('=', 1)[0].replace('__', '.')
+        section, separator, key = setting_name.partition('.')
+        if not separator:
+            return None
+
+        allowed_keys = REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section)
+        if allowed_keys is not None and key not in allowed_keys:
+            return f'.{section}.{key}'
+        return None
+
     @staticmethod
     def validate_user_args(args: list) -> (bool, str):
         try:
@@ -43,6 +58,9 @@ class CliArgs:
                 if arg.startswith('--'):
                     arg_word = arg.lower()
                     arg_word = arg_word.replace('__', '.')  # replace double underscore with dot, e.g. --openai__key -> --openai.key
+                    host_only_arg = CliArgs._host_only_setting_arg(arg_word)
+                    if host_only_arg:
+                        return False, host_only_arg
                     for forbidden_arg_word in forbidden_cli_args:
                         if forbidden_arg_word in arg_word:
                             return False, forbidden_arg_word

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -1,0 +1,9 @@
+"""Shared configuration boundaries for repository-provided settings."""
+
+# Sections that touch host-level capabilities cannot be fully configured from
+# a repository's settings file. The same allowlist is used by repo settings
+# application and CLI argument validation so the two entry points cannot drift.
+REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
+    "skills": frozenset({"enabled", "max_skills_tokens"}),
+    "push_outputs": frozenset(),
+}

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -3,6 +3,18 @@
 # Sections that touch host-level capabilities cannot be fully configured from
 # a repository's settings file. The same allowlist is used by repo settings
 # application and CLI argument validation so the two entry points cannot drift.
+# For each section listed here, only the keys in its allowlist may be set from a
+# repository; every other key is dropped with a warning.
+#
+# skills: `enabled` and `max_skills_tokens` are safe per-repo preferences (a repo can opt in to, or
+# size, the host's admin-curated skill library). `paths` is NOT overridable: it points at the
+# PR-Agent host's filesystem, so letting a repo set it would allow a malicious repo to read
+# sensitive host files (e.g. ~/.ssh/*) into the LLM prompt. `paths` therefore stays host-only.
+#
+# push_outputs: routes review data to operator-controlled sinks (webhook/slack/file). Letting a
+# repo set any of these would let a malicious repo exfiltrate review data to an arbitrary host,
+# reach internal endpoints (SSRF), or append to arbitrary host files. The whole section is
+# therefore host-only (empty allowlist -> every key dropped).
 REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
     "skills": frozenset({"enabled", "max_skills_tokens"}),
     "push_outputs": frozenset(),

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -1,0 +1,8 @@
+"""Shared configuration boundaries for repository-provided settings."""
+
+# Sections that touch host-level capabilities cannot be fully configured from
+# a repository's settings file. The same allowlist is used by repo settings
+# application and CLI argument validation so the two entry points cannot drift.
+REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
+    "skills": frozenset({"enabled", "max_skills_tokens"}),
+}

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -12,23 +12,10 @@ from dynaconf.loaders import env_loader
 from starlette_context import context
 
 from pr_agent.config_loader import get_settings
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
 from pr_agent.custom_merge_loader import MAX_TOML_SIZE_IN_BYTES, validate_file_security
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
-
-# Sections that touch host-level capabilities and so cannot be fully configured
-# from a repo's .pr_agent.toml. For each section listed here, only the keys in
-# its allowlist may be overridden by repo settings; every other key is dropped
-# with a warning.
-#
-# skills: `enabled` and `max_skills_tokens` are safe per-repo preferences (a repo
-# can opt in to, or size, the host's admin-curated skill library). `paths` is NOT
-# overridable: it points at the PR-Agent host's filesystem, so letting a repo set
-# it would allow a malicious repo to read sensitive host files (e.g. ~/.ssh/*)
-# into the LLM prompt. `paths` therefore stays host-only.
-_REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
-    "skills": frozenset({"enabled", "max_skills_tokens"}),
-}
 
 _MAX_EXTRA_CONFIG_BYTES = 1 * 1024 * 1024  # 1 MB cap for a remote .toml
 _FETCH_TIMEOUT_SECONDS = 10
@@ -351,7 +338,7 @@ def _apply_repo_settings_file(repo_settings_file):
         if not isinstance(contents, dict) or not contents:
             get_logger().debug(f"Skipping non-table or empty section: {section}")
             continue
-        allowed_keys = _REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
+        allowed_keys = REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
         if allowed_keys is not None:
             rejected = [k for k in contents if k.lower() not in allowed_keys]
             if rejected:

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -12,29 +12,10 @@ from dynaconf.loaders import env_loader
 from starlette_context import context
 
 from pr_agent.config_loader import get_settings
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
 from pr_agent.custom_merge_loader import MAX_TOML_SIZE_IN_BYTES, validate_file_security
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
-
-# Sections that touch host-level capabilities and so cannot be fully configured
-# from a repo's .pr_agent.toml. For each section listed here, only the keys in
-# its allowlist may be overridden by repo settings; every other key is dropped
-# with a warning.
-#
-# skills: `enabled` and `max_skills_tokens` are safe per-repo preferences (a repo
-# can opt in to, or size, the host's admin-curated skill library). `paths` is NOT
-# overridable: it points at the PR-Agent host's filesystem, so letting a repo set
-# it would allow a malicious repo to read sensitive host files (e.g. ~/.ssh/*)
-# into the LLM prompt. `paths` therefore stays host-only.
-#
-# push_outputs: routes review data to operator-controlled sinks (webhook/slack/file). Letting a
-# repo's .pr_agent.toml set any of these would let a malicious repo exfiltrate review data to an
-# arbitrary host, reach internal endpoints (SSRF), or append to arbitrary host files. The whole
-# section is therefore host-only (empty allowlist -> every key dropped).
-_REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
-    "skills": frozenset({"enabled", "max_skills_tokens"}),
-    "push_outputs": frozenset(),
-}
 
 _MAX_EXTRA_CONFIG_BYTES = 1 * 1024 * 1024  # 1 MB cap for a remote .toml
 _FETCH_TIMEOUT_SECONDS = 10
@@ -357,7 +338,7 @@ def _apply_repo_settings_file(repo_settings_file):
         if not isinstance(contents, dict) or not contents:
             get_logger().debug(f"Skipping non-table or empty section: {section}")
             continue
-        allowed_keys = _REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
+        allowed_keys = REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION.get(section.lower())
         if allowed_keys is not None:
             rejected = [k for k in contents if k.lower() not in allowed_keys]
             if rejected:

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -83,6 +83,7 @@ HOST_ONLY_ARGS = [
     "--skills.paths=/etc",
     "--skills__paths=/etc",
     "--skills.unknown=value",
+    "--skills={paths:[/etc]}",
 ]
 
 

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -56,6 +56,8 @@ FORBIDDEN_ARGS = [
 ALLOWED_ARGS_SINGLE = [
     "--pr_reviewer.num_code_suggestions=3",
     "--pr_reviewer.require_tests_review=true",
+    "--skills.enabled=true",
+    "--skills.max_skills_tokens=1000",
     "--config.response_language=zh-tw",
     "--pr_description.publish_labels=false",
     # non-flag arguments are not validated against the forbidden list
@@ -66,6 +68,13 @@ ALLOWED_ARGS_SINGLE = [
 ]
 
 
+HOST_ONLY_ARGS = [
+    "--skills.paths=/etc",
+    "--skills__paths=/etc",
+    "--skills.unknown=value",
+]
+
+
 @pytest.mark.parametrize("forbidden", FORBIDDEN_ARGS)
 def test_validate_user_args_rejects_forbidden(forbidden):
     ok, offending = CliArgs.validate_user_args([forbidden])
@@ -73,6 +82,13 @@ def test_validate_user_args_rejects_forbidden(forbidden):
     assert isinstance(offending, str) and offending, (
         f"Expected an offending-token string for {forbidden!r}, got {offending!r}"
     )
+
+
+@pytest.mark.parametrize("host_only", HOST_ONLY_ARGS)
+def test_validate_user_args_rejects_keys_not_in_repo_allowlist(host_only):
+    ok, offending = CliArgs.validate_user_args([host_only])
+    assert ok is False
+    assert offending.lstrip('.') in host_only.lower().replace('__', '.')
 
 
 @pytest.mark.parametrize("allowed", ALLOWED_ARGS_SINGLE)

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -67,6 +67,8 @@ FORBIDDEN_ARGS = [
 ALLOWED_ARGS_SINGLE = [
     "--pr_reviewer.num_code_suggestions=3",
     "--pr_reviewer.require_tests_review=true",
+    "--skills.enabled=true",
+    "--skills.max_skills_tokens=1000",
     "--config.response_language=zh-tw",
     "--pr_description.publish_labels=false",
     # non-flag arguments are not validated against the forbidden list
@@ -77,6 +79,13 @@ ALLOWED_ARGS_SINGLE = [
 ]
 
 
+HOST_ONLY_ARGS = [
+    "--skills.paths=/etc",
+    "--skills__paths=/etc",
+    "--skills.unknown=value",
+]
+
+
 @pytest.mark.parametrize("forbidden", FORBIDDEN_ARGS)
 def test_validate_user_args_rejects_forbidden(forbidden):
     ok, offending = CliArgs.validate_user_args([forbidden])
@@ -84,6 +93,13 @@ def test_validate_user_args_rejects_forbidden(forbidden):
     assert isinstance(offending, str) and offending, (
         f"Expected an offending-token string for {forbidden!r}, got {offending!r}"
     )
+
+
+@pytest.mark.parametrize("host_only", HOST_ONLY_ARGS)
+def test_validate_user_args_rejects_keys_not_in_repo_allowlist(host_only):
+    ok, offending = CliArgs.validate_user_args([host_only])
+    assert ok is False
+    assert offending.lstrip('.') in host_only.lower().replace('__', '.')
 
 
 @pytest.mark.parametrize("allowed", ALLOWED_ARGS_SINGLE)


### PR DESCRIPTION
## Summary
- share the repository-settings host-section allowlist with CLI argument validation
- reject whole-section assignments to protected sections before comment settings are parsed
- cover the `--skills={paths:[/etc]}` bypass while preserving existing CLI denylist behavior and safe skills overrides

Fixes #2946

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/unittest/test_cli_args_security.py tests/unittest/test_apply_repo_settings_security.py -q` — 75 passed (run with a task-local Windows TEMP/TMP directory)
- `.\.venv\Scripts\ruff.exe check --fix pr_agent/algo/cli_args.py pr_agent/config_security.py pr_agent/git_providers/utils.py tests/unittest/test_cli_args_security.py` — passed
- `.\.venv\Scripts\python.exe -m compileall -q pr_agent/algo/cli_args.py pr_agent/config_security.py pr_agent/git_providers/utils.py` — passed
- `pre-commit run --files pr_agent/algo/cli_args.py pr_agent/config_security.py pr_agent/git_providers/utils.py tests/unittest/test_cli_args_security.py` — passed
- `git diff --check` — passed
- `.\.venv\Scripts\python.exe -m pytest tests/unittest -q` — 2833 passed, 1 skipped, 1 xfailed, 17 unrelated Windows-specific failures (line-ending/encoding assumptions, LiteLLM cancellation timing, and skills path assumptions)
- `docker build -f docker/Dockerfile --target test -t pr-agent-review:test .` — blocked twice by external image mirrors (TLS handshake timeout and Debian `InRelease` 502); the Docker test container was not run
- `mypy` — not run; repository-wide baseline errors were already recorded on the original PR
