### PR TITLE
docs(usage-guide): add extension guide and fill contributor onboarding gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thank you for your interest in contributing to the PR-Agent project!
    so the unit suite is the default local check.
 8. Lint your changed files, then run the pre-commit hooks on them:
    ```bash
-   uv run ruff check --fix <changed files>
+   uv run ruff check --fix <changed Python files>
    uv run pre-commit run --files <changed files>
    ```
 9. Commit your changes using conventional commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,19 @@ Thank you for your interest in contributing to the PR-Agent project!
    - For bug fixes: `git checkout -b fix/issue-description`
 5. Make your changes
 6. Write or update tests as needed
-7. Run tests locally to ensure everything passes
-8. Commit your changes using conventional commit messages
-9. Push to your fork and submit a pull request
+7. Run tests locally to ensure everything passes:
+   ```bash
+   PYTHONPATH=. uv run pytest tests/unittest
+   ```
+   The end-to-end and health suites require provider tokens or API keys,
+   so the unit suite is the default local check.
+8. Lint your changed files, then run the pre-commit hooks on them:
+   ```bash
+   uv run ruff check --fix <changed files>
+   uv run pre-commit run --files <changed files>
+   ```
+9. Commit your changes using conventional commit messages.
+10. Push to your fork and submit a pull request
 
 ## Development Guidelines
 

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -20,7 +20,7 @@ Here is a list of PR-Agent tools, each with a dedicated page that explains how t
 Each tool can be triggered in two ways:
 
 - **As a comment** — write the command (e.g. `/review`) as a comment, and PR-Agent replies. Most tools are commented on a PR; issue-scoped tools such as `similar_issue` are commented on an issue.
-- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`. Issue-scoped tools take `--issue_url=<ISSUE_URL>` instead of `--pr_url`.
+- **From the [CLI](../usage-guide/automations_and_usage.md#local-repo-cli)** — run `python -m pr_agent.cli --pr_url=<PR_URL> <tool>`. Issue-scoped tools take `--issue_url=<ISSUE_URL>` instead of `--pr_url`. The module form works only from an environment where the `pr_agent` package is importable (for example, the venv created by `uv sync`). If `pr-agent` is on your `PATH`, run it directly.
 
 Both accept the same tool arguments and [configuration overrides](../usage-guide/configuration_options.md).
 

--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -9,8 +9,8 @@ Tool calls go through LiteLLM (`pr_agent/algo/ai_handlers/litellm_ai_handler.py`
 
 ```toml
 [config]
-model="gpt-5.6"
-fallback_models=["gpt-5.6-terra"]
+model="<model-name>"
+fallback_models=["<fallback-model-name>"]
 ```
 
 Set these under `[config]` in `pr_agent/settings/configuration.toml`.
@@ -41,10 +41,10 @@ Implement a `GitProvider` subclass and register it:
 
 ## Adding a tool
 
-1. Implement the tool class in `pr_agent/tools/<name>.py` with an `async def run(self)` entry point (see `pr_reviewer.py`).
+1. Implement the tool class in `pr_agent/tools/pr_<name>.py` with an `async def run(self)` entry point (see `pr_reviewer.py`).
 2. Add a `[pr_<tool>]` section in `pr_agent/settings/configuration.toml` for the option keys the tool reads (`[pr_reviewer]` is the pattern to follow).
 3. Add a prompt TOML under `pr_agent/settings/` and register it in the `settings_files=[...]` list in `pr_agent/config_loader.py` — it is not loaded otherwise.
 4. Match the TOML section name to the settings key the tool reads: `[pr_review_prompt]` in `pr_reviewer_prompts.toml` ↔ `get_settings().pr_review_prompt` in `pr_reviewer.py`.
-5. Register the tool in `command2class` in `pr_agent/agent/pr_agent.py` under a command name, e.g. `"my_tool": PRMyTool`.
+5. Register the tool in `command2class` in `pr_agent/agent/pr_agent.py` under a command name, e.g. `"my_tool": PRMyTool`. Then add it to the hardcoded help surfaces, or it will not show up in `/help`: `pr_agent/tools/pr_help_message.py`, `pr_agent/servers/help.py`, and the command list in `pr_agent/cli.py`.
 6. Add a row to the tool list in `docs/docs/tools/index.md`, a page `docs/docs/tools/<name>.md` (see [`review.md`](../tools/review.md)), and register the page under `Tools` in `docs/mkdocs.yml`.
 7. Add tests under `tests/unittest/` and verify with `PYTHONPATH=. uv run pytest tests/unittest`.

--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -1,0 +1,50 @@
+# Extending PR-Agent
+
+Contributors extending a model, git provider, or tool start here. To only change
+the model, use [Changing a Model](./changing_a_model.md).
+
+## Adding a model
+
+Tool calls go through LiteLLM (`pr_agent/algo/ai_handlers/litellm_ai_handler.py`), the default handler. Most models need only configuration:
+
+```toml
+[config]
+model="gpt-5.6"
+fallback_models=["gpt-5.6-terra"]
+```
+
+Set these under `[config]` in `pr_agent/settings/configuration.toml`.
+Keep model names in configuration, not in tool code.
+
+Models that behave differently are registered in `pr_agent/algo/__init__.py`:
+`NO_SUPPORT_TEMPERATURE_MODELS` for models that reject a temperature
+parameter; `CLAUDE_EXTENDED_THINKING_MODELS` for Claude models that
+take extended thinking. Add the exact model name to the matching list.
+
+Context windows are registered in `MAX_TOKENS` in `pr_agent/algo/__init__.py`:
+add the model name and its context-window token count, or set
+`config.custom_model_max_tokens` in `configuration.toml`. Without
+either, `get_max_tokens()` raises.
+
+Verify with `PYTHONPATH=. uv run pytest tests/unittest`.
+
+## Adding a git provider
+
+Implement a `GitProvider` subclass and register it:
+
+1. Create `pr_agent/git_providers/<name>_provider.py`, extending the interface in `pr_agent/git_providers/git_provider.py` (`gitlab_provider.py` is the reference).
+2. Register the class in `_GIT_PROVIDERS` in `pr_agent/git_providers/__init__.py`. Keys already used: `github`, `gitlab`, `bitbucket`, `bitbucket_server`, `azure`, `codecommit`, `local`, `gerrit`, `gitea`, `plain-diff`.
+3. Select it via `[config]` → `git_provider="<name>"` in `pr_agent/settings/configuration.toml`.
+4. Add `docs/docs/installation/<name>.md` (see [`gitlab.md`](../installation/gitlab.md)) and register it under `Installation` in `docs/mkdocs.yml`.
+5. Select provider-dependent behavior with capability checks like `provider.is_supported("feature")` rather than provider-type checks.
+6. Add unit tests under `tests/unittest/test_<name>_provider.py` (see `test_bitbucket_provider.py`) and list the required env vars in `pr_agent/settings/.secrets_template.toml`.
+
+## Adding a tool
+
+1. Implement the tool class in `pr_agent/tools/<name>.py` with an `async def run(self)` entry point (see `pr_reviewer.py`).
+2. Add a `[pr_<tool>]` section in `pr_agent/settings/configuration.toml` for the option keys the tool reads (`[pr_reviewer]` is the pattern to follow).
+3. Add a prompt TOML under `pr_agent/settings/` and register it in the `settings_files=[...]` list in `pr_agent/config_loader.py` — it is not loaded otherwise.
+4. Match the TOML section name to the settings key the tool reads: `[pr_review_prompt]` in `pr_reviewer_prompts.toml` ↔ `get_settings().pr_review_prompt` in `pr_reviewer.py`.
+5. Register the tool in `command2class` in `pr_agent/agent/pr_agent.py` under a command name, e.g. `"my_tool": PRMyTool`.
+6. Add a row to the tool list in `docs/docs/tools/index.md`, a page `docs/docs/tools/<name>.md` (see [`review.md`](../tools/review.md)), and register the page under `Tools` in `docs/mkdocs.yml`.
+7. Add tests under `tests/unittest/` and verify with `PYTHONPATH=. uv run pytest tests/unittest`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,6 +9,12 @@ nav:
   - Installation:
     - 'installation/index.md'
     - PR-Agent: 'installation/pr_agent.md'
+    - Locally: 'installation/locally.md'
+    - GitHub Integration: 'installation/github.md'
+    - GitLab Integration: 'installation/gitlab.md'
+    - BitBucket Integration: 'installation/bitbucket.md'
+    - Azure DevOps Integration: 'installation/azure.md'
+    - Gitea Integration: 'installation/gitea.md'
   - Usage Guide:
     - 'usage-guide/index.md'
     - Introduction: 'usage-guide/introduction.md'
@@ -16,6 +22,7 @@ nav:
     - Usage and Automation: 'usage-guide/automations_and_usage.md'
     - Managing Mail Notifications: 'usage-guide/mail_notifications.md'
     - Changing a Model: 'usage-guide/changing_a_model.md'
+    - Extending PR-Agent: 'usage-guide/extending_pr_agent.md'
     - Additional Configurations: 'usage-guide/additional_configurations.md'
     - Plain-Diff Mode: 'usage-guide/plain_diff_mode.md'
     - Local Git Provider: 'usage-guide/local_git_provider.md'


### PR DESCRIPTION
## What

- New `docs/docs/usage-guide/extending_pr_agent.md`: how to add a model, a git provider, or a tool, with file paths for each step.
- `CONTRIBUTING.md`: steps 7-10 now give the working test command (`PYTHONPATH=. uv run pytest tests/unittest`), the lint/pre-commit steps required by AGENTS.md, and a note that the e2e/health suites need provider tokens or API keys.
- `docs/mkdocs.yml`: the six installation pages are now reachable from the sidebar; the new page is registered under Usage Guide.
- `docs/docs/tools/index.md`: the `python -m pr_agent.cli` examples now note that the module form needs an importable `pr_agent` package.

## Why

Closes #2961.

## Testing

- `mkdocs build -f docs/mkdocs.yml` (mkdocs-material + mkdocs-glightbox): clean.
- `pre-commit run --files` on all touched files: all hooks pass.
- Docs-only change; no unit tests affected.

## Risks/Impact

None.