### PR TITLE
feat(skills): apply configured skills to top-level ask

### DIFF
--- a/docs/docs/core-abilities/agent_skills.md
+++ b/docs/docs/core-abilities/agent_skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-`Supported Tools: Review, Improve, Describe, Ask (opt-in)`
+`Supported Tools: Review, Improve, Describe, Ask`
 
 ## Overview
 
@@ -19,7 +19,7 @@ description: Use when reviewing Terraform code — checks state safety and risky
 - ...
 ```
 
-When enabled, PR-Agent discovers every `SKILL.md` under the configured paths, parses it, and injects the skill's `name`, `description`, and body into the `/review`, `/improve`, and `/describe` prompts alongside `extra_instructions`. Top-level `/ask` can use the same context when `skills.apply_to_ask` is enabled. The model applies the guidance it judges relevant to the PR or question, using each skill's `description` as the signal for when the skill applies.
+When enabled, PR-Agent discovers every `SKILL.md` under the configured paths, parses it, and injects the skill's `name`, `description`, and body into the `/review`, `/improve`, `/describe`, and top-level `/ask` prompts alongside `extra_instructions`. The model applies the guidance it judges relevant to the PR or question, using each skill's `description` as the signal for when the skill applies.
 
 The value proposition is **org-wide, host-level skill libraries**: install one curated set of skills on your PR-Agent deployment and reuse it across many repositories, without checking guidance into each repo.
 
@@ -32,18 +32,16 @@ Skills are **disabled by default** and configured in `configuration.toml` (or an
 enabled = false
 paths = []                # directories scanned recursively for "*/SKILL.md"; supports ~ and $VAR
 max_skills_tokens = 8000  # token budget for the combined skills block
-apply_to_ask = false      # opt in for top-level /ask; /ask_line is unchanged
 ```
 
 - `enabled` — turn the feature on.
 - `paths` — a list of directories (scanned recursively for `*/SKILL.md`) or direct paths to a `SKILL.md` file. `~` and `$VAR`/`${VAR}` are expanded.
 - `max_skills_tokens` — caps the combined size of the injected skills block. Skills past the cap are dropped from the end with a warning; if the first skill alone exceeds the budget it is clipped and marked `[truncated]`.
-- `apply_to_ask` — when `true`, inject the same bounded skills context into top-level `/ask`. It defaults to `false` and does not affect `/ask_line`.
 
 !!! warning "`skills.paths` is host-level only"
     `skills.paths` **cannot be set from a repository's `.pr_agent.toml`** and is configurable only where the deployment is administered. Because it reads files from the PR-Agent host's filesystem, allowing a repository to set it would let a malicious repo point PR-Agent at sensitive host files (e.g. `~/.ssh/*`) and exfiltrate their contents into the model prompt. A repo-supplied `skills.paths` is ignored with a warning.
 
-A repository *may* set the safe per-repo preferences `skills.enabled`, `skills.max_skills_tokens`, and `skills.apply_to_ask` in its own `.pr_agent.toml` — e.g. to opt in to (or size) the host's admin-curated skill library for that repo. It can never redirect the filesystem scan.
+    A repository *may* set the safe per-repo preferences `skills.enabled` and `skills.max_skills_tokens` in its own `.pr_agent.toml` — e.g. to opt in to (or size) the host's admin-curated skill library for that repo. It can never redirect the filesystem scan.
 
 ## Bundled resources
 

--- a/docs/docs/core-abilities/agent_skills.md
+++ b/docs/docs/core-abilities/agent_skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-`Supported Tools: Review, Improve, Describe`
+`Supported Tools: Review, Improve, Describe, Ask (opt-in)`
 
 ## Overview
 
@@ -19,7 +19,7 @@ description: Use when reviewing Terraform code — checks state safety and risky
 - ...
 ```
 
-When enabled, PR-Agent discovers every `SKILL.md` under the configured paths, parses it, and injects the skill's `name`, `description`, and body into the `/review`, `/improve`, and `/describe` prompts alongside `extra_instructions`. The model applies the guidance it judges relevant to the PR, using each skill's `description` as the signal for when the skill applies.
+When enabled, PR-Agent discovers every `SKILL.md` under the configured paths, parses it, and injects the skill's `name`, `description`, and body into the `/review`, `/improve`, and `/describe` prompts alongside `extra_instructions`. Top-level `/ask` can use the same context when `skills.apply_to_ask` is enabled. The model applies the guidance it judges relevant to the PR or question, using each skill's `description` as the signal for when the skill applies.
 
 The value proposition is **org-wide, host-level skill libraries**: install one curated set of skills on your PR-Agent deployment and reuse it across many repositories, without checking guidance into each repo.
 
@@ -32,16 +32,18 @@ Skills are **disabled by default** and configured in `configuration.toml` (or an
 enabled = false
 paths = []                # directories scanned recursively for "*/SKILL.md"; supports ~ and $VAR
 max_skills_tokens = 8000  # token budget for the combined skills block
+apply_to_ask = false      # opt in for top-level /ask; /ask_line is unchanged
 ```
 
 - `enabled` — turn the feature on.
 - `paths` — a list of directories (scanned recursively for `*/SKILL.md`) or direct paths to a `SKILL.md` file. `~` and `$VAR`/`${VAR}` are expanded.
 - `max_skills_tokens` — caps the combined size of the injected skills block. Skills past the cap are dropped from the end with a warning; if the first skill alone exceeds the budget it is clipped and marked `[truncated]`.
+- `apply_to_ask` — when `true`, inject the same bounded skills context into top-level `/ask`. It defaults to `false` and does not affect `/ask_line`.
 
 !!! warning "`skills.paths` is host-level only"
     `skills.paths` **cannot be set from a repository's `.pr_agent.toml`** and is configurable only where the deployment is administered. Because it reads files from the PR-Agent host's filesystem, allowing a repository to set it would let a malicious repo point PR-Agent at sensitive host files (e.g. `~/.ssh/*`) and exfiltrate their contents into the model prompt. A repo-supplied `skills.paths` is ignored with a warning.
 
-    A repository *may* set the safe per-repo preferences `skills.enabled` and `skills.max_skills_tokens` in its own `.pr_agent.toml` — e.g. to opt in to (or size) the host's admin-curated skill library for that repo. It can never redirect the filesystem scan.
+A repository *may* set the safe per-repo preferences `skills.enabled`, `skills.max_skills_tokens`, and `skills.apply_to_ask` in its own `.pr_agent.toml` — e.g. to opt in to (or size) the host's admin-curated skill library for that repo. It can never redirect the filesystem scan.
 
 ## Bundled resources
 
@@ -51,7 +53,7 @@ The agent-skills standard supports bundled files alongside `SKILL.md`. PR-Agent 
 - `scripts/` and `assets/` subdirectories are **skipped**: PR-Agent runs single-shot model calls with no tool-use loop, so it cannot execute scripts or load binary assets on demand.
 - A nested directory that contains its own `SKILL.md` is treated as a separate skill and not inlined into its parent.
 
-In short, PR-Agent supports **text-only** agent skills.
+In short, PR-Agent supports **text-only** agent skills. `/ask_line` remains outside the skills injection scope because its prompt is separately budgeted around a selected diff hunk and optional thread history.
 
 ## Limitations
 

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -80,6 +80,10 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
         <td>Optional extra instructions to the tool. For example: "Do not answer questions that ask to rate PR quality on a scale of 1 to 10. Instead, tell the user this type of question is not allowed."</td>
       </tr>
       <tr>
+        <td><b>skills.apply_to_ask</b></td>
+        <td>If set to true, the top-level <code>/ask</code> prompt receives the host-administered Agent Skills context. This also requires <code>skills.enabled=true</code>; the existing <code>skills.max_skills_tokens</code> budget applies. Default is false. This does not affect <code>/ask_line</code>.</td>
+      </tr>
+      <tr>
         <td><b>enable_help_text</b></td>
         <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
       </tr>
@@ -95,6 +99,10 @@ Example usage in a configuration file:
 [pr_questions]
 ask_heading = "Architecture Question"
 extra_instructions = "Do not answer questions that ask to rate PR quality on a scale of 1 to 10."
+
+[skills]
+enabled = true
+apply_to_ask = true
 ```
 
 The heading above renders as `### **Architecture Question** ❓`.

--- a/docs/docs/tools/ask.md
+++ b/docs/docs/tools/ask.md
@@ -80,10 +80,6 @@ See a full video tutorial [here](https://codium.ai/images/pr_agent/ask_image_vid
         <td>Optional extra instructions to the tool. For example: "Do not answer questions that ask to rate PR quality on a scale of 1 to 10. Instead, tell the user this type of question is not allowed."</td>
       </tr>
       <tr>
-        <td><b>skills.apply_to_ask</b></td>
-        <td>If set to true, the top-level <code>/ask</code> prompt receives the host-administered Agent Skills context. This also requires <code>skills.enabled=true</code>; the existing <code>skills.max_skills_tokens</code> budget applies. Default is false. This does not affect <code>/ask_line</code>.</td>
-      </tr>
-      <tr>
         <td><b>enable_help_text</b></td>
         <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
       </tr>
@@ -99,10 +95,6 @@ Example usage in a configuration file:
 [pr_questions]
 ask_heading = "Architecture Question"
 extra_instructions = "Do not answer questions that ask to rate PR quality on a scale of 1 to 10."
-
-[skills]
-enabled = true
-apply_to_ask = true
 ```
 
 The heading above renders as `### **Architecture Question** ❓`.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -489,7 +489,8 @@ uri = "./lancedb"
 
 [skills]
 # Agent skills (SKILL.md) support: discovers SKILL.md files from the configured
-# filesystem paths and injects their content into review/improve/describe prompts.
+# filesystem paths and injects their content into review/improve/describe prompts;
+# top-level /ask can opt in separately with apply_to_ask.
 # Sibling *.md files in the skill directory tree (e.g. references/guide.md) are
 # inlined alongside SKILL.md. PR-Agent supports text-only skills: scripts/ and
 # assets/ subdirectories are skipped because PR-Agent uses a single-shot model
@@ -499,6 +500,7 @@ uri = "./lancedb"
 enabled = false
 paths = [] # directories to scan recursively for "*/SKILL.md"; supports ~ and $VAR
 max_skills_tokens = 8000 # token budget for the combined skills_context block
+apply_to_ask = false # opt in to skills_context for top-level /ask; /ask_line is unchanged
 
 [best_practices]
 content = ""

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -489,8 +489,8 @@ uri = "./lancedb"
 
 [skills]
 # Agent skills (SKILL.md) support: discovers SKILL.md files from the configured
-# filesystem paths and injects their content into review/improve/describe prompts;
-# top-level /ask can opt in separately with apply_to_ask.
+# filesystem paths and injects their content into review/improve/describe and
+# top-level /ask prompts.
 # Sibling *.md files in the skill directory tree (e.g. references/guide.md) are
 # inlined alongside SKILL.md. PR-Agent supports text-only skills: scripts/ and
 # assets/ subdirectories are skipped because PR-Agent uses a single-shot model
@@ -500,7 +500,6 @@ uri = "./lancedb"
 enabled = false
 paths = [] # directories to scan recursively for "*/SKILL.md"; supports ~ and $VAR
 max_skills_tokens = 8000 # token budget for the combined skills_context block
-apply_to_ask = false # opt in to skills_context for top-level /ask; /ask_line is unchanged
 
 [best_practices]
 content = ""

--- a/pr_agent/settings/pr_questions_prompts.toml
+++ b/pr_agent/settings/pr_questions_prompts.toml
@@ -5,6 +5,15 @@ Your goal is to answer questions\\tasks about the new code introduced in the PR 
 Be informative, constructive, and give examples. Try to be as specific as possible.
 Don't avoid answering the questions. You must answer the questions, as best as you can, without adding any unrelated content.
 
+{%- if skills_context %}
+
+
+Organizational standards and skills (apply the ones relevant to this question and PR):
+======
+{{ skills_context }}
+======
+{%- endif %}
+
 {%- if extra_instructions %}
 
 

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -31,7 +31,7 @@ class PRQuestions:
         settings = get_settings()
         skills_context = (
             get_skills_context()
-            if settings.skills.get("enabled", False) and settings.skills.get("apply_to_ask", False)
+            if settings.skills.get("enabled", False)
             else ""
         )
         self.vars = {

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -6,6 +6,7 @@ from jinja2 import Environment, StrictUndefined
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
+from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import ModelType, format_pr_questions_header
 from pr_agent.config_loader import get_settings
@@ -27,6 +28,12 @@ class PRQuestions:
         self.ai_handler.main_pr_language = self.main_pr_language
 
         self.question_str = question_str
+        settings = get_settings()
+        skills_context = (
+            get_skills_context()
+            if settings.skills.get("enabled", False) and settings.skills.get("apply_to_ask", False)
+            else ""
+        )
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
@@ -35,7 +42,8 @@ class PRQuestions:
             "diff": "",  # empty diff for initial calculation
             "questions": self.question_str,
             "commit_messages_str": self.git_provider.get_commit_messages(),
-            "extra_instructions": get_settings().pr_questions.extra_instructions,
+            "extra_instructions": settings.pr_questions.extra_instructions,
+            "skills_context": skills_context,
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/tests/unittest/test_pr_questions_helpers.py
+++ b/tests/unittest/test_pr_questions_helpers.py
@@ -486,14 +486,20 @@ class TestExtraInstructionsPromptRendering:
             "pr_questions.extra_instructions",
             "Do not answer questions that ask to rate PR quality.",
         )
-        variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
+        variables = {
+            "extra_instructions": get_settings().pr_questions.extra_instructions,
+            "skills_context": "",
+        }
         system_prompt = _render_jinja_template(get_settings().pr_questions_prompt.system, variables)
         assert "Do not answer questions that ask to rate PR quality." in system_prompt
         assert "take precedence over any conflicting guidance" in system_prompt
 
     def test_ask_system_prompt_omits_extra_instructions_block_when_empty(self, extra_instructions_settings):
         extra_instructions_settings.set("pr_questions.extra_instructions", "")
-        variables = {"extra_instructions": get_settings().pr_questions.extra_instructions}
+        variables = {
+            "extra_instructions": get_settings().pr_questions.extra_instructions,
+            "skills_context": "",
+        }
         system_prompt = _render_jinja_template(get_settings().pr_questions_prompt.system, variables)
         assert "Extra instructions from the user" not in system_prompt
 

--- a/tests/unittest/test_pr_questions_skills.py
+++ b/tests/unittest/test_pr_questions_skills.py
@@ -1,4 +1,4 @@
-"""Regression tests for the opt-in Agent Skills context in top-level /ask."""
+"""Regression tests for Agent Skills context in top-level /ask."""
 
 from types import SimpleNamespace
 
@@ -46,12 +46,11 @@ def _build_pr_questions(monkeypatch):
     )
 
 
-def test_top_level_ask_injects_skills_when_opted_in(monkeypatch):
+def test_top_level_ask_injects_skills_when_enabled(monkeypatch):
     settings = get_settings()
-    saved = snapshot_settings(("skills.enabled", "skills.apply_to_ask"))
+    saved = snapshot_settings(("skills.enabled",))
     try:
         settings.set("skills.enabled", True)
-        settings.set("skills.apply_to_ask", True)
         tool = _build_pr_questions(monkeypatch)
     finally:
         restore_settings(saved)
@@ -59,12 +58,12 @@ def test_top_level_ask_injects_skills_when_opted_in(monkeypatch):
     assert tool.vars["skills_context"] == "### Skill: security-review"
 
 
-def test_top_level_ask_does_not_load_skills_when_opt_out(monkeypatch):
+def test_top_level_ask_does_not_load_skills_when_disabled(monkeypatch):
     settings = get_settings()
-    saved = snapshot_settings(("skills.apply_to_ask",))
+    saved = snapshot_settings(("skills.enabled",))
     calls = []
     try:
-        settings.set("skills.apply_to_ask", False)
+        settings.set("skills.enabled", False)
         monkeypatch.setattr(
             pr_questions,
             "get_skills_context",
@@ -84,7 +83,7 @@ def test_top_level_ask_prompt_renders_skills_context():
         "skills_context": "### Skill: security-review\nRequire an authentication check.",
         "extra_instructions": "",
     }
-    prompt = Environment(undefined=StrictUndefined).from_string(
+    prompt = Environment(undefined=StrictUndefined, autoescape=True).from_string(
         get_settings().pr_questions_prompt.system
     ).render(variables)
 
@@ -94,7 +93,7 @@ def test_top_level_ask_prompt_renders_skills_context():
 
 def test_top_level_ask_prompt_omits_skills_block_when_empty():
     variables = {"skills_context": "", "extra_instructions": ""}
-    prompt = Environment(undefined=StrictUndefined).from_string(
+    prompt = Environment(undefined=StrictUndefined, autoescape=True).from_string(
         get_settings().pr_questions_prompt.system
     ).render(variables)
 

--- a/tests/unittest/test_pr_questions_skills.py
+++ b/tests/unittest/test_pr_questions_skills.py
@@ -1,0 +1,101 @@
+"""Regression tests for the opt-in Agent Skills context in top-level /ask."""
+
+from types import SimpleNamespace
+
+from jinja2 import Environment, StrictUndefined
+
+import pr_agent.tools.pr_questions as pr_questions
+from pr_agent.config_loader import get_settings
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+
+class _FakeProvider:
+    def __init__(self):
+        self.pr = SimpleNamespace(title="Skills context question")
+
+    def get_languages(self):
+        return ["Python"]
+
+    def get_files(self):
+        return ["src/example.py"]
+
+    def get_pr_branch(self):
+        return "feature/skills"
+
+    def get_pr_description(self):
+        return "Add a small change."
+
+    def get_commit_messages(self):
+        return "Add a small change"
+
+
+class _FakeAIHandler:
+    main_pr_language = None
+
+
+def _build_pr_questions(monkeypatch):
+    provider = _FakeProvider()
+    monkeypatch.setattr(pr_questions, "get_git_provider", lambda: lambda _url: provider)
+    monkeypatch.setattr(pr_questions, "get_main_pr_language", lambda _languages, _files: "Python")
+    monkeypatch.setattr(pr_questions, "TokenHandler", lambda *_args: object())
+    monkeypatch.setattr(pr_questions, "get_skills_context", lambda: "### Skill: security-review", raising=False)
+    return pr_questions.PRQuestions(
+        "https://github.com/example/repo/pull/1",
+        args=["Does this follow the security policy?"],
+        ai_handler=_FakeAIHandler,
+    )
+
+
+def test_top_level_ask_injects_skills_when_opted_in(monkeypatch):
+    settings = get_settings()
+    saved = snapshot_settings(("skills.enabled", "skills.apply_to_ask"))
+    try:
+        settings.set("skills.enabled", True)
+        settings.set("skills.apply_to_ask", True)
+        tool = _build_pr_questions(monkeypatch)
+    finally:
+        restore_settings(saved)
+
+    assert tool.vars["skills_context"] == "### Skill: security-review"
+
+
+def test_top_level_ask_does_not_load_skills_when_opt_out(monkeypatch):
+    settings = get_settings()
+    saved = snapshot_settings(("skills.apply_to_ask",))
+    calls = []
+    try:
+        settings.set("skills.apply_to_ask", False)
+        monkeypatch.setattr(
+            pr_questions,
+            "get_skills_context",
+            lambda: calls.append("loaded") or "### Skill: should-not-load",
+            raising=False,
+        )
+        tool = _build_pr_questions(monkeypatch)
+    finally:
+        restore_settings(saved)
+
+    assert tool.vars["skills_context"] == ""
+    assert calls == []
+
+
+def test_top_level_ask_prompt_renders_skills_context():
+    variables = {
+        "skills_context": "### Skill: security-review\nRequire an authentication check.",
+        "extra_instructions": "",
+    }
+    prompt = Environment(undefined=StrictUndefined).from_string(
+        get_settings().pr_questions_prompt.system
+    ).render(variables)
+
+    assert "Organizational standards and skills" in prompt
+    assert "Require an authentication check." in prompt
+
+
+def test_top_level_ask_prompt_omits_skills_block_when_empty():
+    variables = {"skills_context": "", "extra_instructions": ""}
+    prompt = Environment(undefined=StrictUndefined).from_string(
+        get_settings().pr_questions_prompt.system
+    ).render(variables)
+
+    assert "Organizational standards and skills" not in prompt

--- a/tests/unittest/test_skills_loader.py
+++ b/tests/unittest/test_skills_loader.py
@@ -408,15 +408,13 @@ class TestResourceGathering:
         """Safe per-repo preferences may be set from a
         repo's .pr_agent.toml; only the host-only skills.paths is refused.
         """
-        repo_toml = b'[skills]\nenabled = true\nmax_skills_tokens = 1234\napply_to_ask = true\n'
+        repo_toml = b'[skills]\nenabled = true\nmax_skills_tokens = 1234\n'
         settings = self._apply_repo_skills_toml(monkeypatch, repo_toml)
 
         assert settings.skills.enabled is True, \
             "Repo settings should be able to toggle skills.enabled"
         assert int(settings.skills.max_skills_tokens) == 1234, \
             "Repo settings should be able to set skills.max_skills_tokens"
-        assert settings.skills.apply_to_ask is True, \
-            "Repo settings should be able to opt top-level /ask into skills"
 
     def test_format_skills_context_includes_resource_content(self, tmp_path):
         _write_skill(tmp_path, "doc")

--- a/tests/unittest/test_skills_loader.py
+++ b/tests/unittest/test_skills_loader.py
@@ -405,16 +405,18 @@ class TestResourceGathering:
             "Repo settings must not be able to inject skills.paths"
 
     def test_repo_settings_can_override_safe_skills_keys(self, monkeypatch):
-        """Safe per-repo preferences (enabled, max_skills_tokens) may be set from a
+        """Safe per-repo preferences may be set from a
         repo's .pr_agent.toml; only the host-only skills.paths is refused.
         """
-        repo_toml = b'[skills]\nenabled = true\nmax_skills_tokens = 1234\n'
+        repo_toml = b'[skills]\nenabled = true\nmax_skills_tokens = 1234\napply_to_ask = true\n'
         settings = self._apply_repo_skills_toml(monkeypatch, repo_toml)
 
         assert settings.skills.enabled is True, \
             "Repo settings should be able to toggle skills.enabled"
         assert int(settings.skills.max_skills_tokens) == 1234, \
             "Repo settings should be able to set skills.max_skills_tokens"
+        assert settings.skills.apply_to_ask is True, \
+            "Repo settings should be able to opt top-level /ask into skills"
 
     def test_format_skills_context_includes_resource_content(self, tmp_path):
         _write_skill(tmp_path, "doc")


### PR DESCRIPTION
## Summary

Add an opt-in `skills.apply_to_ask` setting that injects the existing bounded Agent Skills context into top-level `/ask` prompts.

## Motivation

PR-Agent already supports reusable host-administered `SKILL.md` guidance for `/review`, `/improve`, and `/describe`. Users also use top-level `/ask` for security, API-contract, migration, and domain questions, but that path currently cannot see the same curated guidance.

## Implementation

- Add `[skills].apply_to_ask = false`, with opt-in behavior for top-level `/ask`.
- Reuse `get_skills_context()` and pass its bounded result through `PRQuestions.vars` into the existing Jinja prompt.
- Keep `skills.paths` host-only and allow only the safe `enabled`, `max_skills_tokens`, and `apply_to_ask` preferences from repository settings.
- Leave `/ask_line` unchanged because its hunk/history prompt has a separate context budget.
- Add fake-provider regressions and update Agent Skills and `/ask` documentation.

## Compatibility and security

The default remains `false`, so existing prompts and provider requests are unchanged unless an administrator and repository explicitly opt in. The existing `skills.enabled`, `skills.max_skills_tokens`, host-only paths, text-only resource handling, and single-shot model-call behavior remain in force. This change does not add MCP, network tools, a tool-calling loop, or cross-PR memory.

## Tests

- Baseline red fake-provider harness on unmodified `origin/main`: `3 failed` because top-level `/ask` had no `skills_context` variable or prompt block.
- Focused regression and adjacent suites: `271 passed`.
- Full `tests/unittest` in the Docker `test` image: `2848 passed, 1 skipped, 1 xfailed`.
- Docker `test` target build: passed.
- Full Ruff check: passed.
- All enabled pre-commit hooks: passed.
- Non-strict MkDocs build: passed; strict mode reports existing repository documentation warnings outside this change.

## Related issue

Fixes #2965
