### PR TITLE
feat: fall back to LiteLLM metadata for max tokens

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1282,9 +1282,11 @@ def get_max_tokens(model):
     Get the maximum number of tokens allowed for a model.
     logic:
     (1) If the model is in './pr_agent/algo/__init__.py', use the value from there.
-    (2) else, the user needs to define explicitly 'config.custom_model_max_tokens'
+    (2) else if 'config.custom_model_max_tokens' is set to a positive value, use it.
+    (3) else, fall back to litellm.get_model_info(model)["max_input_tokens"].
+    (4) else, raise an error.
 
-    For both cases, we further limit the number of tokens to 'config.max_model_tokens' if it is set.
+    For all cases, we further limit the number of tokens to 'config.max_model_tokens' if it is set.
     This aims to improve the algorithmic quality, as the AI model degrades in performance when the input is too long.
     """
     settings = get_settings()
@@ -1294,8 +1296,29 @@ def get_max_tokens(model):
     elif custom_max_tokens > 0:
         max_tokens_model = custom_max_tokens
     else:
-        get_logger().error(f"Model {model} is not defined in MAX_TOKENS in ./pr_agent/algo/__init__.py and no custom_model_max_tokens is set")
-        raise Exception(f"Ensure {model} is defined in MAX_TOKENS in ./pr_agent/algo/__init__.py or set a positive value for it in config.custom_model_max_tokens")
+        # Fallback: ask LiteLLM for the model's metadata before giving up.
+        max_tokens_model = 0
+        import litellm
+        try:
+            model_info = litellm.get_model_info(model)
+        except Exception:
+            get_logger().debug(f"litellm.get_model_info could not resolve model '{model}'")
+            model_info = None
+        if model_info:
+            litellm_max = model_info.get("max_input_tokens")
+            if litellm_max and int(litellm_max) > 0:
+                max_tokens_model = int(litellm_max)
+                get_logger().debug(f"Resolved max_input_tokens for '{model}' from litellm: {max_tokens_model}")
+
+        if max_tokens_model <= 0:
+            get_logger().error(
+                f"Model {model} is not defined in MAX_TOKENS in ./pr_agent/algo/__init__.py"
+                f" and no custom_model_max_tokens is set"
+            )
+            raise Exception(
+                f"Ensure {model} is defined in MAX_TOKENS in ./pr_agent/algo/__init__.py"
+                f" or set a positive value for it in config.custom_model_max_tokens"
+            )
 
     max_model_tokens = _as_int(settings.config.max_model_tokens) if settings.config.max_model_tokens else 0
     if max_model_tokens > 0:

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -1,3 +1,4 @@
+import litellm
 import pytest
 
 import pr_agent.algo.utils as utils
@@ -480,3 +481,102 @@ class TestGetMaxTokens:
         monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
 
         assert get_max_tokens(model) == 1048576
+
+    # --- LiteLLM fallback tests (issue #2957) ---
+
+    def test_max_tokens_takes_precedence_over_litellm(self, monkeypatch):
+        """MAX_TOKENS lookup must not consult LiteLLM."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("litellm.get_model_info should not be called")
+
+        monkeypatch.setattr(litellm, "get_model_info", fail_if_called)
+
+        model = "gpt-3.5-turbo"
+        assert get_max_tokens(model) == MAX_TOKENS[model]
+
+    def test_custom_model_max_tokens_takes_precedence_over_litellm(self, monkeypatch):
+        """Positive custom_model_max_tokens must not consult LiteLLM."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 7000,
+                'max_model_tokens': 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("litellm.get_model_info should not be called")
+
+        monkeypatch.setattr(litellm, "get_model_info", fail_if_called)
+
+        assert get_max_tokens("fake-provider/fake-model-xyz") == 7000
+
+    def test_litellm_fallback_returns_max_input_tokens(self, monkeypatch):
+        """Unknown model resolved via litellm.get_model_info max_input_tokens."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        monkeypatch.setattr(litellm, "get_model_info",
+                            lambda model: {"max_input_tokens": 65536})
+
+        assert get_max_tokens("fake-provider/fake-model-xyz") == 65536
+
+    def test_litellm_fallback_uses_max_input_tokens_not_max_tokens(self, monkeypatch):
+        """Must use max_input_tokens, not max_tokens from litellm metadata."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        monkeypatch.setattr(litellm, "get_model_info", lambda model: {
+            "max_input_tokens": 32000,
+            "max_tokens": 99999,
+        })
+
+        assert get_max_tokens("fake-provider/fake-model-xyz") == 32000
+
+    def test_litellm_fallback_failure_preserves_existing_error(self, monkeypatch):
+        """When litellm also cannot resolve, the existing error path fires."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        def raise_for_unknown(model):
+            raise Exception("This model isn't mapped yet")
+
+        monkeypatch.setattr(litellm, "get_model_info", raise_for_unknown)
+
+        with pytest.raises(Exception, match="Ensure .* is defined in MAX_TOKENS"):
+            get_max_tokens("fake-provider/fake-unknown-model")
+
+    def test_litellm_fallback_respects_max_model_tokens_cap(self, monkeypatch):
+        """max_model_tokens cap applies to LiteLLM-resolved values."""
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 8000
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        monkeypatch.setattr(litellm, "get_model_info",
+                            lambda model: {"max_input_tokens": 65536})
+
+        assert get_max_tokens("fake-provider/fake-model-xyz") == 8000

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -580,3 +580,25 @@ class TestGetMaxTokens:
                             lambda model: {"max_input_tokens": 65536})
 
         assert get_max_tokens("fake-provider/fake-model-xyz") == 8000
+
+    def test_litellm_fallback_uses_real_registry(self, monkeypatch):
+        """Unknown model resolved against the real installed LiteLLM model registry."""
+        model = "cohere/command-r-plus"
+
+        assert model not in MAX_TOKENS
+
+        model_info = litellm.get_model_info(model)
+        expected_max_input_tokens = model_info["max_input_tokens"]
+
+        assert isinstance(expected_max_input_tokens, int)
+        assert expected_max_input_tokens > 0
+
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0,
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == expected_max_input_tokens


### PR DESCRIPTION
## Summary

Adds a LiteLLM metadata fallback to `get_max_tokens()` when a model is not present in `MAX_TOKENS` and no positive `custom_model_max_tokens` is configured.

The resolution order remains:

`MAX_TOKENS` → `custom_model_max_tokens` → `litellm.get_model_info(model)["max_input_tokens"]` → existing unresolved-model error

The existing `config.max_model_tokens` cap is still applied after resolution.

The LiteLLM lookup is wrapped so unknown model IDs fall through to the existing error path instead of propagating LiteLLM's exception.

## Tests

Added regression coverage for:

- `MAX_TOKENS` precedence
- `custom_model_max_tokens` precedence
- successful LiteLLM fallback
- use of `max_input_tokens` rather than `max_tokens`
- unresolved LiteLLM models falling through to the existing error
- final `max_model_tokens` cap
- real LiteLLM registry compatibility for `max_input_tokens` metadata

Local validation:

- 116 targeted tests passed
- Ruff passed
- pre-commit hooks passed
- `git diff --check` passed

Closes #2957