### PR TITLE
docs: remove unbacked Bitbucket Data Center configuration claims

### DIFF
--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -94,29 +94,19 @@ For example, in the GitHub organization `qodo-ai`:
 
 ## Project/Group level configuration file
 
-`Platforms supported: GitLab, Bitbucket Data Center`
+`Platforms supported: GitLab`
 
-Create a repository named `pr-agent-settings` within a specific project (Bitbucket) or a group/subgroup (Gitlab).
-The configuration file in this repository will apply to all repositories directly under the same project/group/subgroup.
+Create a repository named `pr-agent-settings` within a group/subgroup.
+The configuration file in this repository will apply to all repositories directly under the same group/subgroup.
 
 !!! note "Note"
     For Gitlab, in case of a repository nested in several sub groups, the lookup for a pr-agent-settings repo will be only on one level above such repository.
 
 
-## Organization level configuration file
-
-`Relevant platforms: Bitbucket Data Center`
-
-Create a dedicated project to hold a global configuration file that affects all repositories across all projects in your organization.
-
-**Setting up organization-level global configuration:**
-
-1. Create a new project with both the name and key: PR_AGENT_SETTINGS.
-2. Inside the PR_AGENT_SETTINGS project, create a repository named pr-agent-settings.
-3. In this repository, add a `.pr_agent.toml` configuration file—structured similarly to the global configuration file described above.
-4. Optionally, you can add organizational-level [global best practices](../tools/improve.md#global-hierarchical-best-practices).
-
-Repositories across your entire Bitbucket organization will inherit the configuration from this file.
+!!! note "Bitbucket Data Center"
+    Bitbucket Data Center reads the repository's own `.pr_agent.toml` only. It has no
+    project-level or organization-level settings lookup, so a `pr-agent-settings`
+    repository has no effect there.
 
 !!! note "Note"
     If both organization-level and project-level global settings are defined, the project-level settings will take precedence over the organization-level configuration. Additionally, parameters from a repository’s local .pr_agent.toml file will always override both global settings.


### PR DESCRIPTION
Closes #2252

The configuration docs list `Bitbucket Data Center` under both **Project/Group level configuration file** and **Organization level configuration file**. Only the first is implemented.

Since #3143, `BitbucketServerProvider._fetch_global_repo_settings` reads `<project>/pr-agent-settings/.pr_agent.toml`, which is the project-level lookup the first section describes, and the **Global configuration file** section already lists it. Nothing in the codebase looks up a `PR_AGENT_SETTINGS` project, so the organization-level section, which listed no other platform, describes a lookup that does not exist.

This removes that section and its precedence note. Nothing in `docs/` linked the removed heading.

Reported by @SzymonNastaly, who read the docs, searched the codebase, found no supporting code and asked rather than assuming they had missed something.
