### PR TITLE
fix: handle Gitea inline comment API errors

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -400,14 +400,21 @@ class GiteaProvider(GitProvider):
 
 
     def publish_inline_comments(self, comments: List[Dict[str, Any]],body : str = "Inline comment") -> bool:
-        response = self.repo_api.create_inline_comment(
-            owner=self.owner,
-            repo=self.repo,
-            pr_number=self.pr_number if self.enabled_pr else self.issue_number,
-            body=body,
-            commit_id=self.last_commit.sha if self.last_commit else "",
-            comments=comments
-        )
+        try:
+            response = self.repo_api.create_inline_comment(
+                owner=self.owner,
+                repo=self.repo,
+                pr_number=self.pr_number if self.enabled_pr else self.issue_number,
+                body=body,
+                commit_id=self.last_commit.sha if self.last_commit else "",
+                comments=comments
+            )
+        except ApiException as e:
+            self.logger.error(f"Error publishing inline comment: {e}")
+            return False
+        except Exception as e:
+            self.logger.error(f"Unexpected error publishing inline comment: {e}")
+            return False
 
         if not response:
             self.logger.error("Failed to publish inline comment")

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -839,6 +839,15 @@ class TestGiteaProviderInlineCommentStatus:
 
         assert provider.publish_inline_comments([{"path": "a.py", "body": "x"}]) is False
 
+    @pytest.mark.parametrize(
+        "error", [ApiException(reason="API rejected the comment"), RuntimeError("transport failed")]
+    )
+    def test_publish_inline_comments_reports_exception_as_failure(self, error):
+        provider = self._provider()
+        provider.repo_api.create_inline_comment.side_effect = error
+
+        assert provider.publish_inline_comments([{"path": "a.py", "body": "x"}]) is False
+
     def test_publish_code_suggestions_does_not_republish_on_success(self):
         # Before the fix, a truthy result here was still treated as failure by
         # PRCodeSuggestions.push_inline_code_suggestions, which republished
@@ -867,6 +876,22 @@ class TestGiteaProviderInlineCommentStatus:
         # suggestion, no retries.
         provider = self._provider()
         provider.repo_api.create_inline_comment.side_effect = [MagicMock(), None, MagicMock()]
+        suggestions = [
+            {"body": "**Suggestion:** one", "relevant_file": "a.py", "relevant_lines_start": 1},
+            {"body": "**Suggestion:** two", "relevant_file": "a.py", "relevant_lines_start": 2},
+            {"body": "**Suggestion:** three", "relevant_file": "a.py", "relevant_lines_start": 3},
+        ]
+
+        result = provider.publish_code_suggestions(suggestions)
+
+        assert result is True
+        assert provider.repo_api.create_inline_comment.call_count == 3
+
+    def test_publish_code_suggestions_reports_success_on_partial_exception(self):
+        provider = self._provider()
+        provider.repo_api.create_inline_comment.side_effect = [
+            MagicMock(), ApiException(reason="API rejected the comment"), MagicMock()
+        ]
         suggestions = [
             {"body": "**Suggestion:** one", "relevant_file": "a.py", "relevant_lines_start": 1},
             {"body": "**Suggestion:** two", "relevant_file": "a.py", "relevant_lines_start": 2},


### PR DESCRIPTION
Closes #2973

## Problem

Gitea's inline-comment publisher lets ApiException and other transport failures escape. That prevents the caller from receiving False and taking its per-suggestion fallback path, so a failed batch can lose all suggestions.

## Solution

Catch failures at the Gitea API boundary, log them, and return False. This preserves the existing aggregate behavior: a first/only failure can trigger fallback, while a failure after an earlier successful publish still reports overall success to avoid duplicating accepted suggestions.

## Changes

- Handle Gitea ApiException and unexpected exceptions in publish_inline_comments.
- Add regression coverage for API and transport exceptions.
- Cover partial-success behavior when a later inline-comment call raises.

## Testing

- Red baseline after adding the regression tests but before the implementation: 3 failed, 6 passed in TestGiteaProviderInlineCommentStatus.
- PYTHONPATH=. uv run pytest tests/unittest/test_gitea_provider.py tests/unittest/test_pr_code_suggestions_core.py -q: 126 passed.
- uv run pre-commit run --files pr_agent/git_providers/gitea_provider.py tests/unittest/test_gitea_provider.py: passed.
- A full tests/unittest run on Windows was not used as green evidence: it reported failures and later stalled at 92%, so it was interrupted. The repository's Linux Docker CI remains the authoritative full-suite check.

## Reviewer notes

This change does not add retries inside the provider and does not change the existing partial-success rule; it only converts API exceptions into the same boolean failure contract already used for falsy responses.

## AI assistance

Codex assisted with issue validation, implementation, and running the commands reported above. All result claims in this description come from observed local command output.