### PR TITLE
fix(#2973): catch ApiException and Exception in GiteaProvider.publish_inline_comments

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -400,14 +400,21 @@ class GiteaProvider(GitProvider):
 
 
     def publish_inline_comments(self, comments: List[Dict[str, Any]],body : str = "Inline comment") -> bool:
-        response = self.repo_api.create_inline_comment(
-            owner=self.owner,
-            repo=self.repo,
-            pr_number=self.pr_number if self.enabled_pr else self.issue_number,
-            body=body,
-            commit_id=self.last_commit.sha if self.last_commit else "",
-            comments=comments
-        )
+        try:
+            response = self.repo_api.create_inline_comment(
+                owner=self.owner,
+                repo=self.repo,
+                pr_number=self.pr_number if self.enabled_pr else self.issue_number,
+                body=body,
+                commit_id=self.last_commit.sha if self.last_commit else "",
+                comments=comments
+            )
+        except ApiException as e:
+            self.logger.error(f"ApiException publishing inline comment: {e}")
+            return False
+        except Exception as e:
+            self.logger.error(f"Failed to publish inline comment: {e}")
+            return False
 
         if not response:
             self.logger.error("Failed to publish inline comment")


### PR DESCRIPTION
## Description
Fixes #2973.

Catches `ApiException` and generic exceptions during `create_inline_comment` execution within `GiteaProvider.publish_inline_comments`. This ensures API errors log appropriately and return `False` rather than bubbling up unhandled and bypassing the suggestion fallback path.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)