### PR TITLE
fix(config): add missing enable_auto_approval default to configuration.toml

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -23,6 +23,7 @@ use_repo_settings_file=true
 use_global_settings_file=true
 extra_config_url="" # optional URL or path to an additional .pr_agent.toml merged before the repo-local config; also settable via --extra_config_url or PR_AGENT_EXTRA_CONFIG_URL. See docs/docs/usage-guide/configuration_options.md#external-configuration-url.
 disable_auto_feedback = false
+enable_auto_approval = false # when true, auto-approves PRs that meet the conditions in auto_approve_logic()
 ai_timeout=120 # 2 minutes
 skip_keys = []
 custom_reasoning_model = false # when true, disables system messages and temperature controls for models that don't support chat-style inputs


### PR DESCRIPTION
## What

Adds the missing `enable_auto_approval = false` default to `pr_agent/settings/configuration.toml`.

## Why

`pr_agent/tools/pr_reviewer.py:690` reads this key by attribute access:

```python
if get_settings().config.enable_auto_approval:
```

Because the key had no default in `configuration.toml`, this raised `BoxKeyError: 'DynaBox' object has no attribute 'enable_auto_approval'` whenever `auto_approve_logic()` was called. The call is currently commented out at `pr_reviewer.py:158-160`, but re-enabling it would crash immediately.

## Fix

Added one line under `[config]`, alongside the similar `disable_auto_feedback` setting:

```toml
enable_auto_approval = false # when true, auto-approves PRs that meet the conditions in auto_approve_logic()
```

`false` is the safe default — it disables auto-approval unless explicitly enabled in a repo-level `.pr_agent.toml`. The existing CLI security test already blocks this key from being overridden via command-line arguments.

Fixes #2971
