### PR TITLE
fix: restore compatible PyJWT issuer handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dependencies = [
   "msrest==0.7.1",
   "openai>=1.55.3",
   "PyGithub==1.59.*",
-  "PyJWT>=2.13.0,<3",
+  # PyJWT 2.11+ rejects the integer GitHub App JWT issuer required by GitHub (#2955).
+  "PyJWT>=2.10.1,<2.11",
   "PyYAML==6.0.1",
   "python-gitlab==8.3.0",
   "retry==0.9.2",


### PR DESCRIPTION
Fixes #2955.

Restores the PyJWT range that accepts GitHub App JWTs with GitHub's required integer `iss` claim. PyJWT 2.11 introduced the incompatible issuer validation, and the uv migration removed the earlier compatibility bound.

Validation:

- Created a signed JWT with integer `iss` using PyJWT 2.10.1.
- `git diff --check`

`uv lock` cannot complete because the existing `lancedb==0.5.1` resolution is unsatisfiable for the Python 3.14/Windows split. This is the lock blocker described in the issue comment, so this PR intentionally leaves `uv.lock` unchanged.