### PR TITLE
fix(gitea): run slash commands from issue_comment events (synthesize PR URL)

### DIFF
--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -120,10 +120,27 @@ async def handle_comment_event(body: Dict[str, Any], event: str, action: str, ag
     if not comment_body or not comment_body.startswith("/"):
         return
 
+    # Gitea's issue_comment payload has no top-level `pull_request` key; the
+    # parent PR is under `issue` (whose `pull_request` metadata carries only
+    # merge state, no URL). Prefer the event's own URL when present
+    # (forward-compat), otherwise synthesize the PR URL the provider parses:
+    # {GITEA.URL}/{owner}/{repo}/pulls/{number}.
     pr_url = body.get("pull_request", {}).get("url")
     if not pr_url:
-        return
+        issue = body.get("issue", {})
+        is_pull = body.get("is_pull") or issue.get("pull_request") is not None
+        repo_full_name = body.get("repository", {}).get("full_name", "")
+        pr_number = issue.get("number")
+        if not is_pull:
+            get_logger().debug("Ignoring slash command on a plain issue")
+            return
+        if not repo_full_name or not pr_number:
+            get_logger().warning("issue_comment event missing repository.full_name or issue.number")
+            return
+        base_url = get_settings().get("GITEA.URL", "https://gitea.com").rstrip("/")
+        pr_url = f"{base_url}/{repo_full_name}/pulls/{pr_number}"
 
+    get_logger().info(f"Processing comment command on {pr_url}: {comment_body[:80]}")
     await agent.handle_request(pr_url, comment_body)
 
 async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict, api_url: str):

--- a/tests/unittest/test_gitea_comment_webhook.py
+++ b/tests/unittest/test_gitea_comment_webhook.py
@@ -1,0 +1,94 @@
+"""Slash commands posted as PR comments on Gitea must reach the agent.
+
+Gitea's issue_comment payload has no top-level ``pull_request`` key (unlike
+``pull_request`` events). The parent PR lives under ``issue`` and
+``issue.pull_request`` carries only merge metadata (``has_merged`` /
+``merged``) — no URL. ``handle_comment_event`` must therefore synthesize the
+PR URL from ``repository.full_name`` + ``issue.number`` against
+``GITEA.URL``, and must keep ignoring non-PR comments and non-command text.
+"""
+
+import copy
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.servers import gitea_app
+
+
+class UrlRecordingAgent:
+    def __init__(self):
+        self.calls = []  # list of (url, command)
+
+    async def handle_request(self, url, command, notify=None):
+        self.calls.append((url, command))
+
+
+def _comment_payload(**overrides):
+    payload = {
+        "action": "created",
+        "is_pull": True,
+        "issue": {
+            "number": 1091,
+            "pull_request": {"has_merged": False, "merged": None},
+            "url": "http://example/api/v1/repos/org/repo/issues/1091",
+        },
+        "comment": {"id": 42, "body": "/improve"},
+        "repository": {"full_name": "org/repo"},
+        "sender": {"login": "alice"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def gitea_url():
+    settings = get_settings()
+    original = copy.deepcopy(settings.get("GITEA"))
+    settings.set("GITEA.URL", "http://gitea:3000")
+    try:
+        yield
+    finally:
+        settings.set("GITEA", original)
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_on_pr_synthesizes_url(gitea_url):
+    agent = UrlRecordingAgent()
+    await gitea_app.handle_comment_event(_comment_payload(), "issue_comment", "created", agent)
+    assert agent.calls == [("http://gitea:3000/org/repo/pulls/1091", "/improve")]
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_on_plain_issue_is_ignored(gitea_url):
+    agent = UrlRecordingAgent()
+    payload = _comment_payload(is_pull=False, issue={"number": 7, "title": "bug"})
+    await gitea_app.handle_comment_event(payload, "issue_comment", "created", agent)
+    assert agent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_top_level_pull_request_url_is_preferred(gitea_url):
+    agent = UrlRecordingAgent()
+    payload = {
+        "comment": {"body": "/review"},
+        "pull_request": {"url": "http://gitea:3000/o/r/pulls/5"},
+    }
+    await gitea_app.handle_comment_event(payload, "issue_comment", "created", agent)
+    assert agent.calls == [("http://gitea:3000/o/r/pulls/5", "/review")]
+
+
+@pytest.mark.asyncio
+async def test_non_command_comment_is_ignored(gitea_url):
+    agent = UrlRecordingAgent()
+    payload = _comment_payload(comment={"id": 42, "body": "looks good"})
+    await gitea_app.handle_comment_event(payload, "issue_comment", "created", agent)
+    assert agent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_is_ignored_without_crashing(gitea_url):
+    agent = UrlRecordingAgent()
+    payload = _comment_payload(repository={})
+    await gitea_app.handle_comment_event(payload, "issue_comment", "created", agent)
+    assert agent.calls == []


### PR DESCRIPTION
## Problem

Gitea `issue_comment` webhook payloads have **no top-level `pull_request` key**. The parent PR lives under `issue`, and `issue.pull_request` carries only merge metadata (`has_merged`, `merged`) — no URL (see Gitea source: `services/convert/issue.go` `ToAPIIssue`, `modules/structs/{issue,pull}.go`; `PullRequestMeta` has no URL field).

Yet `handle_comment_event` in `pr_agent/servers/gitea_app.py` reads:

```python
pr_url = body.get("pull_request", {}).get("url")
```

`pr_url` is therefore always `None` for Gitea comment events → early `return` → **slash commands posted in a PR comment thread (`/improve`, `/review`, `/ask`, …) never execute on Gitea.** PR opened/synchronized auto-commands are unaffected (the `pull_request` event payload does carry that key), which masks the bug in logs.

## Fix

- Prefer `body.pull_request.url` when present (forward-compatible).
- Otherwise require `is_pull` / `issue.pull_request` so plain-issue comments stay ignored.
- Synthesize the URL the Gitea provider already parses: `{GITEA.URL}/{repository.full_name}/pulls/{issue.number}`.
- Log the dispatch at info level; warn on malformed payloads instead of silently dropping.

## Verification

- Isolated unit checks of `handle_comment_event` (5 cases): PR comment dispatches `/improve` with the correct URL; plain-issue comment ignored; legacy `pull_request.url` shape still honored; non-slash comment ignored; malformed payload warns without dispatching.
- End-to-end on a live Gitea 1.21.11 instance: fired a real signed `issue_comment` webhook (`/improve`) against the patched server → dispatch log appeared → PR fetched → LLM ran → result comment published to the PR. Identical payload against unpatched code produced no log, no dispatch, no comment.

Tested with Gitea 1.21.11, PR-Agent webhook server (gunicorn + FastAPI).