### PR TITLE
test: limit default pytest discovery to unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Ruff is the single linting tool: `pyproject.toml` configures it and the pre-comm
 ## Testing Guidelines
 
 - Pytest is the standard framework; keep new tests under the closest matching directory (`tests/unittest/` for unit logic, `tests/e2e_tests/` for integration flows, `tests/health_test/` for smoke coverage).
-- Pytest configuration lives in `pyproject.toml`, including `asyncio_mode = "auto"` and `testpaths = ["tests"]`. The Docker test image keeps `pyproject.toml` at `/app` (uv installs from it), so CI inherits these settings as well.
+- Pytest configuration lives in `pyproject.toml`, including `asyncio_mode = "auto"` and `testpaths = ["tests/unittest"]`. The Docker test image keeps `pyproject.toml` at `/app` (uv installs from it), so CI inherits these settings as well. Plain `PYTHONPATH=. uv run pytest` therefore defaults to the unit suite; invoke end-to-end tests explicitly.
 - Prefer focused unit tests that isolate helpers in `pr_agent/algo/`, `pr_agent/tools/`, or provider adapters; use parameterized tests where existing files already do so.
 - Set `PYTHONPATH=.` when invoking pytest from the repository root to avoid import errors.
 - End-to-end suites require provider tokens (`TOKEN_GITHUB`, `TOKEN_GITLAB`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`) and may take several minutes; run them only when credentials and sandboxes are configured.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ https://openai.com/enterprise-privacy
 
 To contribute to the project, get started by reading our [Contributing Guide](https://github.com/the-pr-agent/pr-agent/blob/main/CONTRIBUTING.md).
 
+For local verification, run `PYTHONPATH=. uv run pytest` from the repository root; it discovers the unit-test suite under `tests/unittest` by default. End-to-end tests under `tests/e2e_tests` require provider credentials and should be invoked explicitly, for example `PYTHONPATH=. uv run pytest tests/e2e_tests/test_github_app.py`.
+
 
 ## Big News for PR-Agent
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ tests = []
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = ["tests"]
+testpaths = ["tests/unittest"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/tests/unittest/test_pytest_configuration.py
+++ b/tests/unittest/test_pytest_configuration.py
@@ -1,0 +1,5 @@
+def test_default_pytest_configuration_is_loaded(pytestconfig):
+    assert pytestconfig.inipath is not None
+    assert pytestconfig.inipath.name == "pyproject.toml"
+    assert pytestconfig.getini("testpaths") == ["tests/unittest"]
+    assert pytestconfig.getini("asyncio_mode") == "auto"


### PR DESCRIPTION
## Summary

Limit pytest's default discovery to `tests/unittest`, while keeping E2E tests available through explicit paths.

## Motivation

Running plain `pytest` from the repository root currently discovers the entire `tests/` tree. This also includes `tests/e2e_tests`, even though those tests are different from the normal unit-test suite: they may require provider credentials, external services, network access, and other environment-specific setup.

As a result, a contributor who simply wants to run the project's normal tests can unexpectedly collect E2E tests and encounter credential failures, external-service dependencies, or long-running behavior that is unrelated to the unit tests themselves.

The project's existing CI structure already separates these concerns:

- Normal test and coverage workflows explicitly run `tests/unittest`.
- E2E tests live under `tests/e2e_tests` and are invoked through explicit paths.

This change makes plain local `pytest` follow the same separation.

## Changes

- Change pytest's default `testpaths` from `tests` to `tests/unittest`.
- Keep the existing `asyncio_mode = "auto"` behavior unchanged.
- Add a regression test that verifies pytest actually loads the expected project configuration.
- Document the default unit-test command and explicit E2E execution in `README.md` and `AGENTS.md`.

## Behavior

After this change:

```bash
PYTHONPATH=. uv run pytest
```

runs the unit-test suite by default.

E2E tests are still fully available when requested explicitly:

```bash
PYTHONPATH=. uv run pytest tests/e2e_tests/
```

`testpaths` only controls pytest's default discovery root when no test path is supplied; it does not prevent explicitly selected E2E tests from running.

## Impact

This does not change production/runtime behavior.

It also does not reduce the normal CI test scope, since the unit-test and coverage workflows already explicitly target `tests/unittest`.

The main behavioral change is for developers running plain `pytest`: it will no longer unexpectedly collect credential- and environment-dependent E2E tests.

## Validation

- `Build-and-test` passes on the latest commit.
- `Code-coverage` passes on the latest commit.
- Qodo `/agentic_review` reports no current bugs or rule violations.
- The regression test verifies the active pytest configuration through pytest's public `pytestconfig` fixture.
- Explicit E2E paths remain selectable.

## GitHub Copilot PR Summary

This pull request updates the project's testing configuration and documentation to clarify and enforce that unit tests are the default test suite, while end-to-end tests must be run explicitly. It also adds a test to verify the pytest configuration. The most important changes are:

**Testing configuration changes:**

* Changed the `testpaths` option in `pyproject.toml` to `["tests/unittest"]`, so running pytest by default only discovers unit tests.
* Added a new test, `test_default_pytest_configuration_is_loaded`, to ensure that the pytest configuration is loaded correctly and that the `testpaths` and `asyncio_mode` settings are as expected.

**Documentation updates:**

* Updated `AGENTS.md` to clarify that the default pytest run only executes the unit test suite under `tests/unittest`, and that end-to-end tests should be invoked explicitly.
* Updated `README.md` to provide instructions for running unit tests and end-to-end tests, emphasizing the need for explicit invocation of end-to-end tests and required credentials.