### PR TITLE
fix(bitbucket): harden webhook credential handling

### DIFF
--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -272,10 +272,12 @@ def should_process_pr_logic(data) -> bool:
 async def handle_github_webhooks(background_tasks: BackgroundTasks, request: Request):
     app_name = get_settings().get("CONFIG.APP_NAME", "Unknown")
     log_context = {"server_type": "bitbucket_app", "app_name": app_name}
-    get_logger().debug(request.headers)
     jwt_header = request.headers.get("authorization", None)
-    if jwt_header:
-        input_jwt = jwt_header.split(" ")[1]
+    jwt_parts = jwt_header.split() if jwt_header else []
+    if len(jwt_parts) != 2 or jwt_parts[0].casefold() != "jwt":
+        get_logger().error("Bitbucket webhook authorization header is malformed")
+        return "OK"
+    input_jwt = jwt_parts[1]
     data = await request.json()
     get_logger().debug(data)
 
@@ -399,9 +401,7 @@ async def handle_github_webhooks(request: Request, response: Response):
 async def handle_installed_webhooks(request: Request, response: Response):
     try:
         get_logger().info("handle_installed_webhooks")
-        get_logger().info(request.headers)
         data = await request.json()
-        get_logger().info(data)
         shared_secret = data["sharedSecret"]
         client_key = data["clientKey"]
         username = data["principal"]["username"]

--- a/tests/unittest/test_bitbucket_app_sensitive_logging.py
+++ b/tests/unittest/test_bitbucket_app_sensitive_logging.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+from starlette.background import BackgroundTasks
+
+from pr_agent.servers import bitbucket_app
+
+
+class _Request:
+    def __init__(self, headers, payload):
+        self.headers = headers
+        self._payload = payload
+        self.json_calls = 0
+
+    async def json(self):
+        self.json_calls += 1
+        return self._payload
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, level):
+        def record(*args, **kwargs):
+            self.calls.append((level, args, kwargs))
+
+        return record
+
+
+def _route_endpoint(path, method):
+    return next(
+        route.endpoint for route in bitbucket_app.router.routes if route.path == path and method in route.methods
+    )
+
+
+async def test_webhook_does_not_log_authorization_header(monkeypatch):
+    token = "webhook-authorization-sentinel"
+    authorization = f"jWt {token}"
+    logger = _RecordingLogger()
+    background_tasks = BackgroundTasks()
+    monkeypatch.setattr(bitbucket_app, "get_logger", lambda: logger)
+
+    result = await _route_endpoint("/webhook", "POST")(
+        background_tasks,
+        _Request({"authorization": authorization}, {"event": "pullrequest:created", "data": {}}),
+    )
+
+    assert result == "OK"
+    assert len(background_tasks.tasks) == 1
+    assert token not in repr(logger.calls)
+
+
+@pytest.mark.parametrize("headers", [{}, {"authorization": "JWT"}, {"authorization": "Bearer token"}])
+async def test_webhook_rejects_malformed_authorization_header(monkeypatch, headers):
+    logger = _RecordingLogger()
+    background_tasks = BackgroundTasks()
+    request = _Request(headers, {"event": "pullrequest:created", "data": {}})
+    monkeypatch.setattr(bitbucket_app, "get_logger", lambda: logger)
+
+    result = await _route_endpoint("/webhook", "POST")(
+        background_tasks,
+        request,
+    )
+
+    assert result == "OK"
+    assert request.json_calls == 0
+    assert not background_tasks.tasks
+    assert "Bitbucket webhook authorization header is malformed" in repr(logger.calls)
+
+
+async def test_installed_webhook_does_not_log_credentials(monkeypatch):
+    authorization = "JWT install-authorization-sentinel"
+    shared_secret = "shared-secret-sentinel"
+    logger = _RecordingLogger()
+    stored = []
+    secret_provider = type("SecretProvider", (), {"store_secret": lambda self, *args: stored.append(args)})()
+    monkeypatch.setattr(bitbucket_app, "get_logger", lambda: logger)
+    monkeypatch.setattr(bitbucket_app, "get_fork_safe_secret_provider", lambda: secret_provider)
+
+    result = await _route_endpoint("/installed", "POST")(
+        _Request(
+            {"authorization": authorization},
+            {"sharedSecret": shared_secret, "clientKey": "client-key", "principal": {"username": "user"}},
+        ),
+        None,
+    )
+
+    logged = repr(logger.calls)
+    assert result is None
+    assert authorization not in logged
+    assert shared_secret not in logged
+    assert "handle_installed_webhooks" in logged
+    assert json.loads(stored[0][1])["shared_secret"] == shared_secret


### PR DESCRIPTION
Stop logging Bitbucket webhook and installation request headers, as well as installation payloads that contain the shared secret.

Reject malformed webhook authorization headers before reading the payload or scheduling background work, and cover the credential-safe paths with regression tests.

## GitHub Copilot PR Summary

This pull request focuses on improving the security and privacy of logging in the Bitbucket webhook server by ensuring that sensitive information such as authorization headers and secrets are not logged. It also adds comprehensive tests to verify this behavior and improves error handling for malformed authorization headers.

Sensitive information handling and logging:

* Removed logging of the full request headers (which could include sensitive authorization tokens) in both the `/webhook` and `/installed` endpoints of `bitbucket_app.py`. [[1]](diffhunk://#diff-963a9de391ff22ad3083c3a28c1d5736d68a6e1e40b0bedb52d4bfd124325badL275-R280) [[2]](diffhunk://#diff-963a9de391ff22ad3083c3a28c1d5736d68a6e1e40b0bedb52d4bfd124325badL402-L404)
* Improved authorization header parsing in the `/webhook` endpoint to properly validate the format and log an error (without sensitive data) if malformed. The function now rejects requests with incorrect or missing headers without processing the request body.

Testing for sensitive logging:

* Added a new test module `test_bitbucket_app_sensitive_logging.py` to ensure that sensitive data (authorization tokens and secrets) are not logged, and that malformed headers are handled and logged correctly.