### PR TITLE
docs(usage-guide): note importable-env requirement for CLI commands

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -9,6 +9,8 @@ Examples of invoking the different tools via the CLI:
 - **Ask**:          `python -m pr_agent.cli --pr_url=<pr_url>  ask "Write me a poem about this PR"`
 - **Update Changelog**:      `python -m pr_agent.cli --pr_url=<pr_url>  update_changelog`
 
+The commands above assume the `pr_agent` package is importable — use the venv created by `uv sync`, or install PR-Agent.
+
 `<pr_url>` is the url of the relevant PR (for example: [#50](https://github.com/the-pr-agent/pr-agent/pull/50)).
 
 **Notes:**


### PR DESCRIPTION
## What

- `docs/docs/tools/index.md`: note under the tools table that the CLI commands need an importable `pr_agent` package.
- `docs/docs/usage-guide/automations_and_usage.md`: the same note under the Local repo (CLI) bullets.

## Why

Follow-up to #2966 — the review's scoping note: readers copy from the table and the CLI bullets, which still showed the bare `python -m pr_agent.cli`. Completes the last remaining point of #2961.

## Testing

- `mkdocs build` (mkdocs-material + mkdocs-glightbox): clean.
- `pre-commit run --files` on both files: hooks pass.
- Docs-only; no unit tests affected.

## Risks/Impact

None.