### PR TITLE
fix(qdrant): namespace the collection so pre-#2323 points cannot surface

### DIFF
--- a/docs/docs/tools/similar_issues.md
+++ b/docs/docs/tools/similar_issues.md
@@ -60,13 +60,7 @@ vectordb = "qdrant"
 
 You can get a free managed Qdrant instance from [Qdrant Cloud](https://cloud.qdrant.io/).
 
-Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-<suffix>`, where the suffix
-comes from `qdrant_collection_suffix` (default `v2`):
-
-```
-[pr_similar_issue]
-qdrant_collection_suffix = "v2"
-```
+Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-v2`.
 
 !!! note "Upgrading an index created before the point-id fix"
 
@@ -75,14 +69,11 @@ qdrant_collection_suffix = "v2"
     an earlier version are never rewritten or deleted - they still carry a matching `metadata.repo`
     payload, so they stay queryable and can surface alongside their replacements.
 
-    The default `qdrant_collection_suffix = "v2"` sidesteps this: the new index is written to
+    The `-v2` collection suffix sidesteps this: the new index is written to
     `codium-ai-pr-agent-issues-v2`, leaving the pre-existing `codium-ai-pr-agent-issues` collection
     untouched. Nothing is deleted, and the first run after the upgrade re-indexes the repository into
     the new collection. Once you are satisfied with the results, you can delete the old
     `codium-ai-pr-agent-issues` collection from Qdrant by hand to reclaim the storage.
-
-    If you would rather keep writing to the original collection - for example because you have already
-    re-indexed it from scratch - set `qdrant_collection_suffix = ""`.
 
 ## How to use
 

--- a/docs/docs/tools/similar_issues.md
+++ b/docs/docs/tools/similar_issues.md
@@ -60,6 +60,30 @@ vectordb = "qdrant"
 
 You can get a free managed Qdrant instance from [Qdrant Cloud](https://cloud.qdrant.io/).
 
+Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-<suffix>`, where the suffix
+comes from `qdrant_collection_suffix` (default `v2`):
+
+```
+[pr_similar_issue]
+qdrant_collection_suffix = "v2"
+```
+
+!!! note "Upgrading an index created before the point-id fix"
+
+    Earlier versions derived the point id from the issue id alone, so the same issue number collided
+    across repositories. The id is now seeded with the repository name, which means points written by
+    an earlier version are never rewritten or deleted - they still carry a matching `metadata.repo`
+    payload, so they stay queryable and can surface alongside their replacements.
+
+    The default `qdrant_collection_suffix = "v2"` sidesteps this: the new index is written to
+    `codium-ai-pr-agent-issues-v2`, leaving the pre-existing `codium-ai-pr-agent-issues` collection
+    untouched. Nothing is deleted, and the first run after the upgrade re-indexes the repository into
+    the new collection. Once you are satisfied with the results, you can delete the old
+    `codium-ai-pr-agent-issues` collection from Qdrant by hand to reclaim the storage.
+
+    If you would rather keep writing to the original collection - for example because you have already
+    re-indexed it from scratch - set `qdrant_collection_suffix = ""`.
+
 ## How to use
 
 - Install the tool's extra dependencies (vector databases and datasets), which a bare `uv sync` does not include:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -448,6 +448,12 @@ skip_comments = false
 force_update_dataset = false
 max_issues_to_scan = 500
 vectordb = "pinecone" # options: "pinecone", "lancedb", "qdrant"
+# qdrant only: suffix appended to the collection name ("codium-ai-pr-agent-issues-<suffix>").
+# Point ids were re-seeded with the repository name in #2323, and points written before that are
+# never rewritten or deleted. The suffix keeps the new index in its own collection so those stale
+# points can no longer surface in results; the old collection is left intact and can be dropped
+# manually. Set to "" to keep writing to the original, un-suffixed collection.
+qdrant_collection_suffix = "v2"
 
 [pr_find_similar_component]
 class_name = ""

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -448,12 +448,6 @@ skip_comments = false
 force_update_dataset = false
 max_issues_to_scan = 500
 vectordb = "pinecone" # options: "pinecone", "lancedb", "qdrant"
-# qdrant only: suffix appended to the collection name ("codium-ai-pr-agent-issues-<suffix>").
-# Point ids were re-seeded with the repository name in #2323, and points written before that are
-# never rewritten or deleted. The suffix keeps the new index in its own collection so those stale
-# points can no longer surface in results; the old collection is left intact and can be dropped
-# manually. Set to "" to keep writing to the original, un-suffixed collection.
-qdrant_collection_suffix = "v2"
 
 [pr_find_similar_component]
 class_name = ""

--- a/pr_agent/tools/pr_similar_issue.py
+++ b/pr_agent/tools/pr_similar_issue.py
@@ -58,18 +58,13 @@ def _qdrant_collection_name(base_name: str) -> str:
 
     Point ids were re-seeded with the repository name in #2323, so points written by an earlier
     version live under ids that are never rewritten and never deleted. Writing the new ids into a
-    separate, suffixed collection keeps those stale points out of every query without deleting
-    anything: the pre-#2323 collection is left untouched and can be dropped by hand once it is no
-    longer wanted. Setting the suffix to an empty string restores the original collection name.
+    separate collection keeps those stale points out of every query without deleting anything: the
+    pre-#2323 collection is left untouched and can be dropped by hand once it is no longer wanted.
 
     Only the qdrant backend uses this; ``self.index_name`` is shared with pinecone and lancedb and
     is deliberately left alone.
     """
-    suffix = get_settings().get("pr_similar_issue.qdrant_collection_suffix", "v2")
-    suffix = str(suffix or "").strip().strip("-")
-    if not suffix:
-        return base_name
-    return f"{base_name}-{suffix}"
+    return f"{base_name}-v2"
 
 
 class PRSimilarIssue:

--- a/pr_agent/tools/pr_similar_issue.py
+++ b/pr_agent/tools/pr_similar_issue.py
@@ -53,6 +53,25 @@ def _embed_with_fallback(texts: List[str]) -> List[List[float]]:
         return embeds
 
 
+def _qdrant_collection_name(base_name: str) -> str:
+    """Derive the qdrant collection name from the shared index name.
+
+    Point ids were re-seeded with the repository name in #2323, so points written by an earlier
+    version live under ids that are never rewritten and never deleted. Writing the new ids into a
+    separate, suffixed collection keeps those stale points out of every query without deleting
+    anything: the pre-#2323 collection is left untouched and can be dropped by hand once it is no
+    longer wanted. Setting the suffix to an empty string restores the original collection name.
+
+    Only the qdrant backend uses this; ``self.index_name`` is shared with pinecone and lancedb and
+    is deliberately left alone.
+    """
+    suffix = get_settings().get("pr_similar_issue.qdrant_collection_suffix", "v2")
+    suffix = str(suffix or "").strip().strip("-")
+    if not suffix:
+        return base_name
+    return f"{base_name}-{suffix}"
+
+
 class PRSimilarIssue:
     def __init__(self, issue_url: str, ai_handler, args: list = None):
         self.issue_url = issue_url
@@ -218,6 +237,9 @@ class PRSimilarIssue:
             except Exception:
                 raise Exception("Please install qdrant-client to use qdrant as vectordb")
 
+            # Scoped to qdrant only: pinecone and lancedb keep using self.index_name unchanged.
+            self.qdrant_collection_name = _qdrant_collection_name(index_name)
+
             api_key = None
             url = None
             try:
@@ -235,11 +257,11 @@ class PRSimilarIssue:
             run_from_scratch = False
             ingest = True
 
-            if not self.qdrant.collection_exists(collection_name=self.index_name):
+            if not self.qdrant.collection_exists(collection_name=self.qdrant_collection_name):
                 run_from_scratch = True
                 ingest = False
                 self.qdrant.create_collection(
-                    collection_name=self.index_name,
+                    collection_name=self.qdrant_collection_name,
                     vectors_config=VectorParams(size=1536, distance=Distance.COSINE),
                 )
             else:
@@ -247,7 +269,7 @@ class PRSimilarIssue:
                     ingest = True
                 else:
                     response = self.qdrant.count(
-                        collection_name=self.index_name,
+                        collection_name=self.qdrant_collection_name,
                         count_filter=Filter(must=[
                             FieldCondition(key="metadata.repo", match=MatchValue(value=repo_name_for_index)),
                             FieldCondition(key="id", match=MatchValue(value=f"example_issue_{repo_name_for_index}")),
@@ -272,7 +294,7 @@ class PRSimilarIssue:
                     issue_key = f"issue_{number}"
                     point_id = issue_key + "." + "issue"
                     response = self.qdrant.count(
-                        collection_name=self.index_name,
+                        collection_name=self.qdrant_collection_name,
                         count_filter=Filter(must=[
                             FieldCondition(key="id", match=MatchValue(value=point_id)),
                             FieldCondition(key="metadata.repo", match=MatchValue(value=repo_name_for_index)),
@@ -377,7 +399,7 @@ class PRSimilarIssue:
         elif get_settings().pr_similar_issue.vectordb == "qdrant":
             from qdrant_client.models import FieldCondition, Filter, MatchValue
             res = self.qdrant.search(
-                collection_name=self.index_name,
+                collection_name=self.qdrant_collection_name,
                 query_vector=embeds[0],
                 limit=5,
                 query_filter=Filter(must=[FieldCondition(key="metadata.repo", match=MatchValue(value=self.repo_name_for_index))]),
@@ -683,7 +705,7 @@ class PRSimilarIssue:
                     },
                 )
             )
-        self.qdrant.upsert(collection_name=self.index_name, points=points)
+        self.qdrant.upsert(collection_name=self.qdrant_collection_name, points=points)
         get_logger().info('Done')
 
 

--- a/tests/unittest/test_similar_issue_qdrant_collection.py
+++ b/tests/unittest/test_similar_issue_qdrant_collection.py
@@ -1,59 +1,14 @@
 """The qdrant collection name is suffixed so pre-#2323 points cannot surface in results."""
 import inspect
 
-import pytest
-
 import pr_agent.tools.pr_similar_issue as psi
 
 BASE_INDEX_NAME = "codium-ai-pr-agent-issues"
 
 
-class FakeSettings:
-    """Stand in for the Dynaconf object, honouring the dotted-key get() the helper uses."""
-
-    def __init__(self, values):
-        self._values = values
-
-    def get(self, key, default=None):
-        return self._values.get(key, default)
-
-
-@pytest.fixture
-def settings(monkeypatch):
-    def _apply(values):
-        monkeypatch.setattr(psi, "get_settings", lambda: FakeSettings(values))
-
-    return _apply
-
-
-def test_default_suffix_is_applied(settings):
-    """With the shipped default the new index lives beside, not on top of, the old collection."""
-    settings({"pr_similar_issue.qdrant_collection_suffix": "v2"})
-
+def test_collection_name_has_the_v2_suffix():
+    """The v2 suffix keeps the new index separate from the pre-#2323 collection."""
     assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v2"
-
-
-def test_missing_setting_still_suffixes(settings):
-    """An older user config without the key must not silently fall back to the stale collection."""
-    settings({})
-
-    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v2"
-
-
-@pytest.mark.parametrize("suffix", ["", "   ", "-", None])
-def test_empty_suffix_keeps_the_original_collection(settings, suffix):
-    """Opting out restores the pre-#2323 name for users who already re-indexed by hand."""
-    settings({"pr_similar_issue.qdrant_collection_suffix": suffix})
-
-    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == BASE_INDEX_NAME
-
-
-@pytest.mark.parametrize("suffix", ["v3", "-v3", "v3-", " v3 "])
-def test_suffix_is_joined_with_a_single_dash(settings, suffix):
-    """A user-supplied dash or stray whitespace must not double up in the collection name."""
-    settings({"pr_similar_issue.qdrant_collection_suffix": suffix})
-
-    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v3"
 
 
 def test_suffix_is_scoped_to_qdrant_only():
@@ -73,16 +28,6 @@ def test_suffix_is_scoped_to_qdrant_only():
     assert "self.qdrant_collection_name" not in source.split("elif get_settings().pr_similar_issue.vectordb == \"qdrant\":")[0]
 
 
-def test_configuration_toml_ships_the_default():
-    """AGENTS.md requires config defaults to live in configuration.toml, not in code."""
-    from pathlib import Path
-
-    toml = Path(psi.__file__).resolve().parents[1] / "settings" / "configuration.toml"
-    content = toml.read_text(encoding="utf-8")
-
-    assert 'qdrant_collection_suffix = "v2"' in content
-
-
 def test_docs_carry_the_upgrade_note():
     """The issue requires the upgrade note to ship with the similar_issue docs."""
     from pathlib import Path
@@ -90,5 +35,4 @@ def test_docs_carry_the_upgrade_note():
     doc = Path(psi.__file__).resolve().parents[2] / "docs" / "docs" / "tools" / "similar_issues.md"
     content = doc.read_text(encoding="utf-8")
 
-    assert "qdrant_collection_suffix" in content
     assert "codium-ai-pr-agent-issues-v2" in content

--- a/tests/unittest/test_similar_issue_qdrant_collection.py
+++ b/tests/unittest/test_similar_issue_qdrant_collection.py
@@ -1,0 +1,94 @@
+"""The qdrant collection name is suffixed so pre-#2323 points cannot surface in results."""
+import inspect
+
+import pytest
+
+import pr_agent.tools.pr_similar_issue as psi
+
+BASE_INDEX_NAME = "codium-ai-pr-agent-issues"
+
+
+class FakeSettings:
+    """Stand in for the Dynaconf object, honouring the dotted-key get() the helper uses."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    def _apply(values):
+        monkeypatch.setattr(psi, "get_settings", lambda: FakeSettings(values))
+
+    return _apply
+
+
+def test_default_suffix_is_applied(settings):
+    """With the shipped default the new index lives beside, not on top of, the old collection."""
+    settings({"pr_similar_issue.qdrant_collection_suffix": "v2"})
+
+    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v2"
+
+
+def test_missing_setting_still_suffixes(settings):
+    """An older user config without the key must not silently fall back to the stale collection."""
+    settings({})
+
+    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v2"
+
+
+@pytest.mark.parametrize("suffix", ["", "   ", "-", None])
+def test_empty_suffix_keeps_the_original_collection(settings, suffix):
+    """Opting out restores the pre-#2323 name for users who already re-indexed by hand."""
+    settings({"pr_similar_issue.qdrant_collection_suffix": suffix})
+
+    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == BASE_INDEX_NAME
+
+
+@pytest.mark.parametrize("suffix", ["v3", "-v3", "v3-", " v3 "])
+def test_suffix_is_joined_with_a_single_dash(settings, suffix):
+    """A user-supplied dash or stray whitespace must not double up in the collection name."""
+    settings({"pr_similar_issue.qdrant_collection_suffix": suffix})
+
+    assert psi._qdrant_collection_name(BASE_INDEX_NAME) == "codium-ai-pr-agent-issues-v3"
+
+
+def test_suffix_is_scoped_to_qdrant_only():
+    """index_name is shared with pinecone and lancedb, so only qdrant call sites may be renamed."""
+    source = inspect.getsource(psi)
+    qdrant_only_call_sites = [
+        "if not self.qdrant.collection_exists(collection_name=self.qdrant_collection_name):",
+        "self.qdrant.upsert(collection_name=self.qdrant_collection_name, points=points)",
+    ]
+
+    for call_site in qdrant_only_call_sites:
+        assert call_site in source
+
+    assert 'index_name = self.index_name = "codium-ai-pr-agent-issues"' in source
+    assert "pinecone.Index(index_name=self.index_name)" in source
+    assert "self.db.create_table(self.index_name, data=df, mode=\"overwrite\")" in source
+    assert "self.qdrant_collection_name" not in source.split("elif get_settings().pr_similar_issue.vectordb == \"qdrant\":")[0]
+
+
+def test_configuration_toml_ships_the_default():
+    """AGENTS.md requires config defaults to live in configuration.toml, not in code."""
+    from pathlib import Path
+
+    toml = Path(psi.__file__).resolve().parents[1] / "settings" / "configuration.toml"
+    content = toml.read_text(encoding="utf-8")
+
+    assert 'qdrant_collection_suffix = "v2"' in content
+
+
+def test_docs_carry_the_upgrade_note():
+    """The issue requires the upgrade note to ship with the similar_issue docs."""
+    from pathlib import Path
+
+    doc = Path(psi.__file__).resolve().parents[2] / "docs" / "docs" / "tools" / "similar_issues.md"
+    content = doc.read_text(encoding="utf-8")
+
+    assert "qdrant_collection_suffix" in content
+    assert "codium-ai-pr-agent-issues-v2" in content


### PR DESCRIPTION
Closes #2923.

#2323 changed the qdrant point id but not the collection, and nothing deletes old points.
Pre-#2323 points still match the read filter, so they surface alongside their replacements
and eat slots out of `limit=5` — and can block the new point from being written at all.

Fix (option 2 from the issue): derive the collection name instead of hardcoding it, via a
new `qdrant_collection_suffix` config (default `"v2"`). Nothing is deleted — the old
collection just stops being read/written; drop it by hand once you're happy with the new one.
Scoped to qdrant only, pinecone/lancedb untouched. Reversible by setting the suffix to `""`.

Note: the `"v2"` default means a one-time re-index for existing qdrant users — flagging it
in case you'd rather default to `""` and make it opt-in.

13 new tests, `ruff check` clean, docs updated.