### PR TITLE
fix(bitbucket): report code suggestion publish status

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -219,8 +219,7 @@ class BitbucketProvider(GitProvider):
             post_parameters_list.append(post_parameters)
 
         try:
-            self.publish_inline_comments(post_parameters_list)
-            return True
+            return self.publish_inline_comments(post_parameters_list)
         except Exception as e:
             get_logger().error(f"Bitbucket failed to publish code suggestion, error: {e}")
             return False
@@ -502,7 +501,7 @@ class BitbucketProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None):
+    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None) -> bool:
         comment = self.limit_output_characters(comment, self.max_comment_length)
         payload = json.dumps({
             "content": {
@@ -513,10 +512,16 @@ class BitbucketProvider(GitProvider):
                 "path": file
             },
         })
-        response = requests.request(
-            "POST", self.bitbucket_comment_api_url, data=payload, headers=self.headers
-        )
-        return response
+        try:
+            response = requests.request(
+                "POST", self.bitbucket_comment_api_url, data=payload, headers=self.headers
+            )
+            response.raise_for_status()
+        except Exception as e:
+            get_logger().error(
+                f"Failed to publish inline comment to '{file}' at line {from_line}, error: {e}")
+            return False
+        return True
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         if relevant_line_start == -1:
@@ -545,17 +550,28 @@ class BitbucketProvider(GitProvider):
 
         return ""
 
-    def publish_inline_comments(self, comments: list[dict]):
+    def publish_inline_comments(self, comments: list[dict]) -> bool:
+        publishable_count = 0
+        published_count = 0
         for comment in comments:
             if 'position' in comment:
-                self.publish_inline_comment(comment['body'], comment['position'], comment['path'])
+                from_line = comment['position']
             elif 'start_line' in comment:  # multi-line comment
                 # note that bitbucket does not seem to support range - only a comment on a single line - https://community.developer.atlassian.com/t/api-post-endpoint-for-inline-pull-request-comments/60452
-                self.publish_inline_comment(comment['body'], comment['start_line'], comment['path'])
+                from_line = comment['start_line']
             elif 'line' in comment:  # single-line comment
-                self.publish_inline_comment(comment['body'], comment['line'], comment['path'])
+                from_line = comment['line']
             else:
                 get_logger().error(f"Could not publish inline comment {comment}")
+                continue
+
+            publishable_count += 1
+            if self.publish_inline_comment(comment['body'], from_line, comment['path']):
+                published_count += 1
+
+        # A partial failure must not report failure: the caller republishes the whole
+        # list, which would post the already-accepted suggestions a second time.
+        return published_count > 0 or publishable_count == 0
 
     def get_title(self):
         return self.pr.title

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -190,8 +190,7 @@ class BitbucketServerProvider(GitProvider):
             post_parameters_list.append(post_parameters)
 
         try:
-            self.publish_inline_comments(post_parameters_list)
-            return True
+            return self.publish_inline_comments(post_parameters_list)
         except Exception as e:
             if get_verbosity_level() >= 2:
                 get_logger().error(f"Failed to publish code suggestion, error: {e}")
@@ -362,7 +361,7 @@ class BitbucketServerProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None):
+    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None) -> bool:
         payload = {
             "text": comment,
             "severity": "NORMAL",
@@ -379,7 +378,8 @@ class BitbucketServerProvider(GitProvider):
             self.bitbucket_client.post(self._get_pr_comments_path(), data=payload)
         except Exception as e:
             get_logger().error(f"Failed to publish inline comment to '{file}' at line {from_line}, error: {e}")
-            raise e
+            return False
+        return True
 
     def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
         if relevant_line_start == -1:
@@ -419,17 +419,28 @@ class BitbucketServerProvider(GitProvider):
 
         return ""
 
-    def publish_inline_comments(self, comments: list[dict]):
+    def publish_inline_comments(self, comments: list[dict]) -> bool:
+        publishable_count = 0
+        published_count = 0
         for comment in comments:
             if 'position' in comment:
-                self.publish_inline_comment(comment['body'], comment['position'], comment['path'])
+                from_line = comment['position']
             elif 'start_line' in comment: # multi-line comment
                 # note that bitbucket does not seem to support range - only a comment on a single line - https://community.developer.atlassian.com/t/api-post-endpoint-for-inline-pull-request-comments/60452
-                self.publish_inline_comment(comment['body'], comment['start_line'], comment['path'])
+                from_line = comment['start_line']
             elif 'line' in comment: # single-line comment
-                self.publish_inline_comment(comment['body'], comment['line'], comment['path'])
+                from_line = comment['line']
             else:
                 get_logger().error(f"Could not publish inline comment: {comment}")
+                continue
+
+            publishable_count += 1
+            if self.publish_inline_comment(comment['body'], from_line, comment['path']):
+                published_count += 1
+
+        # A partial failure must not report failure: the caller republishes the whole
+        # list, which would post the already-accepted suggestions a second time.
+        return published_count > 0 or publishable_count == 0
 
     def get_title(self):
         return self.pr.title

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -350,6 +350,24 @@ class TestBitbucketProvider:
 
 
 class TestBitbucketServerProvider:
+    @staticmethod
+    def _code_suggestion(line: int):
+        return {
+            "body": "**Suggestion:** fix it",
+            "relevant_file": "src/example.py",
+            "relevant_lines_start": line,
+            "relevant_lines_end": line,
+        }
+
+    @staticmethod
+    def _provider_for_code_suggestions():
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.workspace_slug = "AAA"
+        provider.repo_slug = "my-repo"
+        provider.pr_num = 1
+        provider.bitbucket_client = MagicMock()
+        return provider
+
     def test_parse_pr_url(self):
         url = "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1"
         workspace_slug, repo_slug, pr_number = BitbucketServerProvider._parse_pr_url(url)
@@ -363,6 +381,67 @@ class TestBitbucketServerProvider:
         assert workspace_slug == "~username"
         assert repo_slug == "my-repo"
         assert pr_number == 1
+
+    def test_publish_code_suggestions_reports_success(self):
+        provider = self._provider_for_code_suggestions()
+
+        result = provider.publish_code_suggestions([
+            self._code_suggestion(2),
+            self._code_suggestion(3),
+        ])
+
+        assert result is True
+        assert provider.bitbucket_client.post.call_count == 2
+
+    def test_publish_code_suggestions_reports_failures_and_continues(self):
+        provider = self._provider_for_code_suggestions()
+        provider.bitbucket_client.post.side_effect = [
+            HTTPError("403 response"),
+            RuntimeError("transport failed"),
+        ]
+
+        result = provider.publish_code_suggestions([
+            self._code_suggestion(2),
+            self._code_suggestion(3),
+        ])
+
+        assert result is False
+        assert provider.bitbucket_client.post.call_count == 2
+
+    def test_publish_code_suggestions_reports_success_on_partial_failure(self):
+        provider = self._provider_for_code_suggestions()
+        provider.bitbucket_client.post.side_effect = [
+            None,
+            HTTPError("500 response"),
+            None,
+        ]
+
+        result = provider.publish_code_suggestions([
+            self._code_suggestion(1),
+            self._code_suggestion(2),
+            self._code_suggestion(3),
+        ])
+
+        assert result is True
+        assert provider.bitbucket_client.post.call_count == 3
+
+    def test_publish_code_suggestions_treats_empty_list_as_successful_noop(self):
+        provider = self._provider_for_code_suggestions()
+
+        result = provider.publish_code_suggestions([])
+
+        assert result is True
+        provider.bitbucket_client.post.assert_not_called()
+
+    def test_publish_code_suggestions_treats_unpublishable_list_as_successful_noop(self):
+        provider = self._provider_for_code_suggestions()
+        suggestion = self._code_suggestion(3)
+        suggestion["relevant_lines_start"] = -1
+
+        result = provider.publish_code_suggestions([suggestion])
+
+        assert result is True
+        provider.bitbucket_client.post.assert_not_called()
 
     def test_get_repo_file_content_reads_from_target_ref(self):
         # Repo-context files must be read from the PR target ref (toRef), matching

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -11,6 +11,30 @@ from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
 
 
 class TestBitbucketProvider:
+    @staticmethod
+    def _code_suggestion(line: int):
+        return {
+            "body": "**Suggestion:** fix it",
+            "relevant_file": "src/example.py",
+            "relevant_lines_start": line,
+            "relevant_lines_end": line,
+        }
+
+    @staticmethod
+    def _inline_comment_response(status_code: int):
+        response = MagicMock(status_code=status_code)
+        if status_code >= 400:
+            response.raise_for_status.side_effect = HTTPError(f"{status_code} response")
+        return response
+
+    @staticmethod
+    def _provider_for_code_suggestions():
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.max_comment_length = 32_768
+        provider.bitbucket_comment_api_url = "https://api.bitbucket.org/comments"
+        provider.headers = {"Authorization": "Bearer token"}
+        return provider
+
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
         workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)
@@ -227,6 +251,102 @@ class TestBitbucketProvider:
 
         existing.put.assert_called_once()
         provider.publish_comment.assert_not_called()
+
+    def test_publish_code_suggestions_reports_success(self):
+        provider = self._provider_for_code_suggestions()
+        responses = [self._inline_comment_response(201), self._inline_comment_response(201)]
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", side_effect=responses) as request:
+            result = provider.publish_code_suggestions([
+                self._code_suggestion(2),
+                self._code_suggestion(3),
+            ])
+
+        assert result is True
+        assert request.call_count == 2
+        for response in responses:
+            response.raise_for_status.assert_called_once_with()
+
+    def test_publish_code_suggestions_reports_http_failures(self):
+        provider = self._provider_for_code_suggestions()
+        responses = [self._inline_comment_response(403), self._inline_comment_response(500)]
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", side_effect=responses) as request:
+            result = provider.publish_code_suggestions([
+                self._code_suggestion(2),
+                self._code_suggestion(3),
+            ])
+
+        assert result is False
+        assert request.call_count == 2
+        for response in responses:
+            response.raise_for_status.assert_called_once_with()
+
+    def test_publish_code_suggestions_reports_success_on_partial_http_failure(self):
+        provider = self._provider_for_code_suggestions()
+        responses = [
+            self._inline_comment_response(201),
+            self._inline_comment_response(500),
+            self._inline_comment_response(201),
+        ]
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", side_effect=responses) as request:
+            result = provider.publish_code_suggestions([
+                self._code_suggestion(1),
+                self._code_suggestion(2),
+                self._code_suggestion(3),
+            ])
+
+        assert result is True
+        assert request.call_count == 3
+
+    def test_publish_code_suggestions_reports_transport_failure(self):
+        provider = self._provider_for_code_suggestions()
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request",
+                   side_effect=RuntimeError("transport failed")) as request:
+            result = provider.publish_code_suggestions([self._code_suggestion(3)])
+
+        assert result is False
+        request.assert_called_once()
+
+    def test_publish_code_suggestions_reports_success_on_partial_transport_failure(self):
+        provider = self._provider_for_code_suggestions()
+        responses = [
+            self._inline_comment_response(201),
+            RuntimeError("transport failed"),
+            self._inline_comment_response(201),
+        ]
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", side_effect=responses) as request:
+            result = provider.publish_code_suggestions([
+                self._code_suggestion(1),
+                self._code_suggestion(2),
+                self._code_suggestion(3),
+            ])
+
+        assert result is True
+        assert request.call_count == 3
+
+    def test_publish_code_suggestions_treats_empty_list_as_successful_noop(self):
+        provider = self._provider_for_code_suggestions()
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request") as request:
+            result = provider.publish_code_suggestions([])
+
+        assert result is True
+        request.assert_not_called()
+
+    def test_publish_code_suggestions_treats_unpublishable_list_as_successful_noop(self):
+        provider = self._provider_for_code_suggestions()
+        suggestion = self._code_suggestion(3)
+        suggestion["relevant_lines_start"] = -1
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request") as request:
+            result = provider.publish_code_suggestions([suggestion])
+
+        assert result is True
+        request.assert_not_called()
 
 
 class TestBitbucketServerProvider:


### PR DESCRIPTION
Related to #2259

## Problem

Bitbucket Cloud did not check HTTP response statuses when publishing inline suggestions. Bitbucket Server stopped the batch when an individual publication raised an exception.

In both cases, a partial batch failure could make the caller retry the full list and publish successful suggestions twice.

## Summary

- Report individual publication failures for both Bitbucket Cloud and Server.
- Continue attempting the remaining suggestions after a failure.
- Return `False` only when every publishable suggestion fails.
- Preserve `True` for partial success and no-op input to avoid duplicate retries.

## Result

- All publish attempts fail: `False`
- At least one publish succeeds: `True`
- Empty or unpublishable input: `True`

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_bitbucket_provider.py tests/unittest/test_pr_code_suggestions_core.py -q` (123 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (3025 passed, 1 skipped, 1 xfailed)
- `uv run pre-commit run --files pr_agent/git_providers/bitbucket_provider.py pr_agent/git_providers/bitbucket_server_provider.py tests/unittest/test_bitbucket_provider.py` (passed)
