### PR TITLE
feat(codecommit): review all pull request targets

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -805,7 +805,7 @@ CONFIG__SECRET_PROVIDER=aws_secrets_manager
 
 ### AWS CodeCommit Setup
 
-Not all features have been added to CodeCommit yet.  As of right now, CodeCommit has been implemented to run the PR-Agent CLI on the command line, using AWS credentials stored in environment variables.  (More features will be added in the future.)  The following is a set of instructions to have PR-Agent do a review of your CodeCommit pull request from the command line:
+Not all features have been added to CodeCommit yet.  As of right now, CodeCommit has been implemented to run the PR-Agent CLI on the command line, using AWS credentials stored in environment variables.  CodeCommit pull requests with multiple targets are reviewed across every target repository and commit comparison; single-target pull requests keep the same behavior.  The following is a set of instructions to have PR-Agent do a review of your CodeCommit pull request from the command line:
 
 1. Create an IAM user that you will use to read CodeCommit pull requests and post comments
     - Note: That user should have CLI access only, not Console access

--- a/pr_agent/git_providers/codecommit_client.py
+++ b/pr_agent/git_providers/codecommit_client.py
@@ -36,10 +36,11 @@ class CodeCommitPullRequestResponse:
     class CodeCommitPullRequestTarget:
         """
         CodeCommitPullRequestTarget is a subclass of CodeCommitPullRequestResponse that
-        holds details about an individual target commit.
+        holds details about an individual target repository and commit comparison.
         """
 
         def __init__(self, json: dict):
+            self.repository_name = json.get("repositoryName", "")
             self.source_commit = json.get("sourceCommit", "")
             self.source_branch = json.get("sourceReference", "")
             self.destination_commit = json.get("destinationCommit", "")

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -19,9 +19,10 @@ class PullRequestCCMimic:
     This class mimics the PullRequest class from the PyGithub library for the CodeCommitProvider.
     """
 
-    def __init__(self, title: str, diff_files: List[FilePatchInfo]):
+    def __init__(self, title: str, diff_files: List[FilePatchInfo], targets=None):
         self.title = title
         self.diff_files = diff_files
+        self.targets = targets or []
         self.description = None
         self.source_commit = None
         self.source_branch = None  # the branch containing your new code changes
@@ -41,6 +42,9 @@ class CodeCommitFile:
         b_path: str,
         b_blob_id: str,
         edit_type: EDIT_TYPE,
+        repository_name: Optional[str] = None,
+        source_commit: Optional[str] = None,
+        destination_commit: Optional[str] = None,
     ):
         self.a_path = a_path
         self.a_blob_id = a_blob_id
@@ -48,6 +52,9 @@ class CodeCommitFile:
         self.b_blob_id = b_blob_id
         self.edit_type: EDIT_TYPE = edit_type
         self.filename = b_path if b_path else a_path
+        self.repository_name = repository_name
+        self.source_commit = source_commit
+        self.destination_commit = destination_commit
 
 
 class CodeCommitProvider(GitProvider):
@@ -92,13 +99,23 @@ class CodeCommitProvider(GitProvider):
             return self.git_files
 
         self.git_files = []
-        differences = self.codecommit_client.get_differences(self.repo_name, self.pr.destination_commit, self.pr.source_commit)
-        for item in differences:
-            self.git_files.append(CodeCommitFile(item.before_blob_path,
-                                                 item.before_blob_id,
-                                                 item.after_blob_path,
-                                                 item.after_blob_id,
-                                                 CodeCommitProvider._get_edit_type(item.change_type)))
+        for target in self._get_target_contexts():
+            differences = self.codecommit_client.get_differences(
+                target["repository_name"], target["destination_commit"], target["source_commit"]
+            )
+            for item in differences:
+                self.git_files.append(
+                    CodeCommitFile(
+                        item.before_blob_path,
+                        item.before_blob_id,
+                        item.after_blob_path,
+                        item.after_blob_id,
+                        CodeCommitProvider._get_edit_type(item.change_type),
+                        repository_name=target["repository_name"],
+                        source_commit=target["source_commit"],
+                        destination_commit=target["destination_commit"],
+                    )
+                )
         return self.git_files
 
     def get_diff_files(self) -> list[FilePatchInfo]:
@@ -123,11 +140,14 @@ class CodeCommitProvider(GitProvider):
                 continue
 
             patch_filename = ""
+            repository_name = diff_item.repository_name or self.repo_name
+            destination_commit = diff_item.destination_commit or self.pr.destination_commit
+            source_commit = diff_item.source_commit or self.pr.source_commit
             try:
                 if diff_item.a_blob_id:
                     patch_filename = diff_item.a_path
                     original_file_content_str = self.codecommit_client.get_file(
-                        self.repo_name, diff_item.a_path, self.pr.destination_commit)
+                        repository_name, diff_item.a_path, destination_commit)
                     if isinstance(original_file_content_str, (bytes, bytearray)):
                         original_file_content_str = original_file_content_str.decode("utf-8")
                 else:
@@ -136,7 +156,7 @@ class CodeCommitProvider(GitProvider):
                 if diff_item.b_blob_id:
                     patch_filename = diff_item.b_path
                     new_file_content_str = self.codecommit_client.get_file(
-                        self.repo_name, diff_item.b_path, self.pr.source_commit)
+                        repository_name, diff_item.b_path, source_commit)
                     if isinstance(new_file_content_str, (bytes, bytearray)):
                         new_file_content_str = new_file_content_str.decode("utf-8")
                 else:
@@ -181,13 +201,14 @@ class CodeCommitProvider(GitProvider):
         pr_comment = CodeCommitProvider._add_additional_newlines(pr_comment)
 
         try:
-            self.codecommit_client.publish_comment(
-                repo_name=self.repo_name,
-                pr_number=self.pr_num,
-                destination_commit=self.pr.destination_commit,
-                source_commit=self.pr.source_commit,
-                comment=pr_comment,
-            )
+            for target in self._get_target_contexts():
+                self.codecommit_client.publish_comment(
+                    repo_name=target["repository_name"],
+                    pr_number=self.pr_num,
+                    destination_commit=target["destination_commit"],
+                    source_commit=target["source_commit"],
+                    comment=pr_comment,
+                )
         except Exception as e:
             raise ValueError(f"CodeCommit Cannot publish comment for PR: {self.pr_num}") from e
 
@@ -199,20 +220,24 @@ class CodeCommitProvider(GitProvider):
                 get_logger().warning(f"Skipping code suggestion #{counter}: Each suggestion must have 'body', 'relevant_file', 'relevant_lines_start' keys")
                 continue
 
-            # Publish the code suggestion to CodeCommit
-            try:
-                get_logger().debug(f"Code Suggestion #{counter} in file: {suggestion['relevant_file']}: {suggestion['relevant_lines_start']}")
-                self.codecommit_client.publish_comment(
-                    repo_name=self.repo_name,
-                    pr_number=self.pr_num,
-                    destination_commit=self.pr.destination_commit,
-                    source_commit=self.pr.source_commit,
-                    comment=suggestion["body"],
-                    annotation_file=suggestion["relevant_file"],
-                    annotation_line=suggestion["relevant_lines_start"],
-                )
-            except Exception as e:
-                raise ValueError(f"CodeCommit Cannot publish code suggestions for PR: {self.pr_num}") from e
+            target_contexts = self._get_target_contexts_for_file(suggestion["relevant_file"])
+            for target in target_contexts:
+                try:
+                    get_logger().debug(
+                        f"Code Suggestion #{counter} in file: {suggestion['relevant_file']}: "
+                        f"{suggestion['relevant_lines_start']} for repository: {target['repository_name']}"
+                    )
+                    self.codecommit_client.publish_comment(
+                        repo_name=target["repository_name"],
+                        pr_number=self.pr_num,
+                        destination_commit=target["destination_commit"],
+                        source_commit=target["source_commit"],
+                        comment=suggestion["body"],
+                        annotation_file=suggestion["relevant_file"],
+                        annotation_line=suggestion["relevant_lines_start"],
+                    )
+                except Exception as e:
+                    raise ValueError(f"CodeCommit Cannot publish code suggestions for PR: {self.pr_num}") from e
 
             counter += 1
 
@@ -303,7 +328,10 @@ class CodeCommitProvider(GitProvider):
     def get_repo_settings(self):
         # a local ".pr_agent.toml" settings file is optional
         settings_filename = ".pr_agent.toml"
-        return self.codecommit_client.get_file(self.repo_name, settings_filename, self.pr.source_commit, optional=True)
+        target = self._get_target_contexts()[0]
+        return self.codecommit_client.get_file(
+            target["repository_name"], settings_filename, target["source_commit"], optional=True
+        )
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         get_logger().info("CodeCommit provider does not support eyes reaction yet")
@@ -373,16 +401,9 @@ class CodeCommitProvider(GitProvider):
         if len(response.targets) == 0:
             raise ValueError(f"No files found in CodeCommit PR: {self.pr_num}")
 
-        # TODO: implement support for multiple targets in one CodeCommit PR
-        #       for now, we are only using the first target in the PR
-        if len(response.targets) > 1:
-            get_logger().warning(
-                "Multiple targets in one PR is not supported for CodeCommit yet. Continuing, using the first target only..."
-            )
-
         # Return our object that mimics PullRequest class from the PyGithub library
         # (This strategy was copied from the LocalGitProvider)
-        mimic = PullRequestCCMimic(response.title, self.diff_files)
+        mimic = PullRequestCCMimic(response.title, self.diff_files, targets=response.targets)
         mimic.description = response.description
         mimic.source_commit = response.targets[0].source_commit
         mimic.source_branch = response.targets[0].source_branch
@@ -390,6 +411,55 @@ class CodeCommitProvider(GitProvider):
         mimic.destination_branch = response.targets[0].destination_branch
 
         return mimic
+
+    def _get_target_contexts(self):
+        """Return the CodeCommit comparisons represented by this pull request.
+
+        CodeCommit can associate one pull request with multiple repository/branch
+        targets. Keep a scalar fallback for callers and tests that construct the
+        legacy PR mimic directly.
+        """
+        targets = getattr(self.pr, "targets", None) or []
+        if not targets:
+            return [{
+                "repository_name": self.repo_name,
+                "source_commit": self.pr.source_commit,
+                "destination_commit": self.pr.destination_commit,
+            }]
+
+        return [
+            {
+                "repository_name": getattr(target, "repository_name", "") or self.repo_name,
+                "source_commit": target.source_commit,
+                "destination_commit": target.destination_commit,
+            }
+            for target in targets
+        ]
+
+    def _get_target_contexts_for_file(self, filename: str):
+        """Return target comparisons whose CodeCommit diff contains ``filename``.
+
+        Suggestions are tied to a file comparison. Publishing an annotation to
+        every target would fail when only one target changed that path, so route
+        it to matching target comparisons and retain the legacy first-target
+        fallback for malformed or synthetic suggestions.
+        """
+        normalized_filename = filename.lstrip("/")
+        matching_contexts = []
+        for diff_file in self.get_files():
+            paths = {diff_file.a_path, diff_file.b_path}
+            normalized_paths = {path.lstrip("/") for path in paths if path}
+            if filename not in paths and normalized_filename not in normalized_paths:
+                continue
+            context = {
+                "repository_name": diff_file.repository_name or self.repo_name,
+                "source_commit": diff_file.source_commit or self.pr.source_commit,
+                "destination_commit": diff_file.destination_commit or self.pr.destination_commit,
+            }
+            if context not in matching_contexts:
+                matching_contexts.append(context)
+
+        return matching_contexts or self._get_target_contexts()[:1]
 
     def get_commit_messages(self):
         return ""  # not implemented yet

--- a/tests/unittest/test_codecommit_client.py
+++ b/tests/unittest/test_codecommit_client.py
@@ -131,7 +131,36 @@ class TestCodeCommitProvider:
         assert pr.title == "My PR"
         assert pr.description == "My PR description"
         assert len(pr.targets) == 1
+        assert pr.targets[0].repository_name == "my_test_repo"
         assert pr.targets[0].source_commit == "commit1"
         assert pr.targets[0].source_branch == "branch1"
         assert pr.targets[0].destination_commit == "commit2"
         assert pr.targets[0].destination_branch == "branch2"
+
+    def test_get_pr_preserves_all_target_repositories(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+        api.boto_client.get_pull_request.return_value = {
+            "pullRequest": {
+                "title": "Multi-target PR",
+                "pullRequestTargets": [
+                    {
+                        "repositoryName": "repo-one",
+                        "sourceCommit": "source-one",
+                        "destinationCommit": "destination-one",
+                    },
+                    {
+                        "repositoryName": "repo-two",
+                        "sourceCommit": "source-two",
+                        "destinationCommit": "destination-two",
+                    },
+                ],
+            }
+        }
+
+        pr = api.get_pr("repo-one", 321)
+
+        assert [(target.repository_name, target.source_commit, target.destination_commit) for target in pr.targets] == [
+            ("repo-one", "source-one", "destination-one"),
+            ("repo-two", "source-two", "destination-two"),
+        ]

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -135,6 +135,165 @@ class TestCodeCommitProvider:
         with pytest.raises(ValueError, match="AWS request failed"):
             provider.get_diff_files()
 
+    def test_get_files_includes_differences_from_every_pull_request_target(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "source-repository"
+        provider.pr_num = 321
+        provider.diff_files = None
+        provider.git_files = None
+        provider.codecommit_client = MagicMock()
+
+        first_target = MagicMock(
+            repository_name="source-repository",
+            source_commit="source-commit-1",
+            source_branch="feature/one",
+            destination_commit="destination-commit-1",
+            destination_branch="main",
+        )
+        second_target = MagicMock(
+            repository_name="destination-repository",
+            source_commit="source-commit-2",
+            source_branch="feature/two",
+            destination_commit="destination-commit-2",
+            destination_branch="release",
+        )
+        provider.codecommit_client.get_pr.return_value = MagicMock(
+            title="Multi-target PR",
+            description="Review both targets",
+            targets=[first_target, second_target],
+        )
+        provider.codecommit_client.get_differences.side_effect = [
+            [MagicMock(before_blob_path="one.py", before_blob_id="before-1",
+                       after_blob_path="one.py", after_blob_id="after-1", change_type="M")],
+            [MagicMock(before_blob_path="two.py", before_blob_id="before-2",
+                       after_blob_path="two.py", after_blob_id="after-2", change_type="M")],
+        ]
+
+        provider.pr = provider._get_pr()
+        files = provider.get_files()
+
+        assert [target.repository_name for target in provider.pr.targets] == [
+            "source-repository", "destination-repository"
+        ]
+        assert [file.filename for file in files] == ["one.py", "two.py"]
+        assert [(file.repository_name, file.destination_commit, file.source_commit) for file in files] == [
+            ("source-repository", "destination-commit-1", "source-commit-1"),
+            ("destination-repository", "destination-commit-2", "source-commit-2"),
+        ]
+        assert provider.codecommit_client.get_differences.call_args_list == [
+            call("source-repository", "destination-commit-1", "source-commit-1"),
+            call("destination-repository", "destination-commit-2", "source-commit-2"),
+        ]
+
+        provider.codecommit_client.get_file.side_effect = (
+            lambda repository, path, commit: {
+                ("source-repository", "one.py", "destination-commit-1"): b"before one\n",
+                ("source-repository", "one.py", "source-commit-1"): b"after one\n",
+                ("destination-repository", "two.py", "destination-commit-2"): b"before two\n",
+                ("destination-repository", "two.py", "source-commit-2"): b"after two\n",
+            }[(repository, path, commit)]
+        )
+        diff_files = provider.get_diff_files()
+
+        assert [(file.filename, file.base_file, file.head_file) for file in diff_files] == [
+            ("one.py", "before one\n", "after one\n"),
+            ("two.py", "before two\n", "after two\n"),
+        ]
+
+    def test_publish_comment_uses_every_pull_request_target(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "source-repository"
+        provider.pr_num = 321
+        provider.codecommit_client = MagicMock()
+        provider.pr = PullRequestCCMimic(
+            "Multi-target PR",
+            [],
+            targets=[
+                MagicMock(
+                    repository_name="source-repository",
+                    source_commit="source-commit-1",
+                    destination_commit="destination-commit-1",
+                ),
+                MagicMock(
+                    repository_name="destination-repository",
+                    source_commit="source-commit-2",
+                    destination_commit="destination-commit-2",
+                ),
+            ],
+        )
+
+        provider.publish_comment("Review\ncomment")
+
+        assert provider.codecommit_client.publish_comment.call_args_list == [
+            call(
+                repo_name="source-repository",
+                pr_number=321,
+                destination_commit="destination-commit-1",
+                source_commit="source-commit-1",
+                comment="Review\n\ncomment",
+            ),
+            call(
+                repo_name="destination-repository",
+                pr_number=321,
+                destination_commit="destination-commit-2",
+                source_commit="source-commit-2",
+                comment="Review\n\ncomment",
+            ),
+        ]
+
+    def test_publish_code_suggestion_uses_target_that_contains_file(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "source-repository"
+        provider.pr_num = 321
+        provider.diff_files = None
+        provider.codecommit_client = MagicMock()
+        provider.pr = PullRequestCCMimic(
+            "Multi-target PR",
+            [],
+            targets=[
+                MagicMock(
+                    repository_name="source-repository",
+                    source_commit="source-commit-1",
+                    destination_commit="destination-commit-1",
+                ),
+                MagicMock(
+                    repository_name="destination-repository",
+                    source_commit="source-commit-2",
+                    destination_commit="destination-commit-2",
+                ),
+            ],
+        )
+        provider.git_files = [
+            CodeCommitFile(
+                "two.py",
+                "before-2",
+                "two.py",
+                "after-2",
+                EDIT_TYPE.MODIFIED,
+                repository_name="destination-repository",
+                source_commit="source-commit-2",
+                destination_commit="destination-commit-2",
+            )
+        ]
+
+        assert provider.publish_code_suggestions([
+            {
+                "body": "Use a constant",
+                "relevant_file": "two.py",
+                "relevant_lines_start": 4,
+            }
+        ]) is True
+
+        provider.codecommit_client.publish_comment.assert_called_once_with(
+            repo_name="destination-repository",
+            pr_number=321,
+            destination_commit="destination-commit-2",
+            source_commit="source-commit-2",
+            comment="Use a constant",
+            annotation_file="two.py",
+            annotation_line=4,
+        )
+
     def test_get_title(self):
         # Test that the get_title() function returns the PR title
         with patch.object(CodeCommitProvider, "__init__", lambda x, y: None):


### PR DESCRIPTION
Fixes #2968

## Summary

CodeCommit pull requests can contain multiple target repository and commit comparisons. The provider previously analyzed only the first target, which could omit changed files and publish comments or suggestions against the wrong comparison.

## Changes

- Preserve repository and commit metadata for every `pullRequestTargets[]` entry.
- Load differences and file contents from every target.
- Publish ordinary review comments for every target comparison.
- Route code suggestions to the target containing the suggested file.
- Preserve single-target behavior and avoid adding configuration.

## Tests

- Focused CodeCommit provider and client tests: 26 passed.
- Full `tests/unittest`: 3118 passed, 1 skipped, 1 xfailed, 91 warnings.
- Docker `test` target and workflow-equivalent unit tests: passed.
- Ruff and all enabled pre-commit hooks: passed.

The strict MkDocs build still reports existing repository warnings; the normal documentation build succeeds.