### PR TITLE
refactor(prompts): share diff-hunk guidance across tools

### DIFF
--- a/pr_agent/algo/prompt_fragments.py
+++ b/pr_agent/algo/prompt_fragments.py
@@ -1,0 +1,14 @@
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
+
+from pr_agent.config_loader import get_settings
+
+
+def render_diff_hunk_format(*, include_line_numbers: bool, include_ai_metadata: bool) -> str:
+    """Render the shared diff-hunk description before inserting it into a tool prompt."""
+    environment = SandboxedEnvironment(undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
+    template = get_settings().prompt_fragments.diff_hunk_format
+    return environment.from_string(template).render(
+        include_line_numbers=include_line_numbers,
+        include_ai_metadata=include_ai_metadata,
+    ).strip()

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -22,6 +22,7 @@ global_settings = Dynaconf(
         "settings/ignore.toml",
         "settings/generated_code_ignore.toml",
         "settings/language_extensions.toml",
+        "settings/prompt_fragments.toml",
         "settings/pr_reviewer_prompts.toml",
         "settings/pr_questions_prompts.toml",
         "settings/pr_line_questions_prompts.toml",

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -15,7 +15,12 @@
 # repo set any of these would let a malicious repo exfiltrate review data to an arbitrary host,
 # reach internal endpoints (SSRF), or append to arbitrary host files. The whole section is
 # therefore host-only (empty allowlist -> every key dropped).
+#
+# prompt_fragments: contains Jinja source rendered by the host before it is inserted into tool
+# prompts. Keep the whole section host-only so repository settings and comment arguments cannot
+# supply executable template expressions.
 REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
     "skills": frozenset({"enabled", "max_skills_tokens"}),
     "push_outputs": frozenset(),
+    "prompt_fragments": frozenset(),
 }

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -7,47 +7,7 @@ Your task is to examine the provided code diff, focusing on new code (lines pref
 {%- endif %}
 
 The PR code diff will be in the following structured format:
-======
-## File: 'src/file1.py'
-{%- if is_ai_metadata %}
-### AI-generated changes summary:
-* ...
-* ...
-{%- endif %}
-
-@@ ... @@ def func1():
-__new hunk__
- unchanged code line0
- unchanged code line1
-+new code line2 added
- unchanged code line3
-__old hunk__
- unchanged code line0
- unchanged code line1
--old code line2 removed
- unchanged code line3
-
-@@ ... @@ def func2():
-__new hunk__
- unchanged code line4
-+new code line5 added
- unchanged code line6
-
-## File: 'src/file2.py'
-...
-======
-
-Important notes about the structured diff format above:
-1. Each PR code chunk is decoupled into separate '__new hunk__' and '__old hunk__' sections:
-  - The '__new hunk__' section shows the code chunk AFTER the PR changes.
-  - The '__old hunk__' section shows the code chunk BEFORE the PR changes. If no code was removed from the chunk, the '__old hunk__' section will be omitted.
-2. The diff uses line prefixes to show changes:
-  '+' → new line code added (will appear only in '__new hunk__')
-  '-' → line code removed (will appear only in '__old hunk__')
-  ' ' → unchanged context lines (will appear in both sections)
-{%- if is_ai_metadata %}
-3. When available, an AI-generated summary will precede each file's diff, with a high-level overview of the changes. Note that this summary may not be fully accurate or complete.
-{%- endif %}
+{{ diff_hunk_format }}
 
 
 Specific guidelines for generating code suggestions:

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_reflect_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_reflect_prompts.toml
@@ -43,42 +43,7 @@ Additional scoring considerations:
 
 
 The PR code diff will be presented in the following structured format:
-======
-## File: 'src/file1.py'
-{%- if is_ai_metadata %}
-### AI-generated changes summary:
-* ...
-* ...
-{%- endif %}
-
-@@ ... @@ def func1():
-__new hunk__
-11  unchanged code line0
-12  unchanged code line1
-13 +new code line2 added
-14  unchanged code line3
-__old hunk__
- unchanged code line0
- unchanged code line1
--old code line2 removed
- unchanged code line3
-
-@@ ... @@ def func2():
-__new hunk__
-...
-__old hunk__
-...
-
-
-## File: 'src/file2.py'
-...
-======
-- In the format above, the diff is organized into separate '__new hunk__' and '__old hunk__' sections for each code chunk. '__new hunk__' contains the updated code, while '__old hunk__' shows the removed code. If no code was added or removed in a specific chunk, the corresponding section will be omitted.
-- Line numbers are included for the '__new hunk__' sections to enable referencing specific lines in the code suggestions. These numbers are for reference only and are not part of the actual code.
-- Code lines are prefixed with symbols: '+' for new code added in the PR, '-' for code removed, and ' ' for unchanged code.
-{%- if is_ai_metadata %}
-- When available, an AI-generated summary will precede each file's diff, with a high-level overview of the changes. Note that this summary may not be fully accurate or comprehensive.
-{%- endif %}
+{{ diff_hunk_format }}
 
 
 The output must be a YAML object equivalent to type $PRCodeSuggestionsFeedback, according to the following Pydantic definitions:

--- a/pr_agent/settings/pr_add_docs.toml
+++ b/pr_agent/settings/pr_add_docs.toml
@@ -4,31 +4,7 @@ Your task is to generate {{ docs_for_language }} for code components in the PR D
 
 
 Example for the PR Diff format:
-======
-## File: 'src/file1.py'
-
-@@ -12,3 +12,4 @@ def func1():
-__new hunk__
-12  code line1 that remained unchanged in the PR
-14 +new code line1 added in the PR
-15 +new code line2 added in the PR
-16  code line2 that remained unchanged in the PR
-__old hunk__
- code line1 that remained unchanged in the PR
--code line that was removed in the PR
- code line2 that remained unchanged in the PR
-
-@@ ... @@ def func2():
-__new hunk__
-...
-__old hunk__
-...
-
-
-## File: 'src/file2.py'
-...
-======
-
+{{ diff_hunk_format }}
 
 Specific instructions:
 - Try to identify edited/added code components (classes/functions/methods...) that are undocumented, and generate {{ docs_for_language }} for each one.

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -5,43 +5,7 @@ The review should focus on new code added in the PR code diff (lines starting wi
 
 
 The format we will use to present the PR code diff:
-======
-## File: 'src/file1.py'
-{%- if is_ai_metadata %}
-### AI-generated changes summary:
-* ...
-* ...
-{%- endif %}
-
-
-@@ ... @@ def func1():
-__new hunk__
-11  unchanged code line0
-12  unchanged code line1
-13 +new code line2 added
-14  unchanged code line3
-__old hunk__
- unchanged code line0
- unchanged code line1
--old code line2 removed
- unchanged code line3
-
-@@ ... @@ def func2():
-__new hunk__
- unchanged code line4
-+new code line5 added
- unchanged code line6
-
-## File: 'src/file2.py'
-...
-======
-
-- In the format above, the diff is organized into separate '__new hunk__' and '__old hunk__' sections for each code chunk. '__new hunk__' contains the updated code, while '__old hunk__' shows the removed code. If no code was removed in a specific chunk, the __old hunk__ section will be omitted.
-- We also added line numbers for the '__new hunk__' code, to help you refer to the code lines in your suggestions. These line numbers are not part of the actual code, and should only be used for reference.
-- Code lines are prefixed with symbols ('+', '-', ' '). The '+' symbol indicates new code added in the PR, the '-' symbol indicates code removed in the PR, and the ' ' symbol indicates unchanged code.
-{%- if is_ai_metadata %}
-- If available, an AI-generated summary will appear and provide a high-level overview of the file changes. Note that this summary may not be fully accurate or complete.
-{%- endif %}
+{{ diff_hunk_format }}
 - When quoting variables, names or file paths from the code, use backticks (`) instead of single quote (').
 - Note that you only see changed code segments (diff hunks in a PR), not the entire codebase. Avoid suggestions that might duplicate existing functionality or questioning code elements (like variables declarations or import statements) that may be defined elsewhere in the codebase.
 - Also note that if the code ends at an opening brace or statement that begins a new scope (like 'if', 'for', 'try'), don't treat it as incomplete. Instead, acknowledge the visible scope boundary and analyze only the code shown.

--- a/pr_agent/settings/prompt_fragments.toml
+++ b/pr_agent/settings/prompt_fragments.toml
@@ -1,0 +1,57 @@
+[prompt_fragments]
+diff_hunk_format="""======
+## File: 'src/file1.py'
+{% if include_ai_metadata %}
+### AI-generated changes summary:
+* ...
+* ...
+{% endif %}
+
+@@ ... @@ def func1():
+__new hunk__
+{% if include_line_numbers %}
+11  unchanged code line0
+12  unchanged code line1
+13 +new code line2 added
+14  unchanged code line3
+{% else %}
+ unchanged code line0
+ unchanged code line1
++new code line2 added
+ unchanged code line3
+{% endif %}
+__old hunk__
+ unchanged code line0
+ unchanged code line1
+-old code line2 removed
+ unchanged code line3
+
+@@ ... @@ def func2():
+__new hunk__
+{% if include_line_numbers %}
+21  unchanged code line4
+22 +new code line5 added
+23  unchanged code line6
+{% else %}
+ unchanged code line4
++new code line5 added
+ unchanged code line6
+{% endif %}
+
+## File: 'src/file2.py'
+...
+======
+
+- Each code chunk is split into separate '__new hunk__' and '__old hunk__' sections. The '__new hunk__' section
+  shows the code chunk after the PR changes. The '__old hunk__' section shows the code chunk before the PR changes
+  and is omitted when the chunk contains no removed code.
+{% if include_line_numbers %}
+- Line numbers appear before the change marker in '__new hunk__' sections to help you refer to specific lines.
+  These numbers are for reference only and are not part of the code. '__old hunk__' sections are not numbered.
+{% endif %}
+- Change markers describe how each line differs: '+' marks added code and appears only in '__new hunk__', '-'
+  marks removed code and appears only in '__old hunk__', and ' ' marks unchanged context that appears in both.
+{% if include_ai_metadata %}
+- If available, an AI-generated summary will appear and provide a high-level overview of the file changes. This
+  summary may not be fully accurate or complete.
+{% endif %}"""

--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, StrictUndefined
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
+from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import load_yaml
 from pr_agent.config_loader import get_settings, get_verbosity_level
@@ -39,6 +40,10 @@ class PRAddDocs:
             "diff": "",  # empty diff for initial calculation
             "extra_instructions": get_settings().pr_add_docs.extra_instructions,
             "commit_messages_str": self.git_provider.get_commit_messages(),
+            "diff_hunk_format": render_diff_hunk_format(
+                include_line_numbers=True,
+                include_ai_metadata=False,
+            ),
             'docs_for_language': get_docs_for_language(self.main_language,
                                                        get_settings().pr_add_docs.docs_style),
         }

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -21,6 +21,7 @@ from pr_agent.algo.pr_processing import (
     get_pr_multi_diffs,
     retry_with_fallback_models,
 )
+from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.run_details import init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
@@ -108,6 +109,7 @@ class PRCodeSuggestions:
             get_settings().set("config.enable_ai_metadata", False)
             get_logger().debug("AI metadata is disabled for this command")
 
+        is_ai_metadata = get_settings().get("config.enable_ai_metadata", False)
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
@@ -122,7 +124,11 @@ class PRCodeSuggestions:
             "suggestion_discussion_context": self._load_suggestion_discussion_context(),
             "commit_messages_str": self.git_provider.get_commit_messages(),
             "relevant_best_practices": "",
-            "is_ai_metadata": get_settings().get("config.enable_ai_metadata", False),
+            "is_ai_metadata": is_ai_metadata,
+            "diff_hunk_format": render_diff_hunk_format(
+                include_line_numbers=False,
+                include_ai_metadata=is_ai_metadata,
+            ),
             "focus_only_on_problems": get_settings().get("pr_code_suggestions.focus_only_on_problems", False),
             "date": datetime.now().strftime('%Y-%m-%d'),
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
@@ -1546,12 +1552,17 @@ class PRCodeSuggestions:
             for i, suggestion in enumerate(suggestion_list):
                 suggestion_str += f"suggestion {i + 1}: " + str(suggestion) + '\n\n'
 
+            is_ai_metadata = get_settings().get("config.enable_ai_metadata", False)
             variables = {'suggestion_list': suggestion_list,
                          'suggestion_str': suggestion_str,
                          "diff": patches_diff,
                          'num_code_suggestions': len(suggestion_list),
                          'prev_suggestions_str': prev_suggestions_str,
-                         "is_ai_metadata": get_settings().get("config.enable_ai_metadata", False),
+                         "is_ai_metadata": is_ai_metadata,
+                         "diff_hunk_format": render_diff_hunk_format(
+                             include_line_numbers=True,
+                             include_ai_metadata=is_ai_metadata,
+                         ),
                          'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False)}
             environment = Environment(undefined=StrictUndefined)
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -17,6 +17,7 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_location_fingerprint,
 )
 from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
+from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
 from pr_agent.algo.run_details import get_run_details, init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
@@ -92,6 +93,7 @@ class PRReviewer:
             get_settings().set("config.enable_ai_metadata", False)
             get_logger().debug("AI metadata is disabled for this command")
 
+        is_ai_metadata = get_settings().get("config.enable_ai_metadata", False)
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
@@ -118,7 +120,11 @@ class PRReviewer:
             "commit_messages_str": self.git_provider.get_commit_messages(),
             "custom_labels": "",
             "enable_custom_labels": get_settings().config.enable_custom_labels,
-            "is_ai_metadata":  get_settings().get("config.enable_ai_metadata", False),
+            "is_ai_metadata": is_ai_metadata,
+            "diff_hunk_format": render_diff_hunk_format(
+                include_line_numbers=True,
+                include_ai_metadata=is_ai_metadata,
+            ),
             "related_tickets": get_settings().get('related_tickets', []),
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
             "date": datetime.datetime.now().strftime('%Y-%m-%d'),

--- a/tests/unittest/test_apply_repo_settings_security.py
+++ b/tests/unittest/test_apply_repo_settings_security.py
@@ -54,7 +54,7 @@ class FakeGitProvider:
         self.comments.append(body)
 
 
-SNAPSHOT_SECTIONS = ("CONFIG", "PR_REVIEWER", "CUSTOM_SECTION_FOR_TEST")
+SNAPSHOT_SECTIONS = ("CONFIG", "PR_REVIEWER", "PROMPT_FRAGMENTS", "CUSTOM_SECTION_FOR_TEST")
 
 
 def _snapshot_settings_sections(settings):
@@ -157,6 +157,22 @@ def test_valid_repo_settings_merge_overrides_key_and_preserves_siblings(monkeypa
     assert pr_reviewer.get("num_max_findings") == 11
     # Unrelated sibling key in the same section must be preserved by the merge logic.
     assert pr_reviewer.get("require_tests_review") == sibling_before
+
+
+def test_repo_settings_cannot_override_prompt_fragments(monkeypatch, settings_snapshot):
+    provider = FakeGitProvider(
+        repo_settings_bytes=b'[prompt_fragments]\ndiff_hunk_format = "UNTRUSTED-FRAGMENT"\n'
+    )
+    captured = _install_provider(monkeypatch, provider)
+
+    get_settings().set("config.use_repo_settings_file", True)
+    settings = get_settings()
+    fragment_before = _section(settings, "prompt_fragments").get("diff_hunk_format")
+
+    apply_repo_settings("https://example.com/owner/repo/pull/1")
+
+    assert captured["errors"] is None
+    assert _section(settings, "prompt_fragments").get("diff_hunk_format") == fragment_before
 
 
 def test_invalid_toml_does_not_pollute_settings(monkeypatch, settings_snapshot):

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -84,6 +84,9 @@ HOST_ONLY_ARGS = [
     "--skills__paths=/etc",
     "--skills.unknown=value",
     "--skills={paths:[/etc]}",
+    "--prompt_fragments.diff_hunk_format={{ cycler.__init__.__globals__ }}",
+    "--prompt_fragments__diff_hunk_format=unsafe",
+    '--prompt_fragments={"diff_hunk_format": "unsafe"}',
 ]
 
 

--- a/tests/unittest/test_prompt_fragments.py
+++ b/tests/unittest/test_prompt_fragments.py
@@ -1,0 +1,236 @@
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from jinja2 import Environment, meta, nodes
+from jinja2.exceptions import SecurityError
+
+from pr_agent.algo.prompt_fragments import render_diff_hunk_format
+from pr_agent.config_loader import get_settings
+from pr_agent.tools import pr_add_docs, pr_code_suggestions, pr_reviewer
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+
+class FakeGitProvider:
+    pr = SimpleNamespace(title="A pull request")
+
+    def __init__(self, description_files=None):
+        self.description_files = description_files or []
+
+    def get_languages(self):
+        return {"Python": 1}
+
+    def get_files(self):
+        return ["example.py"]
+
+    def get_pr_branch(self):
+        return "feature"
+
+    def get_commit_messages(self):
+        return ""
+
+    def get_pr_description(self, split_changes_walkthrough=False):
+        if split_changes_walkthrough:
+            return "Description", self.description_files
+        return "Description"
+
+    def get_num_of_files(self):
+        return 1
+
+
+@pytest.fixture
+def restore_prompt_settings():
+    snapshot = snapshot_settings([
+        "config.enable_ai_metadata",
+        "config.is_auto_command",
+        "prompt_fragments.diff_hunk_format",
+        "pr_code_suggestions.decouple_hunks",
+    ])
+    yield
+    restore_settings(snapshot)
+
+
+def test_shared_diff_hunk_source_accepts_only_variant_flags():
+    source = get_settings().prompt_fragments.diff_hunk_format
+    environment = Environment()
+
+    assert meta.find_undeclared_variables(environment.parse(source)) == {
+        "include_line_numbers",
+        "include_ai_metadata",
+    }
+
+
+@pytest.mark.parametrize("include_line_numbers", [False, True])
+@pytest.mark.parametrize("include_ai_metadata", [False, True])
+def test_render_diff_hunk_format_variants(include_line_numbers, include_ai_metadata):
+    rendered = render_diff_hunk_format(
+        include_line_numbers=include_line_numbers,
+        include_ai_metadata=include_ai_metadata,
+    )
+
+    added_line = next(line for line in rendered.splitlines() if "+new code line2 added" in line)
+    second_added_line = next(line for line in rendered.splitlines() if "+new code line5 added" in line)
+    removed_line = next(line for line in rendered.splitlines() if "-old code line2 removed" in line)
+
+    assert bool(re.match(r"^13 \+new code line2 added$", added_line)) is include_line_numbers
+    assert bool(re.match(r"^22 \+new code line5 added$", second_added_line)) is include_line_numbers
+    assert removed_line == "-old code line2 removed"
+    assert ("line numbers" in rendered.lower()) is include_line_numbers
+    assert ("### AI-generated changes summary:" in rendered) is include_ai_metadata
+    assert ("may not be fully accurate" in rendered) is include_ai_metadata
+    for delimiter in ("{{", "}}", "{%", "%}"):
+        assert delimiter not in rendered
+
+
+@pytest.mark.parametrize(
+    "prompt_name,legacy_example",
+    [
+        ("pr_review_prompt", "11  unchanged code line0\n12  unchanged code line1"),
+        ("pr_add_docs_prompt", "12  code line1 that remained unchanged in the PR"),
+        ("pr_code_suggestions_prompt", "Important notes about the structured diff format above:"),
+        (
+            "pr_code_suggestions_reflect_prompt",
+            "If no code was added or removed in a specific chunk, the corresponding section will be omitted.",
+        ),
+    ],
+)
+def test_affected_templates_delegate_to_shared_fragment_once(prompt_name, legacy_example):
+    system_prompt = get_settings().get(prompt_name).system
+    parsed = Environment().parse(system_prompt)
+    fragment_references = [
+        node for node in parsed.find_all(nodes.Name) if node.name == "diff_hunk_format"
+    ]
+
+    assert len(fragment_references) == 1
+    assert legacy_example not in system_prompt
+
+
+def test_fragment_renderer_sandboxes_host_overrides(restore_prompt_settings):
+    get_settings().set(
+        "prompt_fragments.diff_hunk_format",
+        "{{ cycler.__init__.__globals__.os.getcwd() }}",
+    )
+
+    with pytest.raises(SecurityError):
+        render_diff_hunk_format(include_line_numbers=True, include_ai_metadata=False)
+
+
+@pytest.mark.parametrize("include_ai_metadata", [False, True])
+def test_tool_initializers_supply_the_fragment_before_token_counting(
+    monkeypatch,
+    restore_prompt_settings,
+    include_ai_metadata,
+):
+    description_files = [{"full_file_name": "example.py"}] if include_ai_metadata else []
+    provider = FakeGitProvider(description_files=description_files)
+    settings = get_settings()
+    settings.set("config.enable_ai_metadata", include_ai_metadata)
+    settings.set("config.is_auto_command", include_ai_metadata)
+    settings.set("pr_code_suggestions.decouple_hunks", True)
+
+    monkeypatch.setattr(pr_reviewer, "get_git_provider_with_context", lambda _url: provider)
+    monkeypatch.setattr(pr_reviewer, "get_main_pr_language", lambda _languages, _files: "Python")
+    monkeypatch.setattr(pr_reviewer, "get_skills_context", lambda: "")
+    monkeypatch.setattr(pr_reviewer, "build_repo_context", lambda _provider: "")
+    monkeypatch.setattr(pr_reviewer, "add_ai_metadata_to_diff_files", lambda _provider, _files: None)
+
+    monkeypatch.setattr(pr_add_docs, "get_git_provider", lambda: lambda _url: provider)
+    monkeypatch.setattr(pr_add_docs, "get_main_pr_language", lambda _languages, _files: "Python")
+
+    monkeypatch.setattr(pr_code_suggestions, "get_git_provider_with_context", lambda _url: provider)
+    monkeypatch.setattr(pr_code_suggestions, "get_main_pr_language", lambda _languages, _files: "Python")
+    monkeypatch.setattr(pr_code_suggestions, "get_skills_context", lambda: "")
+    monkeypatch.setattr(pr_code_suggestions, "build_repo_context", lambda _provider: "")
+    monkeypatch.setattr(
+        pr_code_suggestions,
+        "add_ai_metadata_to_diff_files",
+        lambda _provider, _files: None,
+    )
+
+    reviewer = pr_reviewer.PRReviewer("https://example/pr/1", ai_handler=lambda: SimpleNamespace())
+    add_docs = pr_add_docs.PRAddDocs("https://example/pr/1", ai_handler=lambda: SimpleNamespace())
+    suggestions = pr_code_suggestions.PRCodeSuggestions(
+        "https://example/pr/1",
+        ai_handler=lambda: SimpleNamespace(),
+    )
+
+    assert reviewer.vars["diff_hunk_format"] == render_diff_hunk_format(
+        include_line_numbers=True,
+        include_ai_metadata=include_ai_metadata,
+    )
+    assert add_docs.vars["diff_hunk_format"] == render_diff_hunk_format(
+        include_line_numbers=True,
+        include_ai_metadata=False,
+    )
+    assert suggestions.vars["diff_hunk_format"] == render_diff_hunk_format(
+        include_line_numbers=False,
+        include_ai_metadata=include_ai_metadata,
+    )
+    assert reviewer.token_handler.prompt_tokens > 0
+    assert add_docs.token_handler.prompt_tokens > 0
+    assert suggestions.token_handler.prompt_tokens > 0
+
+
+def test_non_decoupled_suggestions_render_without_the_shared_fragment(monkeypatch, restore_prompt_settings):
+    provider = FakeGitProvider()
+    settings = get_settings()
+    settings.set("config.enable_ai_metadata", False)
+    settings.set("config.is_auto_command", False)
+    settings.set("pr_code_suggestions.decouple_hunks", False)
+
+    monkeypatch.setattr(pr_code_suggestions, "get_git_provider_with_context", lambda _url: provider)
+    monkeypatch.setattr(pr_code_suggestions, "get_main_pr_language", lambda _languages, _files: "Python")
+    monkeypatch.setattr(pr_code_suggestions, "get_skills_context", lambda: "")
+    monkeypatch.setattr(pr_code_suggestions, "build_repo_context", lambda _provider: "")
+
+    suggestions = pr_code_suggestions.PRCodeSuggestions(
+        "https://example/pr/1",
+        ai_handler=lambda: SimpleNamespace(),
+    )
+
+    assert suggestions.pr_code_suggestions_prompt_system == (
+        settings.pr_code_suggestions_prompt_not_decoupled.system
+    )
+    assert suggestions.token_handler.prompt_tokens > 0
+
+
+@pytest.mark.parametrize("include_ai_metadata", [False, True])
+async def test_reflection_supplies_the_numbered_fragment(
+    include_ai_metadata,
+    restore_prompt_settings,
+):
+    settings = get_settings()
+    settings.set("config.enable_ai_metadata", include_ai_metadata)
+    ai_handler = SimpleNamespace(chat_completion=AsyncMock(return_value=("REFLECTION_OK", "stop")))
+    tool = pr_code_suggestions.PRCodeSuggestions.__new__(pr_code_suggestions.PRCodeSuggestions)
+    tool.ai_handler = ai_handler
+    diff = "WITH-LINES {{ must_stay_literal_2959 }}"
+
+    result = await tool.self_reflect_on_suggestions(
+        [{"one_sentence_summary": "Keep the shared prompt accurate"}],
+        diff,
+        "test-model",
+    )
+
+    call = ai_handler.chat_completion.await_args.kwargs
+    expected_fragment = render_diff_hunk_format(
+        include_line_numbers=True,
+        include_ai_metadata=include_ai_metadata,
+    )
+    assert result == "REFLECTION_OK"
+    assert call["system"].count(expected_fragment) == 1
+    assert diff in call["user"]
+
+
+def test_non_decoupled_suggestions_prompt_remains_out_of_scope():
+    section = get_settings().pr_code_suggestions_prompt_not_decoupled
+    environment = Environment()
+
+    system_variables = meta.find_undeclared_variables(environment.parse(section.system))
+    user_variables = meta.find_undeclared_variables(environment.parse(section.user))
+
+    assert "diff_hunk_format" not in system_variables
+    assert "__new hunk__" not in section.system
+    assert "__old hunk__" not in section.system
+    assert "diff_no_line_numbers" in user_variables

--- a/tests/unittest/test_repo_context.py
+++ b/tests/unittest/test_repo_context.py
@@ -5,6 +5,7 @@ from github import GithubException
 from jinja2 import Environment, StrictUndefined, select_autoescape
 
 from pr_agent.algo import repo_context
+from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import (
     TRUNCATION_MARKER,
     build_repo_context,
@@ -642,6 +643,17 @@ def test_github_provider_reads_from_default_branch_when_requested():
 )
 def test_prompt_templates_render_configured_repo_context(prompt_name, variables):
     template = getattr(get_settings(), prompt_name).system
+
+    if prompt_name == "pr_review_prompt":
+        variables["diff_hunk_format"] = render_diff_hunk_format(
+            include_line_numbers=True,
+            include_ai_metadata=False,
+        )
+    elif prompt_name == "pr_code_suggestions_prompt":
+        variables["diff_hunk_format"] = render_diff_hunk_format(
+            include_line_numbers=False,
+            include_ai_metadata=False,
+        )
 
     # select_autoescape() leaves string templates unescaped (matching production prompt rendering)
     # while avoiding the hard-coded autoescape=False that static analysis flags.


### PR DESCRIPTION
## Summary

- replace four drifted diff-hunk descriptions with one host-controlled, parameterized canonical fragment
- intentionally update the rendered system prompts for reviewer, Add Docs, decoupled code suggestions, and suggestion reflection; this normalizes their prompt behavior rather than preserving the previous text byte for byte
- preserve each path's input contract: numbered new hunks for reviewer, Add Docs, and reflection; unnumbered hunks for decoupled suggestions; and optional AI metadata where supported
- add render-contract and security coverage for every consumer and supported variant

## Prompt behavior changes

- reviewer and suggestion reflection adopt the rewritten canonical explanation bullets
- decoupled suggestions replace their numbered "Important notes" list with canonical prose
- Add Docs gains a hunk-format explanation block that it did not previously have
- two examples are normalized around line numbering, change markers, and omitted `__old hunk__` sections

## Scope

- leave the default non-decoupled improve prompt unchanged because it has no structured hunk example
- keep the separate extra-instructions deduplication out of scope
- keep the fragment source host-controlled and unavailable to repository or comment-argument overrides

Closes #2959

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_prompt_fragments.py tests/unittest/test_apply_repo_settings_security.py tests/unittest/test_cli_args_security.py tests/unittest/test_repo_context.py -q` (152 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (3134 passed, 1 skipped, 1 xfailed)
- Ruff on all changed Python files (passed)
- pre-commit on all changed files (passed)
- `git diff --check` (passed)
