### PR TITLE
fix(litellm): honor reasoning_effort for Gemini 3.x thinking models

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -119,6 +119,7 @@ MAX_TOKENS = {
     'vertex_ai/gemini-3-pro-preview': 1048576,
     'vertex_ai/gemini-3.1-flash': 1048576,
     'vertex_ai/gemini-3.1-pro': 1048576,
+    'vertex_ai/gemini-3.1-flash-lite': 1048576,
     'vertex_ai/gemini-3.1-flash-lite-preview': 1048576,
     'vertex_ai/gemini-3.1-pro-preview': 1048576,
     'vertex_ai/gemini-3.5-flash': 1048576,
@@ -141,6 +142,7 @@ MAX_TOKENS = {
     'gemini/gemini-3-pro-preview': 1048576,
     'gemini/gemini-3.1-flash': 1048576,
     'gemini/gemini-3.1-pro': 1048576,
+    'gemini/gemini-3.1-flash-lite': 1048576,
     'gemini/gemini-3.1-flash-lite-preview': 1048576,
     'gemini/gemini-3.1-pro-preview': 1048576,
     'gemini/gemini-3.5-flash': 1048576,
@@ -425,6 +427,21 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     # LiteLLMAIHandler routes OpenRouter-prefixed forms through extra_body.reasoning.
     "gemini-2.5-pro",
     "gemini-2.5-flash",
+    # Gemini 3.x thinking models. Same rationale as the 2.5 entries above: without
+    # these, a configured reasoning_effort is silently dropped and the model runs at
+    # its API-default thinking budget. Only ids that LiteLLM 1.98.0 registers with
+    # supports_reasoning=true are listed (gemini-3.1-flash, gemini-3.1-pro and
+    # gemini-3.5-pro are absent from its model registry, so sending the parameter
+    # for them would be rejected rather than mapped).
+    "gemini-3-flash-preview",
+    "gemini-3-pro-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-3.1-flash-lite-preview",
+    "gemini-3.1-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.6-flash",
+    "gemini-3.7-flash",
     # Register each published Grok id separately so provider-prefixed forms match
     # and the allowlist below can clamp model-specific reasoning levels.
     "grok-4.5",

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -127,6 +127,7 @@ MAX_TOKENS = {
     'vertex_ai/gemini-3.5-pro': 1048576,
     'vertex_ai/gemini-3.6-flash': 1048576,
     'vertex_ai/gemini-3.7-flash': 1048576,
+    'vertex_ai/gemini-3.8-flash': 1048576,
     'vertex_ai/gemma2': 8200,
     'gemini/gemini-1.5-pro': 1048576,
     'gemini/gemini-1.5-flash': 1048576,
@@ -150,6 +151,7 @@ MAX_TOKENS = {
     'gemini/gemini-3.5-pro': 1048576,
     'gemini/gemini-3.6-flash': 1048576,
     'gemini/gemini-3.7-flash': 1048576,
+    'gemini/gemini-3.8-flash': 1048576,
     'codechat-bison': 6144,
     'codechat-bison-32k': 32000,
     'anthropic.claude-instant-v1': 100000,
@@ -442,6 +444,9 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     "gemini-3.5-flash-lite",
     "gemini-3.6-flash",
     "gemini-3.7-flash",
+    # 3.8 Flash is absent from LiteLLM 1.98.0's registry (the model postdates
+    # it); litellm_ai_handler registers the id at import so the mapping works.
+    "gemini-3.8-flash",
     # Register each published Grok id separately so provider-prefixed forms match
     # and the allowlist below can clamp model-specific reasoning levels.
     "grok-4.5",

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -425,16 +425,21 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     # Gemini 2.5 exposes a thinking budget controlled by reasoning_effort. Without
     # these entries a configured effort is silently dropped, so a runaway thinking
     # trace can consume the whole output budget and return an empty completion.
-    # LiteLLM maps native provider paths to thinkingConfig.thinkingBudget, while
+    # For these 2.5 ids LiteLLM maps native provider paths to
+    # thinkingConfig.thinkingBudget (the 3.x entries below map differently), while
     # LiteLLMAIHandler routes OpenRouter-prefixed forms through extra_body.reasoning.
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     # Gemini 3.x thinking models. Same rationale as the 2.5 entries above: without
-    # these, a configured reasoning_effort is silently dropped and the model runs at
-    # its API-default thinking budget. Only ids that LiteLLM 1.98.0 registers with
-    # supports_reasoning=true are listed (gemini-3.1-flash, gemini-3.1-pro and
-    # gemini-3.5-pro are absent from its model registry, so sending the parameter
-    # for them would be rejected rather than mapped).
+    # these, a configured reasoning_effort is silently dropped and the model runs
+    # at its API-default thinking. Unlike the 2.5 budget mapping, LiteLLM 1.98.0
+    # maps 3.x ids to thinkingConfig.thinkingLevel (no fixed token ceiling).
+    # Only ids LiteLLM registers with supports_reasoning=true under the gemini/ or
+    # vertex_ai/ prefixes are listed: gemini-3.1-flash and gemini-3.5-pro are
+    # absent from its registry entirely, and gemini-3.1-pro exists only as
+    # deepinfra/google/gemini-3.1-pro — sending the parameter for the unregistered
+    # native forms would be rejected rather than mapped, so they stay out until
+    # LiteLLM registers them.
     "gemini-3-flash-preview",
     "gemini-3-pro-preview",
     "gemini-3.1-flash-lite",

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -35,6 +35,35 @@ from pr_agent.log import get_logger
 MODEL_RETRIES = 2
 DUMMY_LITELLM_API_KEY = "dummy_key"  # placeholder set when no OpenAI key is configured
 
+# The bundled LiteLLM (1.98.0) predates Gemini 3.8 Flash (GA September 2026), so
+# its model registry has no entry for the id. Without one, supports_reasoning()
+# is false and LiteLLM skips the reasoning_effort -> thinkingConfig mapping,
+# silently dropping a configured effort — the same failure the
+# SUPPORT_REASONING_EFFORT_MODELS additions fix for the registered 3.x ids.
+# Register the id at import, mirroring the registry's gemini-3.7-flash entry
+# (same context window and promo pricing per ai.google.dev/pricing/gemini-3,
+# September 2026). Drop this once the bundled LiteLLM registers the model.
+_GEMINI_38_FLASH_MODEL_INFO = {
+    "mode": "chat",
+    "max_tokens": 65536,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-07,
+    "output_cost_per_token": 3.75e-06,
+    "output_cost_per_reasoning_token": 3.75e-06,
+    "supports_reasoning": True,
+    "supports_system_messages": True,
+    "source": "https://ai.google.dev/pricing/gemini-3",
+}
+for _gemini_38_id, _provider in (
+    ("gemini/gemini-3.8-flash", "gemini"),
+    ("vertex_ai/gemini-3.8-flash", "vertex_ai-language-models"),
+):
+    if _gemini_38_id not in litellm.model_cost:
+        litellm.register_model(
+            {_gemini_38_id: {**_GEMINI_38_FLASH_MODEL_INFO, "litellm_provider": _provider}}
+        )
+
 
 class LiteLLMAIHandler(BaseAiHandler):
     """

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -184,6 +184,8 @@ class TestGetMaxTokens:
         "vertex_ai/gemini-3.1-flash",
         "gemini/gemini-3.1-pro",
         "vertex_ai/gemini-3.1-pro",
+        "gemini/gemini-3.1-flash-lite",
+        "vertex_ai/gemini-3.1-flash-lite",
         "gemini/gemini-3.1-flash-lite-preview",
         "vertex_ai/gemini-3.1-flash-lite-preview",
         "gemini/gemini-3.5-flash",
@@ -196,6 +198,8 @@ class TestGetMaxTokens:
         "vertex_ai/gemini-3.6-flash",
         "gemini/gemini-3.7-flash",
         "vertex_ai/gemini-3.7-flash",
+        "gemini/gemini-3.8-flash",
+        "vertex_ai/gemini-3.8-flash",
     ])
     def test_gemini_3_x_models_max_tokens(self, monkeypatch, model):
         fake_settings = type("", (), {

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -877,7 +877,7 @@ class TestLiteLLMReasoningEffortGemini:
 
     @pytest.mark.asyncio
     async def test_gemini_prefixed_forms_get_reasoning_effort(self, monkeypatch, mock_logger):
-        """Bare and provider-prefixed Gemini 2.5 ids all receive the configured reasoning_effort."""
+        """Bare and provider-prefixed Gemini 2.5/3.x ids all receive the configured reasoning_effort."""
         fake_settings = create_mock_settings("low")
         monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
         self._isolate_env(monkeypatch)
@@ -887,6 +887,11 @@ class TestLiteLLMReasoningEffortGemini:
             "gemini-2.5-flash",
             "gemini/gemini-2.5-pro",
             "vertex_ai/gemini-2.5-pro",
+            "gemini-3.7-flash",
+            "gemini/gemini-3.5-flash",
+            "gemini/gemini-3.5-flash-lite",
+            "vertex_ai/gemini-3.5-flash",
+            "gemini/gemini-3.8-flash",
         ]
 
         for model in gemini_models:
@@ -903,12 +908,24 @@ class TestLiteLLMReasoningEffortGemini:
 
     @pytest.mark.asyncio
     async def test_non_listed_gemini_gets_no_reasoning_effort(self, monkeypatch, mock_logger):
-        """A Gemini model not in the support list (e.g. 1.5) must not receive reasoning_effort."""
+        """A Gemini model not in the support list must not receive reasoning_effort.
+
+        Locks in the deliberate 3.x exclusions: gemini-3.1-flash and gemini-3.5-pro
+        are absent from LiteLLM 1.98.0's registry, and gemini-3.1-pro exists only
+        under the deepinfra/google/ prefix — do not add them to
+        SUPPORT_REASONING_EFFORT_MODELS without checking the registry first.
+        """
         fake_settings = create_mock_settings("low")
         monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
         self._isolate_env(monkeypatch)
 
-        for model in ("openrouter/google/gemini-1.5-pro", "gemini-1.5-flash"):
+        for model in (
+            "openrouter/google/gemini-1.5-pro",
+            "gemini-1.5-flash",
+            "gemini/gemini-3.1-flash",
+            "gemini/gemini-3.1-pro",
+            "gemini-3.5-pro",
+        ):
             with patch('pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion', new_callable=AsyncMock) as mock_completion:
                 mock_completion.return_value = create_mock_acompletion_response()
 


### PR DESCRIPTION
## What

Add the Gemini 3.x thinking models to `SUPPORT_REASONING_EFFORT_MODELS`, and add the GA `gemini-3.1-flash-lite` id to `MAX_TOKENS` (only its `-preview` variant was listed).

## Why

`SUPPORT_REASONING_EFFORT_MODELS` stops at Gemini 2.5, so a configured `config.reasoning_effort` is silently dropped for every Gemini 3.x model and each one runs at its API-default thinking budget — the exact failure mode the existing 2.5 comment in the list describes.

We measured this on real PR reviews (16 paired runs, identical prompts): `gemini-3.7-flash` configured at effort `high` spent 0.5–2.8k reasoning tokens per run (its frugal dynamic default) and returned an empty `key_issues_to_review` on 16/16 runs, while `gemini-3.5-flash` at `medium` — equally unconfigured in practice — spent 4–15k via its own generous default. Neither value came from the config; the parameter never reached the API.

## Scope

Ids that LiteLLM 1.98.0 (the pinned version) registers with `supports_reasoning=true` under the native prefixes are added: `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash`, `gemini-3.7-flash`. Excluded and now locked in by `test_non_listed_gemini_gets_no_reasoning_effort`: `gemini-3.1-flash` and `gemini-3.5-pro` (absent from the registry entirely) and `gemini-3.1-pro` (present only as `deepinfra/google/gemini-3.1-pro`, not under `gemini/` or `vertex_ai/`); they can follow when LiteLLM registers the native forms.

**`gemini-3.8-flash`** (GA September 2026) postdates LiteLLM 1.98.0 entirely, so the handler registers the id with LiteLLM at import (mirroring the registry's 3.7 entry) before adding it to the allowlist and `MAX_TOKENS` — without that shim the parameter would be rejected for an unregistered id. The registration is guarded by an `in litellm.model_cost` check and can be dropped once the bundled LiteLLM knows the model. Note the 3.x ids map to `thinkingConfig.thinkingLevel` (no fixed ceiling), unlike the 2.5 entries' `thinkingBudget` — the list comments now say so.

The membership test in `LiteLLMAIHandler` matches bare and provider-prefixed forms (`gemini/…`, `vertex_ai/…`, `openrouter/google/…`), so one bare id per model covers all providers, mirroring the existing 2.5 entries.

## Verified

Ran this patch in our GitHub Action (a source build of this branch; same workflow and prompts, only the pin changed), four legs across two workflows:

- `Adding reasoning_effort with value <effort> to model <id>` now logs for all four Gemini 3.x ids (previously absent from every run's log);
- the two Flash-Lite legs, which never reported any thinking before (`reasoning_tokens: null` in the API usage on every run), now report non-null `reasoning_tokens`;
- all four legs completed on their primary model with no fallback.

One caveat for reviewers to be aware of (pre-existing LiteLLM behavior, not changed here): LiteLLM maps effort to a fixed `thinkingConfig.thinkingBudget` (medium=2048, high=4096 by default, overridable via `DEFAULT_REASONING_EFFORT_*_THINKING_BUDGET` env vars). Those budgets are ceilings, so on Gemini 3.x an explicit `medium` can be *smaller* than the model's own dynamic default. That trade-off exists today for the 2.5 entries as well; this PR only makes the knob reach the API for 3.x like it already does for 2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
