### PR TITLE
docs: make configuration defaults authoritative

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -520,7 +520,7 @@ If you encounter rate limiting:
         OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Add a fallback model for better reliability
-        config.fallback_models: '["gpt-5.6-terra"]'
+        config.fallback_models: '["your-fallback-model"]'
         # Increase timeout for slower models
         config.ai_timeout: "300"
         github_action_config.auto_review: "true"

--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -2,7 +2,7 @@ To run PR-Agent locally, you first need to acquire two keys:
 
 Local execution has two distinct cases: use the hosted-provider examples below for an existing PR/MR URL, or use the [Local Git Provider guide](../usage-guide/local_git_provider.md) for branch comparisons without a hosted PR/MR.
 
-1. An OpenAI key from [here](https://platform.openai.com/api-keys){:target="_blank"}, with access to GPT-5.6 and gpt-5.6-terra (or a key for other [language models](../usage-guide/changing_a_model.md), if you prefer).
+1. An API key for your configured [language model provider](../usage-guide/changing_a_model.md). For OpenAI, create one [here](https://platform.openai.com/api-keys){:target="_blank"}.
 2. A personal access token from your Git platform (GitHub, GitLab, BitBucket, Gitea) with repo scope. GitHub token, for example, can be issued from [here](https://github.com/settings/tokens){:target="_blank"}
 
 ## Using Docker image

--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -87,28 +87,32 @@ The direction of the diagram adapts to its shape. A diagram whose longest chain 
 
 ## Configuration options
 
+The descriptions below explain each option's behavior. See the relevant sections in
+[`configuration.toml`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml)
+for the authoritative default values.
+
 ???+ example "Possible configurations"
 
     <table>
       <tr>
         <td><b>publish_labels</b></td>
-        <td>If set to true, the tool will publish labels to the PR. Default is false.</td>
+        <td>If set to true, the tool will publish labels to the PR.</td>
       </tr>
       <tr>
         <td><b>publish_description_as_comment</b></td>
-        <td>If set to true, the tool will publish the description as a comment to the PR. If false, it will overwrite the original description. Default is false.</td>
+        <td>If set to true, the tool will publish the description as a comment to the PR. If false, it will overwrite the original description.</td>
       </tr>
       <tr>
         <td><b>publish_description_as_comment_persistent</b></td>
-        <td>If set to true and `publish_description_as_comment` is true, the tool will publish the description as a persistent comment to the PR. Default is true.</td>
+        <td>If set to true and `publish_description_as_comment` is true, the tool will publish the description as a persistent comment to the PR.</td>
       </tr>
       <tr>
         <td><b>add_original_user_description</b></td>
-        <td>If set to true, the tool will add the original user description to the generated description. Default is true.</td>
+        <td>If set to true, the tool will add the original user description to the generated description.</td>
       </tr>
       <tr>
         <td><b>generate_ai_title</b></td>
-        <td>If set to true, the tool will also generate an AI title for the PR. Default is false.</td>
+        <td>If set to true, the tool will also generate an AI title for the PR.</td>
       </tr>
       <tr>
         <td><b>extra_instructions</b></td>
@@ -116,51 +120,51 @@ The direction of the diagram adapts to its shape. A diagram whose longest chain 
       </tr>
       <tr>
         <td><b>enable_pr_type</b></td>
-        <td>If set to false, it will not show the `PR type` as a text value in the description content. Default is true.</td>
+        <td>If set to false, it will not show the `PR type` as a text value in the description content.</td>
       </tr>
       <tr>
         <td><b>enable_pr_description</b></td>
-        <td>If set to false, the AI-generated summary section will not be requested from the model, nor shown in the description content. The other sections (diagram, changes walkthrough) are unaffected. Default is true.</td>
+        <td>If set to false, the AI-generated summary section will not be requested from the model, nor shown in the description content. The other sections (diagram, changes walkthrough) are unaffected.</td>
       </tr>
       <tr>
         <td><b>final_update_message</b></td>
-        <td>If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/the-pr-agent/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is true.</td>
+        <td>If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/the-pr-agent/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`.</td>
       </tr>
       <tr>
         <td><b>enable_semantic_files_types</b></td>
-        <td>If set to true, "Changes walkthrough" section will be generated. Default is true.</td>
+        <td>If set to true, "Changes walkthrough" section will be generated.</td>
       </tr>
       <tr>
             <td><b>file_table_collapsible_open_by_default</b></td>
-            <td>If set to true, the file list in the "Changes walkthrough" section will be open by default. If set to false, it will be closed by default. Default is false.</td>
+            <td>Controls whether the file list in the "Changes walkthrough" section is initially open or closed.</td>
       </tr>
       <tr>
         <td><b>collapsible_file_list</b></td>
-        <td>If set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files. Default is "adaptive".</td>
+        <td>If set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files.</td>
       </tr>
       <tr>
         <td><b>enable_large_pr_handling</b></td>
-        <td>If set to true, in case of a large PR the tool will make several calls to the AI and combine them to be able to cover more files. Default is true.</td>
+        <td>If set to true, in case of a large PR the tool will make several calls to the AI and combine them to be able to cover more files.</td>
       </tr>
       <tr>
         <td><b>enable_help_text</b></td>
-        <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
+        <td>If set to true, the tool will display a help text in the comment.</td>
       </tr>
       <tr>
         <td><b>enable_pr_diagram</b></td>
-        <td>If set to true, the tool will generate a Mermaid flowchart summarizing the main pull request changes. This field remains empty if not applicable. Default is true.</td>
+        <td>If set to true, the tool will generate a Mermaid flowchart summarizing the main pull request changes. This field remains empty if not applicable.</td>
       </tr>
       <tr>
         <td><b>pr_diagram_direction</b></td>
-        <td>Direction of the generated Mermaid flowchart: <b>adaptive</b>, <b>LR</b> or <b>TD</b>. With adaptive, the direction is chosen from the shape of the diagram. Default is adaptive.</td>
+        <td>Direction of the generated Mermaid flowchart: <b>adaptive</b>, <b>LR</b> or <b>TD</b>. With adaptive, the direction is chosen from the shape of the diagram.</td>
       </tr>
       <tr>
         <td><b>pr_diagram_direction_threshold</b></td>
-        <td>With <b>adaptive</b> direction, a diagram whose longest chain exceeds this many nodes is drawn top-down instead of left-to-right. Default is 5.</td>
+        <td>With <b>adaptive</b> direction, a diagram whose longest chain exceeds this many nodes is drawn top-down instead of left-to-right.</td>
       </tr>
       <tr>
         <td><b>auto_create_ticket</b></td>
-        <td>If set to true, this will automatically create a ticket in the ticketing system when a PR is opened. Default is false.</td>
+        <td>If set to true, this will automatically create a ticket in the ticketing system when a PR is opened.</td>
       </tr>
     </table>
 

--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -140,7 +140,7 @@ for the authoritative default values.
       </tr>
       <tr>
         <td><b>collapsible_file_list</b></td>
-        <td>If set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files.</td>
+        <td>If set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only when the number of files exceeds <code>collapsible_file_list_threshold</code>.</td>
       </tr>
       <tr>
         <td><b>enable_large_pr_handling</b></td>

--- a/docs/docs/tools/help_docs.md
+++ b/docs/docs/tools/help_docs.md
@@ -110,7 +110,7 @@ When a new issue is opened, you should see a comment from `github-actions` bot w
 
 ## Configuration options
 
-Under the section `pr_help_docs`, the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L199) contains options to customize the 'help docs' tool:
+Under the section `pr_help_docs`, the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) contains options to customize the 'help docs' tool:
 
 - `repo_url`: If not overwritten, will use the repo from where the context came from (issue or PR), otherwise - use the given repo as context.
 - `repo_default_branch`: The branch to use in case repo_url overwritten, otherwise - has no effect.

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -322,6 +322,10 @@ Note: Chunking is primarily relevant for large PRs. For most PRs (up to 600 line
 
 ## Configuration options
 
+The descriptions below explain each option's behavior. See the relevant sections in
+[`configuration.toml`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml)
+for the authoritative default values.
+
 ???+ example "General options"
 
     <table>
@@ -337,48 +341,47 @@ Note: Chunking is primarily relevant for large PRs. For most PRs (up to 600 line
           <code>## Guideline Improvement Suggestions ✨</code>. On GitHub, GitLab, and Azure DevOps,
           changing this value updates the same persistent suggestions comment; it does not create a separate
           suggestions channel. LocalGit uses the same visible heading in <code>improve.md</code>, without a
-          hidden identity marker. The setting does not affect committable inline suggestions. Default is
-          <code>PR Code Suggestions</code>.
+          hidden identity marker. The setting does not affect committable inline suggestions.
         </td>
       </tr>
       <tr>
         <td><b>commitable_code_suggestions</b></td>
-        <td>If set to true, the tool will display the suggestions as committable code comments. Default is false.</td>
+        <td>If set to true, the tool will display the suggestions as committable code comments.</td>
       </tr>
       <tr>
         <td><b>dual_publishing_score_threshold</b></td>
-        <td>Minimum score threshold for suggestions to be presented as committable PR comments in addition to the table. Default is -1 (disabled).</td>
+        <td>Minimum score threshold for suggestions to be presented as committable PR comments in addition to the table.</td>
       </tr>
       <tr>
         <td><b>focus_only_on_problems</b></td>
         <td>If set to true, suggestions will focus primarily on identifying and fixing code problems, and less on
-        style considerations like best practices, maintainability, or readability. Default is true.</td>
+        style considerations like best practices, maintainability, or readability.</td>
       </tr>
       <tr>
         <td><b>persistent_comment</b></td>
-        <td>If set to true, the improve comment will be persistent, meaning that every new improve request will edit the previous one. Default is true.</td>
+        <td>If set to true, the improve comment will be persistent, meaning that every new improve request will edit the previous one.</td>
       </tr>
       <tr>
         <td><b>suggestions_score_threshold</b></td>
-        <td> Any suggestion with importance score less than this threshold will be removed. Default is 0. Highly recommend not to set this value above 7-8, since above it may clip relevant suggestions that can be useful. </td>
+        <td>Any suggestion with importance score less than this threshold will be removed. Values above 7-8 may clip relevant suggestions.</td>
       </tr>
       <tr>
         <td><b>enable_help_text</b></td>
-        <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
+        <td>If set to true, the tool will display a help text in the comment.</td>
       </tr>
       <tr>
         <td><b>enable_chat_text</b></td>
-        <td>If set to true, the tool will display a reference to the PR chat in the comment. Default is false.</td>
+        <td>If set to true, the tool will display a reference to the PR chat in the comment.</td>
       </tr>
       <tr>
         <td><b>publish_output_no_suggestions</b></td>
-        <td>If set to true, the tool will publish a comment even if no suggestions were found. Default is true.</td>
+        <td>If set to true, the tool will publish a comment even if no suggestions were found.</td>
       </tr>
       <tr>
         <td><b>enable_suggestions_coverage_footer</b></td>
         <td>
           If set to true, the tool will display a coverage notice when failed analysis chunks make the
-          suggestions incomplete. Default is true.
+          suggestions incomplete.
         </td>
       </tr>
     </table>
@@ -388,11 +391,11 @@ Note: Chunking is primarily relevant for large PRs. For most PRs (up to 600 line
     <table>
       <tr>
         <td><b>num_code_suggestions_per_chunk</b></td>
-        <td>Number of code suggestions provided by the 'improve' tool, per chunk. Default is 3.</td>
+        <td>Number of code suggestions provided by the 'improve' tool, per chunk.</td>
       </tr>
       <tr>
         <td><b>max_number_of_calls</b></td>
-        <td>Maximum number of chunks. Default is 3.</td>
+        <td>Maximum number of chunks.</td>
       </tr>
     </table>
 

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -51,12 +51,16 @@ extra_instructions = "..."
 
 ## Configuration options
 
+The descriptions below explain each option's behavior. See the relevant sections in
+[`configuration.toml`](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml)
+for the authoritative default values.
+
 ???+ example "General options"
 
     <table>
       <tr>
         <td><b>persistent_comment</b></td>
-        <td>If set to true, the review comment will be persistent, meaning that every new review request will edit the previous one. Default is true.</td>
+        <td>If set to true, the review comment will be persistent, meaning that every new review request will edit the previous one.</td>
       </tr>
       <tr>
         <td><b>review_heading</b></td>
@@ -67,12 +71,11 @@ extra_instructions = "..."
           <code>## Incremental Guideline Compliance Check 🔍</code> for an incremental review.
           On GitHub, GitLab, Azure DevOps, and Bitbucket Cloud, changing this value updates the same
           persistent review comment; it does not create a separate review channel.
-          Default is <code>PR Reviewer Guide</code>.
         </td>
       </tr>
       <tr>
       <td><b>final_update_message</b></td>
-      <td>When set to true, updating a persistent review comment during online commenting will automatically add a short comment with a link to the updated review in the pull request .Default is true.</td>
+      <td>When set to true, updating a persistent review comment during online commenting will automatically add a short comment with a link to the updated review in the pull request.</td>
       </tr>
       <tr>
         <td><b>extra_instructions</b></td>
@@ -80,19 +83,19 @@ extra_instructions = "..."
       </tr>
       <tr>
         <td><b>enable_help_text</b></td>
-        <td>If set to true, the tool will display a help text in the comment. Default is false.</td>
+        <td>If set to true, the tool will display a help text in the comment.</td>
       </tr>
       <tr>
         <td><b>enable_review_coverage_footer</b></td>
-        <td>If set to true, the tool will display a review coverage footer when the token budget leaves files out of the review. Default is true.</td>
+        <td>If set to true, the tool will display a review coverage footer when the token budget leaves files out of the review.</td>
       </tr>
       <tr>
         <td><b>num_max_findings</b></td>
-        <td>Number of maximum returned findings. Default is 3.</td>
+        <td>Maximum number of returned findings.</td>
       </tr>
       <tr>
         <td><b>inline_key_issues</b></td>
-        <td>Azure DevOps only. If set to true, each key issue is published as an inline thread. A finding leaves the review summary when a matching thread exists or Azure accepts the new thread. Findings that cannot be anchored or published stay in the summary. Default is false.</td>
+        <td>Azure DevOps only. If set to true, each key issue is published as an inline thread. A finding leaves the review summary when a matching thread exists or Azure accepts the new thread. Findings that cannot be anchored or published stay in the summary.</td>
       </tr>
     </table>
 
@@ -101,48 +104,48 @@ extra_instructions = "..."
     <table>
       <tr>
         <td><b>require_score_review</b></td>
-        <td>If set to true, the tool will add a section that scores the PR. Default is false.</td>
+        <td>If set to true, the tool will add a section that scores the PR.</td>
       </tr>
       <tr>
         <td><b>require_tests_review</b></td>
-        <td>If set to true, the tool will add a section that checks if the PR contains tests. Default is true.</td>
+        <td>If set to true, the tool will add a section that checks if the PR contains tests.</td>
       </tr>
       <tr>
         <td><b>require_estimate_effort_to_review</b></td>
-        <td>If set to true, the tool will add a section that estimates the effort needed to review the PR. Default is true.</td>
+        <td>If set to true, the tool will add a section that estimates the effort needed to review the PR.</td>
       </tr>
       <tr>
         <td><b>require_estimate_contribution_time_cost</b></td>
-        <td>If set to true, the tool will add a section that estimates the time required for a senior developer to create and submit such changes. Default is false.</td>
+        <td>If set to true, the tool will add a section that estimates the time required for a senior developer to create and submit such changes.</td>
       </tr>
       <tr>
         <td><b>require_can_be_split_review</b></td>
-        <td>If set to true, the tool will add a section that checks if the PR contains several themes, and can be split into smaller PRs. Default is false.</td>
+        <td>If set to true, the tool will add a section that checks if the PR contains several themes, and can be split into smaller PRs.</td>
       </tr>
       <tr>
         <td><b>require_security_review</b></td>
-        <td>If set to true, the tool will add a section that checks if the PR contains a possible security or vulnerability issue. Default is true.</td>
+        <td>If set to true, the tool will add a section that checks if the PR contains a possible security or vulnerability issue.</td>
       </tr>
         <tr>
         <td><b>require_todo_scan</b></td>
-        <td>If set to true, the tool will add a section that lists TODO comments found in the PR code changes. Default is false.
+        <td>If set to true, the tool will add a section that lists TODO comments found in the PR code changes.
         </td>
       </tr>
       <tr>
         <td><b>require_ticket_analysis_review</b></td>
-        <td>If set to true, and the PR contains a GitHub or Jira ticket link, the tool will add a section that checks if the PR in fact fulfilled the ticket requirements. Default is true.</td>
+        <td>If set to true, and the PR contains a GitHub or Jira ticket link, the tool will add a section that checks if the PR in fact fulfilled the ticket requirements.</td>
       </tr>
       <tr>
         <td><b>require_risk_assessment</b></td>
-        <td>If set to true, the tool will add a section that rates the overall risk of the PR as low, medium or high. Default is false.</td>
+        <td>If set to true, the tool will add a section that rates the overall risk of the PR as low, medium or high.</td>
       </tr>
       <tr>
         <td><b>require_merge_recommendation</b></td>
-        <td>If set to true, the tool will add a section with a merge recommendation of safe_to_merge, merge_with_caution or changes_required. Default is false.</td>
+        <td>If set to true, the tool will add a section with a merge recommendation of safe_to_merge, merge_with_caution or changes_required.</td>
       </tr>
       <tr>
         <td><b>require_priority_files</b></td>
-        <td>If set to true, the tool will add a section listing the files a human reviewer should inspect first. Default is false.</td>
+        <td>If set to true, the tool will add a section listing the files a human reviewer should inspect first.</td>
       </tr>
     </table>
 
@@ -153,11 +156,11 @@ extra_instructions = "..."
     <table>
       <tr>
         <td><b>enable_review_labels_security</b></td>
-        <td>If set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.</td>
+        <td>If set to true, the tool will publish a 'possible security issue' label if it detects a security issue.</td>
       </tr>
       <tr>
         <td><b>enable_review_labels_effort</b></td>
-        <td>If set to true, the tool will publish a 'Review effort x/5' label (1–5 scale). Default is true.</td>
+        <td>If set to true, the tool will publish a 'Review effort x/5' label (1–5 scale).</td>
       </tr>
     </table>
 

--- a/docs/docs/tools/similar_issues.md
+++ b/docs/docs/tools/similar_issues.md
@@ -86,4 +86,4 @@ Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-v2`.
 - To invoke the 'similar' issue tool via online usage, [comment](https://github.com/the-pr-agent/pr-agent/issues/178#issuecomment-1716934893) on a PR:
 `/similar_issue`
 
-- You can also enable the 'similar issue' tool to run automatically when a new issue is opened, by adding it to the [pr_commands list in the github_app section](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L229)
+- You can also enable the 'similar issue' tool to run automatically when a new issue is opened, by adding it to the [pr_commands list in the github_app section](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml)

--- a/docs/docs/tools/update_changelog.md
+++ b/docs/docs/tools/update_changelog.md
@@ -15,7 +15,7 @@ It can be invoked manually by commenting on any PR:
 
 ## Configuration options
 
-Under the section `pr_update_changelog`, the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L169) contains options to customize the 'update changelog' tool:
+Under the section `pr_update_changelog`, the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) contains options to customize the 'update changelog' tool:
 
 - `push_changelog_changes`: whether to push the changes to CHANGELOG.md, or just publish them as a comment. Default is false (publish as comment).
 - `extra_instructions`: Optional extra instructions to the tool. For example: "Use the following structure: ..."

--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -42,7 +42,7 @@ On providers that support GitHub-Flavored Markdown this appends a collapsible se
 
 ```
 ⚙️ Agent run details
-- Model: gpt-5.6-terra (fallback)
+- Model: provider/fallback-model (fallback)
 - Tokens: 12,340 in / 1,205 out / 13,545 total
 - Time cost: 8.2s
 - AI calls: 1

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -29,7 +29,7 @@ verbosity_level=2
 
 This is useful for debugging or experimenting with different tools.
 
-3. **git provider**: The [git_provider](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L12) field in a configuration file determines the GIT provider that will be used by PR-Agent. Currently, the following providers are supported:
+3. **git provider**: The [git_provider](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) field in a configuration file determines the GIT provider that will be used by PR-Agent. Currently, the following providers are supported:
 `github` **(default)**, `gitlab`, `bitbucket`, `azure`, `codecommit`, `local`, and `gitea`.
 
 ### CLI Health Check
@@ -96,7 +96,7 @@ When this parameter is set to `true`, PR-Agent will not run any automatic tools 
 
 #### GitHub app automatic tools when a new PR is opened
 
-The [github_app](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L223) section defines GitHub app specific configurations.
+The [github_app](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) section defines GitHub app specific configurations.
 
 The configuration parameter `pr_commands` defines the list of tools that will be **run automatically** when a new PR is opened:
 
@@ -240,7 +240,7 @@ For detailed step-by-step examples of configuring different models (Gemini, Clau
 
 **Common Model Configuration Patterns:**
 
-- **OpenAI**: Set `config.model: "gpt-5.6"` and `OPENAI_KEY`
+- **OpenAI**: Set `config.model: "<openai-model>"` and `OPENAI_KEY`
 - **Gemini**: Set `config.model: "gemini/gemini-1.5-flash"` and `GOOGLE_AI_STUDIO.GEMINI_API_KEY` (no `OPENAI_KEY` needed)
 - **Claude**: Set `config.model: "anthropic/claude-3-opus-20240229"` and `ANTHROPIC.KEY` (no `OPENAI_KEY` needed)
 - **Azure OpenAI**: Set `OPENAI.API_TYPE: "azure"`, `OPENAI.API_BASE`, and `OPENAI.DEPLOYMENT_ID`

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -1,8 +1,8 @@
 ## Changing a model in PR-Agent
 
 See [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py) for a list of supported models in PR-Agent.
-The default model of PR-Agent is `GPT-5.6` from OpenAI.
-To use a different model than the default, you need to edit in the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L7) the fields:
+The current default model and fallback tier are defined in the [configuration file](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml).
+To use different models, edit these fields in that file:
 
 ```toml
 [config]

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -9,7 +9,7 @@ In terms of precedence, local configurations will override global configurations
 
 
 For a list of all possible configurations, see the [configuration options](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) page.
-In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml#L76) section in the configuration file.
+In addition to general configuration options, each tool has its own configurations. For example, the `review` tool will use parameters from the [pr_reviewer](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/configuration.toml) section in the configuration file.
 
 !!! tip "Tip1: Edit only what you need"
     Your configuration file should be minimal, and edit only the relevant values. Don't copy the entire configuration options, since it can lead to legacy problems when something changes.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -157,6 +157,7 @@ publish_description_as_comment_persistent=true
 enable_semantic_files_types=true
 collapsible_file_list='adaptive' # true, false, 'adaptive'
 collapsible_file_list_threshold=6
+file_table_collapsible_open_by_default=false
 inline_file_summary=false # false, true, 'table'
 # markers
 use_description_markers=false

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -5,8 +5,8 @@ health_check (the no-retry behavior itself was proven in 2c). Verify the route a
 200/503 response shape without relying on Starlette's thread-backed TestClient.
 
 Also exercises the REAL health_check() (no stub) to lock in Fix A: the removed
-'stop'-param gate must NOT short-circuit /health for models that lack 'stop' (e.g. the
-shipped gpt-5.x defaults), since PR-Agent's LiteLLMAIHandler never sends 'stop'."""
+'stop'-param gate must NOT short-circuit /health for models that lack 'stop', since
+PR-Agent's LiteLLMAIHandler never sends 'stop'."""
 import httpx
 import litellm
 import pytest
@@ -56,7 +56,7 @@ class TestHealthRoute:
 # under the pinned litellm). Under the OLD (removed) gate, health_check() short-circuited
 # to "Unhealthy: LLM does not support 'stop' parameter" for exactly such models — so these
 # tests would have failed before Fix A. They guard against the gate being reintroduced.
-_MODEL_WITHOUT_STOP = "gpt-5.6"
+_MODEL_WITHOUT_STOP = "o1-preview"
 
 
 @pytest.fixture

--- a/tests/unittest/test_mosaico_health.py
+++ b/tests/unittest/test_mosaico_health.py
@@ -56,7 +56,7 @@ class TestHealthRoute:
 # under the pinned litellm). Under the OLD (removed) gate, health_check() short-circuited
 # to "Unhealthy: LLM does not support 'stop' parameter" for exactly such models — so these
 # tests would have failed before Fix A. They guard against the gate being reintroduced.
-_MODEL_WITHOUT_STOP = "o1-preview"
+_MODEL_WITHOUT_STOP = "perplexity/sonar"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- point documentation at `configuration.toml` as the authoritative source for mutable defaults
- replace line-number deep links with stable file links
- remove duplicated default values from the review, describe, and improve option tables
- decouple the MOSAICO health-test fixture from the shipped default model

Closes #2960.

## Validation

- `PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/unittest/test_mosaico_health.py -q` — 8 passed
- `mkdocs build -f docs/mkdocs.yml` — passed (repository-existing link/imaging warnings remain)
- Ruff check plus the v6 pre-commit hook entry points for AST, conflicts, case conflicts, symlinks, file endings, line endings, trailing whitespace, and debug statements — passed
- `git diff --check` — passed

The aggregate `pre-commit run --files ...` command could not initialize its remote hook environment because GitHub returned a port 443 timeout; the same pinned hook version was installed from PyPI and run directly instead.