### PR TITLE
refactor: generate provider-prefixed Claude model ids

### DIFF
--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -19,12 +19,16 @@ Keep model names in configuration, not in tool code.
 Models that behave differently are registered in `pr_agent/algo/__init__.py`:
 `NO_SUPPORT_TEMPERATURE_MODELS` for models that reject a temperature
 parameter; `CLAUDE_EXTENDED_THINKING_MODELS` for Claude models that
-take extended thinking. Add the exact model name to the matching list.
+take extended thinking. For Claude models with provider-prefixed aliases
+(bare, `anthropic/`, `vertex_ai/`, `bedrock/`), declare the canonical family
+in `_CLAUDE_MODEL_FAMILIES` to expand them across registries automatically.
+Other models can be added directly to the matching list.
 
 Context windows are registered in `MAX_TOKENS` in `pr_agent/algo/__init__.py`:
-add the model name and its context-window token count, or set
-`config.custom_model_max_tokens` in `configuration.toml`. Without
-either, `get_max_tokens()` raises.
+Claude model families declared in `_CLAUDE_MODEL_FAMILIES` populate their
+aliases automatically. For other models, add the model name and its
+context-window token count to `MAX_TOKENS`, or set `config.custom_model_max_tokens`
+in `configuration.toml`. Without either, `get_max_tokens()` raises.
 
 Verify with `PYTHONPATH=. uv run pytest tests/unittest`.
 

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -116,7 +116,36 @@ _CLAUDE_MODEL_FAMILIES = [
 ]
 
 
-def _generate_claude_registries():
+_ALLOWED_FAMILY_KEYS = {
+    "model_id",
+    "max_tokens",
+    "anthropic",
+    "bare",
+    "vertex",
+    "bedrock",
+    "bedrock_name",
+    "bedrock_regions",
+    "extra_aliases",
+    "extra_bedrock",
+    "extra_bedrock_regions",
+    "no_temperature",
+    "extended_thinking",
+    "thinking_bedrock_regions",
+    "extra_no_temperature",
+    "extra_extended_thinking",
+}
+
+
+def _validate_claude_model_family(fam: dict) -> None:
+    """Validate that a Claude model family dict contains only supported keys."""
+    unknown = set(fam) - _ALLOWED_FAMILY_KEYS
+    if unknown:
+        raise ValueError(
+            f"unknown Claude family key(s) for {fam.get('model_id')}: {sorted(unknown)}"
+        )
+
+
+def _generate_claude_registries(families=None):
     """Expand _CLAUDE_MODEL_FAMILIES into token counts and capability lists.
 
     Returns (claude_tokens, claude_no_temp, claude_extended_thinking) where:
@@ -124,11 +153,15 @@ def _generate_claude_registries():
       - claude_no_temp: list[str] of models that do not support temperature
       - claude_extended_thinking: list[str] of models supporting extended thinking
     """
+    if families is None:
+        families = _CLAUDE_MODEL_FAMILIES
+
     claude_tokens = {}
     claude_no_temp = []
     claude_extended_thinking = []
 
-    for fam in _CLAUDE_MODEL_FAMILIES:
+    for fam in families:
+        _validate_claude_model_family(fam)
         mid = fam["model_id"]
         tokens = fam.get("max_tokens")
 
@@ -153,8 +186,17 @@ def _generate_claude_registries():
                     claude_tokens[f"bedrock/{extra_name}"] = tokens
                     for reg in regs:
                         claude_tokens[f"bedrock/{reg}.{extra_name}"] = tokens
-            for extra_alias, extra_tok in fam.get("extra_aliases", {}).items():
-                claude_tokens[extra_alias] = extra_tok
+            for extra_alias, extra_val in fam.get("extra_aliases", {}).items():
+                if isinstance(extra_val, dict):
+                    tok = extra_val.get("max_tokens", tokens)
+                    if tok is not None:
+                        claude_tokens[extra_alias] = tok
+                    if extra_val.get("no_temperature"):
+                        claude_no_temp.append(extra_alias)
+                    if extra_val.get("extended_thinking"):
+                        claude_extended_thinking.append(extra_alias)
+                else:
+                    claude_tokens[extra_alias] = extra_val
 
         # -- NO_SUPPORT_TEMPERATURE_MODELS ------------------------------------
         if fam.get("no_temperature"):
@@ -173,6 +215,9 @@ def _generate_claude_registries():
                     claude_no_temp.append(f"bedrock/{reg}.anthropic.{b_name}")
                 for extra in fam.get("extra_bedrock", ()):
                     claude_no_temp.append(f"bedrock/{extra}")
+
+        for extra_alias in fam.get("extra_no_temperature", ()):
+            claude_no_temp.append(extra_alias)
 
         # -- CLAUDE_EXTENDED_THINKING_MODELS ----------------------------------
         thinking = fam.get("extended_thinking")
@@ -195,6 +240,9 @@ def _generate_claude_registries():
                     )
                     for reg in thinking_regions:
                         claude_extended_thinking.append(f"bedrock/{reg}.anthropic.{b_name}")
+
+        for extra_alias in fam.get("extra_extended_thinking", ()):
+            claude_extended_thinking.append(extra_alias)
 
     return claude_tokens, claude_no_temp, claude_extended_thinking
 

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -1,3 +1,209 @@
+# ---------------------------------------------------------------------------
+# Canonical Claude model-family definitions.
+#
+# Each modern Claude family that follows the standard provider-prefix pattern
+# (bare, anthropic/, vertex_ai/, bedrock/ with optional cross-region prefixes)
+# is declared once here. The _generate_claude_registries() helper expands
+# these declarations into the token counts and capability lists that callers
+# consume via the public MAX_TOKENS, NO_SUPPORT_TEMPERATURE_MODELS, and
+# CLAUDE_EXTENDED_THINKING_MODELS registries.
+#
+# Historical / one-off Claude entries that do NOT follow the repeating
+# provider-prefix pattern are left as static literals inside the registries
+# themselves to avoid over-complicating the generator.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BEDROCK_REGIONS = ("global", "us", "eu", "au", "jp")
+
+_CLAUDE_MODEL_FAMILIES = [
+    # ── 1M-context models (no temperature, no extended thinking) ──────────
+    {
+        "model_id": "claude-opus-4-8",
+        "max_tokens": 1000000,
+        "bedrock_regions": _DEFAULT_BEDROCK_REGIONS,
+        "no_temperature": True,
+    },
+    {
+        "model_id": "claude-opus-5",
+        "max_tokens": 1000000,
+        "bedrock_regions": _DEFAULT_BEDROCK_REGIONS,
+        "no_temperature": True,
+    },
+    {
+        "model_id": "claude-sonnet-5",
+        "max_tokens": 1000000,
+        "bedrock_regions": _DEFAULT_BEDROCK_REGIONS,
+        "no_temperature": True,
+    },
+    {
+        "model_id": "claude-opus-4-7",
+        "max_tokens": 1000000,
+        "bedrock_regions": ("global", "us"),
+        "extra_bedrock": ("anthropic.claude-opus-4-7-v1:0",),
+        "no_temperature": True,
+    },
+    # ── 200K-context models with extended thinking ────────────────────────
+    {
+        "model_id": "claude-sonnet-4-6",
+        "max_tokens": 200000,
+        "bedrock_regions": ("us", "au", "eu", "jp", "apac", "global"),
+        "extra_bedrock_regions": {
+            "anthropic.claude-sonnet-4-6-v1:0": (
+                "us", "au", "eu", "jp", "apac", "global",
+            ),
+        },
+        "extended_thinking": True,
+    },
+    {
+        "model_id": "claude-opus-4-6",
+        "max_tokens": 200000,
+        "bedrock_name": "claude-opus-4-6-v1:0",
+        "bedrock_regions": ("global", "eu", "au", "jp", "apac", "us"),
+        "extra_aliases": {
+            "claude-opus-4-6-20260120": 200000,
+            "anthropic/claude-opus-4-6-20260120": 200000,
+            "vertex_ai/claude-opus-4-6@20260120": 200000,
+            "bedrock/anthropic.claude-opus-4-6-20260120-v1:0": 200000,
+            "bedrock/us.anthropic.claude-opus-4-6-20260120-v1:0": 200000,
+        },
+        "extended_thinking": True,
+    },
+    {
+        "model_id": "claude-haiku-4-5-20251001",
+        "max_tokens": 200000,
+        "vertex": "claude-haiku-4-5@20251001",
+        "bedrock_name": "claude-haiku-4-5-20251001-v1:0",
+        "bedrock_regions": ("us", "eu", "au", "jp", "apac", "global"),
+        "extended_thinking": True,
+    },
+    {
+        "model_id": "claude-opus-4-5-20251101",
+        "max_tokens": 200000,
+        "vertex": "claude-opus-4-5@20251101",
+        "bedrock_name": "claude-opus-4-5-20251101-v1:0",
+        "bedrock_regions": ("global", "eu", "au", "jp", "apac", "us"),
+        "extended_thinking": True,
+    },
+    {
+        "model_id": "claude-sonnet-4-5-20250929",
+        "max_tokens": 200000,
+        "bare": False,  # bare not in MAX_TOKENS
+        "vertex": "claude-sonnet-4-5@20250929",
+        "bedrock_name": "claude-sonnet-4-5-20250929-v1:0",
+        "bedrock_regions": ("us", "au", "eu", "jp", "global"),
+        "extended_thinking": True,
+    },
+    {
+        "model_id": "claude-3-7-sonnet-20250219",
+        "max_tokens": 200000,
+        "vertex": "claude-3-7-sonnet@20250219",
+        "bedrock_name": "claude-3-7-sonnet-20250219-v1:0",
+        "bedrock_regions": ("us", "apac"),
+        # Only bare + anthropic/ get extended thinking for 3.7
+        "extended_thinking": [
+            "anthropic/claude-3-7-sonnet-20250219",
+            "claude-3-7-sonnet-20250219",
+        ],
+    },
+    # ── No-temperature only (not in MAX_TOKENS) ──────────────────────────
+    {
+        "model_id": "claude-fable-5",
+        "max_tokens": None,
+        "vertex": False,
+        "bedrock": False,
+        "no_temperature": True,
+    },
+]
+
+
+def _generate_claude_registries():
+    """Expand _CLAUDE_MODEL_FAMILIES into token counts and capability lists.
+
+    Returns (claude_tokens, claude_no_temp, claude_extended_thinking) where:
+      - claude_tokens: dict[str, int] of generated model-id -> context-window
+      - claude_no_temp: list[str] of models that do not support temperature
+      - claude_extended_thinking: list[str] of models supporting extended thinking
+    """
+    claude_tokens = {}
+    claude_no_temp = []
+    claude_extended_thinking = []
+
+    for fam in _CLAUDE_MODEL_FAMILIES:
+        mid = fam["model_id"]
+        tokens = fam.get("max_tokens")
+
+        # -- Token counts -----------------------------------------------------
+        if tokens is not None:
+            if fam.get("bare", True):
+                claude_tokens[mid] = tokens
+            if fam.get("anthropic", True):
+                claude_tokens[f"anthropic/{mid}"] = tokens
+            vtx = fam.get("vertex", True)
+            if vtx:
+                vtx_name = vtx if isinstance(vtx, str) else mid
+                claude_tokens[f"vertex_ai/{vtx_name}"] = tokens
+            if fam.get("bedrock", True):
+                b_name = fam.get("bedrock_name", mid)
+                claude_tokens[f"bedrock/anthropic.{b_name}"] = tokens
+                for reg in fam.get("bedrock_regions", ()):
+                    claude_tokens[f"bedrock/{reg}.anthropic.{b_name}"] = tokens
+                for extra in fam.get("extra_bedrock", ()):
+                    claude_tokens[f"bedrock/{extra}"] = tokens
+                for extra_name, regs in fam.get("extra_bedrock_regions", {}).items():
+                    claude_tokens[f"bedrock/{extra_name}"] = tokens
+                    for reg in regs:
+                        claude_tokens[f"bedrock/{reg}.{extra_name}"] = tokens
+            for extra_alias, extra_tok in fam.get("extra_aliases", {}).items():
+                claude_tokens[extra_alias] = extra_tok
+
+        # -- NO_SUPPORT_TEMPERATURE_MODELS ------------------------------------
+        if fam.get("no_temperature"):
+            if fam.get("bare", True):
+                claude_no_temp.append(mid)
+            if fam.get("anthropic", True):
+                claude_no_temp.append(f"anthropic/{mid}")
+            vtx = fam.get("vertex", True)
+            if vtx:
+                vtx_name = vtx if isinstance(vtx, str) else mid
+                claude_no_temp.append(f"vertex_ai/{vtx_name}")
+            if fam.get("bedrock", True):
+                b_name = fam.get("bedrock_name", mid)
+                claude_no_temp.append(f"bedrock/anthropic.{b_name}")
+                for reg in fam.get("bedrock_regions", ()):
+                    claude_no_temp.append(f"bedrock/{reg}.anthropic.{b_name}")
+                for extra in fam.get("extra_bedrock", ()):
+                    claude_no_temp.append(f"bedrock/{extra}")
+
+        # -- CLAUDE_EXTENDED_THINKING_MODELS ----------------------------------
+        thinking = fam.get("extended_thinking")
+        if thinking:
+            if isinstance(thinking, (list, tuple)):
+                claude_extended_thinking.extend(thinking)
+            else:
+                if fam.get("anthropic", True):
+                    claude_extended_thinking.append(f"anthropic/{mid}")
+                claude_extended_thinking.append(mid)
+                vtx = fam.get("vertex", True)
+                if vtx:
+                    vtx_name = vtx if isinstance(vtx, str) else mid
+                    claude_extended_thinking.append(f"vertex_ai/{vtx_name}")
+                if fam.get("bedrock", True):
+                    b_name = fam.get("bedrock_name", mid)
+                    claude_extended_thinking.append(f"bedrock/anthropic.{b_name}")
+                    thinking_regions = fam.get(
+                        "thinking_bedrock_regions", ("us", "au", "eu", "jp", "global")
+                    )
+                    for reg in thinking_regions:
+                        claude_extended_thinking.append(f"bedrock/{reg}.anthropic.{b_name}")
+
+    return claude_tokens, claude_no_temp, claude_extended_thinking
+
+
+_claude_tokens, _claude_no_temp, _claude_extended_thinking = (
+    _generate_claude_registries()
+)
+
+
 MAX_TOKENS = {
     'text-embedding-ada-002': 8000,
     'gpt-3.5-turbo': 16000,
@@ -85,26 +291,17 @@ MAX_TOKENS = {
     'meta-llama/Llama-2-7b-chat-hf': 4096,
     'vertex_ai/codechat-bison': 6144,
     'vertex_ai/codechat-bison-32k': 32000,
+    # -- Vertex AI Claude --------------------------------------------------
     'vertex_ai/claude-3-haiku@20240307': 100000,
     'vertex_ai/claude-3-5-haiku@20241022': 100000,
-    'vertex_ai/claude-haiku-4-5@20251001': 200000,
     'vertex_ai/claude-3-sonnet@20240229': 100000,
     'vertex_ai/claude-3-opus@20240229': 100000,
     'vertex_ai/claude-opus-4@20250514': 200000,
     'vertex_ai/claude-opus-4-1@20250805': 200000,
-    'vertex_ai/claude-opus-4-5@20251101': 200000,
-    'vertex_ai/claude-opus-4-6@20260120': 200000,
-    'vertex_ai/claude-opus-4-6': 200000,
-    'vertex_ai/claude-opus-4-7': 1000000,
-    'vertex_ai/claude-opus-4-8': 1000000,
-    'vertex_ai/claude-opus-5': 1000000,
     'vertex_ai/claude-3-5-sonnet@20240620': 100000,
     'vertex_ai/claude-3-5-sonnet-v2@20241022': 100000,
-    'vertex_ai/claude-3-7-sonnet@20250219': 200000,
     'vertex_ai/claude-sonnet-4@20250514': 200000,
-    'vertex_ai/claude-sonnet-4-5@20250929': 200000,
-    'vertex_ai/claude-sonnet-4-6': 200000,
-    'vertex_ai/claude-sonnet-5': 1000000,
+    # -- Vertex AI non-Claude / Gemini -------------------------------------
     'vertex_ai/gemini-1.5-pro': 1048576,
     'vertex_ai/gemini-2.5-pro-preview-03-25': 1048576,
     'vertex_ai/gemini-2.5-pro-preview-05-06': 1048576,
@@ -150,125 +347,42 @@ MAX_TOKENS = {
     'gemini/gemini-3.7-flash': 1048576,
     'codechat-bison': 6144,
     'codechat-bison-32k': 32000,
+    # -- Anthropic Claude --------------------------------------------------
     'anthropic.claude-instant-v1': 100000,
     'anthropic.claude-v1': 100000,
     'anthropic.claude-v2': 100000,
     'anthropic/claude-3-opus-20240229': 100000,
     'anthropic/claude-opus-4-20250514': 200000,
     'anthropic/claude-opus-4-1-20250805': 200000,
-    'anthropic/claude-opus-4-5-20251101': 200000,
-    'anthropic/claude-opus-4-6': 200000,
-    'anthropic/claude-opus-4-6-20260120': 200000,
-    'anthropic/claude-opus-4-7': 1000000,
-    'anthropic/claude-opus-4-8': 1000000,
-    'anthropic/claude-opus-5': 1000000,
     'anthropic/claude-3-5-sonnet-20240620': 100000,
     'anthropic/claude-3-5-sonnet-20241022': 100000,
-    'anthropic/claude-3-7-sonnet-20250219': 200000,
     'anthropic/claude-sonnet-4-20250514': 200000,
-    'anthropic/claude-sonnet-4-5-20250929': 200000,
-    'anthropic/claude-sonnet-4-6': 200000,
-    'anthropic/claude-sonnet-5': 1000000,
+    # -- Bare Claude -------------------------------------------------------
     'claude-opus-4-1-20250805': 200000,
-    'claude-opus-4-5-20251101': 200000,
-    'claude-opus-4-6': 200000,
-    'claude-opus-4-6-20260120': 200000,
-    'claude-opus-4-7': 1000000,
-    'claude-opus-4-8': 1000000,
-    'claude-opus-5': 1000000,
-    'claude-3-7-sonnet-20250219': 200000,
-    'claude-sonnet-4-6': 200000,
-    'claude-sonnet-5': 1000000,
+    # -- Haiku -------------------------------------------------------------
     'anthropic/claude-3-5-haiku-20241022': 100000,
-    'anthropic/claude-haiku-4-5-20251001': 200000,
-    'claude-haiku-4-5-20251001': 200000,
+    # -- Bedrock Claude ----------------------------------------------------
     'bedrock/anthropic.claude-instant-v1': 100000,
     'bedrock/anthropic.claude-v2': 100000,
     'bedrock/anthropic.claude-v2:1': 100000,
     'bedrock/anthropic.claude-3-sonnet-20240229-v1:0': 100000,
     'bedrock/anthropic.claude-opus-4-20250514-v1:0': 200000,
     'bedrock/anthropic.claude-opus-4-1-20250805-v1:0': 200000,
-    'bedrock/anthropic.claude-opus-4-6-20260120-v1:0': 200000,
-    'bedrock/anthropic.claude-opus-4-6-v1:0': 200000,
-    'bedrock/anthropic.claude-opus-4-7': 1000000,
-    'bedrock/anthropic.claude-opus-4-7-v1:0': 1000000,
-    'bedrock/anthropic.claude-opus-4-8': 1000000,
-    'bedrock/anthropic.claude-opus-5': 1000000,
     'bedrock/anthropic.claude-3-haiku-20240307-v1:0': 100000,
     'bedrock/anthropic.claude-3-5-haiku-20241022-v1:0': 100000,
-    'bedrock/anthropic.claude-haiku-4-5-20251001-v1:0': 200000,
     'bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0': 100000,
     'bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0': 100000,
-    'bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0': 200000,
     'bedrock/anthropic.claude-sonnet-4-20250514-v1:0': 200000,
-    'bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0': 200000,
-    'bedrock/anthropic.claude-sonnet-4-6': 200000,
-    'bedrock/anthropic.claude-sonnet-4-6-v1:0': 200000,
-    'bedrock/anthropic.claude-sonnet-5': 1000000,
-    'bedrock/anthropic.claude-opus-4-5-20251101-v1:0': 200000,
+    # -- Bedrock Claude (cross-region) -------------------------------------
     "bedrock/us.anthropic.claude-opus-4-20250514-v1:0": 200000,
     "bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0": 200000,
-    "bedrock/us.anthropic.claude-opus-4-6-20260120-v1:0": 200000,
-    "bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/au.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/jp.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/apac.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0": 200000,
-    "bedrock/global.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/eu.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/au.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/jp.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/apac.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/us.anthropic.claude-opus-4-6-v1:0": 200000,
-    "bedrock/global.anthropic.claude-opus-4-7": 1000000,
-    "bedrock/us.anthropic.claude-opus-4-7": 1000000,
-    "bedrock/global.anthropic.claude-opus-4-8": 1000000,
-    "bedrock/us.anthropic.claude-opus-4-8": 1000000,
-    "bedrock/global.anthropic.claude-opus-5": 1000000,
-    "bedrock/us.anthropic.claude-opus-5": 1000000,
-    "bedrock/eu.anthropic.claude-opus-5": 1000000,
-    "bedrock/au.anthropic.claude-opus-5": 1000000,
-    "bedrock/jp.anthropic.claude-opus-5": 1000000,
-    "bedrock/eu.anthropic.claude-opus-4-8": 1000000,
-    "bedrock/au.anthropic.claude-opus-4-8": 1000000,
-    "bedrock/jp.anthropic.claude-opus-4-8": 1000000,
     "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0": 100000,
-    "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/apac.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0": 200000,
-    "bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0": 200000,
     "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0": 200000,
     "bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0": 200000,
-    "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
-    "bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
-    "bedrock/us.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/us.anthropic.claude-sonnet-4-6-v1:0": 200000,
-    "bedrock/au.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/au.anthropic.claude-sonnet-4-6-v1:0": 200000,
     "bedrock/apac.anthropic.claude-3-5-sonnet-20241022-v2:0": 100000,
-    "bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0": 200000,
     "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0": 200000,
-    "bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
-    "bedrock/eu.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/eu.anthropic.claude-sonnet-4-6-v1:0": 200000,
-    "bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
-    "bedrock/jp.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/jp.anthropic.claude-sonnet-4-6-v1:0": 200000,
-    "bedrock/apac.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/apac.anthropic.claude-sonnet-4-6-v1:0": 200000,
-    "bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
-    "bedrock/global.anthropic.claude-sonnet-4-6": 200000,
-    "bedrock/global.anthropic.claude-sonnet-4-6-v1:0": 200000,
-    "bedrock/us.anthropic.claude-sonnet-5": 1000000,
-    "bedrock/au.anthropic.claude-sonnet-5": 1000000,
-    "bedrock/eu.anthropic.claude-sonnet-5": 1000000,
-    "bedrock/jp.anthropic.claude-sonnet-5": 1000000,
-    "bedrock/global.anthropic.claude-sonnet-5": 1000000,
     'claude-3-5-sonnet': 100000,
+    # -- Non-Claude models -------------------------------------------------
     'bedrock/us.meta.llama4-scout-17b-instruct-v1:0': 128000,
     'bedrock/us.meta.llama4-maverick-17b-instruct-v1:0': 128000,
     "bedrock_mantle/xai.grok-4.3": 1000000,  # 1M context, but may be limited by config.max_model_tokens
@@ -331,7 +445,10 @@ MAX_TOKENS = {
     "codestral/codestral-2405": 8191,
     'xiaomi_mimo/mimo-v2.5': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5, xiaomi_mimo/ is the native LiteLLM Xiaomi provider, but may be limited by config.max_model_tokens
     'xiaomi_mimo/mimo-v2.5-pro': 1048576,  # 1M, matching the LiteLLM registry for mimo-v2.5-pro, but may be limited by config.max_model_tokens
+    # Provider-prefixed Claude model IDs generated from _CLAUDE_MODEL_FAMILIES
+    **_claude_tokens,
 }
+
 
 OPENROUTER_ROUTER_MODEL_ALIASES = {
     "openrouter/auto": "openrouter/openrouter/auto",
@@ -372,43 +489,9 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.2-codex",
     "gpt-5.3-codex",
     "gpt-5-mini",
-    # Anthropic Claude Opus 4-7 — temperature is deprecated (Issue #2400), (Issue #2449)
-    "claude-opus-4-7",
-    "anthropic/claude-opus-4-7",
-    "claude-opus-4-8",
-    "anthropic/claude-opus-4-8",
-    "vertex_ai/claude-opus-4-8",
-    "bedrock/anthropic.claude-opus-4-8",
-    "bedrock/global.anthropic.claude-opus-4-8",
-    "bedrock/us.anthropic.claude-opus-4-8",
-    "bedrock/eu.anthropic.claude-opus-4-8",
-    "bedrock/au.anthropic.claude-opus-4-8",
-    "bedrock/jp.anthropic.claude-opus-4-8",
-    "claude-opus-5",
-    "anthropic/claude-opus-5",
-    "vertex_ai/claude-opus-5",
-    "bedrock/anthropic.claude-opus-5",
-    "bedrock/global.anthropic.claude-opus-5",
-    "bedrock/us.anthropic.claude-opus-5",
-    "bedrock/eu.anthropic.claude-opus-5",
-    "bedrock/au.anthropic.claude-opus-5",
-    "bedrock/jp.anthropic.claude-opus-5",
-    "claude-fable-5",
-    "anthropic/claude-fable-5",
-    "claude-sonnet-5",
-    "anthropic/claude-sonnet-5",
-    "vertex_ai/claude-sonnet-5",
-    "bedrock/anthropic.claude-sonnet-5",
-    "bedrock/global.anthropic.claude-sonnet-5",
-    "bedrock/us.anthropic.claude-sonnet-5",
-    "bedrock/au.anthropic.claude-sonnet-5",
-    "bedrock/eu.anthropic.claude-sonnet-5",
-    "bedrock/jp.anthropic.claude-sonnet-5",
-    "vertex_ai/claude-opus-4-7",
-    "bedrock/anthropic.claude-opus-4-7",
-    "bedrock/anthropic.claude-opus-4-7-v1:0",
-    "bedrock/us.anthropic.claude-opus-4-7",
-    "bedrock/global.anthropic.claude-opus-4-7",
+    # Anthropic Claude -- temperature is deprecated (Issue #2400), (Issue #2449)
+    # Generated from _CLAUDE_MODEL_FAMILIES:
+    *_claude_no_temp,
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [
@@ -449,55 +532,9 @@ GROK_REASONING_EFFORT_LEVELS = {
 # without also adding an adaptive-thinking code path. This list is the built-in
 # default; it can be replaced via the `claude_extended_thinking_models_override`
 # configuration option.
-CLAUDE_EXTENDED_THINKING_MODELS = [
-    "anthropic/claude-3-7-sonnet-20250219",
-    "claude-3-7-sonnet-20250219",
-    "anthropic/claude-sonnet-4-6",
-    "claude-sonnet-4-6",
-    "vertex_ai/claude-sonnet-4-6",
-    "bedrock/anthropic.claude-sonnet-4-6",
-    "bedrock/us.anthropic.claude-sonnet-4-6",
-    "bedrock/au.anthropic.claude-sonnet-4-6",
-    "bedrock/eu.anthropic.claude-sonnet-4-6",
-    "bedrock/jp.anthropic.claude-sonnet-4-6",
-    "bedrock/global.anthropic.claude-sonnet-4-6",
-    "anthropic/claude-sonnet-4-5-20250929",
-    "claude-sonnet-4-5-20250929",
-    "vertex_ai/claude-sonnet-4-5@20250929",
-    "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "anthropic/claude-opus-4-5-20251101",
-    "claude-opus-4-5-20251101",
-    "vertex_ai/claude-opus-4-5@20251101",
-    "bedrock/anthropic.claude-opus-4-5-20251101-v1:0",
-    "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0",
-    "bedrock/au.anthropic.claude-opus-4-5-20251101-v1:0",
-    "bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0",
-    "bedrock/jp.anthropic.claude-opus-4-5-20251101-v1:0",
-    "bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0",
-    "anthropic/claude-opus-4-6",
-    "claude-opus-4-6",
-    "vertex_ai/claude-opus-4-6",
-    "bedrock/anthropic.claude-opus-4-6-v1:0",
-    "bedrock/us.anthropic.claude-opus-4-6-v1:0",
-    "bedrock/au.anthropic.claude-opus-4-6-v1:0",
-    "bedrock/eu.anthropic.claude-opus-4-6-v1:0",
-    "bedrock/jp.anthropic.claude-opus-4-6-v1:0",
-    "bedrock/global.anthropic.claude-opus-4-6-v1:0",
-    "anthropic/claude-haiku-4-5-20251001",
-    "claude-haiku-4-5-20251001",
-    "vertex_ai/claude-haiku-4-5@20251001",
-    "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
-    "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    "bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0",
-    "bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-    "bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0",
-    "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0",
-]
+#
+# Generated from _CLAUDE_MODEL_FAMILIES:
+CLAUDE_EXTENDED_THINKING_MODELS = list(_claude_extended_thinking)
 
 # Models that require streaming mode
 STREAMING_REQUIRED_MODELS = [

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -131,8 +131,12 @@ _ALLOWED_FAMILY_KEYS = {
     "no_temperature",
     "extended_thinking",
     "thinking_bedrock_regions",
-    "extra_no_temperature",
-    "extra_extended_thinking",
+}
+
+_ALLOWED_EXTRA_ALIAS_KEYS = {
+    "max_tokens",
+    "no_temperature",
+    "extended_thinking",
 }
 
 
@@ -143,6 +147,13 @@ def _validate_claude_model_family(fam: dict) -> None:
         raise ValueError(
             f"unknown Claude family key(s) for {fam.get('model_id')}: {sorted(unknown)}"
         )
+    for extra_alias, extra_val in fam.get("extra_aliases", {}).items():
+        if isinstance(extra_val, dict):
+            nested_unknown = set(extra_val) - _ALLOWED_EXTRA_ALIAS_KEYS
+            if nested_unknown:
+                raise ValueError(
+                    f"unknown Claude extra-alias key(s) for {fam.get('model_id')} / {extra_alias}: {sorted(nested_unknown)}"
+                )
 
 
 def _generate_claude_registries(families=None):
@@ -216,9 +227,6 @@ def _generate_claude_registries(families=None):
                 for extra in fam.get("extra_bedrock", ()):
                     claude_no_temp.append(f"bedrock/{extra}")
 
-        for extra_alias in fam.get("extra_no_temperature", ()):
-            claude_no_temp.append(extra_alias)
-
         # -- CLAUDE_EXTENDED_THINKING_MODELS ----------------------------------
         thinking = fam.get("extended_thinking")
         if thinking:
@@ -241,10 +249,8 @@ def _generate_claude_registries(families=None):
                     for reg in thinking_regions:
                         claude_extended_thinking.append(f"bedrock/{reg}.anthropic.{b_name}")
 
-        for extra_alias in fam.get("extra_extended_thinking", ()):
-            claude_extended_thinking.append(extra_alias)
-
     return claude_tokens, claude_no_temp, claude_extended_thinking
+
 
 
 _claude_tokens, _claude_no_temp, _claude_extended_thinking = (

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -699,15 +699,15 @@ class TestGetMaxTokens:
 
         Proves:
         - all current shipped families validate successfully.
-        - an unknown key (e.g. 'bedrock_region') raises ValueError.
-        - the error message identifies both the invalid key and the model_id.
+        - an unknown top-level key (e.g. 'bedrock_region') raises ValueError naming the key and model_id.
+        - an unknown nested extra_aliases key (e.g. 'extended_thinkin') raises ValueError naming the key, alias, and model_id.
         - global family definitions are not mutated.
         """
         # All current shipped families must pass validation
         for fam in _CLAUDE_MODEL_FAMILIES:
             _validate_claude_model_family(fam)
 
-        # Copied family with unknown key must raise ValueError
+        # 1. Copied family with unknown top-level key must raise ValueError
         bad_fam = dict(_CLAUDE_MODEL_FAMILIES[0])
         bad_fam["bedrock_region"] = ("global", "us")
 
@@ -718,11 +718,37 @@ class TestGetMaxTokens:
         assert "bedrock_region" in err_msg
         assert bad_fam["model_id"] in err_msg
 
-        # Generator must also reject the unknown key when expanding
+        # Generator must also reject the unknown top-level key when expanding
         with pytest.raises(ValueError) as exc_info_gen:
             _generate_claude_registries(families=[bad_fam])
         assert "bedrock_region" in str(exc_info_gen.value)
         assert bad_fam["model_id"] in str(exc_info_gen.value)
+
+        # 2. Family with unknown nested extra_aliases key must raise ValueError
+        bad_nested_fam = {
+            "model_id": "claude-opus-4-6",
+            "extra_aliases": {
+                "some/alias": {
+                    "max_tokens": 200000,
+                    "extended_thinkin": True,
+                }
+            },
+        }
+
+        with pytest.raises(ValueError) as exc_info_nested:
+            _validate_claude_model_family(bad_nested_fam)
+
+        err_nested = str(exc_info_nested.value)
+        assert "extended_thinkin" in err_nested
+        assert "some/alias" in err_nested
+        assert "claude-opus-4-6" in err_nested
+
+        # Generator must also reject the unknown nested key
+        with pytest.raises(ValueError) as exc_info_gen_nested:
+            _generate_claude_registries(families=[bad_nested_fam])
+        assert "extended_thinkin" in str(exc_info_gen_nested.value)
+        assert "some/alias" in str(exc_info_gen_nested.value)
+        assert "claude-opus-4-6" in str(exc_info_gen_nested.value)
 
         # Ensure global families list was not mutated
         assert "bedrock_region" not in _CLAUDE_MODEL_FAMILIES[0]
@@ -733,7 +759,7 @@ class TestGetMaxTokens:
         Proves:
         - scalar int extra_aliases only populate token counts.
         - structured extra_aliases route to no_temperature and extended_thinking when flagged.
-        - explicit extra_no_temperature and extra_extended_thinking populate capabilities.
+        - capability flags do not bleed to unrelated aliases.
         """
         synthetic_family = {
             "model_id": "test-claude-synthetic",
@@ -751,8 +777,6 @@ class TestGetMaxTokens:
                     "extended_thinking": True,
                 },
             },
-            "extra_no_temperature": ("test/explicit-extra-no-temp",),
-            "extra_extended_thinking": ("test/explicit-extra-thinking",),
         }
 
         tokens, no_temp, thinking = _generate_claude_registries(families=[synthetic_family])
@@ -764,15 +788,13 @@ class TestGetMaxTokens:
         assert tokens["test/extra-no-temp"] == 500000
         assert tokens["test/extra-thinking"] == 500000
 
-        # No-temperature capability routing
+        # No-temperature capability routing (no bleed)
         assert "test/extra-no-temp" in no_temp
-        assert "test/explicit-extra-no-temp" in no_temp
         assert "test/extra-token-only" not in no_temp
         assert "test/extra-thinking" not in no_temp
 
-        # Extended-thinking capability routing
+        # Extended-thinking capability routing (no bleed)
         assert "test/extra-thinking" in thinking
-        assert "test/explicit-extra-thinking" in thinking
         assert "test/extra-token-only" not in thinking
         assert "test/extra-no-temp" not in thinking
 

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -2,6 +2,7 @@ import litellm
 import pytest
 
 import pr_agent.algo.utils as utils
+from pr_agent.algo import CLAUDE_EXTENDED_THINKING_MODELS, NO_SUPPORT_TEMPERATURE_MODELS
 from pr_agent.algo.utils import MAX_TOKENS, get_max_tokens
 
 
@@ -602,3 +603,87 @@ class TestGetMaxTokens:
         monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
 
         assert get_max_tokens(model) == expected_max_input_tokens
+
+    def test_claude_opus_4_8_family_expansion_and_capabilities(self):
+        """Independent verification of Opus 4.8 generated aliases and capabilities."""
+        expected_aliases = {
+            "claude-opus-4-8",
+            "anthropic/claude-opus-4-8",
+            "vertex_ai/claude-opus-4-8",
+            "bedrock/anthropic.claude-opus-4-8",
+            "bedrock/global.anthropic.claude-opus-4-8",
+            "bedrock/us.anthropic.claude-opus-4-8",
+            "bedrock/eu.anthropic.claude-opus-4-8",
+            "bedrock/au.anthropic.claude-opus-4-8",
+            "bedrock/jp.anthropic.claude-opus-4-8",
+        }
+
+        # Exact set equality against filtered MAX_TOKENS
+        actual_aliases = {k for k in MAX_TOKENS if "claude-opus-4-8" in k}
+        assert actual_aliases == expected_aliases
+
+        # Context window tokens
+        for alias in expected_aliases:
+            assert MAX_TOKENS[alias] == 1000000
+
+        # Capability lists
+        for alias in expected_aliases:
+            assert alias in NO_SUPPORT_TEMPERATURE_MODELS
+            assert alias not in CLAUDE_EXTENDED_THINKING_MODELS
+
+        # Negative checks to ensure no over-generation
+        assert "bedrock/apac.anthropic.claude-opus-4-8" not in MAX_TOKENS
+        assert "bedrock/apac.anthropic.claude-opus-4-8" not in NO_SUPPORT_TEMPERATURE_MODELS
+
+    def test_claude_opus_4_6_family_expansion_and_capabilities(self):
+        """Independent verification of Opus 4.6 generated aliases and capabilities."""
+        expected_max_tokens_aliases = {
+            "claude-opus-4-6",
+            "anthropic/claude-opus-4-6",
+            "vertex_ai/claude-opus-4-6",
+            "bedrock/anthropic.claude-opus-4-6-v1:0",
+            "bedrock/global.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/eu.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/au.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/jp.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/apac.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/us.anthropic.claude-opus-4-6-v1:0",
+            "claude-opus-4-6-20260120",
+            "anthropic/claude-opus-4-6-20260120",
+            "vertex_ai/claude-opus-4-6@20260120",
+            "bedrock/anthropic.claude-opus-4-6-20260120-v1:0",
+            "bedrock/us.anthropic.claude-opus-4-6-20260120-v1:0",
+        }
+
+        # Exact set equality against filtered MAX_TOKENS
+        actual_aliases = {k for k in MAX_TOKENS if "claude-opus-4-6" in k}
+        assert actual_aliases == expected_max_tokens_aliases
+
+        # Context window tokens
+        for alias in expected_max_tokens_aliases:
+            assert MAX_TOKENS[alias] == 200000
+
+        # Extended thinking: 9 aliases
+        expected_thinking_aliases = {
+            "anthropic/claude-opus-4-6",
+            "claude-opus-4-6",
+            "vertex_ai/claude-opus-4-6",
+            "bedrock/anthropic.claude-opus-4-6-v1:0",
+            "bedrock/us.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/au.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/eu.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/jp.anthropic.claude-opus-4-6-v1:0",
+            "bedrock/global.anthropic.claude-opus-4-6-v1:0",
+        }
+        actual_thinking_aliases = {k for k in CLAUDE_EXTENDED_THINKING_MODELS if "claude-opus-4-6" in k}
+        assert actual_thinking_aliases == expected_thinking_aliases
+
+        # Negative checks: apac and dated variants NOT in extended thinking
+        assert "bedrock/apac.anthropic.claude-opus-4-6-v1:0" not in CLAUDE_EXTENDED_THINKING_MODELS
+        assert "claude-opus-4-6-20260120" not in CLAUDE_EXTENDED_THINKING_MODELS
+        assert "anthropic/claude-opus-4-6-20260120" not in CLAUDE_EXTENDED_THINKING_MODELS
+        assert "vertex_ai/claude-opus-4-6@20260120" not in CLAUDE_EXTENDED_THINKING_MODELS
+
+        # Negative checks: no Opus 4.6 in NO_SUPPORT_TEMPERATURE_MODELS
+        for alias in expected_max_tokens_aliases:
+            assert alias not in NO_SUPPORT_TEMPERATURE_MODELS

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -2,7 +2,13 @@ import litellm
 import pytest
 
 import pr_agent.algo.utils as utils
-from pr_agent.algo import CLAUDE_EXTENDED_THINKING_MODELS, NO_SUPPORT_TEMPERATURE_MODELS
+from pr_agent.algo import (
+    _CLAUDE_MODEL_FAMILIES,
+    CLAUDE_EXTENDED_THINKING_MODELS,
+    NO_SUPPORT_TEMPERATURE_MODELS,
+    _generate_claude_registries,
+    _validate_claude_model_family,
+)
 from pr_agent.algo.utils import MAX_TOKENS, get_max_tokens
 
 
@@ -687,3 +693,96 @@ class TestGetMaxTokens:
         # Negative checks: no Opus 4.6 in NO_SUPPORT_TEMPERATURE_MODELS
         for alias in expected_max_tokens_aliases:
             assert alias not in NO_SUPPORT_TEMPERATURE_MODELS
+
+    def test_claude_model_family_metadata_key_validation(self):
+        """Regression test for validating Claude model family metadata keys.
+
+        Proves:
+        - all current shipped families validate successfully.
+        - an unknown key (e.g. 'bedrock_region') raises ValueError.
+        - the error message identifies both the invalid key and the model_id.
+        - global family definitions are not mutated.
+        """
+        # All current shipped families must pass validation
+        for fam in _CLAUDE_MODEL_FAMILIES:
+            _validate_claude_model_family(fam)
+
+        # Copied family with unknown key must raise ValueError
+        bad_fam = dict(_CLAUDE_MODEL_FAMILIES[0])
+        bad_fam["bedrock_region"] = ("global", "us")
+
+        with pytest.raises(ValueError) as exc_info:
+            _validate_claude_model_family(bad_fam)
+
+        err_msg = str(exc_info.value)
+        assert "bedrock_region" in err_msg
+        assert bad_fam["model_id"] in err_msg
+
+        # Generator must also reject the unknown key when expanding
+        with pytest.raises(ValueError) as exc_info_gen:
+            _generate_claude_registries(families=[bad_fam])
+        assert "bedrock_region" in str(exc_info_gen.value)
+        assert bad_fam["model_id"] in str(exc_info_gen.value)
+
+        # Ensure global families list was not mutated
+        assert "bedrock_region" not in _CLAUDE_MODEL_FAMILIES[0]
+
+    def test_claude_exceptional_extra_alias_capabilities(self):
+        """Prove exceptional extra-alias capability routing.
+
+        Proves:
+        - scalar int extra_aliases only populate token counts.
+        - structured extra_aliases route to no_temperature and extended_thinking when flagged.
+        - explicit extra_no_temperature and extra_extended_thinking populate capabilities.
+        """
+        synthetic_family = {
+            "model_id": "test-claude-synthetic",
+            "max_tokens": 500000,
+            "bedrock": False,
+            "vertex": False,
+            "extra_aliases": {
+                "test/extra-token-only": 500000,
+                "test/extra-no-temp": {
+                    "max_tokens": 500000,
+                    "no_temperature": True,
+                },
+                "test/extra-thinking": {
+                    "max_tokens": 500000,
+                    "extended_thinking": True,
+                },
+            },
+            "extra_no_temperature": ("test/explicit-extra-no-temp",),
+            "extra_extended_thinking": ("test/explicit-extra-thinking",),
+        }
+
+        tokens, no_temp, thinking = _generate_claude_registries(families=[synthetic_family])
+
+        # Token verification
+        assert tokens["test-claude-synthetic"] == 500000
+        assert tokens["anthropic/test-claude-synthetic"] == 500000
+        assert tokens["test/extra-token-only"] == 500000
+        assert tokens["test/extra-no-temp"] == 500000
+        assert tokens["test/extra-thinking"] == 500000
+
+        # No-temperature capability routing
+        assert "test/extra-no-temp" in no_temp
+        assert "test/explicit-extra-no-temp" in no_temp
+        assert "test/extra-token-only" not in no_temp
+        assert "test/extra-thinking" not in no_temp
+
+        # Extended-thinking capability routing
+        assert "test/extra-thinking" in thinking
+        assert "test/explicit-extra-thinking" in thinking
+        assert "test/extra-token-only" not in thinking
+        assert "test/extra-no-temp" not in thinking
+
+    def test_claude_registries_baseline_parity_and_no_duplicates(self):
+        """Verify baseline capability parity and that no duplicate entries exist."""
+        # Capability lists have no duplicates
+        assert len(NO_SUPPORT_TEMPERATURE_MODELS) == len(set(NO_SUPPORT_TEMPERATURE_MODELS))
+        assert len(CLAUDE_EXTENDED_THINKING_MODELS) == len(set(CLAUDE_EXTENDED_THINKING_MODELS))
+
+        # Extended thinking and no-temperature for Claude models are disjoint
+        claude_thinking = {m for m in CLAUDE_EXTENDED_THINKING_MODELS if "claude" in m}
+        claude_no_temp = {m for m in NO_SUPPORT_TEMPERATURE_MODELS if "claude" in m}
+        assert claude_thinking.isdisjoint(claude_no_temp)


### PR DESCRIPTION
## Summary

Refactors the Claude model registries to generate provider-prefixed model IDs from a canonical `_CLAUDE_MODEL_FAMILIES` definition instead of maintaining the same aliases by hand across multiple registries.

The existing public `MAX_TOKENS`, `NO_SUPPORT_TEMPERATURE_MODELS`, and `CLAUDE_EXTENDED_THINKING_MODELS` interfaces are preserved.

### What changed

- Added a canonical definition for modern Claude model families.
- Generate bare, Anthropic, Vertex AI, and Bedrock aliases programmatically.
- Preserve provider-specific version and region differences where required.
- Generate no-temperature and extended-thinking capability membership from the same family metadata.
- Keep historical/one-off Claude IDs as static entries where appropriate.
- Added independent regression coverage for Claude Opus 4.6 and 4.8 so the generator is not its own test oracle.
- Updated the contributor documentation for adding Claude models.
- No runtime model-name normalization or `LiteLLMAIHandler` matching behavior was changed.

## Testing

Focused model/handler tests:

- `tests/unittest/test_get_max_tokens.py` — 114 passed
- `tests/unittest/test_litellm_reasoning_effort.py` — 37 passed
- `tests/unittest/test_litellm_chat_completion_core.py` — 75 passed
- `tests/unittest/test_litellm_claude_adaptive_thinking.py` — 18 passed

Total: **244 passed, 0 failed**

Additional checks:

- `ruff check` — passed
- `pre-commit` — passed
- `git diff --check` — clean
- Public registry mappings/capability membership verified against the pre-refactor baseline.

The full unit suite on Windows still contains unrelated platform-specific failures involving line endings, encoding, and home-directory path behavior; none are in the changed or related model-registry tests. Linux CI will provide the repository-level validation.

Closes #2958