### PR TITLE
fix(pr_agent/algo/utils.py): trust only pr-agent's own pyproject.toml for the version

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1941,7 +1941,7 @@ def get_version() -> str:
             try:
                 with open("pyproject.toml", "rb") as f:
                     data = tomllib.load(f)
-            except (OSError, tomllib.TOMLDecodeError) as e:
+            except (OSError, ValueError) as e:  # tomllib raises TOMLDecodeError, or UnicodeDecodeError on non-UTF-8
                 get_logger().warning(f"Unable to read pyproject.toml, falling back to package metadata: {e}")
             else:
                 # only trust this file when it is pr-agent's own pyproject.toml, otherwise an

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1934,15 +1934,22 @@ def process_description(description_full: str) -> Tuple[str, List]:
     return base_description_str, files
 
 def get_version() -> str:
-    # First check pyproject.toml if running directly out of repository
+    # First check pyproject.toml if running directly out of the pr-agent repository
     if os.path.exists("pyproject.toml"):
         if sys.version_info >= (3, 11):
             import tomllib
-            with open("pyproject.toml", "rb") as f:
-                data = tomllib.load(f)
-                if "project" in data and "version" in data["project"]:
-                    return data["project"]["version"]
-                else:
+            try:
+                with open("pyproject.toml", "rb") as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                get_logger().warning(f"Unable to read pyproject.toml, falling back to package metadata: {e}")
+            else:
+                # only trust this file when it is pr-agent's own pyproject.toml, otherwise an
+                # unrelated project in the current working directory would dictate our version
+                project = data.get("project", {})
+                if project.get("name") == "pr-agent":
+                    if "version" in project:
+                        return project["version"]
                     get_logger().warning("Version not found in pyproject.toml")
         else:
             get_logger().warning("Unable to determine local version from pyproject.toml")

--- a/tests/unittest/test_get_version.py
+++ b/tests/unittest/test_get_version.py
@@ -1,0 +1,79 @@
+"""get_version() must not trust a pyproject.toml that belongs to a different project."""
+import pytest
+
+from pr_agent.algo import utils
+from pr_agent.algo.utils import get_version
+
+INSTALLED_VERSION = "9.44.0-from-package-metadata"
+
+
+@pytest.fixture
+def installed_version(monkeypatch):
+    """Make the package-metadata fallback return a recognizable sentinel."""
+    monkeypatch.setattr(utils, "version", lambda name: INSTALLED_VERSION)
+    return INSTALLED_VERSION
+
+
+def write_pyproject(directory, content, encoding="utf-8"):
+    (directory / "pyproject.toml").write_text(content, encoding=encoding)
+
+
+def test_no_pyproject_in_cwd_uses_the_installed_version(tmp_path, monkeypatch, installed_version):
+    monkeypatch.chdir(tmp_path)
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_an_unrelated_pyproject_does_not_dictate_our_version(tmp_path, monkeypatch, installed_version):
+    """Running from any project directory must not report that project's version."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "totally-unrelated"\nversion = "9.9.9"\n')
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_a_uv_init_scaffold_does_not_dictate_our_version(tmp_path, monkeypatch, installed_version):
+    """`uv init` scaffolds version = "0.1.0", the value seen in the wild."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "my-app"\nversion = "0.1.0"\n')
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_the_pr_agent_pyproject_supplies_the_repo_version(tmp_path, monkeypatch, installed_version):
+    """Running out of the pr-agent repository still reports the checkout's version."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "pr-agent"\nversion = "1.2.3"\n')
+
+    assert get_version() == "1.2.3"
+
+
+def test_an_unparseable_pyproject_falls_back_instead_of_raising(tmp_path, monkeypatch, installed_version):
+    """A malformed file in the cwd must not take down every pr-agent command."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, "this is not valid toml at all\n")
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_a_pyproject_with_a_utf8_bom_falls_back_instead_of_raising(tmp_path, monkeypatch, installed_version):
+    """tomllib rejects a BOM, which Windows editors and PowerShell write by default."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "pr-agent"\nversion = "1.2.3"\n', encoding="utf-8-sig")
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_a_pyproject_without_a_project_table_falls_back(tmp_path, monkeypatch, installed_version):
+    """Poetry-style files have no [project] table."""
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[tool.poetry]\nname = "legacy"\nversion = "2.2.2"\n')
+
+    assert get_version() == INSTALLED_VERSION
+
+
+def test_our_pyproject_without_a_version_falls_back(tmp_path, monkeypatch, installed_version):
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "pr-agent"\n')
+
+    assert get_version() == INSTALLED_VERSION

--- a/tests/unittest/test_get_version.py
+++ b/tests/unittest/test_get_version.py
@@ -64,6 +64,17 @@ def test_a_pyproject_with_a_utf8_bom_falls_back_instead_of_raising(tmp_path, mon
     assert get_version() == INSTALLED_VERSION
 
 
+def test_a_non_utf8_pyproject_falls_back_instead_of_raising(tmp_path, monkeypatch, installed_version):
+    """tomllib decodes the bytes itself, so a cp1252 file raises UnicodeDecodeError before any parsing.
+
+    UnicodeDecodeError is a sibling of TOMLDecodeError under ValueError, not a subclass.
+    """
+    monkeypatch.chdir(tmp_path)
+    write_pyproject(tmp_path, '[project]\nname = "café-app"\nversion = "7.7.7"\n', encoding="cp1252")
+
+    assert get_version() == INSTALLED_VERSION
+
+
 def test_a_pyproject_without_a_project_table_falls_back(tmp_path, monkeypatch, installed_version):
     """Poetry-style files have no [project] table."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Closes #3005

## What

`get_version()` probed for `pyproject.toml` with a **relative** path, so it resolved against the process's current working directory rather than the installed package, and returned that file's `[project].version` without ever checking the file belonged to pr-agent.

Two failure modes followed:

1. **Wrong version reported.** Running from any project directory reported *that* project's version as pr-agent's.
2. **Every command crashed.** An unparseable `pyproject.toml` in the cwd — a UTF-8 BOM is enough — raised `tomllib.TOMLDecodeError` out of `get_version()`. Because the `--version` help string is an f-string evaluated eagerly while `set_parser()` builds the parser, and `run()` builds the parser on every invocation, this broke `--help` and every real command, not just `--version`.

Failure mode 2 is the more serious one: pr-agent becomes unusable in that directory, and the traceback gives no hint that a stray file in the cwd is responsible. Users of `CONFIG__GIT_PROVIDER=local` are the most exposed, since the local provider is by design invoked from inside the user's own repository.

## Change

- Verify `[project].name == "pr-agent"` before trusting the file, so an unrelated project in the cwd can no longer dictate our version.
- Wrap the read in `try/except (OSError, tomllib.TOMLDecodeError)` and fall back to installed package metadata instead of propagating.

Deliberately **no** warning is added for the missing-`pyproject.toml` case — that is the normal installed-package path, and the warning-noise objection that closed #1408 applies to it. The one warning added here fires only when a `pyproject.toml` is present but cannot be parsed, which is a genuine anomaly worth surfacing.

## Behaviour

| cwd contains | before | after |
|---|---|---|
| *nothing* | installed version ✅ | installed version ✅ |
| pr-agent's own `pyproject.toml` | repo version ✅ | repo version ✅ |
| `[project]` `name = "my-app"`, `version = "0.1.0"` | `0.1.0` ❌ | installed version ✅ |
| `[project]` `name = "totally-unrelated"`, `version = "9.9.9"` | `9.9.9` ❌ | installed version ✅ |
| `[tool.poetry]` only, no `[project]` | installed version ✅ | installed version ✅ |
| `pyproject.toml` with a UTF-8 BOM | 💥 crash, exit 1 | installed version + warning ✅ |
| malformed TOML | 💥 crash, exit 1 | installed version + warning ✅ |

## Tests

New `tests/unittest/test_get_version.py`, 8 cases covering the matrix above. Written before the fix: 4 failed against the unpatched function — two on the name check (`assert '0.1.0' == ...`, `assert '9.9.9' == ...`) and two with `TOMLDecodeError` — and the other 4 passed from the start as regression guards on behaviour this change preserves.

The `installed_version` fixture patches `pr_agent.algo.utils.version` to a sentinel so the tests distinguish "read from the cwd's pyproject" from "fell through to package metadata"; an end-to-end run cannot, because an editable install makes both paths yield the same number.

`get_version()` previously had no test coverage.

## Verification

- `PYTHONPATH=. uv run pytest tests/unittest/test_get_version.py -q` → 8 passed.
- Full suite run on a clean tree and with the patch, comparing failure sets: **no new failures**, and exactly the 4 red tests turned green. The remaining failures are pre-existing and unrelated (Windows CRLF and `charmap` decoding, tilde expansion, flaky litellm callback timing) and fail identically with this change stashed.
- `uv run pre-commit run --files pr_agent/algo/utils.py tests/unittest/test_get_version.py` → all hooks pass, ruff included.
- Manual end-to-end against an installed `uv tool install pr-agent`: scaffold, unrelated and BOM directories all report the correct version, the pr-agent checkout still reports its own, and the CLI parser builds from the BOM directory without crashing.

## Notes

The defect was raised during review of #1384, the PR that introduced `get_version()` — "The pyproject.toml path is checked relative to current directory. This might fail if the script is run from a different directory. Consider using absolute path resolution." — but was not addressed before merge.

Beyond `--version`, `get_version()` also feeds the Langfuse observability tags in `litellm_ai_handler.py:587`/`:596` and the payload in `mosaico/card.py:91`, so the wrong-version case silently corrupted version attribution in telemetry for any CLI run started from a Python project directory.