### PR TITLE
feat(github): trigger commands after submitted reviews

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -659,6 +659,7 @@ Allowing you to automate the review process on your private or public repositori
    - Set the following events:
      - Issue comment
      - Pull request
+     - Pull request review
      - Push (if you need to enable triggering on PR update)
      - Pull request review comment (required for `/ask` on review threads)
 

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -207,17 +207,18 @@ Adding `"synchronize"` to this list enables auto tools on new commits pushed to 
 
 #### Automatic tools after a submitted GitHub review
 
-The GitHub App can run configured tools after a human reviewer submits a native GitHub review. This is opt-in: `review_commands` is empty by default. By default, only reviews submitted with the `changes_requested` state trigger the commands; set `review_states` to `approved`, `commented`, or any combination of these supported GitHub review states when a different workflow is needed.
+The GitHub App can run configured tools after a human reviewer submits a native GitHub review. This is opt-in: `review_commands` is empty by default. By default, only reviews submitted with the `changes_requested` state by a `User` review author trigger the commands. This conservative default avoids running on the repository's high-volume `commented` reviews; set `review_states` or `review_author_types` explicitly when a different workflow is needed.
 
 ```toml
 [github_app]
 review_states = ["changes_requested"]
+review_author_types = ["User"]
 review_commands = [
     "/improve",
 ]
 ```
 
-The event must be `submitted`; edited or dismissed reviews do not trigger tools. Existing repository filtering, draft-PR handling, eligibility checks, and `config.disable_auto_feedback` still apply. The review text is not treated as a command; each configured command runs with the normal pull-request context.
+The event must be `submitted`; edited or dismissed reviews do not trigger tools. The review author's `user.type` must match `review_author_types`, which defaults to `User` and prevents bot reviews from triggering commands. Existing repository filtering, draft-PR handling, eligibility checks, and `config.disable_auto_feedback` still apply. The review text is not treated as a command; each configured command runs with the normal pull-request context.
 
 For GitHub Action, add the review event to the workflow and configure the equivalent settings. `github_action_config.*` overrides the corresponding `github_app.*` setting when present.
 
@@ -228,6 +229,7 @@ on:
 
 env:
   github_action_config.review_states: '["changes_requested"]'
+  github_action_config.review_author_types: '["User"]'
   github_action_config.review_commands: '["/improve"]'
 ```
 

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -205,6 +205,32 @@ Adding `"synchronize"` to this list enables auto tools on new commits pushed to 
 
 `github_action_config.push_trigger_ignore_bot_commits` (default `true`) skips processing when the push author is a bot, avoiding redundant runs on automated commits.
 
+#### Automatic tools after a submitted GitHub review
+
+The GitHub App can run configured tools after a human reviewer submits a native GitHub review. This is opt-in: `review_commands` is empty by default. By default, only reviews submitted with the `changes_requested` state trigger the commands; set `review_states` to `approved`, `commented`, or any combination of these supported GitHub review states when a different workflow is needed.
+
+```toml
+[github_app]
+review_states = ["changes_requested"]
+review_commands = [
+    "/improve",
+]
+```
+
+The event must be `submitted`; edited or dismissed reviews do not trigger tools. Existing repository filtering, draft-PR handling, eligibility checks, and `config.disable_auto_feedback` still apply. The review text is not treated as a command; each configured command runs with the normal pull-request context.
+
+For GitHub Action, add the review event to the workflow and configure the equivalent settings. `github_action_config.*` overrides the corresponding `github_app.*` setting when present.
+
+```yaml
+on:
+  pull_request_review:
+    types: [submitted]
+
+env:
+  github_action_config.review_states: '["changes_requested"]'
+  github_action_config.review_commands: '["/improve"]'
+```
+
 `github_action_config.enable_output` are used to enable/disable github actions [output parameter](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions) (default is `true`).
 Review result is output as JSON to `steps.{step-id}.outputs.review` property.
 The JSON structure is equivalent to the yaml data structure defined in [pr_reviewer_prompts.toml](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml).

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -119,6 +119,23 @@ async def _run_review_commands(event_payload):
     review = event_payload.get("review", {})
     review_state = review.get("state", "") if isinstance(review, dict) else ""
     review_state = str(review_state).strip().lower()
+    review_author_type = ""
+    if isinstance(review, dict):
+        review_author = review.get("user", {})
+        if isinstance(review_author, dict):
+            review_author_type = str(review_author.get("type", "")).strip().lower()
+    review_author_types = get_list_setting_or_env(
+        "GITHUB_ACTION_CONFIG.REVIEW_AUTHOR_TYPES",
+        get_settings().get("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"]),
+    )
+    review_author_types = {
+        str(author_type).strip().lower() for author_type in review_author_types if str(author_type).strip()
+    }
+    if review_author_type not in review_author_types:
+        get_logger().info(
+            f"Skipping pull_request_review from {review_author_type=}: author type is not configured"
+        )
+        return
     review_states = get_list_setting_or_env(
         "GITHUB_ACTION_CONFIG.REVIEW_STATES",
         get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]),

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -35,6 +35,25 @@ def get_setting_or_env(key: str, default: Union[str, bool] = None) -> Union[str,
     return value
 
 
+def get_list_setting_or_env(key, fallback=None):
+    value = get_setting_or_env(key, None)
+    if value is None:
+        value = fallback
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
 def _inject_artifact_context():
     """Inject CI artifact content into extra_instructions for configured tools."""
     artifact_path_env = (
@@ -80,6 +99,63 @@ def _inject_artifact_context():
         get_logger().info(f"Injected artifact context into tools: {target_tools}")
     except (OSError, ValueError, TypeError) as e:
         get_logger().warning(f"github action: failed to process artifacts: {e}", exc_info=True)
+
+
+async def _run_review_commands(event_payload):
+    action = event_payload.get("action")
+    if action != "submitted":
+        get_logger().info(f"Skipping pull_request_review action: {action}")
+        return
+    if event_payload.get("sender", {}).get("type") == "Bot":
+        get_logger().info("Skipping pull_request_review event from a bot sender")
+        return
+
+    pull_request = event_payload.get("pull_request", {})
+    pr_url = pull_request.get("url")
+    if not pr_url:
+        get_logger().info("Skipping pull_request_review: pull_request.url is missing")
+        return
+
+    review = event_payload.get("review", {})
+    review_state = review.get("state", "") if isinstance(review, dict) else ""
+    review_state = str(review_state).strip().lower()
+    review_states = get_list_setting_or_env(
+        "GITHUB_ACTION_CONFIG.REVIEW_STATES",
+        get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]),
+    )
+    review_states = {str(state).strip().lower() for state in review_states if str(state).strip()}
+    if review_state not in review_states:
+        get_logger().info(f"Skipping pull_request_review with {review_state=}: state is not configured")
+        return
+
+    review_commands = get_list_setting_or_env(
+        "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS",
+        get_settings().get("GITHUB_APP.REVIEW_COMMANDS", []),
+    )
+    if not review_commands:
+        get_logger().info("No review_commands configured, skipping pull_request_review")
+        return
+
+    feedback_on_draft = get_setting_or_env("GITHUB_ACTION_CONFIG.FEEDBACK_ON_DRAFT_PR", None)
+    if feedback_on_draft is None:
+        feedback_on_draft = get_settings().get("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", False)
+    if pull_request.get("draft", True) and not is_true(feedback_on_draft):
+        get_logger().info(f"Skipping draft PR for pull_request_review: {pr_url=}")
+        return
+
+    disable_auto_feedback = get_setting_or_env("CONFIG.DISABLE_AUTO_FEEDBACK", None)
+    if disable_auto_feedback is None:
+        disable_auto_feedback = get_settings().get("CONFIG.DISABLE_AUTO_FEEDBACK", False)
+    if is_true(disable_auto_feedback):
+        get_logger().info(f"Auto feedback is disabled, skipping pull_request_review: {pr_url=}")
+        return
+
+    _inject_artifact_context()
+    get_settings().config.is_auto_command = True
+    get_settings().pr_description.final_update_message = False
+    get_logger().info(f"Running review commands: {review_commands}")
+    for command in review_commands:
+        await PRAgent().handle_request(pr_url, command)
 
 
 async def run_action():
@@ -242,6 +318,10 @@ async def run_action():
                     await PRCodeSuggestions(pr_url).run()
         else:
             get_logger().info(f"Skipping action: {action}")
+
+    # Handle submitted pull request review event
+    elif GITHUB_EVENT_NAME == "pull_request_review":
+        await _run_review_commands(event_payload)
 
     # Handle issue comment event
     elif GITHUB_EVENT_NAME == "issue_comment" or GITHUB_EVENT_NAME == "pull_request_review_comment":

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -13,7 +13,7 @@ from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import get_logger
-from pr_agent.servers.github_app import handle_line_comments
+from pr_agent.servers.github_app import handle_line_comments, matches_review_state
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -118,7 +118,6 @@ async def _run_review_commands(event_payload):
 
     review = event_payload.get("review", {})
     review_state = review.get("state", "") if isinstance(review, dict) else ""
-    review_state = str(review_state).strip().lower()
     review_author_type = ""
     if isinstance(review, dict):
         review_author = review.get("user", {})
@@ -140,8 +139,7 @@ async def _run_review_commands(event_payload):
         "GITHUB_ACTION_CONFIG.REVIEW_STATES",
         get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]),
     )
-    review_states = {str(state).strip().lower() for state in review_states if str(state).strip()}
-    if review_state not in review_states:
+    if not matches_review_state(review_state, review_states):
         get_logger().info(f"Skipping pull_request_review with {review_state=}: state is not configured")
         return
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -171,6 +171,20 @@ def _normalise_setting_list(value):
     return [value]
 
 
+def matches_review_state(review_state: Any, configured_states: Any) -> bool:
+    """Return whether a review state matches one of the configured states."""
+    if not isinstance(review_state, str) or not review_state.strip():
+        return False
+    configured_states = _normalise_setting_list(configured_states)
+    if not configured_states:
+        return False
+    normalized_state = review_state.strip().lower()
+    return any(
+        isinstance(state, str) and state.strip().lower() == normalized_state
+        for state in configured_states
+    )
+
+
 async def handle_pull_request_review_submitted(body: Dict[str, Any],
                                                event: str,
                                                sender: str,
@@ -190,7 +204,6 @@ async def handle_pull_request_review_submitted(body: Dict[str, Any],
     apply_repo_settings(api_url)
     review = body.get("review", {})
     review_state = review.get("state", "") if isinstance(review, dict) else ""
-    review_state = str(review_state).strip().lower()
     review_author_type = ""
     if isinstance(review, dict):
         review_author = review.get("user", {})
@@ -208,12 +221,9 @@ async def handle_pull_request_review_submitted(body: Dict[str, Any],
             f"Skipping review submission from {review_author_type=}: author type is not configured"
         )
         return {}
-    review_states = {
-        str(state).strip().lower()
-        for state in _normalise_setting_list(get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]))
-        if str(state).strip()
-    }
-    if review_state not in review_states:
+    if not matches_review_state(
+        review_state, get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    ):
         get_logger().info(f"Skipping review submission with {review_state=}: state is not configured")
         return {}
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -191,6 +191,23 @@ async def handle_pull_request_review_submitted(body: Dict[str, Any],
     review = body.get("review", {})
     review_state = review.get("state", "") if isinstance(review, dict) else ""
     review_state = str(review_state).strip().lower()
+    review_author_type = ""
+    if isinstance(review, dict):
+        review_author = review.get("user", {})
+        if isinstance(review_author, dict):
+            review_author_type = str(review_author.get("type", "")).strip().lower()
+    review_author_types = {
+        str(author_type).strip().lower()
+        for author_type in _normalise_setting_list(
+            get_settings().get("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
+        )
+        if str(author_type).strip()
+    }
+    if review_author_type not in review_author_types:
+        get_logger().info(
+            f"Skipping review submission from {review_author_type=}: author type is not configured"
+        )
+        return {}
     review_states = {
         str(state).strip().lower()
         for state in _normalise_setting_list(get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]))

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -160,6 +160,52 @@ async def handle_new_pr_opened(body: Dict[str, Any],
         else:
             get_logger().info(f"User {sender=} is not eligible to process PR {api_url=}")
 
+
+def _normalise_setting_list(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+async def handle_pull_request_review_submitted(body: Dict[str, Any],
+                                               event: str,
+                                               sender: str,
+                                               sender_id: str,
+                                               sender_type: str,
+                                               action: str,
+                                               log_context: Dict[str, Any],
+                                               agent: PRAgent):
+    pull_request, api_url = _check_pull_request_event(action, body, log_context)
+    if not (pull_request and api_url):
+        get_logger().info(f"Invalid PR review event: {action=} {api_url=}")
+        return {}
+    if sender_type == "Bot":
+        get_logger().info(f"Skipping pull_request_review from bot sender: {sender=}")
+        return {}
+
+    apply_repo_settings(api_url)
+    review = body.get("review", {})
+    review_state = review.get("state", "") if isinstance(review, dict) else ""
+    review_state = str(review_state).strip().lower()
+    review_states = {
+        str(state).strip().lower()
+        for state in _normalise_setting_list(get_settings().get("GITHUB_APP.REVIEW_STATES", ["changes_requested"]))
+        if str(state).strip()
+    }
+    if review_state not in review_states:
+        get_logger().info(f"Skipping review submission with {review_state=}: state is not configured")
+        return {}
+
+    if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
+        await _perform_auto_commands_github("review_commands", agent, body, api_url, log_context)
+    else:
+        get_logger().info(f"User {sender=} is not eligible to process review on PR {api_url=}")
+
+
 async def handle_push_trigger_for_new_commits(body: Dict[str, Any],
                         event: str,
                         sender: str,
@@ -355,6 +401,12 @@ async def handle_request(body: Dict[str, Any], event: str):
     if 'check_run' in body:  # handle failed checks
         # get_logger().debug(f'Request body', artifact=body, event=event) # added inside handle_checks
         pass
+    # handle submitted pull request reviews
+    elif event == 'pull_request_review' and action == 'submitted':
+        get_logger().debug('Request body', artifact=body, event=event)
+        await handle_pull_request_review_submitted(
+            body, event, sender, sender_id, sender_type, action, log_context, agent
+        )
     # handle comments on PRs
     elif action == 'created':
         get_logger().debug('Request body', artifact=body, event=event)
@@ -436,14 +488,15 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
     if is_draft and not feedback_on_draft:
         get_logger().info(f"Skipping draft PR {api_url=}")
         return
-    if commands_conf == "pr_commands" and get_settings().config.disable_auto_feedback:  # auto commands for PR, and auto feedback is disabled
+    if commands_conf in ("pr_commands", "review_commands") and get_settings().config.disable_auto_feedback:
+        # auto commands for PR/review, and auto feedback is disabled
         get_logger().info(f"Auto feedback is disabled, skipping auto commands for PR {api_url=}")
         return
     if not should_process_pr_logic(body): # Here we already updated the configuration with the repo settings
         return {}
     commands = get_settings().get(f"github_app.{commands_conf}")
     if not commands:
-        get_logger().info("New PR, but no auto commands configured")
+        get_logger().info(f"No {commands_conf} configured, skipping auto commands")
         return
     get_settings().set("config.is_auto_command", True)
     for command in commands:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -289,6 +289,7 @@ publish_as_check_run = false # when true, publish review/description/improve out
 # push_trigger_ignore_merge_commits = true
 # push_commands = ['/describe', '/review']  # defaults mirror github_app.push_commands
 # review_states = ['changes_requested']  # states that trigger review_commands after a submitted GitHub review
+# review_author_types = ['User']  # review.user.type values allowed to trigger review_commands
 # review_commands = []  # empty by default; falls back to github_app.review_commands when unset
 
 [github_app]
@@ -305,6 +306,7 @@ pr_commands = [
 ]
 # A submitted GitHub review can optionally trigger these commands. The empty default preserves current behavior.
 review_states = ["changes_requested"]
+review_author_types = ["User"]
 review_commands = []
 # settings for "pull_request" event with "synchronize" action - used to detect and handle push triggers for new commits
 handle_push_trigger = false

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -288,6 +288,8 @@ publish_as_check_run = false # when true, publish review/description/improve out
 # push_trigger_ignore_bot_commits = true
 # push_trigger_ignore_merge_commits = true
 # push_commands = ['/describe', '/review']  # defaults mirror github_app.push_commands
+# review_states = ['changes_requested']  # states that trigger review_commands after a submitted GitHub review
+# review_commands = []  # empty by default; falls back to github_app.review_commands when unset
 
 [github_app]
 # these toggles allows running the github app from custom deployments
@@ -301,6 +303,9 @@ pr_commands = [
     "/review",
     "/improve",
 ]
+# A submitted GitHub review can optionally trigger these commands. The empty default preserves current behavior.
+review_states = ["changes_requested"]
+review_commands = []
 # settings for "pull_request" event with "synchronize" action - used to detect and handle push triggers for new commits
 handle_push_trigger = false
 push_trigger_ignore_bot_commits = true

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -180,10 +180,12 @@ def _write_issue_comment_event(tmp_path, sender_type):
     return event_path
 
 
-def _write_review_event(tmp_path, state="changes_requested", sender_type="User", review_author_type="User"):
+def _write_review_event(
+    tmp_path, state="changes_requested", sender_type="User", review_author_type="User", action="submitted"
+):
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({
-        "action": "submitted",
+        "action": action,
         "review": {"state": state, "user": {"type": review_author_type}},
         "pull_request": {
             "url": "https://api.github.com/repos/org/repo/pulls/1",
@@ -212,6 +214,43 @@ def _patch_issue_comment_deps(monkeypatch, handled):
             handled.append((url, body))
 
     monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+
+
+async def _run_review_action_with_settings(
+    monkeypatch,
+    tmp_path,
+    app_review_states,
+    app_review_commands,
+    action_config=None,
+    action="submitted",
+    state="changes_requested",
+):
+    settings = get_settings()
+    settings.set("GITHUB_APP.REVIEW_STATES", app_review_states)
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", app_review_commands)
+    settings.set("GITHUB_APP.FEEDBACK_ON_DRAFT_PR", False)
+    settings.set("CONFIG.DISABLE_AUTO_FEEDBACK", False)
+    settings.set("GITHUB_ACTION_CONFIG", dict(action_config or {}), merge=False)
+
+    handled = []
+    monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda _pr_url: None)
+    monkeypatch.setattr(github_action_runner, "_inject_artifact_context", lambda: None)
+
+    class FakeAgent:
+        async def handle_request(self, url, body, notify=None):
+            handled.append((url, body))
+
+    monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_review")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH",
+        str(_write_review_event(tmp_path, action=action, state=state)),
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    await github_action_runner.run_action()
+    return handled
 
 
 @pytest.mark.asyncio
@@ -305,6 +344,59 @@ async def test_review_submission_ignores_unconfigured_author_type(monkeypatch, t
     await github_action_runner.run_action()
 
     assert handled == []
+
+
+@pytest.mark.asyncio
+async def test_review_submission_is_disabled_without_review_commands(monkeypatch, tmp_path, restore_github_settings):
+    handled = await _run_review_action_with_settings(
+        monkeypatch,
+        tmp_path,
+        app_review_states=["changes_requested"],
+        app_review_commands=[],
+    )
+
+    assert handled == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["edited", "dismissed"])
+async def test_review_submission_ignores_non_submitted_actions(
+    monkeypatch, tmp_path, restore_github_settings, action
+):
+    handled = await _run_review_action_with_settings(
+        monkeypatch,
+        tmp_path,
+        app_review_states=["changes_requested"],
+        app_review_commands=["/review"],
+        action=action,
+    )
+
+    assert handled == []
+
+
+@pytest.mark.asyncio
+async def test_action_review_config_falls_back_to_app_and_overrides_it(
+    monkeypatch, tmp_path, restore_github_settings
+):
+    handled = await _run_review_action_with_settings(
+        monkeypatch,
+        tmp_path,
+        app_review_states=["changes_requested"],
+        app_review_commands=["/app-review"],
+    )
+    assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/app-review")]
+
+    handled = await _run_review_action_with_settings(
+        monkeypatch,
+        tmp_path,
+        app_review_states=["approved"],
+        app_review_commands=["/app-review"],
+        action_config={
+            "review_states": ["changes_requested"],
+            "review_commands": ["/action-review"],
+        },
+    )
+    assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/action-review")]
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -180,6 +180,21 @@ def _write_issue_comment_event(tmp_path, sender_type):
     return event_path
 
 
+def _write_review_event(tmp_path, state="changes_requested", sender_type="User"):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({
+        "action": "submitted",
+        "review": {"state": state},
+        "pull_request": {
+            "url": "https://api.github.com/repos/org/repo/pulls/1",
+            "html_url": "https://github.com/org/repo/pull/1",
+            "draft": False,
+        },
+        "sender": {"type": sender_type},
+    }))
+    return event_path
+
+
 def _patch_issue_comment_deps(monkeypatch, handled):
     monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda pr_url: None)
 
@@ -197,6 +212,65 @@ def _patch_issue_comment_deps(monkeypatch, handled):
             handled.append((url, body))
 
     monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+
+
+@pytest.mark.asyncio
+async def test_review_submission_runs_configured_commands(monkeypatch, tmp_path, restore_github_settings):
+    handled = []
+    monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda pr_url: None)
+
+    class FakeAgent:
+        async def handle_request(self, url, body, notify=None):
+            handled.append((url, body))
+
+    monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_review")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_review_event(tmp_path, "CHANGES_REQUESTED")))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fake_get_setting_or_env(key, default=None):
+        values = {
+            "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            "GITHUB_ACTION_CONFIG.REVIEW_STATES": '["changes_requested"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS": '["/review"]',
+            "GITHUB_ACTION_CONFIG.FEEDBACK_ON_DRAFT_PR": False,
+        }
+        return values.get(key, default)
+
+    monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+    await github_action_runner.run_action()
+
+    assert handled == [("https://api.github.com/repos/org/repo/pulls/1", "/review")]
+
+
+@pytest.mark.asyncio
+async def test_review_submission_ignores_unconfigured_state(monkeypatch, tmp_path, restore_github_settings):
+    handled = []
+    monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda pr_url: None)
+
+    class FakeAgent:
+        async def handle_request(self, url, body, notify=None):
+            handled.append((url, body))
+
+    monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_review")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_review_event(tmp_path, "approved")))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fake_get_setting_or_env(key, default=None):
+        values = {
+            "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            "GITHUB_ACTION_CONFIG.REVIEW_STATES": '["changes_requested"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS": '["/review"]',
+        }
+        return values.get(key, default)
+
+    monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+    await github_action_runner.run_action()
+
+    assert handled == []
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_github_action_runner_core.py
+++ b/tests/unittest/test_github_action_runner_core.py
@@ -180,11 +180,11 @@ def _write_issue_comment_event(tmp_path, sender_type):
     return event_path
 
 
-def _write_review_event(tmp_path, state="changes_requested", sender_type="User"):
+def _write_review_event(tmp_path, state="changes_requested", sender_type="User", review_author_type="User"):
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({
         "action": "submitted",
-        "review": {"state": state},
+        "review": {"state": state, "user": {"type": review_author_type}},
         "pull_request": {
             "url": "https://api.github.com/repos/org/repo/pulls/1",
             "html_url": "https://github.com/org/repo/pull/1",
@@ -232,6 +232,7 @@ async def test_review_submission_runs_configured_commands(monkeypatch, tmp_path,
         values = {
             "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
             "GITHUB_ACTION_CONFIG.REVIEW_STATES": '["changes_requested"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_AUTHOR_TYPES": '["User"]',
             "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS": '["/review"]',
             "GITHUB_ACTION_CONFIG.FEEDBACK_ON_DRAFT_PR": False,
         }
@@ -262,6 +263,39 @@ async def test_review_submission_ignores_unconfigured_state(monkeypatch, tmp_pat
         values = {
             "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
             "GITHUB_ACTION_CONFIG.REVIEW_STATES": '["changes_requested"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_AUTHOR_TYPES": '["User"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS": '["/review"]',
+        }
+        return values.get(key, default)
+
+    monkeypatch.setattr(github_action_runner, "get_setting_or_env", fake_get_setting_or_env)
+
+    await github_action_runner.run_action()
+
+    assert handled == []
+
+
+@pytest.mark.asyncio
+async def test_review_submission_ignores_unconfigured_author_type(monkeypatch, tmp_path, restore_github_settings):
+    handled = []
+    monkeypatch.setattr(github_action_runner, "apply_repo_settings", lambda pr_url: None)
+
+    class FakeAgent:
+        async def handle_request(self, url, body, notify=None):
+            handled.append((url, body))
+
+    monkeypatch.setattr(github_action_runner, "PRAgent", FakeAgent)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_review")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH", str(_write_review_event(tmp_path, review_author_type="Bot"))
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fake_get_setting_or_env(key, default=None):
+        values = {
+            "GITHUB_ACTION_CONFIG.ENABLE_OUTPUT": True,
+            "GITHUB_ACTION_CONFIG.REVIEW_STATES": '["changes_requested"]',
+            "GITHUB_ACTION_CONFIG.REVIEW_AUTHOR_TYPES": '["User"]',
             "GITHUB_ACTION_CONFIG.REVIEW_COMMANDS": '["/review"]',
         }
         return values.get(key, default)

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -337,6 +337,82 @@ async def test_github_automatic_feedback_preserves_quoted_command_arguments(monk
     assert repo_settings_calls == 1
 
 
+def _github_review_event(action="submitted", state="changes_requested", review_author_type="User"):
+    return {
+        "action": action,
+        "review": {"state": state, "user": {"type": review_author_type}},
+        "pull_request": {
+            "url": "https://api.github.com/repos/org/repo/pulls/1",
+            "state": "open",
+            "draft": False,
+            "title": "Regular PR",
+            "labels": [],
+            "head": {"ref": "feature/cache"},
+            "base": {"ref": "main"},
+        },
+        "sender": {"login": "alice", "id": 1, "type": "User"},
+        "repository": {"full_name": "org/repo"},
+    }
+
+
+def test_matches_review_state_is_case_insensitive_and_handles_empty_values():
+    assert github_app.matches_review_state(" CHANGES_REQUESTED ", ["changes_requested"])
+    assert github_app.matches_review_state("approved", "approved")
+    assert not github_app.matches_review_state("approved", [])
+    assert not github_app.matches_review_state("", ["approved"])
+
+
+@pytest.mark.asyncio
+async def test_github_review_submission_is_disabled_without_review_commands(monkeypatch):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", [])
+    settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "should_process_pr_logic", lambda _body: True)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+    monkeypatch.setattr(
+        github_app,
+        "get_identity_provider",
+        lambda: SimpleNamespace(verify_eligibility=lambda *args, **kwargs: Eligibility.ELIGIBLE),
+    )
+
+    try:
+        await github_app.handle_request(_github_review_event(), "pull_request_review")
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["edited", "dismissed"])
+async def test_github_review_submission_ignores_non_submitted_actions(monkeypatch, action):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
+    settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "should_process_pr_logic", lambda _body: True)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+
+    try:
+        await github_app.handle_request(_github_review_event(action=action), "pull_request_review")
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == []
+
+
 @pytest.mark.asyncio
 async def test_github_review_submission_runs_configured_commands(monkeypatch):
     settings = get_settings()

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -338,6 +338,92 @@ async def test_github_automatic_feedback_preserves_quoted_command_arguments(monk
 
 
 @pytest.mark.asyncio
+async def test_github_review_submission_runs_configured_commands(monkeypatch):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
+    settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+    monkeypatch.setattr(
+        github_app,
+        "get_identity_provider",
+        lambda: SimpleNamespace(verify_eligibility=lambda *args, **kwargs: Eligibility.ELIGIBLE),
+    )
+
+    try:
+        await github_app.handle_request(
+            {
+                "action": "submitted",
+                "review": {"state": "changes_requested", "body": "Please fix the validation."},
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": False,
+                    "title": "Regular PR",
+                    "labels": [],
+                    "head": {"ref": "feature/cache"},
+                    "base": {"ref": "main"},
+                },
+                "sender": {"login": "alice", "id": 1, "type": "User"},
+                "repository": {"full_name": "org/repo"},
+            },
+            "pull_request_review",
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == [["/review"]]
+
+
+@pytest.mark.asyncio
+async def test_github_review_submission_ignores_unconfigured_state(monkeypatch):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
+    settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+    monkeypatch.setattr(
+        github_app,
+        "get_identity_provider",
+        lambda: SimpleNamespace(verify_eligibility=lambda *args, **kwargs: Eligibility.ELIGIBLE),
+    )
+
+    try:
+        await github_app.handle_request(
+            {
+                "action": "submitted",
+                "review": {"state": "approved"},
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": False,
+                    "title": "Regular PR",
+                    "labels": [],
+                    "head": {"ref": "feature/cache"},
+                    "base": {"ref": "main"},
+                },
+                "sender": {"login": "alice", "id": 1, "type": "User"},
+                "repository": {"full_name": "org/repo"},
+            },
+            "pull_request_review",
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == []
+
+
+@pytest.mark.asyncio
 async def test_github_automatic_feedback_continues_after_invalid_command(monkeypatch):
     commands, repo_settings_calls = await _run_github_pr_commands(
         monkeypatch,

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -344,6 +344,7 @@ async def test_github_review_submission_runs_configured_commands(monkeypatch):
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
     settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
     settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
 
     agent = RecordingAgent()
     monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
@@ -358,7 +359,11 @@ async def test_github_review_submission_runs_configured_commands(monkeypatch):
         await github_app.handle_request(
             {
                 "action": "submitted",
-                "review": {"state": "changes_requested", "body": "Please fix the validation."},
+                "review": {
+                    "state": "changes_requested",
+                    "body": "Please fix the validation.",
+                    "user": {"type": "User"},
+                },
                 "pull_request": {
                     "url": "https://api.github.com/repos/org/repo/pulls/1",
                     "state": "open",
@@ -387,6 +392,7 @@ async def test_github_review_submission_ignores_unconfigured_state(monkeypatch):
     original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
     settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
     settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
 
     agent = RecordingAgent()
     monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
@@ -401,7 +407,7 @@ async def test_github_review_submission_ignores_unconfigured_state(monkeypatch):
         await github_app.handle_request(
             {
                 "action": "submitted",
-                "review": {"state": "approved"},
+                "review": {"state": "approved", "user": {"type": "User"}},
                 "pull_request": {
                     "url": "https://api.github.com/repos/org/repo/pulls/1",
                     "state": "open",
@@ -412,6 +418,50 @@ async def test_github_review_submission_ignores_unconfigured_state(monkeypatch):
                     "base": {"ref": "main"},
                 },
                 "sender": {"login": "alice", "id": 1, "type": "User"},
+                "repository": {"full_name": "org/repo"},
+            },
+            "pull_request_review",
+        )
+    finally:
+        settings.set("GITHUB_APP", original_github_app)
+        settings.set("CONFIG.IS_AUTO_COMMAND", original_is_auto_command)
+
+    assert agent.commands == []
+
+
+@pytest.mark.asyncio
+async def test_github_review_submission_ignores_unconfigured_author_type(monkeypatch):
+    settings = get_settings()
+    original_github_app = copy.deepcopy(settings.get("GITHUB_APP"))
+    original_is_auto_command = settings.get("CONFIG.IS_AUTO_COMMAND")
+    settings.set("GITHUB_APP.REVIEW_COMMANDS", ["/review"])
+    settings.set("GITHUB_APP.REVIEW_STATES", ["changes_requested"])
+    settings.set("GITHUB_APP.REVIEW_AUTHOR_TYPES", ["User"])
+
+    agent = RecordingAgent()
+    monkeypatch.setattr(github_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(github_app, "PRAgent", lambda: agent)
+    monkeypatch.setattr(
+        github_app,
+        "get_identity_provider",
+        lambda: SimpleNamespace(verify_eligibility=lambda *args, **kwargs: Eligibility.ELIGIBLE),
+    )
+
+    try:
+        await github_app.handle_request(
+            {
+                "action": "submitted",
+                "review": {"state": "changes_requested", "user": {"type": "Bot"}},
+                "pull_request": {
+                    "url": "https://api.github.com/repos/org/repo/pulls/1",
+                    "state": "open",
+                    "draft": False,
+                    "title": "Regular PR",
+                    "labels": [],
+                    "head": {"ref": "feature/cache"},
+                    "base": {"ref": "main"},
+                },
+                "sender": {"login": "review-bot", "id": 1, "type": "User"},
                 "repository": {"full_name": "org/repo"},
             },
             "pull_request_review",


### PR DESCRIPTION
## Summary

Fixes #3008

GitHub native `pull_request_review` events with the `submitted` action were ignored by both the GitHub App and GitHub Action runner. Repositories therefore could not run PR-Agent commands in response to formal review feedback.

This adds an opt-in submitted-review trigger for both integrations:

- dispatch `pull_request_review` / `submitted` events to the existing automatic-command path;
- filter reviews by configured state and `review.user.type` author type;
- let `github_action_config.*` override the corresponding `github_app.*` settings;
- keep the review body as context-free event data rather than interpreting it as a command.

## Configuration

The GitHub App configuration is:

```toml
[github_app]
review_states = ["changes_requested"]
review_author_types = ["User"]
review_commands = ["/review"]
```

For GitHub Action, add `pull_request_review` with the `submitted` activity type to the workflow and configure the equivalent `github_action_config.review_states`, `github_action_config.review_author_types`, and `github_action_config.review_commands` values. Action settings override App settings when present.

The empty `review_commands` default preserves existing behavior. The default `changes_requested` state and `User` author type are intentionally conservative; other review states or author types can be enabled explicitly. Existing repository filtering, draft-PR handling, eligibility checks, bot protection, and `config.disable_auto_feedback` checks remain in effect.

## Tests

- Focused App/Action submitted-review regressions: `6 passed`.
- Full Docker-mounted `pytest -v tests/unittest`: `3193 passed, 1 skipped, 1 xfailed, 93 warnings`.
- Ruff: passed.
- All enabled pre-commit hooks: passed.
- Docker-equivalent full test suite: passed. A fresh Docker `--target test` rebuild was attempted but blocked while downloading `litellm==1.99.0` by a network/extraction timeout.
- Strict MkDocs build: reached documentation validation but exited on 42 existing repository warnings; no publishing step was run.
