### PR TITLE
feat(review): add opt-in large-diff chunking with a stated merge rule

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -260,7 +260,7 @@ extra_instructions = "..."
     | `relevant_tests` | Yes if any chunk found tests |
     | `score` | The lowest score any chunk gave |
     | `risk_level`, `merge_recommendation` | The most conservative value any chunk gave |
-    | `estimated_effort_to_review_[1-5]` | The sum over the chunks, capped at 5 |
+    | `estimated_effort_to_review_[1-5]` | The highest value any chunk gave |
     | `contribution_time_cost_estimate` | The sum over the chunks, per case |
     | `ticket_compliance_check` | One entry per ticket, with its bullet lists unioned across chunks |
 

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -87,6 +87,14 @@ extra_instructions = "..."
         <td>If set to true, the tool will display a review coverage footer when the token budget leaves files out of the review. Default is true.</td>
       </tr>
       <tr>
+        <td><b>enable_large_pr_chunking</b></td>
+        <td>If set to true, and the token budget leaves files out of the review, the diff is split into chunks, each chunk is reviewed separately, and the per-chunk results are merged into one review. See <a href="#reviewing-a-pr-that-does-not-fit-in-one-call">Reviewing a PR that does not fit in one call</a>. Default is false.</td>
+      </tr>
+      <tr>
+        <td><b>max_number_of_calls</b></td>
+        <td>Maximum number of chunk review calls, used only when <code>enable_large_pr_chunking</code> is true. Default is 3.</td>
+      </tr>
+      <tr>
         <td><b>num_max_findings</b></td>
         <td>Number of maximum returned findings. Default is 3.</td>
       </tr>
@@ -227,3 +235,34 @@ extra_instructions = "..."
     """
     ```
     Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.
+
+### Reviewing a PR that does not fit in one call
+
+!!! tip ""
+
+    When a PR diff is larger than the model's token budget, the `review` tool drops whole files
+    until the diff fits, and lists the dropped files in the review coverage footer.
+
+    Setting `enable_large_pr_chunking = true` changes what happens next: the diff is split into up
+    to `max_number_of_calls` chunks, each chunk is reviewed on its own, and the answers are merged
+    into a single review that says how many chunks it was built from. Files that do not fit even
+    after chunking are still listed in the coverage footer. Every chunk is a separate model call,
+    so a chunked review costs roughly `max_number_of_calls` times a normal one.
+
+    Each chunk answers the same questions about a different part of the PR, so the answers are
+    merged field by field:
+
+    | Field | Merge rule |
+    | --- | --- |
+    | `key_issues_to_review` | Union over the chunks, dropping findings that repeat the same file, header and text |
+    | `security_concerns` | Every chunk that reported a concern is kept; "No" only when every chunk said no |
+    | `todo_sections`, `review_priority_files`, `can_be_split` | Union, de-duplicated, in chunk order (`can_be_split` keeps at most 3 sub-PRs) |
+    | `relevant_tests` | Yes if any chunk found tests |
+    | `score` | The lowest score any chunk gave |
+    | `risk_level`, `merge_recommendation` | The most conservative value any chunk gave |
+    | `estimated_effort_to_review_[1-5]` | The sum over the chunks, capped at 5 |
+    | `contribution_time_cost_estimate` | The sum over the chunks, per case |
+    | `ticket_compliance_check` | One entry per ticket, with its bullet lists unioned across chunks |
+
+    The merged verdict is deliberately never less alarming than the worst chunk: a clean chunk
+    cannot raise a score, clear a security concern, or soften a risk level set by another chunk.

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -394,7 +394,8 @@ def get_pr_multi_diffs(git_provider: GitProvider,
                        token_handler: TokenHandler,
                        model: str,
                        max_calls: int = 5,
-                       add_line_numbers: bool = True) -> List[str]:
+                       add_line_numbers: bool = True,
+                       return_remaining_files: bool = False):
     """
     Retrieves the diff files from a Git provider, sorts them by main language, and generates patches for each file.
     The patches are split into multiple groups based on the maximum number of tokens allowed for the given model.
@@ -404,9 +405,13 @@ def get_pr_multi_diffs(git_provider: GitProvider,
         token_handler (TokenHandler): An object that handles tokens in the context of a pull request.
         model (str): The name of the model.
         max_calls (int, optional): The maximum number of calls to retrieve diff files. Defaults to 5.
+        return_remaining_files (bool, optional): Also return the files the token budget left out, in the
+            same shape as `get_pr_diff`. Files without a patch, and delete-only files, are not reported:
+            nothing was omitted for them. Defaults to False.
 
     Returns:
         List[str]: A list of final diff strings, split into multiple groups based on the maximum number of tokens allowed for the given model.
+        With `return_remaining_files`, a tuple of that list and the list of omitted file names.
 
     Raises:
         RateLimitExceededException: If the rate limit for the Git provider API is exceeded.
@@ -435,7 +440,8 @@ def get_pr_multi_diffs(git_provider: GitProvider,
 
     # if we are under the limit, return the full diff
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
-        return ["\n".join(patches_extended)] if patches_extended else []
+        full_diff_list = ["\n".join(patches_extended)] if patches_extended else []
+        return (full_diff_list, []) if return_remaining_files else full_diff_list
 
     # Sort files within each language group by tokens in descending order
     sorted_files = []
@@ -444,6 +450,7 @@ def get_pr_multi_diffs(git_provider: GitProvider,
 
     patches = []
     final_diff_list = []
+    files_in_patches = set()  # files that made it into a chunk
     total_tokens = token_handler.prompt_tokens
     call_number = 1
     for file in sorted_files:
@@ -509,6 +516,7 @@ def get_pr_multi_diffs(git_provider: GitProvider,
 
         if patch:
             patches.append(patch)
+            files_in_patches.add(file.filename)
             total_tokens += new_patch_tokens
             if get_verbosity_level() >= 2:
                 get_logger().info(f"Tokens: {total_tokens}, last filename: {file.filename}")
@@ -518,7 +526,20 @@ def get_pr_multi_diffs(git_provider: GitProvider,
         final_diff = "\n".join(patches)
         final_diff_list.append(final_diff.strip())
 
-    return final_diff_list
+    if not return_remaining_files:
+        return final_diff_list
+
+    remaining_files_list = []
+    for file in sorted_files:
+        if file.filename in files_in_patches or file.filename in remaining_files_list:
+            continue
+        # a file with no patch, or with a delete-only patch, has nothing to review:
+        # the token budget is not what kept it out of the diff
+        if not file.patch or handle_patch_deletions(file.patch, file.base_file, file.head_file,
+                                                    file.filename, file.edit_type) is None:
+            continue
+        remaining_files_list.append(file.filename)
+    return final_diff_list, remaining_files_list
 
 
 def add_ai_metadata_to_diff_files(git_provider, pr_description_files):

--- a/pr_agent/algo/review_merge.py
+++ b/pr_agent/algo/review_merge.py
@@ -8,10 +8,9 @@ one verdict. Three rules cover the schema:
 - Fields that report what a chunk *found* - key issues, security concerns, TODO sections,
   priority files, sub-PRs, ticket bullet lists - are unioned in chunk order, dropping repeats.
 - Fields that are one *judgement* about the whole PR - score, risk level, merge
-  recommendation, "does the PR have tests" - take the most conservative value any chunk
-  reported, so a merged review is never less alarming than its worst chunk.
-- Fields that measure *work* - review effort and contribution time - are summed, because the
-  chunks partition the change and reviewing all of them is the work of reviewing the PR.
+  recommendation, review effort, "does the PR have tests" - take the most conservative value
+  any chunk reported, so a merged review is never less alarming than its worst chunk.
+- Contribution time measures *work* and is summed, because the chunks partition the change.
 
 A key that matches none of the rules keeps the first chunk's non-empty value, so a field
 added to the prompt later still survives the merge instead of disappearing from the review.
@@ -95,11 +94,15 @@ def _as_int(value: Any) -> Optional[int]:
 
 
 def _merge_effort(values: List[Any]) -> Any:
-    """Reviewing every chunk is the work of reviewing the PR, so effort adds up (capped at 5)."""
+    """Effort is a 1-5 judgement, so the merged review reports the hardest chunk.
+
+    Summing would saturate at 5 for any PR of a few modest chunks, and the field would stop
+    telling PRs apart as soon as chunking is on.
+    """
     numbers = [number for number in (_as_int(value) for value in values) if number is not None]
     if not numbers:
         return _first_non_empty(values)
-    return max(1, min(MAX_EFFORT, sum(numbers)))
+    return max(1, min(MAX_EFFORT, max(numbers)))
 
 
 def _merge_score(values: List[Any]) -> Any:

--- a/pr_agent/algo/review_merge.py
+++ b/pr_agent/algo/review_merge.py
@@ -1,0 +1,293 @@
+"""Merge the per-chunk outputs of a chunked `/review` into a single review.
+
+`/review` normally answers from one model call over the whole diff. When the diff does not
+fit, the reviewer can split it into chunks (`get_pr_multi_diffs`) and ask the same questions
+about each chunk. Every chunk answers the same schema, so the answers have to be reduced to
+one verdict. Three rules cover the schema:
+
+- Fields that report what a chunk *found* - key issues, security concerns, TODO sections,
+  priority files, sub-PRs, ticket bullet lists - are unioned in chunk order, dropping repeats.
+- Fields that are one *judgement* about the whole PR - score, risk level, merge
+  recommendation, "does the PR have tests" - take the most conservative value any chunk
+  reported, so a merged review is never less alarming than its worst chunk.
+- Fields that measure *work* - review effort and contribution time - are summed, because the
+  chunks partition the change and reviewing all of them is the work of reviewing the PR.
+
+A key that matches none of the rules keeps the first chunk's non-empty value, so a field
+added to the prompt later still survives the merge instead of disappearing from the review.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Hashable, List, Optional
+
+from pr_agent.algo.utils import is_value_no
+from pr_agent.log import get_logger
+
+MAX_EFFORT = 5
+MAX_SUB_PRS = 3
+CONTRIBUTION_TIME_CASES = ("best_case", "average_case", "worst_case")
+RISK_LEVELS = ("low", "medium", "high")
+MERGE_RECOMMENDATIONS = ("safe_to_merge", "merge_with_caution", "changes_required")
+
+_DURATION_RE = re.compile(r"(\d+(?:\.\d+)?)\s*([mh])", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def merge_review_chunks(chunk_outputs: List[dict]) -> dict:
+    """Reduce the parsed review of every chunk to a single `{'review': {...}}` dict."""
+    reviews = [chunk["review"] for chunk in chunk_outputs
+               if isinstance(chunk, dict) and isinstance(chunk.get("review"), dict)]
+    if not reviews:
+        return {}
+    if len(reviews) == 1:
+        return {"review": dict(reviews[0])}
+
+    # keep the prompt's field order, which is also the order the review is rendered in
+    keys = []
+    for review in reviews:
+        for key in review:
+            if key not in keys:
+                keys.append(key)
+
+    merged = {}
+    for key in keys:
+        values = [review[key] for review in reviews if key in review]
+        merge = _MERGE_RULES.get(_rule_name(key), _first_non_empty)
+        try:
+            merged[key] = merge(values)
+        except Exception as e:
+            get_logger().warning(f"Failed to merge review field '{key}' across chunks, "
+                                 f"keeping the first chunk's value, error: {e}")
+            merged[key] = _first_non_empty(values)
+    return {"review": merged}
+
+
+def _rule_name(key: str) -> str:
+    normalized = str(key).strip().lower()
+    # the effort field carries its scale in its name: 'estimated_effort_to_review_[1-5]'
+    if normalized.startswith("estimated_effort_to_review"):
+        return "estimated_effort_to_review"
+    return normalized
+
+
+def _first_non_empty(values: List[Any]) -> Any:
+    for value in values:
+        if value is not None and value != "" and value != [] and value != {}:
+            return value
+    return values[0]
+
+
+def _normalize_text(value: Any) -> str:
+    return _WHITESPACE_RE.sub(" ", str(value if value is not None else "")).strip().lower()
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).strip().split(",")[0].strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _merge_effort(values: List[Any]) -> Any:
+    """Reviewing every chunk is the work of reviewing the PR, so effort adds up (capped at 5)."""
+    numbers = [number for number in (_as_int(value) for value in values) if number is not None]
+    if not numbers:
+        return _first_non_empty(values)
+    return max(1, min(MAX_EFFORT, sum(numbers)))
+
+
+def _merge_score(values: List[Any]) -> Any:
+    """Lowest score wins: a clean chunk must not raise the grade of a bad one."""
+    scored = [(number, value) for number, value in ((_as_int(value), value) for value in values)
+              if number is not None]
+    if not scored:
+        return _first_non_empty(values)
+    return min(scored, key=lambda pair: pair[0])[1]
+
+
+def _worst_of(order: tuple) -> Callable[[List[Any]], Any]:
+    """Pick the value ranked last in `order`; values outside it are ignored."""
+    def merge(values: List[Any]) -> Any:
+        ranked = [(order.index(choice), value) for choice, value
+                  in ((_normalize_text(value).replace(" ", "_"), value) for value in values)
+                  if choice in order]
+        if not ranked:
+            return _first_non_empty(values)
+        return max(ranked, key=lambda pair: pair[0])[1]
+    return merge
+
+
+def _merge_findings_text(values: List[Any]) -> Any:
+    """Union the chunks that reported something; 'No' only when every chunk said no."""
+    reported, seen = [], set()
+    for value in values:
+        text = str(value if value is not None else "").strip()
+        if is_value_no(text):
+            continue
+        fingerprint = _normalize_text(text)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        reported.append(text)
+    if not reported:
+        return _first_non_empty(values)
+    return "\n\n".join(reported)
+
+
+def _merge_relevant_tests(values: List[Any]) -> Any:
+    """A test added in any chunk is a test added by the PR."""
+    for value in values:
+        if not is_value_no(value):
+            return value
+    return _first_non_empty(values)
+
+
+def _union_of_lists(identity: Callable[[Any], Hashable]) -> Callable[[List[Any]], list]:
+    def merge(values: List[Any]) -> list:
+        merged, seen = [], set()
+        for value in values:
+            for item in value if isinstance(value, list) else []:
+                key = identity(item)
+                if key in seen:
+                    continue
+                seen.add(key)
+                merged.append(item)
+        return merged
+    return merge
+
+
+def _key_issue_identity(issue: Any) -> Hashable:
+    if not isinstance(issue, dict):
+        return _normalize_text(issue)
+    return (_normalize_text(issue.get("relevant_file")),
+            _normalize_text(issue.get("issue_header")),
+            _normalize_text(issue.get("issue_content")))
+
+
+def _todo_identity(todo: Any) -> Hashable:
+    if not isinstance(todo, dict):
+        return _normalize_text(todo)
+    return (_normalize_text(todo.get("relevant_file")),
+            _normalize_text(todo.get("line_number")),
+            _normalize_text(todo.get("content")))
+
+
+def _sub_pr_identity(sub_pr: Any) -> Hashable:
+    if not isinstance(sub_pr, dict):
+        return _normalize_text(sub_pr)
+    relevant_files = sub_pr.get("relevant_files")
+    if isinstance(relevant_files, list) and relevant_files:
+        return frozenset(_normalize_text(name) for name in relevant_files)
+    return _normalize_text(sub_pr.get("title"))
+
+
+def _merge_todo_sections(values: List[Any]) -> Any:
+    return _union_of_lists(_todo_identity)(values) or _first_non_empty(values)
+
+
+def _merge_can_be_split(values: List[Any]) -> list:
+    # the prompt asks for at most 3 sub-PRs, so the merged list keeps the same bound
+    return _union_of_lists(_sub_pr_identity)(values)[:MAX_SUB_PRS]
+
+
+def _merge_priority_files(values: List[Any]) -> list:
+    merged, seen = [], set()
+    for value in values:
+        for item in value if isinstance(value, list) else []:
+            name = str(item).strip()
+            if not name or name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            merged.append(name)
+    return merged
+
+
+def _union_bullet_lines(first: str, second: str) -> str:
+    lines, seen = [], set()
+    for line in f"{first}\n{second}".splitlines():
+        if not line.strip():
+            continue
+        key = _normalize_text(line)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(line.rstrip())
+    return "\n".join(lines)
+
+
+def _merge_ticket_compliance(values: List[Any]) -> list:
+    """One entry per ticket; its bullet lists are unioned across the chunks that saw it.
+
+    A requirement that one chunk met and another did not ends up in both lists, which
+    `ticket_markdown_logic` already renders as 'Partially compliant'.
+    """
+    merged: dict = {}
+    for value in values:
+        entries = value if isinstance(value, list) else [value]
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            ticket = _normalize_text(entry.get("ticket_url"))
+            if ticket not in merged:
+                merged[ticket] = dict(entry)
+                continue
+            target = merged[ticket]
+            for field, field_value in entry.items():
+                if isinstance(field_value, str) and isinstance(target.get(field), str):
+                    target[field] = _union_bullet_lines(target[field], field_value)
+                elif not target.get(field):
+                    target[field] = field_value
+    return list(merged.values())
+
+
+def _duration_minutes(value: Any) -> Optional[float]:
+    match = _DURATION_RE.fullmatch(str(value if value is not None else "").strip())
+    if not match:
+        return None
+    return float(match.group(1)) * (60 if match.group(2).lower() == "h" else 1)
+
+
+def _format_duration(minutes: float) -> str:
+    if minutes < 60:
+        return f"{int(round(minutes))}m"
+    hours = minutes / 60
+    return f"{int(hours)}h" if float(hours).is_integer() else f"{hours:.1f}h"
+
+
+def _merge_contribution_time(values: List[Any]) -> Any:
+    """The chunks partition the change, so the time to write them adds up."""
+    estimates = [value for value in values if isinstance(value, dict)]
+    if not estimates:
+        return _first_non_empty(values)
+    totals = {}
+    for case in CONTRIBUTION_TIME_CASES:
+        minutes = [_duration_minutes(estimate.get(case)) for estimate in estimates]
+        if any(value is None for value in minutes):
+            get_logger().debug("Contribution time estimates cannot be added across chunks, "
+                               "keeping the first chunk's estimate", artifact={"case": case})
+            return _first_non_empty(values)
+        totals[case] = _format_duration(sum(minutes))
+    return totals
+
+
+_MERGE_RULES: dict = {
+    "estimated_effort_to_review": _merge_effort,
+    "score": _merge_score,
+    "risk_level": _worst_of(RISK_LEVELS),
+    "merge_recommendation": _worst_of(MERGE_RECOMMENDATIONS),
+    "security_concerns": _merge_findings_text,
+    "insights_from_user_answers": _merge_findings_text,
+    "relevant_tests": _merge_relevant_tests,
+    "key_issues_to_review": _union_of_lists(_key_issue_identity),
+    "todo_sections": _merge_todo_sections,
+    "can_be_split": _merge_can_be_split,
+    "review_priority_files": _merge_priority_files,
+    "ticket_compliance_check": _merge_ticket_compliance,
+    "contribution_time_cost_estimate": _merge_contribution_time,
+}

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -137,6 +137,10 @@ minimal_minutes_for_incremental_review=0
 enable_intro_text=true
 enable_help_text=false # Determines whether to include help text in the PR review. Enabled by default.
 enable_review_coverage_footer=true
+# large-diff chunking (opt-in). When the token budget leaves files out of the review, split the diff
+# into chunks, review each chunk, and merge the per-chunk results into one review.
+enable_large_pr_chunking=false
+max_number_of_calls=3 # maximum number of chunk review calls, used only when enable_large_pr_chunking is true
 
 [pr_description] # /describe #
 publish_labels=false

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import datetime
 import re
@@ -16,9 +17,15 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_fingerprint,
     key_issue_location_fingerprint,
 )
-from pr_agent.algo.pr_processing import add_ai_metadata_to_diff_files, get_pr_diff, retry_with_fallback_models
+from pr_agent.algo.pr_processing import (
+    add_ai_metadata_to_diff_files,
+    get_pr_diff,
+    get_pr_multi_diffs,
+    retry_with_fallback_models,
+)
 from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
+from pr_agent.algo.review_merge import merge_review_chunks
 from pr_agent.algo.run_details import get_run_details, init_run_details
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
@@ -49,6 +56,12 @@ class PRReviewer:
     """
     The PRReviewer class is responsible for reviewing a pull request and generating feedback using an AI model.
     """
+
+    # State of the chunked flow, rebound by _prepare_chunked_prediction. Class-level immutable
+    # defaults, so the single-call flow carries no bookkeeping.
+    prediction_data = None  # merged review dict; None means "parse self.prediction instead"
+    review_chunk_count = 1
+    review_failed_chunk_count = 0
 
     def __init__(self, pr_url: str, is_answer: bool = False, is_auto: bool = False, args: list = None,
                  ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler):
@@ -265,6 +278,11 @@ class PRReviewer:
             self.patches_diff = output
             self.remaining_files_list = []
 
+        # a non-empty remaining_files_list means the token budget truncated the diff
+        if self.remaining_files_list and get_settings().pr_reviewer.get("enable_large_pr_chunking", False):
+            if await self._prepare_chunked_prediction(model):
+                return
+
         if self.patches_diff:
             get_logger().debug("PR diff", diff=self.patches_diff)
             self.prediction = await self._get_prediction(model)
@@ -272,18 +290,73 @@ class PRReviewer:
             get_logger().warning(f"Empty diff for PR: {self.pr_url}")
             self.prediction = None
 
-    async def _get_prediction(self, model: str) -> str:
+    async def _prepare_chunked_prediction(self, model: str) -> bool:
+        """Review a too-large diff in chunks and merge the per-chunk verdicts.
+
+        Returns False when chunking does not apply, leaving the single-call flow in place.
+        """
+        patches_diff_list, remaining_files_list = get_pr_multi_diffs(
+            self.git_provider,
+            self.token_handler,
+            model,
+            max_calls=get_settings().pr_reviewer.get("max_number_of_calls", 3),
+            add_line_numbers=True,
+            return_remaining_files=True)
+        if len(patches_diff_list) < 2:
+            get_logger().info("Large-diff chunking produced a single chunk, reviewing the PR in one call")
+            return False
+
+        get_logger().info(f"Number of PR chunk calls: {len(patches_diff_list)}")
+        get_logger().debug("PR diff chunks", artifact=patches_diff_list)
+        predictions = await asyncio.gather(
+            *[self._get_prediction(model, patches_diff) for patches_diff in patches_diff_list],
+            return_exceptions=True)
+
+        raw_predictions, chunk_outputs, chunk_errors = [], [], []
+        for chunk_index, prediction in enumerate(predictions):
+            if isinstance(prediction, Exception):
+                chunk_errors.append(prediction)
+                get_logger().warning(f"Failed to review chunk {chunk_index + 1}; retaining successful chunks",
+                                     artifact={"error": prediction})
+                continue
+            if isinstance(prediction, BaseException):
+                raise prediction
+            data = self._load_review_yaml(prediction)
+            if not isinstance(data, dict) or not isinstance(data.get("review"), dict):
+                get_logger().warning(f"Failed to parse the review of chunk {chunk_index + 1}",
+                                     artifact={"data": data})
+                continue
+            raw_predictions.append(prediction)
+            chunk_outputs.append(data)
+
+        if not chunk_outputs:
+            if chunk_errors:
+                raise chunk_errors[0]
+            get_logger().warning("No chunk produced a parsable review, falling back to a single review call")
+            return False
+
+        # the raw text is kept for logging only; the merged verdict is in self.prediction_data
+        self.prediction = "\n".join(raw_predictions)
+        self.prediction_data = merge_review_chunks(chunk_outputs)
+        self.review_chunk_count = len(patches_diff_list)
+        self.review_failed_chunk_count = len(patches_diff_list) - len(chunk_outputs)
+        self.remaining_files_list = remaining_files_list
+        return True
+
+    async def _get_prediction(self, model: str, patches_diff: Optional[str] = None) -> str:
         """
         Generate an AI prediction for the pull request review.
 
         Args:
             model: A string representing the AI model to be used for the prediction.
+            patches_diff: The diff to review. Defaults to the whole prepared diff; the chunked
+                flow passes one chunk per call.
 
         Returns:
             A string representing the AI prediction for the pull request review.
         """
         variables = copy.deepcopy(self.vars)
-        variables["diff"] = self.patches_diff  # update diff
+        variables["diff"] = self.patches_diff if patches_diff is None else patches_diff  # update diff
 
         environment = Environment(undefined=StrictUndefined)
         system_prompt = environment.from_string(get_settings().pr_review_prompt.system).render(variables)
@@ -298,18 +371,20 @@ class PRReviewer:
 
         return response
 
+    @staticmethod
+    def _load_review_yaml(prediction: str) -> dict:
+        return load_yaml(prediction.strip(),
+                         keys_fix_yaml=["ticket_compliance_check", "estimated_effort_to_review_[1-5]:", "risk_level:",
+                                        "merge_recommendation:", "security_concerns:", "key_issues_to_review:",
+                                        "relevant_file:", "relevant_line:", "suggestion:"],
+                         first_key='review', last_key='security_concerns')
+
     def _prepare_pr_review(self) -> str:
         """
         Prepare the PR review by processing the AI prediction and generating a markdown-formatted text that summarizes
         the feedback.
         """
-        first_key = 'review'
-        last_key = 'security_concerns'
-        data = load_yaml(self.prediction.strip(),
-                         keys_fix_yaml=["ticket_compliance_check", "estimated_effort_to_review_[1-5]:", "risk_level:",
-                                        "merge_recommendation:", "security_concerns:", "key_issues_to_review:",
-                                        "relevant_file:", "relevant_line:", "suggestion:"],
-                         first_key=first_key, last_key=last_key)
+        data = self.prediction_data if self.prediction_data is not None else self._load_review_yaml(self.prediction)
         github_action_output(data, 'review')
 
         if 'review' not in data:
@@ -353,6 +428,16 @@ class PRReviewer:
                                             incremental_review_markdown_text,
                                                git_provider=self.git_provider,
                                                files=self.git_provider.get_diff_files())
+
+        if self.review_chunk_count > 1:
+            markdown_text += (
+                "\n\n<hr>\n\n"
+                "ℹ️ **Chunked review:** the diff exceeded the model token budget, so it was reviewed in "
+                f"{self.review_chunk_count} chunks and the per-chunk results were merged."
+            )
+            if self.review_failed_chunk_count:
+                markdown_text += (f" {self.review_failed_chunk_count} chunk(s) failed and are not covered "
+                                  "by this review.")
 
         if self.remaining_files_list and get_settings().pr_reviewer.enable_review_coverage_footer:
             displayed_files = self.remaining_files_list[:MAX_REVIEW_COVERAGE_FILES]

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -183,6 +183,78 @@ def test_get_pr_multi_diffs_clips_large_patch_when_policy_is_clip(monkeypatch):
         settings.config.verbosity_level = original["verbosity_level"]
 
 
+def test_get_pr_multi_diffs_reports_the_files_the_token_budget_left_out(monkeypatch):
+    # /review needs the same coverage list get_pr_diff returns, so the review footer can name
+    # the files that were dropped even when the diff was reviewed in chunks.
+    settings = get_settings()
+    original = {
+        "patch_extra_lines_before": settings.config.patch_extra_lines_before,
+        "patch_extra_lines_after": settings.config.patch_extra_lines_after,
+        "large_patch_policy": settings.config.get("large_patch_policy", "skip"),
+        "verbosity_level": settings.config.verbosity_level,
+    }
+    settings.config.patch_extra_lines_before = 0
+    settings.config.patch_extra_lines_after = 0
+    settings.config.large_patch_policy = "skip"
+    settings.config.verbosity_level = 0
+
+    def _file(filename, patch):
+        return FilePatchInfo(base_file="old\n", head_file="new\n", patch=patch,
+                             filename=filename, edit_type=EDIT_TYPE.MODIFIED)
+
+    hunk = "@@ -1 +1 @@\n-old\n+" + ("alpha " * 60)
+    deleted = FilePatchInfo(base_file="old\n", head_file="", patch="@@ -1 +0,0 @@\n-old",
+                            filename="deleted.py", edit_type=EDIT_TYPE.DELETED)
+    files = [_file("first.py", hunk), _file("second.py", hunk), _file("no_patch.py", ""), deleted]
+    provider = FakeProvider(files)
+    token_handler = FakeTokenHandler(prompt_tokens=100)
+
+    monkeypatch.setattr(pr_processing, "sort_files_by_main_languages", lambda languages, files: [{"files": files}])
+    monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: 1700)
+
+    try:
+        diffs, remaining_files = pr_processing.get_pr_multi_diffs(
+            provider, token_handler, "tiny-model", max_calls=1, add_line_numbers=False,
+            return_remaining_files=True
+        )
+
+        assert len(diffs) == 1
+        assert "first.py" in diffs[0]
+        # second.py did not fit within max_calls; no_patch.py and deleted.py have nothing to
+        # review, so they are not something the token budget left out
+        assert remaining_files == ["second.py"]
+    finally:
+        for key, value in original.items():
+            setattr(settings.config, key, value)
+
+
+def test_get_pr_multi_diffs_reports_no_remaining_files_when_the_whole_diff_fits(monkeypatch):
+    settings = get_settings()
+    original_before = settings.config.patch_extra_lines_before
+    original_after = settings.config.patch_extra_lines_after
+    settings.config.patch_extra_lines_before = 0
+    settings.config.patch_extra_lines_after = 0
+
+    file_info = FilePatchInfo(base_file="old\n", head_file="new\n", patch="@@ -1 +1 @@\n-old\n+new",
+                              filename="small.py", edit_type=EDIT_TYPE.MODIFIED)
+    provider = FakeProvider([file_info])
+    token_handler = FakeTokenHandler(prompt_tokens=100)
+
+    monkeypatch.setattr(pr_processing, "sort_files_by_main_languages", lambda languages, files: [{"files": files}])
+    monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: 100000)
+
+    try:
+        diffs, remaining_files = pr_processing.get_pr_multi_diffs(
+            provider, token_handler, "big-model", add_line_numbers=False, return_remaining_files=True
+        )
+
+        assert len(diffs) == 1
+        assert remaining_files == []
+    finally:
+        settings.config.patch_extra_lines_before = original_before
+        settings.config.patch_extra_lines_after = original_after
+
+
 def test_pr_description_reads_fall_back_when_keys_missing():
     # Regression for "'DynaBox' object has no attribute 'enable_large_pr_handling'":
     # custom_merge_loader replaces a section instead of merging it, so a custom

--- a/tests/unittest/test_review_chunk_merge.py
+++ b/tests/unittest/test_review_chunk_merge.py
@@ -1,0 +1,272 @@
+"""Merge rules for a `/review` that was answered one diff chunk at a time.
+
+Every chunk answers the same schema about a different part of the PR, so each field needs a
+stated rule. The invariant the whole module protects: a merged review is never less alarming
+than its worst chunk.
+"""
+
+import pytest
+
+from pr_agent.algo import review_merge
+from pr_agent.algo.review_merge import merge_review_chunks
+
+
+def _chunk(**review):
+    return {"review": review}
+
+
+def _issue(file="app.py", header="Possible Issue", content="unchecked index", start=3, end=4):
+    return {"relevant_file": file, "issue_header": header, "issue_content": content,
+            "start_line": start, "end_line": end}
+
+
+def test_no_chunk_produces_no_review():
+    assert merge_review_chunks([]) == {}
+    assert merge_review_chunks([{"not_a_review": 1}, {"review": "text"}]) == {}
+
+
+def test_a_single_chunk_is_passed_through_without_being_aliased():
+    review = {"score": "80", "key_issues_to_review": [_issue()]}
+    merged = merge_review_chunks([{"review": review}])
+
+    assert merged == {"review": review}
+    assert merged["review"] is not review
+
+
+def test_chunks_without_a_review_mapping_are_skipped():
+    merged = merge_review_chunks([_chunk(score="90"), {"review": None}, _chunk(score="40")])
+
+    assert merged["review"]["score"] == "40"
+
+
+def test_fields_keep_the_order_they_first_appear_in():
+    merged = merge_review_chunks([
+        _chunk(score="90", relevant_tests="No"),
+        _chunk(security_concerns="No", score="40"),
+    ])
+
+    assert list(merged["review"]) == ["score", "relevant_tests", "security_concerns"]
+
+
+def test_key_issues_from_every_chunk_are_kept_in_chunk_order():
+    first, second = _issue(file="a.py"), _issue(file="b.py", content="off by one")
+    merged = merge_review_chunks([
+        _chunk(key_issues_to_review=[first]),
+        _chunk(key_issues_to_review=[second]),
+    ])
+
+    assert merged["review"]["key_issues_to_review"] == [first, second]
+
+
+def test_the_same_finding_reported_by_two_chunks_is_kept_once():
+    merged = merge_review_chunks([
+        _chunk(key_issues_to_review=[_issue()]),
+        # same file, header and text, restated with different whitespace, casing and lines
+        _chunk(key_issues_to_review=[_issue(header="possible  issue", content="Unchecked index",
+                                            start=30, end=31)]),
+    ])
+
+    assert merged["review"]["key_issues_to_review"] == [_issue()]
+
+
+def test_findings_survive_a_chunk_that_found_nothing():
+    merged = merge_review_chunks([
+        _chunk(key_issues_to_review=[]),
+        _chunk(key_issues_to_review=[_issue()]),
+        _chunk(key_issues_to_review="No"),
+    ])
+
+    assert merged["review"]["key_issues_to_review"] == [_issue()]
+
+
+def test_a_security_concern_in_one_chunk_wins_over_the_chunks_that_found_none():
+    merged = merge_review_chunks([
+        _chunk(security_concerns="No"),
+        _chunk(security_concerns="SQL injection: user input reaches the query unescaped"),
+    ])
+
+    assert merged["review"]["security_concerns"] == "SQL injection: user input reaches the query unescaped"
+
+
+def test_security_concerns_are_only_no_when_every_chunk_said_no():
+    merged = merge_review_chunks([_chunk(security_concerns="No"), _chunk(security_concerns="no")])
+
+    assert merged["review"]["security_concerns"] == "No"
+
+
+def test_two_different_security_concerns_are_both_reported_once():
+    merged = merge_review_chunks([
+        _chunk(security_concerns="XSS: unescaped output"),
+        _chunk(security_concerns="XSS: unescaped output"),
+        _chunk(security_concerns="Secret exposure: the token is logged"),
+    ])
+
+    assert merged["review"]["security_concerns"] == (
+        "XSS: unescaped output\n\nSecret exposure: the token is logged")
+
+
+def test_the_score_of_the_worst_chunk_is_the_score_of_the_pr():
+    merged = merge_review_chunks([_chunk(score="90"), _chunk(score=35), _chunk(score="70")])
+
+    # the winning chunk's own value is returned, so its type and formatting survive
+    assert merged["review"]["score"] == 35
+
+
+def test_an_unreadable_score_does_not_hide_the_scores_that_parsed():
+    merged = merge_review_chunks([_chunk(score="not a score"), _chunk(score="60")])
+
+    assert merged["review"]["score"] == "60"
+
+
+def test_review_effort_adds_up_across_the_chunks():
+    merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "1"}),
+                                  _chunk(**{"estimated_effort_to_review_[1-5]": 2})])
+
+    assert merged["review"]["estimated_effort_to_review_[1-5]"] == 3
+
+
+def test_review_effort_stays_within_the_one_to_five_scale():
+    merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "4"}),
+                                  _chunk(**{"estimated_effort_to_review_[1-5]": "3"}),
+                                  _chunk(**{"estimated_effort_to_review_[1-5]": "5"})])
+
+    assert merged["review"]["estimated_effort_to_review_[1-5]"] == 5
+
+
+def test_unparsable_effort_falls_back_to_the_first_chunk():
+    merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "unknown"}),
+                                  _chunk(**{"estimated_effort_to_review_[1-5]": "also unknown"})])
+
+    assert merged["review"]["estimated_effort_to_review_[1-5]"] == "unknown"
+
+
+@pytest.mark.parametrize("levels, expected", [
+    (["low", "high", "medium"], "high"),
+    (["low", "medium"], "medium"),
+    (["low", "low"], "low"),
+])
+def test_the_riskiest_chunk_sets_the_risk_level(levels, expected):
+    merged = merge_review_chunks([_chunk(risk_level=level) for level in levels])
+
+    assert merged["review"]["risk_level"] == expected
+
+
+@pytest.mark.parametrize("recommendations, expected", [
+    (["safe_to_merge", "changes_required"], "changes_required"),
+    (["safe_to_merge", "merge_with_caution"], "merge_with_caution"),
+    (["safe_to_merge", "safe_to_merge"], "safe_to_merge"),
+])
+def test_the_most_cautious_chunk_sets_the_merge_recommendation(recommendations, expected):
+    merged = merge_review_chunks([_chunk(merge_recommendation=value) for value in recommendations])
+
+    assert merged["review"]["merge_recommendation"] == expected
+
+
+def test_an_unrecognised_risk_level_falls_back_to_the_first_chunk():
+    merged = merge_review_chunks([_chunk(risk_level="unknown"), _chunk(risk_level="also unknown")])
+
+    assert merged["review"]["risk_level"] == "unknown"
+
+
+def test_tests_added_in_any_chunk_count_as_tests_added_by_the_pr():
+    merged = merge_review_chunks([_chunk(relevant_tests="No"), _chunk(relevant_tests="Yes")])
+
+    assert merged["review"]["relevant_tests"] == "Yes"
+
+
+def test_no_tests_when_no_chunk_found_any():
+    merged = merge_review_chunks([_chunk(relevant_tests="No"), _chunk(relevant_tests="No")])
+
+    assert merged["review"]["relevant_tests"] == "No"
+
+
+def test_priority_files_are_unioned_without_repeats():
+    merged = merge_review_chunks([
+        _chunk(review_priority_files=["src/a.py", "src/b.py"]),
+        _chunk(review_priority_files=["src/b.py", "src/c.py"]),
+    ])
+
+    assert merged["review"]["review_priority_files"] == ["src/a.py", "src/b.py", "src/c.py"]
+
+
+def test_todo_sections_are_unioned_and_stay_no_when_no_chunk_found_any():
+    todo = {"relevant_file": "a.py", "line_number": 4, "content": "drop the shim"}
+    merged = merge_review_chunks([_chunk(todo_sections="No"), _chunk(todo_sections=[todo]),
+                                  _chunk(todo_sections=[todo])])
+
+    assert merged["review"]["todo_sections"] == [todo]
+    assert merge_review_chunks([_chunk(todo_sections="No"),
+                                _chunk(todo_sections="No")])["review"]["todo_sections"] == "No"
+
+
+def test_sub_prs_are_unioned_by_their_files_and_stay_within_the_prompt_limit():
+    merged = merge_review_chunks([
+        _chunk(can_be_split=[{"relevant_files": ["a.py"], "title": "first"},
+                             {"relevant_files": ["b.py"], "title": "second"}]),
+        # the same split, restated: same files, different title
+        _chunk(can_be_split=[{"relevant_files": ["a.py"], "title": "first split"},
+                             {"relevant_files": ["c.py"], "title": "third"},
+                             {"relevant_files": ["d.py"], "title": "fourth"}]),
+    ])
+
+    assert [sub_pr["title"] for sub_pr in merged["review"]["can_be_split"]] == [
+        "first", "second", "third"]
+
+
+def test_ticket_compliance_is_grouped_per_ticket_and_its_bullet_lists_are_unioned():
+    merged = merge_review_chunks([
+        _chunk(ticket_compliance_check=[{"ticket_url": "https://tracker/1",
+                                         "fully_compliant_requirements": "- adds the endpoint",
+                                         "not_compliant_requirements": ""}]),
+        _chunk(ticket_compliance_check=[{"ticket_url": "https://tracker/1",
+                                         "fully_compliant_requirements": "- adds the endpoint",
+                                         "not_compliant_requirements": "- no rate limiting"},
+                                        {"ticket_url": "https://tracker/2",
+                                         "fully_compliant_requirements": "- renames the flag"}]),
+    ])
+
+    first, second = merged["review"]["ticket_compliance_check"]
+    assert first["ticket_url"] == "https://tracker/1"
+    assert first["fully_compliant_requirements"] == "- adds the endpoint"
+    assert first["not_compliant_requirements"] == "- no rate limiting"
+    assert second["ticket_url"] == "https://tracker/2"
+
+
+def test_contribution_time_adds_up_across_the_chunks():
+    merged = merge_review_chunks([
+        _chunk(contribution_time_cost_estimate={"best_case": "45m", "average_case": "2h",
+                                                "worst_case": "5h"}),
+        _chunk(contribution_time_cost_estimate={"best_case": "45m", "average_case": "3h",
+                                                "worst_case": "10h"}),
+    ])
+
+    assert merged["review"]["contribution_time_cost_estimate"] == {
+        "best_case": "1.5h", "average_case": "5h", "worst_case": "15h"}
+
+
+def test_contribution_time_falls_back_when_a_chunk_uses_an_unknown_unit():
+    first = {"best_case": "45m", "average_case": "2h", "worst_case": "5h"}
+    merged = merge_review_chunks([
+        _chunk(contribution_time_cost_estimate=first),
+        _chunk(contribution_time_cost_estimate={"best_case": "two days", "average_case": "3h",
+                                                "worst_case": "10h"}),
+    ])
+
+    assert merged["review"]["contribution_time_cost_estimate"] == first
+
+
+def test_a_field_the_rules_do_not_know_keeps_the_first_chunk_that_answered_it():
+    merged = merge_review_chunks([_chunk(a_future_field=""), _chunk(a_future_field="kept"),
+                                  _chunk(a_future_field="dropped")])
+
+    assert merged["review"]["a_future_field"] == "kept"
+
+
+def test_a_field_that_raises_while_merging_keeps_the_first_chunk_instead_of_failing(monkeypatch):
+    def explode(values):
+        raise ValueError("unexpected shape")
+
+    monkeypatch.setitem(review_merge._MERGE_RULES, "score", explode)
+    merged = merge_review_chunks([_chunk(score="90"), _chunk(score="40")])
+
+    assert merged["review"]["score"] == "90"

--- a/tests/unittest/test_review_chunk_merge.py
+++ b/tests/unittest/test_review_chunk_merge.py
@@ -118,17 +118,23 @@ def test_an_unreadable_score_does_not_hide_the_scores_that_parsed():
     assert merged["review"]["score"] == "60"
 
 
-def test_review_effort_adds_up_across_the_chunks():
+def test_review_effort_reports_the_hardest_chunk():
     merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "1"}),
                                   _chunk(**{"estimated_effort_to_review_[1-5]": 2})])
 
-    assert merged["review"]["estimated_effort_to_review_[1-5]"] == 3
+    assert merged["review"]["estimated_effort_to_review_[1-5]"] == 2
+
+
+def test_review_effort_does_not_saturate_across_modest_chunks():
+    merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "2"}) for _ in range(3)])
+
+    assert merged["review"]["estimated_effort_to_review_[1-5]"] == 2
 
 
 def test_review_effort_stays_within_the_one_to_five_scale():
     merged = merge_review_chunks([_chunk(**{"estimated_effort_to_review_[1-5]": "4"}),
                                   _chunk(**{"estimated_effort_to_review_[1-5]": "3"}),
-                                  _chunk(**{"estimated_effort_to_review_[1-5]": "5"})])
+                                  _chunk(**{"estimated_effort_to_review_[1-5]": "7"})])
 
     assert merged["review"]["estimated_effort_to_review_[1-5]"] == 5
 

--- a/tests/unittest/test_review_large_diff_chunking.py
+++ b/tests/unittest/test_review_large_diff_chunking.py
@@ -1,0 +1,263 @@
+"""The opt-in gate and wiring of the chunked `/review` flow.
+
+The merge rules themselves live in tests/unittest/test_review_chunk_merge.py; what is
+covered here is when chunking runs at all, what it does with a chunk that fails, and what
+the published review says about having been assembled from several calls.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_reviewer import PRReviewer
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+_TRACKED_KEYS = ("pr_reviewer.enable_large_pr_chunking", "pr_reviewer.max_number_of_calls")
+
+CHUNK_A = """review:
+  score: "90"
+  key_issues_to_review:
+    - relevant_file: |
+        a.py
+      issue_header: |
+        Possible Issue
+      issue_content: |
+        the index is never checked
+      start_line: 3
+      end_line: 4
+  security_concerns: |
+    No
+"""
+
+CHUNK_B = """review:
+  score: "40"
+  key_issues_to_review: []
+  security_concerns: |
+    SQL injection: the query is built by string concatenation
+"""
+
+
+def _make_reviewer():
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.git_provider = MagicMock()
+    reviewer.token_handler = MagicMock()
+    reviewer.pr_url = "https://example/pr/1"
+    reviewer.incremental = SimpleNamespace(is_incremental=False)
+    reviewer.remaining_files_list = []
+    reviewer.prediction = None
+    return reviewer
+
+
+@pytest.fixture
+def chunking_enabled():
+    snapshot = snapshot_settings(_TRACKED_KEYS)
+    get_settings().set("pr_reviewer.enable_large_pr_chunking", True)
+    get_settings().set("pr_reviewer.max_number_of_calls", 3)
+    yield
+    restore_settings(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_chunking_is_off_by_default_even_when_the_token_budget_truncated_the_diff():
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(return_value=CHUNK_A)
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["left_out.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs") as get_pr_multi_diffs,
+    ):
+        await reviewer._prepare_prediction("model")
+
+    get_pr_multi_diffs.assert_not_called()
+    assert reviewer.prediction == CHUNK_A
+    assert reviewer.prediction_data is None
+    assert reviewer.review_chunk_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_diff_that_fits_is_never_chunked(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(return_value=CHUNK_A)
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", [])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs") as get_pr_multi_diffs,
+    ):
+        await reviewer._prepare_prediction("model")
+
+    get_pr_multi_diffs.assert_not_called()
+    assert reviewer.review_chunk_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_diff_is_reviewed_chunk_by_chunk_and_merged(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[CHUNK_A, CHUNK_B])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], ["still_left_out.py"])) as get_pr_multi_diffs,
+    ):
+        await reviewer._prepare_prediction("model")
+
+    get_pr_multi_diffs.assert_called_once_with(
+        reviewer.git_provider,
+        reviewer.token_handler,
+        "model",
+        max_calls=3,
+        add_line_numbers=True,
+        return_remaining_files=True,
+    )
+    assert [call.args[1] for call in reviewer._get_prediction.await_args_list] == ["chunk-a", "chunk-b"]
+
+    review = reviewer.prediction_data["review"]
+    assert review["score"] == "40"  # the worst chunk sets the score
+    assert [issue["relevant_file"].strip() for issue in review["key_issues_to_review"]] == ["a.py"]
+    assert review["security_concerns"].startswith("SQL injection:")
+    assert reviewer.review_chunk_count == 2
+    assert reviewer.review_failed_chunk_count == 0
+    # the coverage footer keeps reporting what even chunking could not fit
+    assert reviewer.remaining_files_list == ["still_left_out.py"]
+
+
+@pytest.mark.asyncio
+async def test_max_number_of_calls_bounds_the_number_of_chunks(chunking_enabled):
+    get_settings().set("pr_reviewer.max_number_of_calls", 7)
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[CHUNK_A, CHUNK_B])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], [])) as get_pr_multi_diffs,
+    ):
+        await reviewer._prepare_prediction("model")
+
+    assert get_pr_multi_diffs.call_args.kwargs["max_calls"] == 7
+
+
+@pytest.mark.asyncio
+async def test_a_diff_that_fits_in_one_chunk_is_reviewed_by_the_single_call_flow(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(return_value=CHUNK_A)
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs", return_value=(["only-chunk"], [])),
+    ):
+        await reviewer._prepare_prediction("model")
+
+    reviewer._get_prediction.assert_awaited_once_with("model")
+    assert reviewer.prediction == CHUNK_A
+    assert reviewer.prediction_data is None
+    assert reviewer.review_chunk_count == 1
+    assert reviewer.remaining_files_list == ["b.py"]
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_that_fails_does_not_lose_the_chunks_that_succeeded(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[RuntimeError("model refused"), CHUNK_B])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], [])),
+    ):
+        await reviewer._prepare_prediction("model")
+
+    assert reviewer.prediction_data["review"]["score"] == "40"
+    assert reviewer.review_chunk_count == 2
+    assert reviewer.review_failed_chunk_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_review_where_every_chunk_failed_raises_so_a_fallback_model_is_tried(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[RuntimeError("model refused"),
+                                                      RuntimeError("model refused again")])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], [])),
+        pytest.raises(RuntimeError, match="model refused"),
+    ):
+        await reviewer._prepare_prediction("model")
+
+
+@pytest.mark.asyncio
+async def test_chunks_that_answer_nothing_parsable_fall_back_to_a_single_call_review(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=["not yaml at all", "nor is this", CHUNK_A])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], [])),
+    ):
+        await reviewer._prepare_prediction("model")
+
+    assert reviewer._get_prediction.await_count == 3
+    assert reviewer.prediction == CHUNK_A
+    assert reviewer.prediction_data is None
+
+
+def _render_review(reviewer):
+    reviewer.prediction = "review: {}"
+    reviewer.git_provider.get_diff_files.return_value = []
+    reviewer.git_provider.is_supported.return_value = False
+    reviewer.set_review_labels = MagicMock()
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.load_yaml", return_value={"review": {}}),
+        patch("pr_agent.tools.pr_reviewer.github_action_output"),
+        patch("pr_agent.tools.pr_reviewer.convert_to_markdown_v2", return_value="original review"),
+    ):
+        return reviewer._prepare_pr_review()
+
+
+def test_a_chunked_review_says_how_many_chunks_it_was_built_from():
+    reviewer = _make_reviewer()
+    reviewer.review_chunk_count = 3
+
+    review = _render_review(reviewer)
+
+    assert review.startswith("original review")
+    assert "ℹ️ **Chunked review:**" in review
+    assert "reviewed in 3 chunks" in review
+    assert "failed" not in review
+
+
+def test_a_chunked_review_reports_the_chunks_that_failed():
+    reviewer = _make_reviewer()
+    reviewer.review_chunk_count = 3
+    reviewer.review_failed_chunk_count = 1
+
+    review = _render_review(reviewer)
+
+    assert "1 chunk(s) failed and are not covered by this review." in review
+
+
+def test_a_single_call_review_says_nothing_about_chunks():
+    review = _render_review(_make_reviewer())
+
+    assert review == "original review"
+
+
+def test_the_chunk_note_comes_before_the_review_coverage_footer():
+    reviewer = _make_reviewer()
+    reviewer.review_chunk_count = 2
+    reviewer.remaining_files_list = ["left_out.py"]
+    snapshot = snapshot_settings(("pr_reviewer.enable_review_coverage_footer",))
+    try:
+        get_settings().set("pr_reviewer.enable_review_coverage_footer", True)
+        review = _render_review(reviewer)
+    finally:
+        restore_settings(snapshot)
+
+    assert review.index("Chunked review:") < review.index("⚠️ **Review coverage:**")
+    assert "- `left_out.py`" in review


### PR DESCRIPTION
When a diff exceeds the model token budget, /review drops whole files and
reviews what is left. With pr_reviewer.enable_large_pr_chunking = true the
diff is instead split with get_pr_multi_diffs, each chunk is reviewed on its
own, and the per-chunk answers are merged into one review that says how many
chunks it was built from. The flag defaults to false, so nothing changes for
an existing install.

Merging is the part that needed a decision, since a review emits single-valued
judgements over the whole PR. pr_agent/algo/review_merge.py states one rule per
field, under a single invariant: a merged review is never less alarming than
its worst chunk.

- evidence fields (key issues, security concerns, TODO sections, priority
  files, sub-PRs, ticket bullet lists) are unioned in chunk order, de-duplicated
- judgement fields (score, risk level, merge recommendation, review effort) take
  the most conservative value any chunk gave; tests count as added if any chunk saw them
- contribution time is summed, since the chunks partition the change
- an unknown key keeps the first chunk's non-empty value, so a field added to
  the prompt later survives the merge

get_pr_multi_diffs gains an opt-in return_remaining_files, mirroring get_pr_diff,
so the review coverage footer keeps naming the files that did not fit even after
chunking. Files with no patch, and delete-only files, are not reported: the token
budget is not what kept them out.

Refs #2978

