### PR TITLE
fix(gitlab): skip suggestions pointing past blanked head content

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1253,7 +1253,13 @@ class GitLabProvider(GitProvider):
                     continue
                 range = relevant_lines_end - relevant_lines_start # no need to add 1
                 body = body.replace('```suggestion', f'```suggestion:-0+{range}')
-                lines = target_file.head_file.splitlines()
+                lines = target_file.head_file.splitlines() if target_file.head_file else []
+                if not 0 < relevant_lines_start <= len(lines):
+                    get_logger().warning(
+                        f"Skipping suggestion: line {relevant_lines_start} out of range "
+                        f"for '{relevant_file}' (head content has {len(lines)} lines)"
+                    )
+                    continue
                 relevant_line_in_file = lines[relevant_lines_start - 1]
 
                 # edit_type, found, source_line_no, target_file, target_line_no = self.find_in_file(target_file,

--- a/tests/unittest/test_gitlab_publish_guard.py
+++ b/tests/unittest/test_gitlab_publish_guard.py
@@ -1,0 +1,49 @@
+"""Skip suggestions that point past blanked head content instead of indexing the file."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.git_providers import gitlab_provider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+HEAD = "line1\nline2\nline3"
+
+
+def _provider(monkeypatch, head=HEAD):
+    logger = MagicMock()
+    monkeypatch.setattr(gitlab_provider, "get_logger", lambda: logger)
+    monkeypatch.setattr(gitlab_provider, "get_settings",
+                        lambda: {"gitlab.publish_code_suggestions_as_review": False})
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.resolve_outdated_inline_threads = lambda: None
+    provider.get_diff_files = lambda: [FilePatchInfo(base_file="", head_file=head, patch="",
+                                                     filename="a.py", edit_type=EDIT_TYPE.MODIFIED)]
+    provider.sent = []
+    provider.send_inline_comment = lambda *args, **kwargs: provider.sent.append(args)
+    return provider, logger
+
+
+def _suggestion(start=2, end=3):
+    return {'body': '```suggestion\nfixed\n```', 'relevant_file': 'a.py',
+            'relevant_lines_start': start, 'relevant_lines_end': end}
+
+
+@pytest.mark.parametrize("head,start", [("", 2), (HEAD, 99), (HEAD, 0)])
+def test_unpublishable_suggestion_is_skipped_with_warning(monkeypatch, head, start):
+    """Blank head, out-of-range, or zero line numbers must not raise IndexError."""
+    provider, logger = _provider(monkeypatch, head)
+
+    assert provider.publish_code_suggestions([_suggestion(start=start, end=start)]) is True
+    assert provider.sent == []
+    warned = [c[0][0] for c in logger.warning.call_args_list]
+    assert any("Skipping suggestion" in w for w in warned)
+
+
+def test_populated_head_file_still_publishes(monkeypatch):
+    """Keep the existing behaviour where head content is present."""
+    provider, _ = _provider(monkeypatch)
+
+    assert provider.publish_code_suggestions([_suggestion()]) is True
+    assert len(provider.sent) == 1
+    assert provider.sent[0][4] == "line2"


### PR DESCRIPTION
## What

- `gitlab_provider.py`: guard `publish_code_suggestions` against blank or
  out-of-range `head_file` — warn and skip instead of indexing.
- `tests/unittest/test_gitlab_publish_guard.py`: 4 tests (blank, out-of-range,
  zero line, normal path).

## Why

Closes #3010. Past 50 files, `head_file` is blanked by design and publishing
threw IndexError, silently dropping the suggestion with a traceback.

## Testing

- New tests: 4 passed; verified they fail without the fix.
- Existing `test_gitlab_batch_publish_suggestions.py`: 8 passed.
- `ruff check`: clean.

## Risks/Impact

Low. The normal publish path is unchanged; only previously-crashing inputs
now skip with a warning.