### PR TITLE
fix(gerrit): return commit messages as text

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -259,8 +259,8 @@ class GerritProvider(GitProvider):
         raise NotImplementedError(
             'Removing reactions is not implemented for the gerrit provider')
 
-    def get_commit_messages(self):
-        return [self.repo.head.commit.message]
+    def get_commit_messages(self) -> str:
+        return self.repo.head.commit.message
 
     def get_repo_settings(self):
         try:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -576,7 +576,7 @@ class GitProvider(ABC):
 
     #### commits operations ####
     @abstractmethod
-    def get_commit_messages(self):
+    def get_commit_messages(self) -> str:
         pass
 
     def get_pr_url(self) -> str:

--- a/tests/unittest/test_gerrit_provider.py
+++ b/tests/unittest/test_gerrit_provider.py
@@ -21,6 +21,13 @@ def _make_repo(tmp_path, filenames):
     return repo
 
 
+def test_get_commit_messages_returns_text(tmp_path):
+    provider = object.__new__(GerritProvider)
+    provider.repo = _make_repo(tmp_path, ["app.py"])
+
+    assert provider.get_commit_messages() == "initial files"
+
+
 def test_get_diff_files_preserves_deleted_filename(tmp_path):
     repo = _make_repo(tmp_path, ["keep.py", "gone.py"])
     (tmp_path / "gone.py").unlink()


### PR DESCRIPTION
## What changed

- Align `GitProvider.get_commit_messages()` and the Gerrit implementation to return `str`.
- Add a regression test covering the Gerrit provider.

## Why

Gerrit currently returns a one-item list while the shared provider contract and other implementations return plain text. This causes commit messages to be rendered in prompts with list brackets and escaped newlines.

This PR addresses the live `get_commit_messages` drift from #3009 only.

## Validation

- `PYTHONPATH=. uv run pytest tests/unittest/test_gerrit_provider.py -q`
- `uv run ruff check pr_agent/git_providers/git_provider.py pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py`
- `uv run pre-commit run --files pr_agent/git_providers/git_provider.py pr_agent/git_providers/gerrit_provider.py tests/unittest/test_gerrit_provider.py`
- `git diff --check`

Related to #3009