### PR TITLE
fix(gitea): walk every page of PR files and commits

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -1013,15 +1013,21 @@ class RepoApi(giteapy.RepositoryApi):
             body=body
         )
 
-    def get_change_file_pull_request(self, owner: str, repo: str, pr_number: int):
-        """Get changed files in the pull request"""
-        try:
-            url = f'/repos/{owner}/{repo}/pulls/{pr_number}/files'
+    def _list_all_pages(self, url: str, page_size: int = 50) -> list:
+        """Walk a paginated list endpoint until it answers with an empty page.
 
+        Gitea serves at most `limit` items per page and caps `limit` at the server's own
+        MAX_RESPONSE_ITEMS, so a page shorter than `page_size` is not necessarily the last
+        one. Errors propagate: a failure mid-way must not yield a silently truncated list.
+        """
+        items = []
+        page = 1
+        while True:
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
+                query_params=[('page', page), ('limit', page_size)],
                 response_type=None,
                 _return_http_data_only=False,
                 _preload_content=False,
@@ -1030,15 +1036,21 @@ class RepoApi(giteapy.RepositoryApi):
 
             if hasattr(response, 'data'):
                 raw_data = response.data.read()
-                diff_content = raw_data.decode('utf-8')
-                return json.loads(diff_content) if isinstance(diff_content, str) else diff_content
             elif isinstance(response, tuple):
                 raw_data = response[0].read()
-                diff_content = raw_data.decode('utf-8')
-                return json.loads(diff_content) if isinstance(diff_content, str) else diff_content
+            else:
+                return items
 
-            return []
+            page_items = json.loads(raw_data.decode('utf-8'))
+            if not isinstance(page_items, list) or not page_items:
+                return items
+            items.extend(page_items)
+            page += 1
 
+    def get_change_file_pull_request(self, owner: str, repo: str, pr_number: int):
+        """Get changed files in the pull request"""
+        try:
+            return self._list_all_pages(f'/repos/{owner}/{repo}/pulls/{pr_number}/files')
         except ApiException as e:
             self.logger.error(f"Error getting changed files: {e}")
             return []
@@ -1181,29 +1193,7 @@ class RepoApi(giteapy.RepositoryApi):
     def get_pr_commits(self, owner: str, repo: str, pr_number: int):
         """Get all commits in a pull request"""
         try:
-            url = f'/repos/{owner}/{repo}/pulls/{pr_number}/commits'
-
-            response = self.api_client.call_api(
-                url,
-                'GET',
-                path_params={},
-                response_type=None,
-                _return_http_data_only=False,
-                _preload_content=False,
-                auth_settings=['AuthorizationHeaderToken']
-            )
-
-            if hasattr(response, 'data'):
-                raw_data = response.data.read()
-                commits_data = json.loads(raw_data.decode('utf-8'))
-                return commits_data
-            elif isinstance(response, tuple):
-                raw_data = response[0].read()
-                commits_data = json.loads(raw_data.decode('utf-8'))
-                return commits_data
-
-            return []
-
+            return self._list_all_pages(f'/repos/{owner}/{repo}/pulls/{pr_number}/commits')
         except ApiException as e:
             self.logger.error(f"Error getting PR commits: {e}")
             return []

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1,4 +1,6 @@
+import json
 from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -919,3 +921,82 @@ class TestGiteaProviderInlineCommentStatus:
 
         _, kwargs = client.call_api.call_args
         assert kwargs["body"]["event"] == "COMMENT"
+
+
+def _page(items):
+    """A raw (non-preloaded) giteapy response carrying one JSON page."""
+    return SimpleNamespace(data=BytesIO(json.dumps(items).encode("utf-8")))
+
+
+class TestGiteaRepoApiPagination:
+    """Gitea answers list endpoints one page at a time (30 items by default), so the PR
+    files and commits must be collected across every page."""
+
+    @staticmethod
+    def _repo_api(pages):
+        from pr_agent.git_providers.gitea_provider import RepoApi
+
+        repo_api = RepoApi(MagicMock())
+        repo_api.logger = MagicMock()
+        repo_api.api_client.call_api.side_effect = [_page(items) for items in pages]
+        return repo_api
+
+    @staticmethod
+    def _requested_pages(repo_api):
+        return [dict(call.kwargs["query_params"])["page"] for call in repo_api.api_client.call_api.call_args_list]
+
+    def test_pr_files_are_collected_across_pages(self):
+        repo_api = self._repo_api([
+            [{"filename": "a.py"}, {"filename": "b.py"}],
+            [{"filename": "c.py"}],
+            [],
+        ])
+
+        files = repo_api.get_change_file_pull_request(owner="owner", repo="repo", pr_number=7)
+
+        assert [f["filename"] for f in files] == ["a.py", "b.py", "c.py"]
+        assert self._requested_pages(repo_api) == [1, 2, 3]
+
+    def test_pr_commits_are_collected_across_pages(self):
+        repo_api = self._repo_api([
+            [{"sha": "newest"}, {"sha": "middle"}],
+            [{"sha": "oldest"}],
+            [],
+        ])
+
+        commits = repo_api.get_pr_commits(owner="owner", repo="repo", pr_number=7)
+
+        assert [c["sha"] for c in commits] == ["newest", "middle", "oldest"]
+        assert self._requested_pages(repo_api) == [1, 2, 3]
+
+    def test_a_page_shorter_than_the_requested_limit_is_not_the_last_page(self):
+        # A server capped at 30 items answers a limit of 50 with 30 items; only an empty
+        # page ends the walk, otherwise the original truncation would be back.
+        repo_api = self._repo_api([
+            [{"sha": str(i)} for i in range(30)],
+            [{"sha": str(i)} for i in range(30, 35)],
+            [],
+        ])
+
+        commits = repo_api.get_pr_commits(owner="owner", repo="repo", pr_number=7)
+
+        assert len(commits) == 35
+        assert self._requested_pages(repo_api) == [1, 2, 3]
+
+    def test_every_page_request_authenticates_via_header(self):
+        repo_api = self._repo_api([[{"filename": "a.py"}], []])
+
+        repo_api.get_change_file_pull_request(owner="owner", repo="repo", pr_number=7)
+
+        for call in repo_api.api_client.call_api.call_args_list:
+            assert call.kwargs["auth_settings"] == ["AuthorizationHeaderToken"]
+            assert "token" not in dict(call.kwargs["query_params"])
+
+    def test_a_failure_mid_way_does_not_return_a_partial_list(self):
+        repo_api = self._repo_api([])
+        repo_api.api_client.call_api.side_effect = [_page([{"filename": "a.py"}]), ApiException(status=502)]
+
+        files = repo_api.get_change_file_pull_request(owner="owner", repo="repo", pr_number=7)
+
+        assert files == []
+        repo_api.logger.error.assert_called_once()


### PR DESCRIPTION
Gitea answers list endpoints one page at a time, 30 items by default, and
`RepoApi.get_change_file_pull_request` / `get_pr_commits` issued a single call
with no paging. Any PR past the page size was reviewed against a partial file
list, silently.

Both now walk the pages through one helper, `_list_all_pages`. The earlier
attempt in #2147 stalled on three points, and each is addressed here:

- every page request keeps the header token auth the rest of the provider
  uses, so no credential lands in a query string
- the walk stops only at an empty page, not at a page shorter than the
  requested limit: the server caps `limit` at its own `MAX_RESPONSE_ITEMS`,
  so a capped page must not end the walk early
- a failure mid-way propagates to the existing handlers and yields the same
  empty result a failed call always did, never a partial list

The tests cover a multi-page walk for files and for commits, a server that
caps the page below the requested limit, header auth on every page, and the
mid-way failure. All five fail on `main`.

Closes #2138
