### PR TITLE
feat(git-providers): add public register_git_provider

### DIFF
--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -43,6 +43,20 @@ Implement a `GitProvider` subclass and register it:
 5. Select provider-dependent behavior with capability checks like `provider.is_supported("feature")` rather than provider-type checks.
 6. Add unit tests under `tests/unittest/test_<name>_provider.py` (see `test_bitbucket_provider.py`) and list the required env vars in `pr_agent/settings/.secrets_template.toml`.
 
+### Registering a provider from another package
+
+A provider does not have to live in this repository. Call `register_git_provider` from your own package before PR-Agent resolves the provider, for example from the module that starts your server or wraps the CLI:
+
+```python
+from pr_agent.git_providers import register_git_provider
+
+from my_package.forge_provider import ForgeProvider
+
+register_git_provider("forge", ForgeProvider)
+```
+
+Then select it with `git_provider="forge"` under `[config]`. The class must extend `GitProvider`. Registering the same class twice is a no-op, and registering a different class under an id that is already taken raises, so a package cannot silently replace a built-in provider.
+
 ## Adding a tool
 
 1. Implement the tool class in `pr_agent/tools/pr_<name>.py` with an `async def run(self)` entry point (see `pr_reviewer.py`).

--- a/pr_agent/git_providers/__init__.py
+++ b/pr_agent/git_providers/__init__.py
@@ -27,6 +27,21 @@ _GIT_PROVIDERS = {
 }
 
 
+def register_git_provider(provider_id: str, provider_class: type[GitProvider]) -> None:
+    """Make `provider_class` selectable through `config.git_provider = provider_id`.
+
+    Meant for providers that live outside this package. Registering the same class again is a
+    no-op, so an import-time registration may run twice; a different class under an id that is
+    already taken raises, so a package cannot silently shadow a built-in provider.
+    """
+    if not (isinstance(provider_class, type) and issubclass(provider_class, GitProvider)):
+        raise TypeError(f"Git provider {provider_id!r} must be a GitProvider subclass, got {provider_class!r}")
+    registered = _GIT_PROVIDERS.get(provider_id)
+    if registered is not None and registered is not provider_class:
+        raise ValueError(f"Git provider {provider_id!r} is already registered to {registered.__name__}")
+    _GIT_PROVIDERS[provider_id] = provider_class
+
+
 def get_git_provider():
     try:
         provider_id = get_settings().config.git_provider

--- a/pr_agent/mosaico/provider_registration.py
+++ b/pr_agent/mosaico/provider_registration.py
@@ -1,9 +1,8 @@
 """Idempotent registration of DiffInputProvider into pr-agent's provider registry.
 
-Importing this module inserts the "mosaico_diff" provider via setdefault (never
-clobbers existing keys). Only the MOSAICO server imports it, so the registry is
-untouched on every other code path."""
-from pr_agent.git_providers import _GIT_PROVIDERS
+Importing this module registers the "mosaico_diff" provider. Only the MOSAICO server imports
+it, so the registry is untouched on every other code path."""
+from pr_agent.git_providers import register_git_provider
 from pr_agent.mosaico.diff_provider import DiffInputProvider
 
-_GIT_PROVIDERS.setdefault("mosaico_diff", DiffInputProvider)
+register_git_provider("mosaico_diff", DiffInputProvider)

--- a/pr_agent/mosaico/provider_registration.py
+++ b/pr_agent/mosaico/provider_registration.py
@@ -1,7 +1,8 @@
 """Idempotent registration of DiffInputProvider into pr-agent's provider registry.
 
 Importing this module registers the "mosaico_diff" provider. Only the MOSAICO server imports
-it, so the registry is untouched on every other code path."""
+it, so the registry is untouched on every other code path. Importing it again is a no-op; if
+"mosaico_diff" is already bound to a different class, the import raises rather than keeping it."""
 from pr_agent.git_providers import register_git_provider
 from pr_agent.mosaico.diff_provider import DiffInputProvider
 

--- a/pr_agent/mosaico/server.py
+++ b/pr_agent/mosaico/server.py
@@ -56,7 +56,7 @@ def _configure_runtime() -> None:
     The JSON logger is configured in start() instead (real runtime), where the config is
     already loaded. build_app() does not depend on the JSON sink."""
     apply_mosaico_env()
-    # Idempotent registry insert (_GIT_PROVIDERS.setdefault("mosaico_diff", ...)).
+    # Idempotent registration (register_git_provider("mosaico_diff", ...)).
     import pr_agent.mosaico.provider_registration  # noqa: F401
     _configure_langfuse()
 

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -79,7 +79,7 @@ class TestParseUnifiedDiff:
 
 class TestProviderRegistration:
     def test_registry_has_mosaico_diff_and_originals_intact(self):
-        import pr_agent.mosaico.provider_registration  # noqa: F401 (triggers setdefault)
+        import pr_agent.mosaico.provider_registration  # noqa: F401 (registers mosaico_diff)
         from pr_agent.git_providers import _GIT_PROVIDERS
         assert _GIT_PROVIDERS.get("mosaico_diff") is DiffInputProvider
         # original keys intact (setdefault did not clobber)

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -82,21 +82,39 @@ class TestProviderRegistration:
         import pr_agent.mosaico.provider_registration  # noqa: F401 (registers mosaico_diff)
         from pr_agent.git_providers import _GIT_PROVIDERS
         assert _GIT_PROVIDERS.get("mosaico_diff") is DiffInputProvider
-        # original keys intact (setdefault did not clobber)
+        # original keys intact
         for key in ("github", "gitlab", "bitbucket", "azure", "local", "gerrit", "gitea"):
             assert key in _GIT_PROVIDERS
 
-    def test_setdefault_does_not_clobber(self):
+    def test_importing_the_registration_again_is_a_no_op(self):
+        import importlib
+
+        import pr_agent.mosaico.provider_registration as registration
         from pr_agent.git_providers import _GIT_PROVIDERS
-        sentinel = object()
-        original = _GIT_PROVIDERS.get("mosaico_diff")
+
+        importlib.reload(registration)
+
+        assert _GIT_PROVIDERS["mosaico_diff"] is DiffInputProvider
+
+    def test_a_foreign_mosaico_diff_provider_is_not_replaced_silently(self):
+        """Where setdefault kept a foreign class quietly, register_git_provider raises at import,
+        so the MOSAICO server cannot come up on a provider it did not register."""
+        import importlib
+
+        import pr_agent.mosaico.provider_registration as registration
+        from pr_agent.git_providers import _GIT_PROVIDERS
+
+        class ForeignProvider(DiffInputProvider):
+            pass
+
+        original = _GIT_PROVIDERS["mosaico_diff"]
+        _GIT_PROVIDERS["mosaico_diff"] = ForeignProvider
         try:
-            _GIT_PROVIDERS["mosaico_diff"] = sentinel
-            _GIT_PROVIDERS.setdefault("mosaico_diff", DiffInputProvider)
-            assert _GIT_PROVIDERS["mosaico_diff"] is sentinel
+            with pytest.raises(ValueError, match="already registered"):
+                importlib.reload(registration)
+            assert _GIT_PROVIDERS["mosaico_diff"] is ForeignProvider
         finally:
-            if original is not None:
-                _GIT_PROVIDERS["mosaico_diff"] = original
+            _GIT_PROVIDERS["mosaico_diff"] = original
 
 
 class TestDiffInputProviderBasics:

--- a/tests/unittest/test_register_git_provider.py
+++ b/tests/unittest/test_register_git_provider.py
@@ -1,20 +1,95 @@
 """register_git_provider makes an out-of-tree GitProvider selectable through config.git_provider."""
 
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
 from pr_agent import git_providers
-from pr_agent.git_providers import _GIT_PROVIDERS, get_git_provider, register_git_provider
+from pr_agent.algo.types import FilePatchInfo
+from pr_agent.git_providers import (
+    _GIT_PROVIDERS,
+    get_git_provider,
+    get_git_provider_with_context,
+    register_git_provider,
+)
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 
+PR_URL = "https://forge.example/owner/repo/pulls/1"
+
 
 class _ForgeProvider(GitProvider):
-    pass  # the registry stores the class and never instantiates it, so the abstract methods can stay
+    """The smallest provider a package can register: concrete, so the registry can build it for a PR."""
+
+    def __init__(self, pr_url: Optional[str] = None):
+        self.pr_url = pr_url
+
+    def is_supported(self, capability: str) -> bool:
+        return False
+
+    def get_files(self) -> list:
+        return []
+
+    def get_diff_files(self) -> list[FilePatchInfo]:
+        return []
+
+    def publish_description(self, pr_title: str, pr_body: str):
+        pass
+
+    def publish_code_suggestions(self, code_suggestions: list) -> bool:
+        return False
+
+    def get_languages(self):
+        return {}
+
+    def get_pr_branch(self):
+        return "main"
+
+    def get_user_id(self):
+        return "forge"
+
+    def get_pr_description_full(self) -> str:
+        return ""
+
+    def get_repo_settings(self):
+        return b""
+
+    def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        pass
+
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
+        pass
+
+    def publish_inline_comments(self, comments: list[dict]):
+        pass
+
+    def remove_initial_comment(self):
+        pass
+
+    def remove_comment(self, comment):
+        pass
+
+    def get_issue_comments(self):
+        return []
+
+    def publish_labels(self, labels):
+        pass
+
+    def get_pr_labels(self, update=False):
+        return []
+
+    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
+        return None
+
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        return False
+
+    def get_commit_messages(self) -> str:
+        return ""
 
 
-class _OtherForgeProvider(GitProvider):
+class _OtherForgeProvider(_ForgeProvider):
     pass
 
 
@@ -35,6 +110,18 @@ def test_registered_provider_is_selected_through_settings(registry, monkeypatch)
     monkeypatch.setattr(git_providers, "get_settings", lambda: _settings_selecting("forge"))
 
     assert get_git_provider() is _ForgeProvider
+
+
+def test_registered_provider_is_built_for_a_pr_url(registry, monkeypatch):
+    """The path every tool takes: apply_repo_settings resolves the provider through
+    get_git_provider_with_context, which instantiates the registered class."""
+    register_git_provider("forge", _ForgeProvider)
+    monkeypatch.setattr(git_providers, "get_settings", lambda: _settings_selecting("forge"))
+
+    provider = get_git_provider_with_context(PR_URL)
+
+    assert isinstance(provider, _ForgeProvider)
+    assert provider.pr_url == PR_URL
 
 
 def test_registering_the_same_class_again_is_a_no_op(registry):

--- a/tests/unittest/test_register_git_provider.py
+++ b/tests/unittest/test_register_git_provider.py
@@ -1,0 +1,64 @@
+"""register_git_provider makes an out-of-tree GitProvider selectable through config.git_provider."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pr_agent import git_providers
+from pr_agent.git_providers import _GIT_PROVIDERS, get_git_provider, register_git_provider
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+
+
+class _ForgeProvider(GitProvider):
+    pass  # the registry stores the class and never instantiates it, so the abstract methods can stay
+
+
+class _OtherForgeProvider(GitProvider):
+    pass
+
+
+@pytest.fixture
+def registry():
+    before = dict(_GIT_PROVIDERS)
+    yield _GIT_PROVIDERS
+    _GIT_PROVIDERS.clear()
+    _GIT_PROVIDERS.update(before)
+
+
+def _settings_selecting(provider_id):
+    return SimpleNamespace(config=SimpleNamespace(git_provider=provider_id), get=lambda key, default=None: default)
+
+
+def test_registered_provider_is_selected_through_settings(registry, monkeypatch):
+    register_git_provider("forge", _ForgeProvider)
+    monkeypatch.setattr(git_providers, "get_settings", lambda: _settings_selecting("forge"))
+
+    assert get_git_provider() is _ForgeProvider
+
+
+def test_registering_the_same_class_again_is_a_no_op(registry):
+    register_git_provider("forge", _ForgeProvider)
+    register_git_provider("forge", _ForgeProvider)
+
+    assert registry["forge"] is _ForgeProvider
+
+
+def test_a_taken_id_is_not_shadowed(registry):
+    register_git_provider("forge", _ForgeProvider)
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_git_provider("forge", _OtherForgeProvider)
+    with pytest.raises(ValueError, match="already registered"):
+        register_git_provider("github", _ForgeProvider)
+
+    assert registry["forge"] is _ForgeProvider
+    assert registry["github"] is GithubProvider
+
+
+@pytest.mark.parametrize("not_a_provider", [object, GithubProvider.__new__(GithubProvider), "forge"])
+def test_only_git_provider_subclasses_are_accepted(registry, not_a_provider):
+    with pytest.raises(TypeError, match="GitProvider subclass"):
+        register_git_provider("forge", not_a_provider)
+
+    assert "forge" not in registry


### PR DESCRIPTION
Providers outside this package could only be selected by writing into the
private `_GIT_PROVIDERS` dict, the way `pr_agent/mosaico/provider_registration.py`
does. `register_git_provider(provider_id, provider_class)` makes that
supported: it checks the class extends `GitProvider`, treats re-registering
the same class as a no-op so an import-time registration may run twice, and
raises when a different class is registered under an id that is already
taken, so a package cannot silently shadow a built-in provider.

The MOSAICO registration now goes through it, and the extending guide shows
how a package registers its own provider. Entry-point discovery and a
`provider_id` attribute are left out, per the discussion on the issue.

@misery, this is the registration function you were asked for on the issue.
If you already had a branch in progress I am happy to close this in favour
of yours.

Closes #2662
