### PR TITLE
fix(gerrit): require webhook credentials on every call

### DIFF
--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -22,16 +22,16 @@ security = HTTPBasic(auto_error=False)
 
 
 def authorize(credentials: HTTPBasicCredentials = Depends(security)):
-    """Reject unauthenticated calls when webhook credentials are configured."""
+    """Require the configured webhook credentials on every call."""
     gerrit_settings = get_settings().get("gerrit", {})
     username = gerrit_settings.get("webhook_username", None) if gerrit_settings else None
     password = gerrit_settings.get("webhook_password", None) if gerrit_settings else None
-    if not username and not password:
-        return
     if not username or not password:
-        get_logger().error("Incomplete gerrit webhook credentials: set both "
-                           "gerrit.webhook_username and gerrit.webhook_password, or neither")
-        raise HTTPException(status_code=500, detail="Webhook authentication is misconfigured.")
+        # The route runs commands with caller-supplied arguments, so an unconfigured
+        # deployment is refused rather than left open, as the GitHub app does.
+        get_logger().error("Rejecting gerrit webhook: set both "
+                           "gerrit.webhook_username and gerrit.webhook_password")
+        raise HTTPException(status_code=403, detail="Webhook authentication is not configured.")
     if credentials is None:
         raise HTTPException(
             status_code=401,

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -388,7 +388,7 @@ request_timeout = 30 # positive seconds for connection and response-read inactiv
 # improve_path= "path/to/improve.md"
 
 [gerrit]
-# set both to require basic auth on the gerrit webhook endpoint; leave both empty to keep it open
+# both are required: the gerrit webhook endpoint rejects every call until they are set
 webhook_username = ""
 webhook_password = ""
 # endpoint to the gerrit service

--- a/tests/unittest/test_gerrit_ask_dispatch.py
+++ b/tests/unittest/test_gerrit_ask_dispatch.py
@@ -7,13 +7,15 @@ from starlette_context.middleware import RawContextMiddleware
 
 import pr_agent.servers.gerrit_server as gerrit_server
 
+AUTH = ("admin", "s3cret")
+
 
 class SettingsStub:
-    """No webhook credentials configured, so authorize() lets the request through."""
+    """Webhook credentials configured, since authorize() rejects every call without them."""
 
     def get(self, key, default=None):
         if key == "gerrit":
-            return {"webhook_username": "", "webhook_password": ""}
+            return {"webhook_username": AUTH[0], "webhook_password": AUTH[1]}
         return default
 
 
@@ -42,6 +44,7 @@ def test_reject_an_ask_whose_msg_is_only_whitespace(client, msg):
     response = http.post(
         "/api/v1/gerrit/ask",
         json={"refspec": "refs/changes/1", "project": "p", "msg": msg},
+        auth=AUTH,
     )
 
     assert response.status_code == 400
@@ -54,6 +57,7 @@ def test_dispatch_an_ask_with_the_question_taken_from_msg(client):
     response = http.post(
         "/api/v1/gerrit/ask",
         json={"refspec": "refs/changes/1", "project": "p", "msg": "  why is this slow? "},
+        auth=AUTH,
     )
 
     assert response.status_code == 200

--- a/tests/unittest/test_gerrit_webhook_authentication.py
+++ b/tests/unittest/test_gerrit_webhook_authentication.py
@@ -68,15 +68,6 @@ def test_accept_correct_credentials(secured_client):
     assert calls
 
 
-def test_an_unconfigured_deployment_keeps_the_previous_behaviour(monkeypatch):
-    client, calls = build_client(monkeypatch, "", "")
-
-    response = client.post("/api/v1/gerrit/review", json=PAYLOAD)
-
-    assert response.status_code == 200
-    assert calls
-
-
 def test_a_non_ascii_configured_password_rejects_with_401_not_500(monkeypatch):
     client, calls = build_client(monkeypatch, "admin", "şifre")
 
@@ -86,19 +77,30 @@ def test_a_non_ascii_configured_password_rejects_with_401_not_500(monkeypatch):
     assert calls == []
 
 
-@pytest.mark.parametrize("username, password", [("admin", ""), ("", "s3cret")])
-def test_reject_a_half_configured_deployment(monkeypatch, username, password):
-    """Fail closed when only one credential is set, rather than reverting to open access."""
+@pytest.mark.parametrize("username, password", [("", ""), ("admin", ""), ("", "s3cret")])
+def test_reject_a_deployment_without_both_credentials(monkeypatch, username, password):
+    """Fail closed until both credentials are set: the route runs commands with
+    caller-supplied arguments, so it is never left open, the way the GitHub app
+    rejects webhooks while its secret is unconfigured."""
     client, calls = build_client(monkeypatch, username, password)
 
     response = client.post("/api/v1/gerrit/review", json=PAYLOAD)
 
-    assert response.status_code == 500
-    assert response.json() == {"detail": "Webhook authentication is misconfigured."}
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Webhook authentication is not configured."}
     assert calls == []
 
 
-@pytest.mark.parametrize("username, password", [("admin", ""), ("", "s3cret")])
+def test_credentials_do_not_open_an_unconfigured_deployment(monkeypatch):
+    client, calls = build_client(monkeypatch, "", "")
+
+    response = client.post("/api/v1/gerrit/review", json=PAYLOAD, auth=("admin", "s3cret"))
+
+    assert response.status_code == 403
+    assert calls == []
+
+
+@pytest.mark.parametrize("username, password", [("", ""), ("admin", ""), ("", "s3cret")])
 def test_the_misconfiguration_response_names_no_settings(monkeypatch, username, password):
     """Keep configuration key names out of a response an unauthenticated caller can read."""
     client, _ = build_client(monkeypatch, username, password)


### PR DESCRIPTION
The Gerrit route runs `/review`, `/improve` and friends against a
caller-supplied project and refspec, and for `/ask` the caller's text becomes
the command line. #2728 made the endpoint securable, enforcing basic auth once
`gerrit.webhook_username` and `gerrit.webhook_password` are both set, and
this issue was left open for the mandatory-auth follow-up: with the keys
empty the route still ran anything for anyone who could reach port 3000.

Auth is now required. Until both keys are set every call is refused with
403, the same way the GitHub app rejects webhooks while its secret is
unconfigured (`github_app.py:84`), and the log line names the two settings.
The half-configured case folds into the same branch, so one credential set is
refused like none, with the same response. The configuration comment now says
the keys are required rather than optional.

This is a deliberate break for deployments that relied on the open default:
they must set the two keys and send them from Gerrit. The alternative,
keeping the route open by default, is what #2727 describes.

The `ask` dispatch tests now send credentials. The authentication tests cover
unconfigured, half-configured, and unconfigured with credentials sent anyway,
and check that the refusal names no setting. Four of them fail on `main`.

Closes #2727
