### PR TITLE
fix(servers): compare basic-auth credentials as bytes and fail closed on a half-configured pair

### DIFF
--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -6,7 +6,6 @@ import copy
 import json
 import os
 import re
-import secrets
 from urllib.parse import quote, unquote
 
 import uvicorn
@@ -28,6 +27,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.azuredevops_provider import AZURE_AGENT_RESPONSE_MARKER, AzureDevopsProvider
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
+from pr_agent.servers.utils import basic_auth_matches
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 security = HTTPBasic(auto_error=False)
@@ -181,8 +181,13 @@ def handle_line_comment(body: str, thread_id: int, comment_id: int, provider: Az
 # currently only basic auth is supported with azure webhooks
 # for this reason, https must be enabled to ensure the credentials are not sent in clear text
 def authorize(credentials: HTTPBasicCredentials = Depends(security)):
-    if WEBHOOK_USERNAME is None or WEBHOOK_PASSWORD is None:
+    if not WEBHOOK_USERNAME and not WEBHOOK_PASSWORD:
         return
+    if not WEBHOOK_USERNAME or not WEBHOOK_PASSWORD:
+        # Fail closed on a half-configured pair rather than reverting to open access.
+        get_logger().error("Incomplete azure_devops_server webhook credentials: set both "
+                           "webhook_username and webhook_password, or neither")
+        raise HTTPException(status_code=500, detail="Webhook authentication is misconfigured.")
 
     if credentials is None:
         raise HTTPException(
@@ -191,9 +196,7 @@ def authorize(credentials: HTTPBasicCredentials = Depends(security)):
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    is_user_ok = secrets.compare_digest(credentials.username, WEBHOOK_USERNAME)
-    is_pass_ok = secrets.compare_digest(credentials.password, WEBHOOK_PASSWORD)
-    if not (is_user_ok and is_pass_ok):
+    if not basic_auth_matches(credentials, WEBHOOK_USERNAME, WEBHOOK_PASSWORD):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail='Incorrect username or password.',

--- a/pr_agent/servers/gerrit_server.py
+++ b/pr_agent/servers/gerrit_server.py
@@ -1,5 +1,4 @@
 import copy
-import secrets
 from enum import Enum
 from json import JSONDecodeError
 
@@ -15,6 +14,7 @@ from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.gerrit_provider import GerritProvider
 from pr_agent.log import get_logger, setup_logger
+from pr_agent.servers.utils import basic_auth_matches
 
 setup_logger()
 router = APIRouter()
@@ -38,9 +38,7 @@ def authorize(credentials: HTTPBasicCredentials = Depends(security)):
             detail="Missing credentials.",
             headers={"WWW-Authenticate": "Basic"},
         )
-    is_user_ok = secrets.compare_digest(credentials.username, username)
-    is_pass_ok = secrets.compare_digest(credentials.password, password)
-    if not (is_user_ok and is_pass_ok):
+    if not basic_auth_matches(credentials, username, password):
         raise HTTPException(
             status_code=401,
             detail="Incorrect username or password.",

--- a/pr_agent/servers/utils.py
+++ b/pr_agent/servers/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import secrets
 import time
 from collections import defaultdict
 from typing import Any, Callable
@@ -23,6 +24,20 @@ def verify_signature(payload_body, secret_token, signature_header):
     expected_signature = "sha256=" + hash_object.hexdigest()
     if not hmac.compare_digest(expected_signature, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
+
+
+def basic_auth_matches(credentials, username, password) -> bool:
+    """Compare HTTP basic credentials against the configured pair in constant time.
+
+    The comparison runs on UTF-8 bytes: given `str` arguments, secrets.compare_digest
+    accepts ASCII only and raises TypeError otherwise, so a configured username or
+    password with a non-ASCII character would turn every authenticated call into a 500.
+    Both fields are compared before the result is combined, so a wrong username costs
+    the same as a wrong password.
+    """
+    user_ok = secrets.compare_digest(credentials.username.encode("utf-8"), str(username).encode("utf-8"))
+    pass_ok = secrets.compare_digest(credentials.password.encode("utf-8"), str(password).encode("utf-8"))
+    return user_ok and pass_ok
 
 
 class RateLimitExceeded(Exception):

--- a/tests/unittest/test_azure_devops_webhook_auth.py
+++ b/tests/unittest/test_azure_devops_webhook_auth.py
@@ -55,10 +55,47 @@ async def test_correct_credentials_are_accepted(app):
 
 
 @pytest.mark.asyncio
-async def test_auth_is_skipped_when_no_credentials_are_configured(monkeypatch):
-    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", None)
-    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", None)
+@pytest.mark.parametrize("unset", [None, ""])
+async def test_auth_is_skipped_when_no_credentials_are_configured(monkeypatch, unset):
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", unset)
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", unset)
 
     response = await _post(_build_app())
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("username, password", [("admin", None), (None, "s3cret"), ("admin", "")])
+async def test_a_half_configured_pair_fails_closed(monkeypatch, username, password):
+    """Only one credential set is a misconfiguration, not a request to skip auth."""
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", username)
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", password)
+    app = _build_app()
+
+    assert (await _post(app)).status_code == 500
+    assert (await _post(app, auth=("admin", "s3cret"))).status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_a_non_ascii_configured_password_rejects_with_401_not_500(monkeypatch):
+    """secrets.compare_digest raises TypeError on non-ASCII str, which turned every
+    authenticated call into a 500 once the configured password held such a character.
+    FastAPI decodes the header as ASCII, so such a password can never match; the
+    contract is a clean 401."""
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", "admin")
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", "şifre")
+
+    response = await _post(_build_app(), auth=("admin", "sifre"))
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a_non_string_configured_credential_is_compared_as_text(monkeypatch):
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_USERNAME", "admin")
+    monkeypatch.setattr(azure_webhook, "WEBHOOK_PASSWORD", 123456)
+    app = _build_app()
+
+    assert (await _post(app, auth=("admin", "123456"))).status_code == 200
+    assert (await _post(app, auth=("admin", "654321"))).status_code == 401

--- a/tests/unittest/test_gerrit_webhook_authentication.py
+++ b/tests/unittest/test_gerrit_webhook_authentication.py
@@ -77,6 +77,15 @@ def test_an_unconfigured_deployment_keeps_the_previous_behaviour(monkeypatch):
     assert calls
 
 
+def test_a_non_ascii_configured_password_rejects_with_401_not_500(monkeypatch):
+    client, calls = build_client(monkeypatch, "admin", "şifre")
+
+    response = client.post("/api/v1/gerrit/review", json=PAYLOAD, auth=("admin", "sifre"))
+
+    assert response.status_code == 401
+    assert calls == []
+
+
 @pytest.mark.parametrize("username, password", [("admin", ""), ("", "s3cret")])
 def test_reject_a_half_configured_deployment(monkeypatch, username, password):
     """Fail closed when only one credential is set, rather than reverting to open access."""


### PR DESCRIPTION
Two defects in the basic auth of the Azure DevOps and Gerrit webhook routes,
the second noted on #2728.

The Azure route skipped auth when only one of `webhook_username` /
`webhook_password` was set: `authorize()` returned early on
`USERNAME is None or PASSWORD is None`. It now fails closed on that case with
the same 500 and log line the Gerrit route uses, and treats an empty string as
unset, so `webhook_username = ""` no longer enforces auth against an empty
name.

Both routes compared credentials with `secrets.compare_digest` on `str`, which
accepts ASCII only and raises `TypeError` otherwise. A configured password with
a non-ASCII character, or a non-string value read from the environment, turned
every authenticated call into a 500 with a traceback. The comparison moves into
`basic_auth_matches()` in `servers/utils.py`, shared by both routes, which
compares UTF-8 bytes and coerces the configured value to text. FastAPI decodes
the `Authorization` header as ASCII, so a non-ASCII configured password still
cannot match; it gets a 401 now instead of a 500. Both fields are compared
before the result is combined, as before.

Tests cover the half-configured pair, the empty-string pair, the non-ASCII and
the integer configured password on Azure, and the non-ASCII password on Gerrit.
Seven of them fail on `main`.

Closes #3025
