### PR TITLE
fix(gitea): resolve base_url_html on first use so a repo-level web_url applies

### DIFF
--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -39,7 +39,7 @@ class CliArgs:
                 'c2hhcmVkX3NlY3JldA==:dXNlcg==:c3lzdGVt'
                 ':ZW5hYmxlX2NvbW1lbnRfYXBwcm92YWw=:ZW5hYmxlX21hbnVhbF9hcHByb3ZhbA=='
                 ':ZW5hYmxlX2F1dG9fYXBwcm92YWw=:YXBwcm92ZV9wcl9vbl9zZWxmX3Jldmlldw=='
-                ':YmFzZV91cmw=:dXJs:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy'
+                ':YmFzZV91cmw=:dXJs:d2ViX3VybA==:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy'
                 ':Z2l0X3Byb3ZpZGVy:c2tpcF9rZXlz:b3BlbmFpLmtleQ==:QU5BTFlUSUNTX0ZPTERFUg=='
                 ':dXJp:YXBwX2lk:d2ViaG9va19zZWNyZXQ=:YmVhcmVyX3Rva2Vu'
                 ':UEVSU09OQUxfQUNDRVNTX1RPS0VO:b3ZlcnJpZGVfZGVwbG95bWVudF90eXBl'

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -37,6 +37,8 @@ class _GiteaCommitAdapter:
 
 
 class GiteaProvider(GitProvider):
+    _base_url_html: Optional[str] = None  # resolved on first use, see base_url_html
+
     def __init__(self, url: Optional[str] = None):
         super().__init__()
         self.logger = get_logger()
@@ -117,7 +119,18 @@ class GiteaProvider(GitProvider):
         else:
             self.pr_commits = None
 
-        self.base_url_html = self._resolve_base_url_html()
+    @property
+    def base_url_html(self) -> str:
+        """User-facing base URL, resolved on first use rather than in the constructor:
+        apply_repo_settings builds the provider before it merges the repo's .pr_agent.toml,
+        so resolving here is what lets a repo-level `gitea.web_url` take effect."""
+        if self._base_url_html is None:
+            self._base_url_html = self._resolve_base_url_html()
+        return self._base_url_html
+
+    @base_url_html.setter
+    def base_url_html(self, value: str) -> None:
+        self._base_url_html = value
 
     def _resolve_base_url_html(self) -> str:
         """User-facing base URL interpolated into links published in comments.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -357,9 +357,8 @@ url = "https://gitea.com"
 # users browse a different external URL, or where the server's own ROOT_URL is
 # misconfigured. Defaults to `url` when it differs from the shipped default
 # above, else derived from the PR's html_url.
-# Like `url`, this is read when the provider is constructed, before repo-level
-# .pr_agent.toml settings are merged, so a per-repo override does not apply to
-# /describe, /review and /improve - set it globally or via GITEA__WEB_URL.
+# Resolved when the first link is built, after repo-level .pr_agent.toml settings
+# are merged, so a per-repo override applies as well.
 # web_url = ""
 handle_push_trigger = false
 pr_commands = [

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -357,8 +357,6 @@ url = "https://gitea.com"
 # users browse a different external URL, or where the server's own ROOT_URL is
 # misconfigured. Defaults to `url` when it differs from the shipped default
 # above, else derived from the PR's html_url.
-# Resolved when the first link is built, after repo-level .pr_agent.toml settings
-# are merged, so a per-repo override applies as well.
 # web_url = ""
 handle_push_trigger = false
 pr_commands = [

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -24,6 +24,9 @@ FORBIDDEN_ARGS = [
     "--litellm.api_type=azure",
     "--litellm.api_version=2024-01-01",
     "--jira.jira_base_url=https://evil.example",
+    # gitea.web_url is resolved on first use, so a comment could otherwise redirect published links
+    "--gitea.web_url=https://evil.example",
+    "--gitea__web_url=https://evil.example",
     "--config.url=https://evil.example",
     "--config.uri=https://evil.example",
     # provider / auth selection and skip lists

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -1000,3 +1000,66 @@ class TestGiteaRepoApiPagination:
 
         assert files == []
         repo_api.logger.error.assert_called_once()
+
+
+class TestBaseUrlHtmlIsResolvedOnFirstUse:
+    """apply_repo_settings builds the provider before it merges the repo's .pr_agent.toml,
+    so a user-facing URL fixed in the constructor would ignore a repo-level web_url."""
+
+    @staticmethod
+    def _settings(values):
+        settings = MagicMock()
+        settings.get.side_effect = lambda k, d=None: values.get(k, d)
+        return settings
+
+    @staticmethod
+    def _provider():
+        provider = GiteaProvider.__new__(GiteaProvider)
+        provider.logger = MagicMock()
+        provider.owner = "owner"
+        provider.repo = "repo"
+        provider.pr_number = 4
+        provider.base_url = "http://forgejo:3000"
+        provider.pr = MagicMock(html_url="http://forgejo:3000/owner/repo/pulls/4")
+        provider.get_pr_branch = MagicMock(return_value="feature")
+        return provider
+
+    @patch("pr_agent.git_providers.gitea_provider.giteapy.ApiClient")
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_the_constructor_leaves_the_url_unresolved(self, mock_get_settings, _):
+        mock_get_settings.return_value = self._settings({"GITEA.PERSONAL_ACCESS_TOKEN": "token"})
+
+        provider = GiteaProvider("https://gitea.example.com/repository")
+
+        assert provider._base_url_html is None
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_a_web_url_merged_after_construction_is_honoured(self, mock_get_settings):
+        values = {"GITEA.WEB_URL": ""}
+        mock_get_settings.return_value = self._settings(values)
+        provider = self._provider()
+        # The repo's .pr_agent.toml lands after the provider exists and before any link is built.
+        values["GITEA.WEB_URL"] = "https://git.example.com"
+
+        link = provider.get_line_link("src/app.py", 7)
+
+        assert link == "https://git.example.com/owner/repo/src/branch/feature/src/app.py#L7"
+        assert provider.get_pr_url() == "https://git.example.com/owner/repo/pulls/4"
+
+    @patch("pr_agent.git_providers.gitea_provider.get_settings")
+    def test_the_url_is_resolved_once(self, mock_get_settings):
+        values = {"GITEA.WEB_URL": "https://git.example.com"}
+        mock_get_settings.return_value = self._settings(values)
+        provider = self._provider()
+
+        first = provider.base_url_html
+        values["GITEA.WEB_URL"] = "https://changed.example.com"
+
+        assert provider.base_url_html == first == "https://git.example.com"
+
+    def test_an_assigned_url_is_used_as_is(self):
+        provider = self._provider()
+
+        provider.base_url_html = "https://assigned.example.com"
+
+        assert provider.base_url_html == "https://assigned.example.com"


### PR DESCRIPTION
`apply_repo_settings()` builds the provider before it merges the repo's
`.pr_agent.toml`, and `GiteaProvider.__init__` resolved `base_url_html` as its
last step, so a repo-level `[gitea] web_url` never reached the links published
in comments. #2617 documented that as a caveat on the `web_url` setting; the
constructor was the wrong place for it, as noted on #2620.

`base_url_html` is now a property, resolved on first use and cached, with a
setter so callers and tests that assign it keep working. Its only readers,
`get_line_link()` and `get_pr_url()`, run after the settings merge. The
`web_url` comment in `configuration.toml` no longer says the setting is fixed at
construction. It does not promise a per-repo override either: `gitea.repo_setting`
has no default, so on a stock install `get_repo_settings()` returns `b""` and
`apply_repo_settings()` never merges a repo-level file (raised in review, tracked
separately).

Tests: the constructor leaves the URL unresolved, a `web_url` that lands after
construction is used by both readers, resolution happens once, and an assigned
value is used as is. Three of the four fail on `main`.

Closes #3026

