### PR TITLE
fix(bitbucket): parse patches from hunk headers

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -15,6 +15,7 @@ from ..algo.language_handler import is_valid_file
 from ..algo.utils import add_pr_review_identity, comment_matches_identity, find_line_number_of_relevant_line_in_file
 from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
+from .diff_parsing import to_hunk_only_patch
 from .git_provider import MAX_FILES_ALLOWED_FULL, GitProvider, get_cached_global_settings, redact_credentials
 
 
@@ -298,32 +299,20 @@ class BitbucketProvider(GitProvider):
         if len(diff_split) != len(diffs):
             get_logger().error(f"Error - failed to split the diff into {len(diffs)} parts")
             return []
-        # bitbucket diff has a header for each file, we need to remove it:
-        # "diff --git filename
-        # new file mode 100644 (optional)
-        #  index caa56f0..61528d7 100644
-        #   --- a/pr_agent/cli_pip.py
-        #  +++ b/pr_agent/cli_pip.py
-        #   @@ -... @@"
-        for i, _ in enumerate(diff_split):
-            diff_split_lines = diff_split[i].splitlines()
-            if (len(diff_split_lines) >= 6) and \
-                    ((diff_split_lines[2].startswith("---") and
-                      diff_split_lines[3].startswith("+++") and
-                      diff_split_lines[4].startswith("@@")) or
-                     (diff_split_lines[3].startswith("---") and  # new or deleted file
-                      diff_split_lines[4].startswith("+++") and
-                      diff_split_lines[5].startswith("@@"))):
-                diff_split[i] = "\n".join(diff_split_lines[4:])
+        # Bitbucket headers vary by change type and may include mode or rename
+        # metadata. Keep only the unified-diff hunks consumed downstream.
+        for i, patch in enumerate(diff_split):
+            diff_split[i] = to_hunk_only_patch(patch)
+            if diff_split[i]:
+                continue
+
+            if diffs[i].data.get('lines_added', 0) == 0 and diffs[i].data.get('lines_removed', 0) == 0:
+                continue
+
+            if len(patch.splitlines()) <= 3:
+                get_logger().info(f"Disregarding empty diff for file {_gef_filename(diffs[i])}")
             else:
-                if diffs[i].data.get('lines_added', 0) == 0 and diffs[i].data.get('lines_removed', 0) == 0:
-                    diff_split[i] = ""
-                elif len(diff_split_lines) <= 3:
-                    diff_split[i] = ""
-                    get_logger().info(f"Disregarding empty diff for file {_gef_filename(diffs[i])}")
-                else:
-                    get_logger().warning(f"Bitbucket failed to get diff for file {_gef_filename(diffs[i])}")
-                    diff_split[i] = ""
+                get_logger().warning(f"Bitbucket failed to get diff for file {_gef_filename(diffs[i])}")
 
         invalid_files_names = []
         diff_files = []

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -35,12 +35,208 @@ class TestBitbucketProvider:
         provider.headers = {"Authorization": "Bearer token"}
         return provider
 
+    @staticmethod
+    def _get_single_diff_file(raw_diff, status, lines_added, lines_removed, filename, old_filename=None):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.diff_files = None
+        provider.pr = MagicMock()
+
+        diffstat = MagicMock()
+        diffstat.new.path = None if status == "removed" else filename
+        diffstat.old.path = None if status == "added" else old_filename or filename
+        diffstat.data = {
+            "status": status,
+            "lines_added": lines_added,
+            "lines_removed": lines_removed,
+        }
+        provider.pr.diffstat.return_value = [diffstat]
+        provider.pr.diff.return_value = raw_diff
+
+        settings = MagicMock()
+        settings.get.return_value = True
+        with (
+            patch("pr_agent.git_providers.bitbucket_provider.filter_ignored", return_value=[diffstat]),
+            patch("pr_agent.git_providers.bitbucket_provider.get_settings", return_value=settings),
+        ):
+            return provider.get_diff_files()[0]
+
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
         workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)
         assert workspace_slug == "WORKSPACE_XYZ"
         assert repo_slug == "MY_TEST_REPO"
         assert pr_number == 321
+
+    @pytest.mark.parametrize(
+        ("status", "lines_added", "lines_removed", "filename", "old_filename", "raw_diff", "expected_patch", "edit_type"),
+        [
+            (
+                "modified",
+                1,
+                1,
+                "src/example.py",
+                None,
+                """diff --git a/src/example.py b/src/example.py
+index 1111111..2222222 100644
+--- a/src/example.py
++++ b/src/example.py
+@@ -1 +1 @@
+-old
++new
+""",
+                "@@ -1 +1 @@\n-old\n+new\n",
+                EDIT_TYPE.MODIFIED,
+            ),
+            (
+                "added",
+                1,
+                0,
+                "src/added.py",
+                None,
+                """diff --git a/src/added.py b/src/added.py
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/src/added.py
+@@ -0,0 +1 @@
++new
+""",
+                "@@ -0,0 +1 @@\n+new\n",
+                EDIT_TYPE.ADDED,
+            ),
+            (
+                "removed",
+                0,
+                1,
+                "src/deleted.py",
+                None,
+                """diff --git a/src/deleted.py b/src/deleted.py
+deleted file mode 100644
+index 1111111..0000000
+--- a/src/deleted.py
++++ /dev/null
+@@ -1 +0,0 @@
+-old
+""",
+                "@@ -1 +0,0 @@\n-old\n",
+                EDIT_TYPE.DELETED,
+            ),
+            (
+                "renamed",
+                2,
+                2,
+                "src/new_name.py",
+                "src/old_name.py",
+                """diff --git a/src/old_name.py b/src/new_name.py
+similarity index 80%
+rename from src/old_name.py
+rename to src/new_name.py
+index 1111111..2222222 100644
+--- a/src/old_name.py
++++ b/src/new_name.py
+@@ -1 +1 @@
+-old
++new
+@@ -5 +5 @@
+-before
++after
+""",
+                "@@ -1 +1 @@\n-old\n+new\n@@ -5 +5 @@\n-before\n+after\n",
+                EDIT_TYPE.RENAMED,
+            ),
+            (
+                "modified",
+                1,
+                1,
+                "scripts/run.sh",
+                None,
+                """diff --git a/scripts/run.sh b/scripts/run.sh
+old mode 100644
+new mode 100755
+index 1111111..2222222
+--- a/scripts/run.sh
++++ b/scripts/run.sh
+@@ -1 +1 @@
+-echo old
++echo new
+""",
+                "@@ -1 +1 @@\n-echo old\n+echo new\n",
+                EDIT_TYPE.MODIFIED,
+            ),
+        ],
+    )
+    def test_get_diff_files_strips_variable_headers(
+        self, status, lines_added, lines_removed, filename, old_filename, raw_diff, expected_patch, edit_type
+    ):
+        diff_file = self._get_single_diff_file(
+            raw_diff,
+            status,
+            lines_added,
+            lines_removed,
+            filename,
+            old_filename,
+        )
+
+        assert diff_file.filename == filename
+        assert diff_file.patch == expected_patch
+        assert diff_file.edit_type == edit_type
+
+    @pytest.mark.parametrize(
+        ("status", "filename", "old_filename", "raw_diff", "edit_type"),
+        [
+            (
+                "renamed",
+                "src/new_name.py",
+                "src/old_name.py",
+                """diff --git a/src/old_name.py b/src/new_name.py
+similarity index 100%
+rename from src/old_name.py
+rename to src/new_name.py
+""",
+                EDIT_TYPE.RENAMED,
+            ),
+            (
+                "added",
+                "src/generated.py",
+                None,
+                """diff --git a/src/generated.py b/src/generated.py
+new file mode 100644
+index 0000000..2222222
+Binary files /dev/null and b/src/generated.py differ
+""",
+                EDIT_TYPE.ADDED,
+            ),
+        ],
+    )
+    def test_get_diff_files_keeps_no_hunk_changes_empty(
+        self, status, filename, old_filename, raw_diff, edit_type
+    ):
+        diff_file = self._get_single_diff_file(raw_diff, status, 0, 0, filename, old_filename)
+
+        assert diff_file.patch == ""
+        assert diff_file.edit_type == edit_type
+
+    def test_get_diff_files_warns_for_nonempty_change_without_hunks(self):
+        raw_diff = """diff --git a/src/example.py b/src/example.py
+index 1111111..2222222 100644
+--- a/src/example.py
++++ b/src/example.py
+not a valid hunk
+"""
+
+        with patch("pr_agent.git_providers.bitbucket_provider.get_logger") as get_logger:
+            diff_file = self._get_single_diff_file(
+                raw_diff,
+                "modified",
+                1,
+                1,
+                "src/example.py",
+            )
+
+        assert diff_file.patch == ""
+        get_logger.return_value.warning.assert_called_once_with(
+            "Bitbucket failed to get diff for file src/example.py"
+        )
 
     def test_get_repo_file_content_reads_from_target_branch(self):
         # Repo-context files must be read from the PR destination (target) branch,


### PR DESCRIPTION
Fixes #3031

## What changed

- Normalize each Bitbucket Cloud file patch from its first `@@` hunk instead of relying on fixed header positions.
- Preserve empty patches for pure renames and binary/no-hunk changes, and keep diagnostics for unexpected non-empty diffs without hunks.
- Add provider-level regression coverage for modified, added, deleted, renamed-and-modified, mode-changed, pure-rename, binary, and malformed diff shapes.

## Why

Bitbucket diff headers can contain a variable number of extended headers. The previous fixed-position parser retained `+++` as changed content for added/deleted files and discarded renamed files with edits when their hunk header appeared later.

The shared review pipeline expects hunk-only patches. Starting from the first hunk prevents bogus line `-1` content and keeps renamed changes in review context.

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_bitbucket_provider.py` (`53 passed`)
- `PYTHONPATH=. uv run pytest -q tests/unittest` (`3261 passed, 1 skipped, 1 xfailed`)
- `uv run ruff check pr_agent/git_providers/bitbucket_provider.py tests/unittest/test_bitbucket_provider.py` (passed)
- `uv run pre-commit run --files pr_agent/git_providers/bitbucket_provider.py tests/unittest/test_bitbucket_provider.py` (passed)
