### PR TITLE
feat(improve): cap suggestions per file after chunk aggregation

### DIFF
--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -312,6 +312,9 @@ PR-Agent uses a dynamic strategy to generate code suggestions based on the size 
 #### 2. Generating suggestions
 
 - For each chunk, PR-Agent generates up to `pr_code_suggestions.num_code_suggestions_per_chunk` suggestions (default: 3).
+- To bound output from large or chunked PRs, set `pr_code_suggestions.max_suggestions_per_file` to a positive integer.
+  After all chunks are merged, the highest-scored suggestions are retained per file; ties keep their original order.
+  The default value `0` disables this cap.
 
 This approach has two main benefits:
 
@@ -392,6 +395,13 @@ for the authoritative default values.
       <tr>
         <td><b>num_code_suggestions_per_chunk</b></td>
         <td>Number of code suggestions provided by the 'improve' tool, per chunk.</td>
+      </tr>
+      <tr>
+        <td><b>max_suggestions_per_file</b></td>
+        <td>
+          Maximum number of suggestions retained for each file after chunk results are combined. The highest-scored
+          suggestions are retained. Set to <code>0</code> to preserve the uncapped behavior.
+        </td>
       </tr>
       <tr>
         <td><b>max_number_of_calls</b></td>

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -205,6 +205,8 @@ new_score_mechanism_th_medium=7
 # params for '/improve --extended' mode
 auto_extended_mode=true
 num_code_suggestions_per_chunk=3
+# Maximum suggestions retained per file after all chunks are merged; 0 disables the cap.
+max_suggestions_per_file = 0
 max_number_of_calls = 3
 parallel_calls = true
 

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -877,6 +877,57 @@ class PRCodeSuggestions:
 
         return data
 
+    @staticmethod
+    def _suggestion_file_key(suggestion: Dict) -> str:
+        relevant_file = suggestion.get("relevant_file", "") if isinstance(suggestion, dict) else ""
+        return relevant_file.strip() if isinstance(relevant_file, str) else ""
+
+    @staticmethod
+    def _suggestion_score(suggestion: Dict) -> int:
+        try:
+            return int(suggestion.get("score", 0))
+        except (AttributeError, TypeError, ValueError):
+            return 0
+
+    def _limit_suggestions_per_file(self, suggestions: List[Dict]) -> List[Dict]:
+        raw_limit = get_settings().get("pr_code_suggestions.max_suggestions_per_file", 0)
+        try:
+            max_suggestions_per_file = int(raw_limit)
+        except (TypeError, ValueError):
+            get_logger().warning(
+                f"max_suggestions_per_file is not a number ({raw_limit!r}); disabling the per-file cap")
+            return suggestions
+
+        if max_suggestions_per_file <= 0 or not suggestions:
+            return suggestions
+
+        indexed_suggestions = list(enumerate(suggestions))
+        ranked_suggestions = sorted(
+            indexed_suggestions,
+            key=lambda item: (-self._suggestion_score(item[1]), item[0]),
+        )
+        kept_indices = set()
+        suggestions_per_file = {}
+        for index, suggestion in ranked_suggestions:
+            file_key = self._suggestion_file_key(suggestion)
+            if not file_key:
+                kept_indices.add(index)
+                continue
+            if suggestions_per_file.get(file_key, 0) >= max_suggestions_per_file:
+                continue
+            suggestions_per_file[file_key] = suggestions_per_file.get(file_key, 0) + 1
+            kept_indices.add(index)
+
+        limited_suggestions = [
+            suggestion for index, suggestion in indexed_suggestions if index in kept_indices
+        ]
+        dropped_count = len(suggestions) - len(limited_suggestions)
+        if dropped_count:
+            get_logger().info(
+                f"Limited PR code suggestions to {max_suggestions_per_file} per file; "
+                f"removed {dropped_count} lower-scored suggestion(s)")
+        return limited_suggestions
+
     async def push_inline_code_suggestions(self, data, include_coverage_footer: bool = True) -> None:
         code_suggestions = []
         fallback_comments = []
@@ -1360,6 +1411,7 @@ class PRCodeSuggestions:
                         except Exception as e:
                             get_logger().error(f"Error getting PR diff for suggestion {i} in call {j}, error: {e}",
                                                artifact={"prediction": prediction})
+            data["code_suggestions"] = self._limit_suggestions_per_file(data["code_suggestions"])
             self.data = data
         else:
             get_logger().warning("Empty PR diff list")

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -67,6 +67,60 @@ code_suggestions:
     assert data["code_suggestions"][0]["improved_code"] == "new()"
 
 
+@pytest.mark.asyncio
+async def test_prepare_prediction_main_caps_suggestions_per_file_after_chunk_merge():
+    settings_snapshot = snapshot_settings((
+        "pr_code_suggestions.decouple_hunks",
+        "pr_code_suggestions.parallel_calls",
+        "pr_code_suggestions.max_suggestions_per_file",
+    ))
+    settings = get_settings()
+    settings.pr_code_suggestions.decouple_hunks = True
+    settings.pr_code_suggestions.parallel_calls = False
+    settings.set("pr_code_suggestions.max_suggestions_per_file", 1)
+    tool = _make_tool()
+    tool.token_handler = MagicMock()
+
+    async def fake_get_prediction(model, patches_diff, patches_diff_no_line_numbers):
+        return {"code_suggestions": [_valid_suggestion(
+            one_sentence_summary=f"Finding from {patches_diff}",
+            relevant_lines_start=1 if patches_diff == "chunk-a" else 2,
+        )]}
+
+    try:
+        with patch.object(pr_code_suggestions_module, "get_pr_multi_diffs", return_value=["chunk-a", "chunk-b"]):
+            tool._get_prediction = fake_get_prediction
+
+            data = await tool.prepare_prediction_main("primary-model")
+    finally:
+        restore_settings(settings_snapshot)
+
+    assert data["code_suggestions"] == [_valid_suggestion(
+        one_sentence_summary="Finding from chunk-a",
+        relevant_lines_start=1,
+    )]
+
+
+def test_limit_suggestions_per_file_keeps_highest_scores_and_preserves_other_files():
+    settings_snapshot = snapshot_settings(("pr_code_suggestions.max_suggestions_per_file",))
+    settings = get_settings()
+    settings.set("pr_code_suggestions.max_suggestions_per_file", 2)
+    tool = _make_tool()
+    suggestions = [
+        _valid_suggestion(one_sentence_summary="Low", score=3),
+        _valid_suggestion(one_sentence_summary="High", score=9),
+        _valid_suggestion(one_sentence_summary="Medium", score=6),
+        _valid_suggestion(one_sentence_summary="Other file", relevant_file="worker.py", score=1),
+    ]
+
+    try:
+        limited = tool._limit_suggestions_per_file(suggestions)
+    finally:
+        restore_settings(settings_snapshot)
+
+    assert limited == [suggestions[1], suggestions[2], suggestions[3]]
+
+
 def test_prepare_pr_code_suggestions_renames_critical_label_when_focusing_only_on_problems():
     settings = get_settings()
     original_focus = settings.get("pr_code_suggestions.focus_only_on_problems", False)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -121,6 +121,16 @@ def test_limit_suggestions_per_file_keeps_highest_scores_and_preserves_other_fil
     assert limited == [suggestions[1], suggestions[2], suggestions[3]]
 
 
+def test_limit_suggestions_per_file_is_inert_at_the_shipped_default():
+    tool = _make_tool()
+    suggestions = [
+        _valid_suggestion(one_sentence_summary="First", score=3),
+        _valid_suggestion(one_sentence_summary="Second", score=9),
+    ]
+
+    assert tool._limit_suggestions_per_file(suggestions) == suggestions
+
+
 def test_prepare_pr_code_suggestions_renames_critical_label_when_focusing_only_on_problems():
     settings = get_settings()
     original_focus = settings.get("pr_code_suggestions.focus_only_on_problems", False)


### PR DESCRIPTION
## Summary

- add an opt-in `max_suggestions_per_file` setting for `/improve`
- apply the cap after score filtering and cross-chunk aggregation
- retain highest-scored suggestions per normalized file with stable tie ordering
- keep existing behavior by default with `0`

## Issue

Closes #3033

## Validation

- `pytest -q tests/unittest/test_pr_code_suggestions_core.py`: 94 passed
- `pytest -q tests/unittest`: 3255 passed, 1 skipped, 1 xfailed, 93 warnings
- `uv run --frozen ruff check .`: passed
- `uv run --frozen pre-commit run --all-files`: passed
- Docker test target: 3255 passed, 1 skipped, 1 xfailed, 91 warnings; coverage 70%
- read-only docs build: passed
- `uv run --frozen ruff format --check .`: repository baseline reports 245 files would be reformatted; no formatting changes made

## AI disclosure

This change was developed with AI assistance. I remain responsible for the implementation, tests, and claims in this PR.
