### PR TITLE
fix(tickets): refresh prompt budgets after extraction

### DIFF
--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -66,7 +66,7 @@ class TokenHandler:
     CLAUDE_MODEL = "claude-3-7-sonnet-20250219"
     CLAUDE_MAX_CONTENT_SIZE = 9_000_000 # Maximum allowed content size (9MB) for Claude API
 
-    def __init__(self, pr=None, vars: dict = {}, system="", user=""):
+    def __init__(self, pr=None, vars: dict = {}, system="", user="", model=None):
         """
         Initializes the TokenHandler object.
 
@@ -75,8 +75,9 @@ class TokenHandler:
         - vars: A dictionary of variables.
         - system: The system string.
         - user: The user string.
+        - model: Optional model name whose tokenizer should be used.
         """
-        self.encoder = TokenEncoder.get_token_encoder()
+        self.encoder = TokenEncoder.get_token_encoder(model)
 
         if pr is not None:
             self.prompt_tokens = self._get_system_user_tokens(pr, self.encoder, vars, system, user)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -121,6 +121,12 @@ class PRDescription:
 
             # ticket extraction if exists
             await extract_and_cache_pr_tickets(self.git_provider, self.vars)
+            self.token_handler = TokenHandler(
+                self.git_provider.pr,
+                self.vars,
+                get_settings().pr_description_prompt.system,
+                get_settings().pr_description_prompt.user,
+            )
 
             await retry_with_fallback_models(self._prepare_prediction, ModelType.WEAK)
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -39,6 +39,7 @@ from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.ticket_pr_compliance_check import (
     extract_and_cache_pr_tickets,
+    fit_related_tickets_to_prompt_budget,
 )
 
 
@@ -121,12 +122,7 @@ class PRDescription:
 
             # ticket extraction if exists
             await extract_and_cache_pr_tickets(self.git_provider, self.vars)
-            self.token_handler = TokenHandler(
-                self.git_provider.pr,
-                self.vars,
-                get_settings().pr_description_prompt.system,
-                get_settings().pr_description_prompt.user,
-            )
+            self._raw_prompt_vars = copy.deepcopy(self.vars)
 
             await retry_with_fallback_models(self._prepare_prediction, ModelType.WEAK)
 
@@ -254,6 +250,15 @@ class PRDescription:
             get_logger().info("Markers were enabled, but user description does not contain markers. Skipping AI prediction")
             return None
 
+        raw_prompt_vars = getattr(self, "_raw_prompt_vars", getattr(self, "vars", None))
+        if raw_prompt_vars is not None:
+            self.vars, self.token_handler = fit_related_tickets_to_prompt_budget(
+                self.git_provider.pr,
+                raw_prompt_vars,
+                get_settings().pr_description_prompt.system,
+                get_settings().pr_description_prompt.user,
+                model,
+            )
         large_pr_handling = get_settings().pr_description.get("enable_large_pr_handling", True) and "pr_description_only_files_prompts" in get_settings()
         output = get_pr_diff(self.git_provider, self.token_handler, model, large_pr_handling=large_pr_handling, return_remaining_files=True)
         if isinstance(output, tuple):
@@ -279,11 +284,12 @@ class PRDescription:
         else:
             # get the diff in multiple patches, with the token handler only for the files prompt
             get_logger().debug('large_pr_handling for describe')
-            token_handler_only_files_prompt = TokenHandler(
+            self.vars, token_handler_only_files_prompt = fit_related_tickets_to_prompt_budget(
                 self.git_provider.pr,
-                self.vars,
+                raw_prompt_vars if raw_prompt_vars is not None else self.vars,
                 get_settings().pr_description_only_files_prompts.system,
                 get_settings().pr_description_only_files_prompts.user,
+                model,
             )
             (patches_compressed_list, total_tokens_list, deleted_files_list, remaining_files_list, file_dict,
              files_in_patches_list) = get_pr_diff_multiple_patchs(
@@ -319,11 +325,12 @@ class PRDescription:
                     get_logger().debug(f"failed to generate predictions in iteration {i + 1} for describe files")
 
             # generate files_walkthrough string, with proper token handling
-            token_handler_only_description_prompt = TokenHandler(
+            self.vars, token_handler_only_description_prompt = fit_related_tickets_to_prompt_budget(
                 self.git_provider.pr,
-                self.vars,
+                raw_prompt_vars if raw_prompt_vars is not None else self.vars,
                 get_settings().pr_description_only_description_prompts.system,
-                get_settings().pr_description_only_description_prompts.user)
+                get_settings().pr_description_only_description_prompts.user,
+                model)
             files_walkthrough = "\n".join(file_description_str_list)
             files_walkthrough_prompt = copy.deepcopy(files_walkthrough)
             MAX_EXTRA_FILES_TO_PROMPT = 50

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -186,6 +186,12 @@ class PRReviewer:
 
             # ticket extraction if exists
             await extract_and_cache_pr_tickets(self.git_provider, self.vars)
+            self.token_handler = TokenHandler(
+                self.git_provider.pr,
+                self.vars,
+                get_settings().pr_review_prompt.system,
+                get_settings().pr_review_prompt.user,
+            )
 
             if (
                 self.incremental.is_incremental

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -46,7 +46,10 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.git_provider import IncrementalPR, get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
-from pr_agent.tools.ticket_pr_compliance_check import extract_and_cache_pr_tickets
+from pr_agent.tools.ticket_pr_compliance_check import (
+    extract_and_cache_pr_tickets,
+    fit_related_tickets_to_prompt_budget,
+)
 
 MAX_REVIEW_COVERAGE_FILES = 50
 _SUGGESTION_FENCE_RE = re.compile(r"```[ \t]*suggestion\b", re.IGNORECASE)
@@ -186,12 +189,7 @@ class PRReviewer:
 
             # ticket extraction if exists
             await extract_and_cache_pr_tickets(self.git_provider, self.vars)
-            self.token_handler = TokenHandler(
-                self.git_provider.pr,
-                self.vars,
-                get_settings().pr_review_prompt.system,
-                get_settings().pr_review_prompt.user,
-            )
+            self._raw_prompt_vars = copy.deepcopy(self.vars)
 
             if (
                 self.incremental.is_incremental
@@ -272,6 +270,15 @@ class PRReviewer:
         return get_settings().pr_reviewer.get('publish_output_no_suggestions', True) or "No major issues detected" not in pr_review
 
     async def _prepare_prediction(self, model: str) -> None:
+        raw_prompt_vars = getattr(self, "_raw_prompt_vars", getattr(self, "vars", None))
+        if raw_prompt_vars is not None:
+            self.vars, self.token_handler = fit_related_tickets_to_prompt_budget(
+                self.git_provider.pr,
+                raw_prompt_vars,
+                get_settings().pr_review_prompt.system,
+                get_settings().pr_review_prompt.user,
+                model,
+            )
         output = get_pr_diff(self.git_provider,
                              self.token_handler,
                              model,

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import re
 import traceback
@@ -5,6 +6,9 @@ from urllib.parse import urlparse
 
 import aiohttp
 
+from pr_agent.algo.pr_processing import OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+from pr_agent.algo.token_handler import TokenHandler
+from pr_agent.algo.utils import get_max_tokens
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import AzureDevopsProvider, GithubProvider, GitLabProvider
 from pr_agent.log import get_logger
@@ -59,6 +63,73 @@ GITLAB_TICKET_PATTERN = re.compile(
     r"|(?<![\w/#])#(?P<local_issue>\d+)\b"
 )
 GITLAB_ISSUE_PATH_PATTERN = re.compile(r"/-/issues/(?P<iid>\d+)(?=/|$)")
+
+
+def fit_related_tickets_to_prompt_budget(
+    pr,
+    raw_vars: dict,
+    system_prompt: str,
+    user_prompt: str,
+    model: str,
+) -> tuple[dict, TokenHandler]:
+    """Fit complete related-ticket records while preserving room for the PR diff."""
+    prompt_vars = copy.deepcopy(raw_vars)
+    related_tickets = prompt_vars.get("related_tickets")
+    if not isinstance(related_tickets, list) or not related_tickets:
+        return prompt_vars, TokenHandler(
+            pr,
+            prompt_vars,
+            system_prompt,
+            user_prompt,
+            model=model,
+        )
+
+    raw_tickets = copy.deepcopy(related_tickets)
+    prompt_vars["related_tickets"] = []
+    token_handler = TokenHandler(
+        pr,
+        prompt_vars,
+        system_prompt,
+        user_prompt,
+        model=model,
+    )
+    prompt_token_limit = max(
+        token_handler.prompt_tokens,
+        get_max_tokens(model) - 2 * OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD,
+    )
+
+    lower_bound = 1
+    upper_bound = len(raw_tickets)
+    while lower_bound <= upper_bound:
+        prefix_size = (lower_bound + upper_bound) // 2
+        candidate_vars = copy.deepcopy(prompt_vars)
+        candidate_vars["related_tickets"] = copy.deepcopy(raw_tickets[:prefix_size])
+        candidate_handler = TokenHandler(
+            pr,
+            candidate_vars,
+            system_prompt,
+            user_prompt,
+            model=model,
+        )
+        if candidate_handler.prompt_tokens > prompt_token_limit:
+            upper_bound = prefix_size - 1
+        else:
+            prompt_vars = candidate_vars
+            token_handler = candidate_handler
+            lower_bound = prefix_size + 1
+
+    included_tickets = len(prompt_vars["related_tickets"])
+    if included_tickets < len(raw_tickets):
+        get_logger().info(
+            "Clipped related tickets to preserve the prompt token budget",
+            artifact={
+                "included_tickets": included_tickets,
+                "omitted_tickets": len(raw_tickets) - included_tickets,
+                "model": model,
+            },
+        )
+
+    return prompt_vars, token_handler
 
 
 def find_asana_tickets(text: str | None) -> list:

--- a/tests/unittest/test_linked_ticket_token_budget.py
+++ b/tests/unittest/test_linked_ticket_token_budget.py
@@ -1,4 +1,4 @@
-"""Regression tests for linked-ticket prompt token accounting."""
+"""Regression tests for bounded linked-ticket prompt context."""
 
 import copy
 from types import SimpleNamespace
@@ -6,112 +6,113 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pr_agent.algo.pr_processing import OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD, generate_full_patch
-from pr_agent.algo.token_handler import TokenHandler
+from pr_agent.algo.pr_processing import (
+    OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD,
+    generate_full_patch,
+)
 from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
 from pr_agent.tools import pr_description as pr_description_module
 from pr_agent.tools import pr_reviewer as pr_reviewer_module
+from pr_agent.tools import ticket_pr_compliance_check as tickets_module
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_reviewer import PRReviewer
-from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+from pr_agent.tools.ticket_pr_compliance_check import fit_related_tickets_to_prompt_budget
 
 
-class _RecordingTokenHandler:
-    instances = []
+class _PromptCountingTokenHandler:
+    """A deterministic stand-in whose ticket sizes do not depend on tiktoken."""
 
-    def __init__(self, _pr, vars_, _system, _user):
-        self.related_tickets = copy.deepcopy(vars_.get("related_tickets"))
-        self.prompt_tokens = len(str(self.related_tickets))
-        self.instances.append(self)
+    baseline_tokens = 100
 
-
-def _make_tool(tool_name, provider, initial_handler):
-    if tool_name == "review":
-        provider.get_files.return_value = ["src/app.py"]
-        tool = PRReviewer.__new__(PRReviewer)
-        tool.pr_url = "https://example.test/pull/1"
-        tool.incremental = SimpleNamespace(is_incremental=False)
-        tool.vars = {"related_tickets": []}
-        module = pr_reviewer_module
-    else:
-        tool = PRDescription.__new__(PRDescription)
-        tool.pr_id = "1"
-        tool.vars = {"related_tickets": ""}
-        module = pr_description_module
-    tool.git_provider = provider
-    tool.token_handler = initial_handler
-    tool.prediction = None
-    return tool, module
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("tool_name", ["review", "description"])
-async def test_tool_refreshes_prompt_budget_after_ticket_extraction(monkeypatch, tool_name):
-    settings_snapshot = snapshot_settings(
-        (
-            "config.publish_output",
-            "config.is_auto_command",
-            "config.propagate_tool_errors",
-            "pr_description.enable_large_pr_handling",
+    def __init__(self, _pr, vars_, _system, _user, model=None):
+        self.vars = copy.deepcopy(vars_)
+        self.model = model
+        self.prompt_tokens = self.baseline_tokens + sum(
+            ticket["_test_tokens"] for ticket in self.vars.get("related_tickets", [])
         )
+
+
+def _tickets(count, tokens=200):
+    return [
+        {
+            "ticket_id": index,
+            "title": f"Ticket {index}",
+            "body": ("ticket context " * (tokens // 15 + 1))[:tokens],
+            "labels": ["bug"],
+            "nested": {"index": index},
+            "_test_tokens": tokens,
+        }
+        for index in range(count)
+    ]
+
+
+@pytest.fixture
+def prompt_budget(monkeypatch):
+    """Use a 1,500-token diff/output reserve with deterministic prompt sizes."""
+
+    def configure(model_limits):
+        monkeypatch.setattr(tickets_module, "TokenHandler", _PromptCountingTokenHandler)
+        monkeypatch.setattr(tickets_module, "get_max_tokens", lambda model: model_limits[model])
+
+    return configure
+
+
+def test_ticket_payload_keeps_exact_prefix_that_fits_prompt_budget(prompt_budget):
+    # max=3,500 -> max(100, 3,500 - 2*1,500) = 500.  Two 200-token tickets fit exactly.
+    prompt_budget({"model": 3500})
+    raw_vars = {"related_tickets": _tickets(3)}
+
+    prompt_vars, handler = fit_related_tickets_to_prompt_budget(
+        object(), raw_vars, "system", "{{ related_tickets }}", "model"
     )
-    provider = MagicMock()
-    initial_handler = SimpleNamespace(prompt_tokens=0)
-    tool, module = _make_tool(tool_name, provider, initial_handler)
-    tickets = [{"title": "Bug", "body": "Acceptance criteria and reproduction details"}]
-    captured_handlers = []
 
-    async def extract_tickets(_provider, vars_):
-        vars_["related_tickets"] = tickets
-
-    def capture_handler(_provider, token_handler, _model, **_kwargs):
-        captured_handlers.append(token_handler)
-        return ""
-
-    async def run_once(prepare_prediction, *_args, **_kwargs):
-        await prepare_prediction("gpt-4o")
-
-    _RecordingTokenHandler.instances = []
-    monkeypatch.setattr(module, "extract_and_cache_pr_tickets", extract_tickets)
-    monkeypatch.setattr(module, "TokenHandler", _RecordingTokenHandler)
-    monkeypatch.setattr(module, "get_pr_diff", capture_handler)
-    monkeypatch.setattr(module, "retry_with_fallback_models", run_once)
-
-    settings = get_settings()
-    settings.config.publish_output = False
-    settings.config.is_auto_command = False
-    settings.config.propagate_tool_errors = False
-    settings.pr_description.enable_large_pr_handling = False
-
-    try:
-        await tool.run()
-    finally:
-        restore_settings(settings_snapshot)
-
-    assert len(_RecordingTokenHandler.instances) == 1
-    refreshed_handler = _RecordingTokenHandler.instances[0]
-    assert captured_handlers == [refreshed_handler]
-    assert tool.token_handler is refreshed_handler
-    assert refreshed_handler is not initial_handler
-    assert tool.vars["related_tickets"] is tickets
-    assert refreshed_handler.related_tickets == tickets
-    assert refreshed_handler.related_tickets is not tickets
-    assert refreshed_handler.prompt_tokens > initial_handler.prompt_tokens
+    assert [ticket["ticket_id"] for ticket in prompt_vars["related_tickets"]] == [0, 1]
+    assert handler.prompt_tokens == 500
+    assert handler.prompt_tokens <= 3500 - 2 * OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
 
 
-def test_linked_ticket_tokens_reduce_the_available_diff_budget():
-    prompt = "Linked tickets:\n{{ related_tickets }}"
-    base_handler = TokenHandler(object(), {"related_tickets": []}, "Review this pull request.", prompt)
-    ticket_handler = TokenHandler(
+def test_under_budget_ticket_payload_is_preserved_without_aliasing_raw_cache(prompt_budget):
+    prompt_budget({"model": 4000})
+    raw_tickets = _tickets(3)
+    raw_vars = {"related_tickets": raw_tickets, "title": "Original title"}
+    raw_before = copy.deepcopy(raw_vars)
+
+    prompt_vars, handler = fit_related_tickets_to_prompt_budget(
+        object(), raw_vars, "system", "{{ related_tickets }}", "model"
+    )
+
+    assert prompt_vars == raw_before
+    assert prompt_vars is not raw_vars
+    assert prompt_vars["related_tickets"] is not raw_tickets
+    assert prompt_vars["related_tickets"][0] is not raw_tickets[0]
+    assert prompt_vars["related_tickets"][0]["nested"] is not raw_tickets[0]["nested"]
+    prompt_vars["related_tickets"][0]["nested"]["changed"] = True
+    assert raw_vars == raw_before
+    assert handler.vars == raw_before
+    assert handler.vars is not raw_vars
+
+
+def test_oversized_ticket_payload_keeps_diff_budget_and_raw_cache(monkeypatch):
+    monkeypatch.setattr(tickets_module, "get_max_tokens", lambda _model: 32000)
+    raw_vars = {"related_tickets": _tickets(33, tokens=10000)}
+    raw_before = copy.deepcopy(raw_vars)
+
+    prompt_vars, handler = fit_related_tickets_to_prompt_budget(
         object(),
-        {"related_tickets": [{"body": "acceptance criteria " * 20}]},
+        raw_vars,
         "Review this pull request.",
-        prompt,
+        "{% for ticket in related_tickets %}{{ ticket.body }}{% endfor %}",
+        "gpt-4o",
     )
+
+    assert 0 < len(prompt_vars["related_tickets"]) < len(raw_vars["related_tickets"])
+    assert handler.prompt_tokens <= 32000 - 2 * OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+    assert raw_vars == raw_before
+
     patch = "@@ -1 +1 @@\n-old_value\n+new_value"
-    patch_tokens = base_handler.count_tokens(f"\n\n{patch}")
-    max_tokens = base_handler.prompt_tokens + patch_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+    patch_tokens = handler.count_tokens(f"\n\n{patch}")
+    max_tokens = handler.prompt_tokens + patch_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
     file_dict = {
         "src/app.py": {
             "patch": patch,
@@ -120,11 +121,176 @@ def test_linked_ticket_tokens_reduce_the_available_diff_budget():
         }
     }
 
-    base_result = generate_full_patch(True, file_dict, max_tokens, ["src/app.py"], base_handler)
-    ticket_result = generate_full_patch(True, file_dict, max_tokens, ["src/app.py"], ticket_handler)
+    result = generate_full_patch(True, file_dict, max_tokens, ["src/app.py"], handler)
 
-    assert ticket_handler.prompt_tokens > base_handler.prompt_tokens
-    assert base_result[1] == [f"\n\n{patch}"]
-    assert base_result[2] == []
-    assert ticket_result[1] == []
-    assert ticket_result[2] == ["src/app.py"]
+    assert result[1] == [f"\n\n{patch}"]
+    assert result[2] == []
+
+
+def test_smaller_fallback_model_recalculates_from_raw_tickets(prompt_budget):
+    prompt_budget({"primary": 4100, "fallback": 3500})
+    raw_vars = {"related_tickets": _tickets(5)}
+
+    primary_vars, primary_handler = fit_related_tickets_to_prompt_budget(
+        object(), raw_vars, "system", "{{ related_tickets }}", "primary"
+    )
+    fallback_vars, fallback_handler = fit_related_tickets_to_prompt_budget(
+        object(), raw_vars, "system", "{{ related_tickets }}", "fallback"
+    )
+
+    assert len(primary_vars["related_tickets"]) == 5
+    assert len(fallback_vars["related_tickets"]) == 2
+    assert primary_handler.model == "primary"
+    assert fallback_handler.model == "fallback"
+    assert raw_vars["related_tickets"] == _tickets(5)
+
+
+def test_baseline_overflow_uses_no_ticket_context(prompt_budget):
+    _PromptCountingTokenHandler.baseline_tokens = 600
+    prompt_budget({"model": 3500})
+    raw_vars = {"related_tickets": _tickets(2)}
+    try:
+        prompt_vars, handler = fit_related_tickets_to_prompt_budget(
+            object(), raw_vars, "system", "{{ related_tickets }}", "model"
+        )
+    finally:
+        _PromptCountingTokenHandler.baseline_tokens = 100
+
+    assert prompt_vars["related_tickets"] == []
+    assert handler.prompt_tokens == 600
+    assert raw_vars["related_tickets"] == _tickets(2)
+
+
+def _make_tool(tool_name):
+    provider = MagicMock()
+    if tool_name == "review":
+        tool = PRReviewer.__new__(PRReviewer)
+        tool.pr_url = "https://example.test/pull/1"
+        tool.incremental = SimpleNamespace(is_incremental=False)
+        tool.remaining_files_list = []
+        module = pr_reviewer_module
+    else:
+        tool = PRDescription.__new__(PRDescription)
+        tool.pr_id = "1"
+        tool.user_description = ""
+        tool.keys_fix = []
+        module = pr_description_module
+    tool.git_provider = provider
+    tool.vars = {"related_tickets": _tickets(33)}
+    tool._raw_prompt_vars = copy.deepcopy(tool.vars)
+    tool.token_handler = SimpleNamespace(prompt_tokens=0)
+    tool.prediction = None
+    return tool, module
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["review", "description"])
+async def test_tools_use_the_same_bounded_ticket_vars_for_packing_and_rendering(monkeypatch, tool_name):
+    tool, module = _make_tool(tool_name)
+    raw_snapshot = copy.deepcopy(tool._raw_prompt_vars)
+    prompt_vars = {"related_tickets": _tickets(2)}
+    handler = SimpleNamespace(prompt_tokens=500)
+    helper_calls = []
+    diff_handlers = []
+    rendered_vars = []
+
+    def fit_payload(pr, raw_vars, _system, _user, model):
+        helper_calls.append((pr, raw_vars, model))
+        return prompt_vars, handler
+
+    def get_diff(_provider, token_handler, _model, **_kwargs):
+        diff_handlers.append(token_handler)
+        return "@@ -1 +1 @@\n-old\n+new"
+
+    async def get_prediction(_model, *_args, **_kwargs):
+        rendered_vars.append(tool.vars)
+        return "prediction"
+
+    monkeypatch.setattr(module, "fit_related_tickets_to_prompt_budget", fit_payload)
+    monkeypatch.setattr(module, "get_pr_diff", get_diff)
+    monkeypatch.setattr(tool, "_get_prediction", get_prediction)
+    if tool_name == "description":
+        monkeypatch.setattr(module, "build_repo_context", lambda _provider: "")
+
+    settings = get_settings()
+    original_semantic_files_types = settings.pr_description.enable_semantic_files_types
+    settings.pr_description.enable_semantic_files_types = False
+    try:
+        await tool._prepare_prediction("fallback-model")
+    finally:
+        settings.pr_description.enable_semantic_files_types = original_semantic_files_types
+
+    assert helper_calls == [(tool.git_provider.pr, tool._raw_prompt_vars, "fallback-model")]
+    assert diff_handlers == [handler]
+    assert rendered_vars == [prompt_vars]
+    assert tool.vars is prompt_vars
+    assert tool.token_handler is handler
+    assert tool._raw_prompt_vars == raw_snapshot
+
+
+@pytest.mark.asyncio
+async def test_description_large_pr_fits_each_prompt_from_raw_tickets(monkeypatch):
+    tool, module = _make_tool("description")
+    raw_snapshot = copy.deepcopy(tool._raw_prompt_vars)
+    prompt_vars = [
+        {"related_tickets": _tickets(33)},
+        {"related_tickets": _tickets(2)},
+        {"related_tickets": _tickets(1)},
+    ]
+    handlers = [
+        SimpleNamespace(prompt_tokens=0),
+        SimpleNamespace(prompt_tokens=500),
+        SimpleNamespace(prompt_tokens=300, encoder=SimpleNamespace(encode=lambda _text: [])),
+    ]
+    fit_calls = []
+    packed_handlers = []
+    prediction_calls = []
+
+    def fit_payload(_pr, raw_vars, _system, _user, model):
+        call_index = len(fit_calls)
+        fit_calls.append((raw_vars, model))
+        return prompt_vars[call_index], handlers[call_index]
+
+    def get_multiple_patches(_provider, token_handler, _model):
+        packed_handlers.append(token_handler)
+        return ([["@@ -1 +1 @@\n-old\n+new"]], [10], [], [], {}, [[]])
+
+    async def get_prediction(_model, patches_diff=None, prompt=None):
+        prediction_calls.append((prompt, patches_diff, tool.vars))
+        if prompt == "pr_description_only_files_prompts":
+            return "pr_files:\n- filename: src/app.py"
+        return "title: Test\ndescription: Test"
+
+    monkeypatch.setattr(module, "fit_related_tickets_to_prompt_budget", fit_payload)
+    monkeypatch.setattr(module, "get_pr_diff", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(module, "get_pr_diff_multiple_patchs", get_multiple_patches)
+    monkeypatch.setattr(module, "get_max_tokens", lambda _model: 32000)
+    monkeypatch.setattr(tool, "_get_prediction", get_prediction)
+    monkeypatch.setattr(tool, "extend_uncovered_files", lambda _prediction: _empty_string())
+
+    settings = get_settings()
+    original_large_pr_handling = settings.pr_description.enable_large_pr_handling
+    settings.pr_description.enable_large_pr_handling = True
+    try:
+        await tool._prepare_prediction("fallback-model")
+    finally:
+        settings.pr_description.enable_large_pr_handling = original_large_pr_handling
+
+    assert fit_calls == [
+        (tool._raw_prompt_vars, "fallback-model"),
+        (tool._raw_prompt_vars, "fallback-model"),
+        (tool._raw_prompt_vars, "fallback-model"),
+    ]
+    assert tool._raw_prompt_vars == raw_snapshot
+    assert packed_handlers == [handlers[1]]
+    assert prediction_calls[0] == (
+        "pr_description_only_files_prompts",
+        "@@ -1 +1 @@\n-old\n+new",
+        prompt_vars[1],
+    )
+    assert prediction_calls[1][0] == "pr_description_only_description_prompts"
+    assert prediction_calls[1][2] is prompt_vars[2]
+
+
+async def _empty_string():
+    return ""

--- a/tests/unittest/test_linked_ticket_token_budget.py
+++ b/tests/unittest/test_linked_ticket_token_budget.py
@@ -1,0 +1,130 @@
+"""Regression tests for linked-ticket prompt token accounting."""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.algo.pr_processing import OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD, generate_full_patch
+from pr_agent.algo.token_handler import TokenHandler
+from pr_agent.algo.types import EDIT_TYPE
+from pr_agent.config_loader import get_settings
+from pr_agent.tools import pr_description as pr_description_module
+from pr_agent.tools import pr_reviewer as pr_reviewer_module
+from pr_agent.tools.pr_description import PRDescription
+from pr_agent.tools.pr_reviewer import PRReviewer
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+
+class _RecordingTokenHandler:
+    instances = []
+
+    def __init__(self, _pr, vars_, _system, _user):
+        self.related_tickets = copy.deepcopy(vars_.get("related_tickets"))
+        self.prompt_tokens = len(str(self.related_tickets))
+        self.instances.append(self)
+
+
+def _make_tool(tool_name, provider, initial_handler):
+    if tool_name == "review":
+        provider.get_files.return_value = ["src/app.py"]
+        tool = PRReviewer.__new__(PRReviewer)
+        tool.pr_url = "https://example.test/pull/1"
+        tool.incremental = SimpleNamespace(is_incremental=False)
+        tool.vars = {"related_tickets": []}
+        module = pr_reviewer_module
+    else:
+        tool = PRDescription.__new__(PRDescription)
+        tool.pr_id = "1"
+        tool.vars = {"related_tickets": ""}
+        module = pr_description_module
+    tool.git_provider = provider
+    tool.token_handler = initial_handler
+    tool.prediction = None
+    return tool, module
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["review", "description"])
+async def test_tool_refreshes_prompt_budget_after_ticket_extraction(monkeypatch, tool_name):
+    settings_snapshot = snapshot_settings(
+        (
+            "config.publish_output",
+            "config.is_auto_command",
+            "config.propagate_tool_errors",
+            "pr_description.enable_large_pr_handling",
+        )
+    )
+    provider = MagicMock()
+    initial_handler = SimpleNamespace(prompt_tokens=0)
+    tool, module = _make_tool(tool_name, provider, initial_handler)
+    tickets = [{"title": "Bug", "body": "Acceptance criteria and reproduction details"}]
+    captured_handlers = []
+
+    async def extract_tickets(_provider, vars_):
+        vars_["related_tickets"] = tickets
+
+    def capture_handler(_provider, token_handler, _model, **_kwargs):
+        captured_handlers.append(token_handler)
+        return ""
+
+    async def run_once(prepare_prediction, *_args, **_kwargs):
+        await prepare_prediction("gpt-4o")
+
+    _RecordingTokenHandler.instances = []
+    monkeypatch.setattr(module, "extract_and_cache_pr_tickets", extract_tickets)
+    monkeypatch.setattr(module, "TokenHandler", _RecordingTokenHandler)
+    monkeypatch.setattr(module, "get_pr_diff", capture_handler)
+    monkeypatch.setattr(module, "retry_with_fallback_models", run_once)
+
+    settings = get_settings()
+    settings.config.publish_output = False
+    settings.config.is_auto_command = False
+    settings.config.propagate_tool_errors = False
+    settings.pr_description.enable_large_pr_handling = False
+
+    try:
+        await tool.run()
+    finally:
+        restore_settings(settings_snapshot)
+
+    assert len(_RecordingTokenHandler.instances) == 1
+    refreshed_handler = _RecordingTokenHandler.instances[0]
+    assert captured_handlers == [refreshed_handler]
+    assert tool.token_handler is refreshed_handler
+    assert refreshed_handler is not initial_handler
+    assert tool.vars["related_tickets"] is tickets
+    assert refreshed_handler.related_tickets == tickets
+    assert refreshed_handler.related_tickets is not tickets
+    assert refreshed_handler.prompt_tokens > initial_handler.prompt_tokens
+
+
+def test_linked_ticket_tokens_reduce_the_available_diff_budget():
+    prompt = "Linked tickets:\n{{ related_tickets }}"
+    base_handler = TokenHandler(object(), {"related_tickets": []}, "Review this pull request.", prompt)
+    ticket_handler = TokenHandler(
+        object(),
+        {"related_tickets": [{"body": "acceptance criteria " * 20}]},
+        "Review this pull request.",
+        prompt,
+    )
+    patch = "@@ -1 +1 @@\n-old_value\n+new_value"
+    patch_tokens = base_handler.count_tokens(f"\n\n{patch}")
+    max_tokens = base_handler.prompt_tokens + patch_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+    file_dict = {
+        "src/app.py": {
+            "patch": patch,
+            "tokens": patch_tokens,
+            "edit_type": EDIT_TYPE.MODIFIED,
+        }
+    }
+
+    base_result = generate_full_patch(True, file_dict, max_tokens, ["src/app.py"], base_handler)
+    ticket_result = generate_full_patch(True, file_dict, max_tokens, ["src/app.py"], ticket_handler)
+
+    assert ticket_handler.prompt_tokens > base_handler.prompt_tokens
+    assert base_result[1] == [f"\n\n{patch}"]
+    assert base_result[2] == []
+    assert ticket_result[1] == []
+    assert ticket_result[2] == ["src/app.py"]


### PR DESCRIPTION
Fixes #3035

Related to #2861 and #2862, which addressed the same late-loaded-context budgeting pattern for `/ask_line`.

## What changed

- Recalculate `/review` and `/describe` prompt budgets after linked-ticket extraction for each attempted model.
- Bound a copied ticket payload before diff packing, preserving room for both diff content and the existing output reserve without mutating cached ticket data.
- Fit the normal and large-PR `/describe` prompts independently so packing and rendering use the same bounded context.
- Add regression coverage for both tool paths, oversized ticket sets, fallback models, cache immutability, and constrained diff packing.

## Why

Both tools cached prompt size before ticket extraction, then rendered the final prompt with the extracted tickets. Diff selection therefore used a smaller prompt cost than the request that was actually sent. Counting every ticket without a bound could also consume the entire input budget and leave no room for the diff.

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_linked_ticket_token_budget.py` — 8 passed
- Focused and neighboring ticket/review/description suites — 242 passed
- `PYTHONPATH=. uv run pytest -q tests/unittest` — 3479 passed, 1 skipped, 1 xfailed
- Ruff and pre-commit hooks on changed files — passed
