### PR TITLE
docs: sync GitBook navigation with MkDocs

### DIFF
--- a/docs/docs/summary.md
+++ b/docs/docs/summary.md
@@ -7,6 +7,12 @@
 
 * [Installation](installation/index.md)
 * [PR-Agent](installation/pr_agent.md)
+* [Locally](installation/locally.md)
+* [GitHub Integration](installation/github.md)
+* [GitLab Integration](installation/gitlab.md)
+* [BitBucket Integration](installation/bitbucket.md)
+* [Azure DevOps Integration](installation/azure.md)
+* [Gitea Integration](installation/gitea.md)
 
 ## Usage Guide
 
@@ -16,8 +22,10 @@
 * [Usage and Automation](usage-guide/automations_and_usage.md)
 * [Managing Mail Notifications](usage-guide/mail_notifications.md)
 * [Changing a Model](usage-guide/changing_a_model.md)
+* [Extending PR-Agent](usage-guide/extending_pr_agent.md)
 * [Additional Configurations](usage-guide/additional_configurations.md)
 * [Plain-Diff Mode](usage-guide/plain_diff_mode.md)
+* [Local Git Provider](usage-guide/local_git_provider.md)
 * [Frequently Asked Questions](faq/index.md)
 
 ## Tools

--- a/docs/docs/usage-guide/extending_pr_agent.md
+++ b/docs/docs/usage-guide/extending_pr_agent.md
@@ -39,7 +39,7 @@ Implement a `GitProvider` subclass and register it:
 1. Create `pr_agent/git_providers/<name>_provider.py`, extending the interface in `pr_agent/git_providers/git_provider.py` (`gitlab_provider.py` is the reference).
 2. Register the class in `_GIT_PROVIDERS` in `pr_agent/git_providers/__init__.py`. Keys already used: `github`, `gitlab`, `bitbucket`, `bitbucket_server`, `azure`, `codecommit`, `local`, `gerrit`, `gitea`, `plain-diff`.
 3. Select it via `[config]` → `git_provider="<name>"` in `pr_agent/settings/configuration.toml`.
-4. Add `docs/docs/installation/<name>.md` (see [`gitlab.md`](../installation/gitlab.md)) and register it under `Installation` in `docs/mkdocs.yml`.
+4. Add `docs/docs/installation/<name>.md` (see [`gitlab.md`](../installation/gitlab.md)) and register it under `Installation` in both `docs/mkdocs.yml` and `docs/docs/summary.md`.
 5. Select provider-dependent behavior with capability checks like `provider.is_supported("feature")` rather than provider-type checks.
 6. Add unit tests under `tests/unittest/test_<name>_provider.py` (see `test_bitbucket_provider.py`) and list the required env vars in `pr_agent/settings/.secrets_template.toml`.
 
@@ -50,5 +50,5 @@ Implement a `GitProvider` subclass and register it:
 3. Add a prompt TOML under `pr_agent/settings/` and register it in the `settings_files=[...]` list in `pr_agent/config_loader.py` — it is not loaded otherwise.
 4. Match the TOML section name to the settings key the tool reads: `[pr_review_prompt]` in `pr_reviewer_prompts.toml` ↔ `get_settings().pr_review_prompt` in `pr_reviewer.py`.
 5. Register the tool in `command2class` in `pr_agent/agent/pr_agent.py` under a command name, e.g. `"my_tool": PRMyTool`. Then add it to the hardcoded help surfaces, or it will not show up in `/help`: `pr_agent/tools/pr_help_message.py`, `pr_agent/servers/help.py`, and the command list in `pr_agent/cli.py`.
-6. Add a row to the tool list in `docs/docs/tools/index.md`, a page `docs/docs/tools/<name>.md` (see [`review.md`](../tools/review.md)), and register the page under `Tools` in `docs/mkdocs.yml`.
+6. Add a row to the tool list in `docs/docs/tools/index.md`, a page `docs/docs/tools/<name>.md` (see [`review.md`](../tools/review.md)), and register the page under `Tools` in both `docs/mkdocs.yml` and `docs/docs/summary.md`.
 7. Add tests under `tests/unittest/` and verify with `PYTHONPATH=. uv run pytest tests/unittest`.


### PR DESCRIPTION
## Summary

- add the eight active MkDocs pages missing from the GitBook summary
- keep their labels and ordering aligned with `docs/mkdocs.yml`
- update the provider and tool extension checklists so future pages are registered in both navigation files

## Assumption

This takes the issue's “GitBook is still active” branch. `summary.md` has continued to receive upstream maintenance after `.gitbook.yaml` was added, including changes in March and twice in August 2026; the issue author made the most recent upstream change on August 10. If GitBook is intentionally being retired instead, I am happy for this PR to be closed in favor of removing the obsolete structure file.

## Validation

- parsed both navigation structures after the change: each contains 39 active Markdown pages, with no missing paths, no extras, and no nonexistent files
- intentionally excluded the commented-out `finetuning_benchmark/index.md`, which does not exist
- `.venv/bin/pre-commit run --files docs/docs/summary.md docs/docs/usage-guide/extending_pr_agent.md`
- `git diff --check origin/main...HEAD`

Generating one navigation file from the other or enforcing parity in CI could further prevent drift, but this PR keeps the fix to the issue's requested documentation scope.

Closes #3038

AI assistance was used during implementation and review; I verified the navigation sources, final diff, repository history, and checks above.
