### PR TITLE
fix(security): block gitea.web_url as a user-supplied argument

### DIFF
--- a/pr_agent/algo/cli_args.py
+++ b/pr_agent/algo/cli_args.py
@@ -39,7 +39,7 @@ class CliArgs:
                 'c2hhcmVkX3NlY3JldA==:dXNlcg==:c3lzdGVt'
                 ':ZW5hYmxlX2NvbW1lbnRfYXBwcm92YWw=:ZW5hYmxlX21hbnVhbF9hcHByb3ZhbA=='
                 ':ZW5hYmxlX2F1dG9fYXBwcm92YWw=:YXBwcm92ZV9wcl9vbl9zZWxmX3Jldmlldw=='
-                ':YmFzZV91cmw=:dXJs:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy'
+                ':YmFzZV91cmw=:dXJs:d2ViX3VybA==:YXBwX25hbWU=:c2VjcmV0X3Byb3ZpZGVy'
                 ':Z2l0X3Byb3ZpZGVy:c2tpcF9rZXlz:b3BlbmFpLmtleQ==:QU5BTFlUSUNTX0ZPTERFUg=='
                 ':dXJp:YXBwX2lk:d2ViaG9va19zZWNyZXQ=:YmVhcmVyX3Rva2Vu'
                 ':UEVSU09OQUxfQUNDRVNTX1RPS0VO:b3ZlcnJpZGVfZGVwbG95bWVudF90eXBl'

--- a/tests/unittest/test_cli_args_security.py
+++ b/tests/unittest/test_cli_args_security.py
@@ -24,6 +24,8 @@ FORBIDDEN_ARGS = [
     "--litellm.api_type=azure",
     "--litellm.api_version=2024-01-01",
     "--jira.jira_base_url=https://evil.example",
+    "--gitea.web_url=https://evil.example",
+    "--gitea__web_url=https://evil.example",
     "--config.url=https://evil.example",
     "--config.uri=https://evil.example",
     # provider / auth selection and skip lists


### PR DESCRIPTION
## Summary

`GITEA.WEB_URL` is read by `GiteaProvider` to build the links published in comments (`get_pr_url`, `get_line_link`). `cli_args.py` already blocks `base_url` and `url` as user-supplied arguments, but not `web_url`, so a comment argument could redirect those links.

Measured before and after on today's main:

```
--gitea.web_url=https://evil.example    before: (True, '')    after: (False, '.web_url')
--gitea__web_url=https://evil.example   before: (True, '')    after: (False, '.web_url')
--config.model=gpt-4                    before: (True, '')    after: (True, '')
```

## Scope

Comment and CLI arguments only. `validate_user_args` is called from one place, `pr_agent/agent/pr_agent.py:208`, so `apply_repo_settings` is unaffected and a repo-level `gitea.web_url` in `.pr_agent.toml` keeps working. That matters because #3029 exists to make exactly that case work, and this should land first.

Full unit suite: 3440 passed, 1 skipped, 1 xfailed (main is 3438, plus the two new parametrised cases). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uEfquYG4H96b9DjhLi7VT