### PR TITLE
fix(improve): validate committable Python suggestions

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -811,6 +811,7 @@ class PRCodeSuggestions:
 
     @staticmethod
     def _truncate_if_needed(suggestion):
+        suggestion.pop('_is_truncated', None)
         max_code_suggestion_length = get_settings().get("PR_CODE_SUGGESTIONS.MAX_CODE_SUGGESTION_LENGTH", 0)
         suggestion_truncation_message = get_settings().get("PR_CODE_SUGGESTIONS.SUGGESTION_TRUNCATION_MESSAGE", "")
         if max_code_suggestion_length > 0:
@@ -819,6 +820,7 @@ class PRCodeSuggestions:
                                   f"characters to {max_code_suggestion_length} characters")
                 suggestion['improved_code'] = suggestion['improved_code'][:max_code_suggestion_length]
                 suggestion['improved_code'] += f"\n{suggestion_truncation_message}"
+                suggestion['_is_truncated'] = True
         return suggestion
 
     def _prepare_pr_code_suggestions(self, predictions: str) -> Dict:
@@ -919,6 +921,23 @@ class PRCodeSuggestions:
             if new_code_snippet and has_valid_anchor:
                 new_code_snippet = self.dedent_code(relevant_file, relevant_lines_start, new_code_snippet)
 
+            requires_pr_fallback = False
+            if d.get('_is_truncated'):
+                is_applicable = False
+                fallback_reason = "the proposed code was truncated"
+                requires_pr_fallback = True
+            elif new_code_snippet and is_applicable:
+                python_syntax_is_valid = self._validate_python_replacement_syntax(
+                    relevant_file,
+                    relevant_lines_start,
+                    relevant_lines_end,
+                    new_code_snippet,
+                )
+                if python_syntax_is_valid is False:
+                    is_applicable = False
+                    fallback_reason = "the proposed Python code has invalid syntax"
+                    requires_pr_fallback = True
+
             score = d.get("score")
             header = f"**Suggestion:** {content} [{label}, importance: {score}]" if score \
                 else f"**Suggestion:** {content} [{label}]"
@@ -929,8 +948,11 @@ class PRCodeSuggestions:
                 if new_code_snippet:
                     body += (f"\n\nProposed code (not offered as a committable change because {fallback_reason}):\n"
                              f"```\n{new_code_snippet}\n```")
+                elif requires_pr_fallback:
+                    body += f"\n\nNot offered as a committable change because {fallback_reason}."
 
-            if not has_valid_anchor:
+            # Keep safety-rejected suggestions out of provider patch APIs while preserving standalone artifacts.
+            if not has_valid_anchor or (requires_pr_fallback and not supports_suggestions_artifact):
                 fallback_comments.append(f"{body}\n\nLocation: `{relevant_file}:"
                                          f"{relevant_lines_start}-{relevant_lines_end}`")
             else:
@@ -967,6 +989,47 @@ class PRCodeSuggestions:
             if file.filename and file.filename.strip() == relevant_file:
                 return file
         return None
+
+    def _validate_python_replacement_syntax(
+        self,
+        relevant_file: str,
+        relevant_lines_start: int,
+        relevant_lines_end: int,
+        new_code_snippet: str,
+    ) -> Optional[bool]:
+        """Return False only when a verified replacement makes valid Python fail compilation."""
+        if not relevant_file.lower().endswith((".py", ".pyi", ".pyw")):
+            return None
+
+        diff_file = self._get_diff_file(relevant_file)
+        if (diff_file is None
+                or not diff_file.head_file
+                or not getattr(diff_file, "head_file_is_complete", True)):
+            return None
+
+        try:
+            compile(diff_file.head_file, relevant_file, "exec", dont_inherit=True)
+        except (SyntaxError, ValueError):
+            return None
+        except Exception as e:
+            get_logger().warning(f"Could not validate Python suggestion syntax: {e}")
+            return None
+
+        file_lines = diff_file.head_file.splitlines()
+        if (relevant_lines_start < 1
+                or relevant_lines_end < relevant_lines_start
+                or relevant_lines_end > len(file_lines)):
+            return None
+        file_lines[relevant_lines_start - 1:relevant_lines_end] = new_code_snippet.splitlines()
+
+        try:
+            compile("\n".join(file_lines), relevant_file, "exec", dont_inherit=True)
+        except (SyntaxError, ValueError):
+            return False
+        except Exception as e:
+            get_logger().warning(f"Could not validate Python suggestion syntax: {e}")
+            return None
+        return True
 
     @staticmethod
     def _get_patch_range_lines(patch, relevant_lines_start, relevant_lines_end) -> Optional[List[str]]:

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -865,6 +865,218 @@ async def test_suggestion_covering_the_anchored_range_is_published_as_committabl
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("improved_code", ["return new(", "return await new()"])
+async def test_invalid_python_replacement_is_published_as_a_pr_comment(improved_code):
+    git_provider = _provider_with_file("def fetch():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old()",
+            improved_code=improved_code,
+            score=8,
+        )
+    ]})
+
+    git_provider.publish_code_suggestions.assert_not_called()
+    body = git_provider.publish_comment.call_args.args[0]
+    assert "```suggestion" not in body
+    assert "because the proposed Python code has invalid syntax" in body
+    assert "`app.py:2-2`" in body
+
+
+@pytest.mark.asyncio
+async def test_invalid_python_replacement_stays_in_a_noncommittable_artifact():
+    git_provider = _provider_with_file("def fetch():\n    return old()\n")
+    git_provider.supports_code_suggestions_artifact.return_value = True
+    git_provider.publish_code_suggestions_artifact.return_value = True
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old()",
+            improved_code="return new(",
+            score=8,
+        )
+    ]})
+
+    published = git_provider.publish_code_suggestions_artifact.call_args.args[0]
+    assert len(published) == 1
+    assert "```suggestion" not in published[0]["body"]
+    assert "because the proposed Python code has invalid syntax" in published[0]["body"]
+    git_provider.publish_code_suggestions.assert_not_called()
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_context_dependent_multiline_python_replacement_remains_committable():
+    git_provider = _provider_with_file(
+        "async def fetch():\n"
+        "    return await old(\n"
+        "        source,\n"
+        "    )\n"
+    )
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=4,
+            existing_code="return await old(\n    source,\n)",
+            improved_code="return await new()",
+            score=8,
+        )
+    ]})
+
+    body = _published_suggestion(git_provider)["body"]
+    assert "```suggestion\n    return await new()\n```" in body
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_python_replacement_remains_best_effort():
+    git_provider = _provider_with_file(
+        "function fetch() {\n  return old();\n}\n",
+        filename="app.js",
+    )
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_file="app.js",
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old();",
+            improved_code="return (",
+            score=8,
+            language="python",
+        )
+    ]})
+
+    assert "```suggestion\n  return (\n```" in _published_suggestion(git_provider)["body"]
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_python_replacement_with_incomplete_file_context_remains_best_effort():
+    git_provider = MagicMock()
+    git_provider.diff_files = [FilePatchInfo(
+        base_file="",
+        head_file="def fetch():\n    return old()\n",
+        patch="@@ -19,2 +19,2 @@\n def fetch():\n-    return older()\n+    return old()\n",
+        filename="app.py",
+        head_file_is_complete=False,
+    )]
+    git_provider.publish_code_suggestions.return_value = True
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=20,
+            relevant_lines_end=20,
+            existing_code="return old()",
+            improved_code="return new(",
+            score=8,
+        )
+    ]})
+
+    assert "```suggestion\n    return new(\n```" in _published_suggestion(git_provider)["body"]
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_python_replacement_in_an_unparseable_file_remains_best_effort():
+    git_provider = _provider_with_file("def broken(:\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        _valid_suggestion(
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old()",
+            improved_code="return new()",
+            score=8,
+        )
+    ]})
+
+    assert "```suggestion\n    return new()\n```" in _published_suggestion(git_provider)["body"]
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compile_side_effect", [
+    [RecursionError("baseline too deeply nested")],
+    [None, RecursionError("replacement too deeply nested")],
+])
+async def test_python_validation_failure_remains_best_effort(compile_side_effect):
+    git_provider = _provider_with_file("def fetch():\n    return old()\n")
+    tool = _make_tool(git_provider)
+
+    with patch(
+        "pr_agent.tools.pr_code_suggestions.compile",
+        side_effect=compile_side_effect,
+        create=True,
+    ):
+        await tool.push_inline_code_suggestions({"code_suggestions": [
+            _valid_suggestion(
+                relevant_lines_start=2,
+                relevant_lines_end=2,
+                existing_code="return old()",
+                improved_code="return new()",
+                score=8,
+            )
+        ]})
+
+    assert "```suggestion\n    return new()\n```" in _published_suggestion(git_provider)["body"]
+    git_provider.publish_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("max_length", "improved_code", "truncated_code"), [
+    (6, "return new_value", "return"),
+    (2, "    return new()", ""),
+])
+async def test_truncated_replacement_is_published_as_a_pr_comment(
+        max_length, improved_code, truncated_code):
+    settings = get_settings()
+    snapshot = snapshot_settings((
+        "pr_code_suggestions.max_code_suggestion_length",
+        "pr_code_suggestions.suggestion_truncation_message",
+    ))
+    try:
+        settings.set("pr_code_suggestions.max_code_suggestion_length", max_length)
+        settings.set("pr_code_suggestions.suggestion_truncation_message", "")
+        git_provider = _provider_with_file(
+            "function fetch() {\n  return old();\n}\n",
+            filename="app.js",
+        )
+        tool = _make_tool(git_provider)
+        suggestion = PRCodeSuggestions._truncate_if_needed(_valid_suggestion(
+            relevant_file="app.js",
+            relevant_lines_start=2,
+            relevant_lines_end=2,
+            existing_code="return old();",
+            improved_code=improved_code,
+            score=8,
+        ))
+
+        assert suggestion["improved_code"].rstrip() == truncated_code
+        await tool.push_inline_code_suggestions({"code_suggestions": [suggestion]})
+
+        git_provider.publish_code_suggestions.assert_not_called()
+        body = git_provider.publish_comment.call_args.args[0]
+        assert "```suggestion" not in body
+        assert "because the proposed code was truncated" in body
+        assert "`app.js:2-2`" in body
+    finally:
+        restore_settings(snapshot)
+
+
+@pytest.mark.asyncio
 async def test_suggestion_rewriting_more_lines_than_it_replaces_is_published_as_a_plain_comment():
     git_provider = _provider_with_file("def f():\n    return old(\n        arg)\n")
     tool = _make_tool(git_provider)

--- a/tests/unittest/test_pr_code_suggestions_filtering.py
+++ b/tests/unittest/test_pr_code_suggestions_filtering.py
@@ -78,9 +78,10 @@ def test_truncate_if_needed_keeps_short_code_unchanged():
     snapshot = snapshot_settings(TRUNCATION_SETTINGS)
     settings.set("pr_code_suggestions.max_code_suggestion_length", 1000)
     try:
-        suggestion = _valid_suggestion(improved_code="short()")
+        suggestion = _valid_suggestion(improved_code="short()", _is_truncated=True)
         result = PRCodeSuggestions._truncate_if_needed(suggestion)
         assert result["improved_code"] == "short()"
+        assert "_is_truncated" not in result
     finally:
         restore_settings(snapshot)
 


### PR DESCRIPTION
## Summary

- validate Python-family suggestions by compiling the reconstructed full head file after applying the proposed replacement at its verified range
- downgrade suggestions that introduce invalid Python syntax, and every character-truncated suggestion, instead of publishing them as one-click committable changes
- publish safety-rejected hosted suggestions as normal PR comments while preserving them as non-committable entries for standalone artifact providers
- retain best-effort behavior for unsupported languages, incomplete file context, pre-existing invalid Python, and unexpected compiler failures

## Why

`/improve` previously validated a suggestion's file and line anchor but not the generated replacement itself. Invalid Python could therefore be published inside a committable suggestion block.

The optional length limit also truncates generated code at a raw character boundary, which can leave syntactically incomplete output. Truncated suggestions now retain explicit provenance and cannot become committable, including when truncation leaves only whitespace.

## Scope

This validates syntax only. Import resolution and other semantic checks remain outside this change, as does the separate missing-import prompt question raised in the issue.

Closes #3042

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest` (`3471 passed, 1 skipped, 1 xfailed`)
- `PYTHONPATH=. uv run pytest -q tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_filtering.py` (`123 passed`)
- pre-commit on all changed files (passed)
- `git diff --check` (passed)
