### PR TITLE
refactor: centralize primary command descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ PR-Agent tools run as a comment on a PR or from the CLI. A few common ones:
 
 ```bash
 # Comment on a PR (GitHub/GitLab/Bitbucket/…):
-/describe                        # generate title, summary, walkthrough and labels
-/review                          # findings, security, review effort and tests
-/improve                         # actionable code-improvement suggestions
+/describe
+/review
+/improve
 /ask "What does this PR change?" # free-text Q&A about the PR
 
 # Or locally via the CLI:

--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels.
+Generate a PR title, type, summary, code walkthrough and labels.
 
 The tool can be triggered automatically every time a new PR is [opened](../usage-guide/automations_and_usage.md#github-app-automatic-tools-when-a-new-pr-is-opened), or it can be invoked manually by commenting on any PR:
 

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The `improve` tool scans the PR code changes, and automatically generates meaningful suggestions for improving the PR code.
+Generate actionable code suggestions for improving the PR.
 The tool can be triggered automatically every time a new PR is [opened](../usage-guide/automations_and_usage.md#github-app-automatic-tools-when-a-new-pr-is-opened), or it can be invoked manually by commenting on any PR:
 
 ```toml

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -1,19 +1,17 @@
 # Tools
 
-Here is a list of PR-Agent tools, each with a dedicated page that explains how to use it:
+Each PR-Agent tool has a dedicated page that explains its behavior and usage:
 
-| Tool                                                                                     | Description                                                                                                                                 |
-|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| **[PR Description (`/describe`)](./describe.md)**                                        | Automatically generating PR description - title, type, summary, code walkthrough and labels                                                 |
-| **[PR Review (`/review`)](./review.md)**                                                 | Adjustable feedback about the PR, possible issues, security concerns, review effort and more                                                |
-| **[Code Suggestions (`/improve`)](./improve.md)**                                        | Code suggestions for improving the PR                                                                                                       |
-| **[Question Answering (`/ask ...`)](./ask.md)**                                          | Answering free-text questions about the PR, or on specific code lines                                                                       |
-| **[Add Documentation (`/add_docs`)](./add_docs.md)**                                     | Generate documentation for code components that are missing it                                                                              |
-| **[Generate Labels (`/generate_labels`)](./generate_labels.md)**                         | Generate custom labels for the PR based on the code changes                                                                                 |
-| **[Similar Issues (`/similar_issue`)](./similar_issues.md)**                             | Find similar issues in the repository based on the current issue                                                                            |
-| **[Help (`/help`)](./help.md)**                                                          | Provides a list of all the available tools                                                                                                  |
-| **[Help Docs (`/help_docs`)](./help_docs.md)**                                           | Answer a free-text question based on a git documentation folder                                                                             |
-| **[Update Changelog (`/update_changelog`)](./update_changelog.md)**                      | Automatically updating the CHANGELOG.md file with the PR changes                                                                            |
+- [PR Description (`/describe`)](./describe.md)
+- [PR Review (`/review`)](./review.md)
+- [Code Suggestions (`/improve`)](./improve.md)
+- [Question Answering (`/ask ...`)](./ask.md)
+- [Add Documentation (`/add_docs`)](./add_docs.md)
+- [Generate Labels (`/generate_labels`)](./generate_labels.md)
+- [Similar Issues (`/similar_issue`)](./similar_issues.md)
+- [Help (`/help`)](./help.md)
+- [Help Docs (`/help_docs`)](./help_docs.md)
+- [Update Changelog (`/update_changelog`)](./update_changelog.md)
 
 ## Usage examples
 

--- a/docs/docs/tools/index.md
+++ b/docs/docs/tools/index.md
@@ -2,16 +2,18 @@
 
 Each PR-Agent tool has a dedicated page that explains its behavior and usage:
 
-- [PR Description (`/describe`)](./describe.md)
-- [PR Review (`/review`)](./review.md)
-- [Code Suggestions (`/improve`)](./improve.md)
-- [Question Answering (`/ask ...`)](./ask.md)
-- [Add Documentation (`/add_docs`)](./add_docs.md)
-- [Generate Labels (`/generate_labels`)](./generate_labels.md)
-- [Similar Issues (`/similar_issue`)](./similar_issues.md)
-- [Help (`/help`)](./help.md)
-- [Help Docs (`/help_docs`)](./help_docs.md)
-- [Update Changelog (`/update_changelog`)](./update_changelog.md)
+| Tool | Description |
+|------|-------------|
+| **[PR Description (`/describe`)](./describe.md)** | Generate a PR title, type, summary, code walkthrough and labels. |
+| **[PR Review (`/review`)](./review.md)** | Generate a PR review with feedback on possible issues, security concerns, tests and review effort. |
+| **[Code Suggestions (`/improve`)](./improve.md)** | Generate actionable code suggestions for improving the PR. |
+| **[Question Answering (`/ask ...`)](./ask.md)** | Answering free-text questions about the PR, or on specific code lines |
+| **[Add Documentation (`/add_docs`)](./add_docs.md)** | Generate documentation for code components that are missing it |
+| **[Generate Labels (`/generate_labels`)](./generate_labels.md)** | Generate custom labels for the PR based on the code changes |
+| **[Similar Issues (`/similar_issue`)](./similar_issues.md)** | Find similar issues in the repository based on the current issue |
+| **[Help (`/help`)](./help.md)** | Provides a list of all the available tools |
+| **[Help Docs (`/help_docs`)](./help_docs.md)** | Answer a free-text question based on a git documentation folder |
+| **[Update Changelog (`/update_changelog`)](./update_changelog.md)** | Automatically updating the CHANGELOG.md file with the PR changes |
 
 ## Usage examples
 

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The `review` tool scans the PR code changes, and generates feedback about the PR, aiming to aid the reviewing process.
+Generate a PR review with feedback on possible issues, security concerns, tests and review effort.
 <br>
 The tool can be triggered automatically every time a new PR is [opened](../usage-guide/automations_and_usage.md#github-app-automatic-tools-when-a-new-pr-is-opened), or can be invoked manually by commenting on any PR:
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -10,6 +10,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     litellm_callbacks_registered,
 )
 from pr_agent.algo.utils import get_version
+from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger, setup_logger
 
@@ -19,7 +20,7 @@ setup_logger(log_level)
 
 def set_parser():
     parser = argparse.ArgumentParser(description='AI based pull request analyzer', usage=
-    """\
+    f"""\
     Usage: cli.py --pr_url=<URL on supported git hosting service> <command> [<args>].
     For example:
     - cli.py --pr_url=... review
@@ -31,13 +32,13 @@ def set_parser():
     - cli.py --pr_url/--issue_url= help_docs [<asked question>]
 
     Supported commands:
-    - review / review_pr - Add a review that includes a summary of the PR and specific suggestions for improvement.
+    - review / review_pr - {COMMAND_DESCRIPTIONS["review"]}
 
     - ask / ask_question [question] - Ask a question about the PR.
 
-    - describe / describe_pr - Modify the PR title and description based on the PR's contents.
+    - describe / describe_pr - {COMMAND_DESCRIPTIONS["describe"]}
 
-    - improve / improve_code - Suggest improvements to the code in the PR as pull request comments ready to commit.
+    - improve / improve_code - {COMMAND_DESCRIPTIONS["improve"]}
     Extended mode ('improve --extended') employs several calls, and provides a more thorough feedback
 
     - reflect - Ask the PR author questions about the PR.

--- a/pr_agent/command_descriptions.py
+++ b/pr_agent/command_descriptions.py
@@ -1,0 +1,5 @@
+COMMAND_DESCRIPTIONS = {
+    "describe": "Generate a PR title, type, summary, code walkthrough and labels.",
+    "review": "Generate a PR review with feedback on possible issues, security concerns, tests and review effort.",
+    "improve": "Generate actionable code suggestions for improving the PR.",
+}

--- a/pr_agent/servers/help.py
+++ b/pr_agent/servers/help.py
@@ -1,9 +1,12 @@
+from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
+
+
 class HelpMessage:
     @staticmethod
     def get_general_commands_text():
-       commands_text = "> - **/review**: Request a review of your Pull Request.   \n" \
-                "> - **/describe**: Update the PR title and description based on the contents of the PR.   \n" \
-                "> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   \n" \
+       commands_text = f"> - **/review**: {COMMAND_DESCRIPTIONS['review']}   \n" \
+                f"> - **/describe**: {COMMAND_DESCRIPTIONS['describe']}   \n" \
+                f"> - **/improve [--extended]**: {COMMAND_DESCRIPTIONS['improve']} Extended mode provides more thorough feedback.   \n" \
                 "> - **/ask \\<QUESTION\\>**: Ask a question about the PR.   \n" \
                 "> - **/update_changelog**: Update the changelog based on the PR's contents.   \n" \
                 "> - **/help_docs \\<QUESTION\\>**: Given a path to documentation (either for this repository or for a given one), ask a question.   \n" \
@@ -22,7 +25,8 @@ class HelpMessage:
     @staticmethod
     def get_review_usage_guide():
         output ="**Overview:**\n"
-        output +=("The `review` tool scans the PR code changes, and generates a PR review which includes several types of feedbacks, such as possible PR issues, security threats and relevant test in the PR. More feedbacks can be [added](https://pr-agent-docs.codium.ai/tools/review/#general-configurations) by configuring the tool.\n\n"
+        output += (f"{COMMAND_DESCRIPTIONS['review']} "
+                  "More feedback can be [added](https://pr-agent-docs.codium.ai/tools/review/#general-configurations) by configuring the tool.\n\n"
                   "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on any PR.\n")
         output +="""\
 - When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L23) related to the review tool (`pr_reviewer` section), use the following template:
@@ -46,7 +50,7 @@ some_config2=...
     @staticmethod
     def get_describe_usage_guide():
         output = "**Overview:**\n"
-        output += "The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. "
+        output += f"{COMMAND_DESCRIPTIONS['describe']} "
         output += "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
         output += """\
 
@@ -168,7 +172,7 @@ You can ask questions about the entire PR, about specific code lines, or about a
     @staticmethod
     def get_improve_usage_guide():
         output = "**Overview:**\n"
-        output += "The code suggestions tool, named `improve`, scans the PR code changes, and automatically generates code suggestions for improving the PR."
+        output += f"{COMMAND_DESCRIPTIONS['improve']} "
         output += "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
         output += """\
 - When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L78) related to the improve tool (`pr_code_suggestions` section), use the following template:

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -11,6 +11,7 @@ from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import ModelType, clip_tokens, get_max_tokens, load_yaml
+from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import BitbucketServerProvider, GithubProvider, get_git_provider_with_context
 from pr_agent.log import get_logger
@@ -214,9 +215,9 @@ class PRHelpMessage:
                 tool_names.append(f"[GENERATE CUSTOM LABELS]({base_path}/generate_labels/)")
 
                 descriptions = []
-                descriptions.append("Generates PR description - title, type, summary, code walkthrough and labels")
-                descriptions.append("Adjustable feedback about the PR, possible issues, security concerns, review effort and more")
-                descriptions.append("Code suggestions for improving the PR")
+                descriptions.append(COMMAND_DESCRIPTIONS["describe"])
+                descriptions.append(COMMAND_DESCRIPTIONS["review"])
+                descriptions.append(COMMAND_DESCRIPTIONS["improve"])
                 descriptions.append("Automatically updates the changelog")
                 descriptions.append("Answers a question regarding this repository, or a given one, based on given documentation path")
                 descriptions.append("Generates documentation to methods/functions/classes that changed in the PR")

--- a/tests/unittest/test_command_descriptions.py
+++ b/tests/unittest/test_command_descriptions.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pr_agent.cli import set_parser
+from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
+from pr_agent.config_loader import get_settings
+from pr_agent.servers.help import HelpMessage
+from pr_agent.tools.pr_help_message import PRHelpMessage
+
+
+def test_cli_and_bot_help_use_canonical_command_descriptions():
+    cli_usage = set_parser().format_usage()
+    bot_help = HelpMessage.get_general_commands_text()
+
+    for description in COMMAND_DESCRIPTIONS.values():
+        assert description in cli_usage
+        assert description in bot_help
+
+
+@pytest.mark.parametrize(
+    ("usage_guide", "command"),
+    [
+        (HelpMessage.get_describe_usage_guide, "describe"),
+        (HelpMessage.get_review_usage_guide, "review"),
+        (HelpMessage.get_improve_usage_guide, "improve"),
+    ],
+)
+def test_tool_usage_guides_use_canonical_command_descriptions(usage_guide, command):
+    assert COMMAND_DESCRIPTIONS[command] in usage_guide()
+
+
+@pytest.mark.asyncio
+async def test_pr_help_table_uses_canonical_command_descriptions():
+    class FakeProvider:
+        def __init__(self):
+            self.comment = ""
+
+        @staticmethod
+        def is_supported(_feature):
+            return True
+
+        def publish_comment(self, comment):
+            self.comment = comment
+
+    help_message = object.__new__(PRHelpMessage)
+    help_message.git_provider = FakeProvider()
+    help_message.question_str = ""
+
+    settings = get_settings()
+    publish_output = settings.config.publish_output
+    settings.set("config.publish_output", True)
+    try:
+        await help_message.run()
+    finally:
+        settings.set("config.publish_output", publish_output)
+
+    for description in COMMAND_DESCRIPTIONS.values():
+        assert description in help_message.git_provider.comment

--- a/tests/unittest/test_command_descriptions.py
+++ b/tests/unittest/test_command_descriptions.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from pr_agent.cli import set_parser
@@ -5,6 +7,8 @@ from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
 from pr_agent.config_loader import get_settings
 from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.pr_help_message import PRHelpMessage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_cli_and_bot_help_use_canonical_command_descriptions():
@@ -26,6 +30,12 @@ def test_cli_and_bot_help_use_canonical_command_descriptions():
 )
 def test_tool_usage_guides_use_canonical_command_descriptions(usage_guide, command):
     assert COMMAND_DESCRIPTIONS[command] in usage_guide()
+
+
+@pytest.mark.parametrize("command", COMMAND_DESCRIPTIONS)
+def test_tool_docs_use_canonical_command_descriptions(command):
+    tool_docs = REPO_ROOT / "docs" / "docs" / "tools" / f"{command}.md"
+    assert COMMAND_DESCRIPTIONS[command] in tool_docs.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add one canonical description map for `/describe`, `/review`, and `/improve`
- use those descriptions in the CLI, bot help, per-tool usage guides, and PR help table
- replace duplicated README and tools-index summaries with links to the dedicated tool pages
- add regression coverage for every runtime help surface

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_command_descriptions.py tests/unittest/test_cli_plain_diff_mode.py tests/unittest/test_cli_config_branch.py -q` (16 passed)
- `uv run ruff check pr_agent/command_descriptions.py pr_agent/cli.py pr_agent/servers/help.py pr_agent/tools/pr_help_message.py tests/unittest/test_command_descriptions.py`
- `python -m py_compile pr_agent/command_descriptions.py pr_agent/cli.py pr_agent/servers/help.py pr_agent/tools/pr_help_message.py tests/unittest/test_command_descriptions.py`
- `python -X utf8 -m mkdocs build -f docs/mkdocs.yml`

Closes #3039