### PR TITLE
fix(bitbucket-server): update persistent reviews in place

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -334,6 +334,7 @@ class BitbucketServerProvider(GitProvider):
             return self.bitbucket_client.add_pull_request_comment(
                 self.workspace_slug, self.repo_slug, self.pr_num, pr_comment
             )
+        return None
 
     def publish_persistent_comment(self, pr_comment: str,
                                    initial_header: str,

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -538,6 +538,7 @@ class BitbucketServerProvider(GitProvider):
             self.workspace_slug,
             self.repo_slug,
             self.pr_num,
+            limit=100,
         )
         for activity in activities:
             if not isinstance(activity, dict) or activity.get("action") != "COMMENTED":
@@ -560,6 +561,11 @@ class BitbucketServerProvider(GitProvider):
                 user=SimpleNamespace(login=author.get("name") or author.get("slug") or ""),
             ))
         return comments
+
+    def get_issue_comments_newest_first(self):
+        # The activities feed has no documented ordering, so order by comment id,
+        # which Bitbucket Server assigns monotonically.
+        return sorted(self.get_issue_comments(), key=lambda comment: comment.id, reverse=True)
 
     def get_comment_url(self, comment) -> str:
         return f"{self._get_pr_web_url()}/overview?commentId={comment.id}"

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -2,6 +2,7 @@ import difflib
 import re
 import shlex
 import subprocess
+from types import SimpleNamespace
 from typing import Optional, Tuple
 from urllib.parse import quote_plus, urlparse
 
@@ -200,7 +201,7 @@ class BitbucketServerProvider(GitProvider):
         pass
 
     def is_supported(self, capability: str) -> bool:
-        if capability in ['get_issue_comments', 'get_labels', 'gfm_markdown', 'publish_file_comments']:
+        if capability in ['get_labels', 'gfm_markdown', 'publish_file_comments']:
             return False
         return True
 
@@ -328,9 +329,76 @@ class BitbucketServerProvider(GitProvider):
         self.diff_files = diff_files
         return diff_files
 
-    def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+    def publish_comment(self, pr_comment: str, is_temporary: bool = False, as_thread: bool = False):
         if not is_temporary:
-            self.bitbucket_client.add_pull_request_comment(self.workspace_slug, self.repo_slug, self.pr_num, pr_comment)
+            return self.bitbucket_client.add_pull_request_comment(
+                self.workspace_slug, self.repo_slug, self.pr_num, pr_comment
+            )
+
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_header: str,
+                                   update_header: bool = True,
+                                   name='review',
+                                   final_update_message=True,
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        return self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            as_thread,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
+
+    def supports_review_comment_identity(self) -> bool:
+        return True
+
+    def edit_comment(self, comment, body: str) -> bool:
+        try:
+            self.bitbucket_client.update_pull_request_comment(
+                self.workspace_slug,
+                self.repo_slug,
+                self.pr_num,
+                comment.id,
+                body,
+                comment.version,
+            )
+            return True
+        except HTTPError as e:
+            if getattr(getattr(e, "response", None), "status_code", None) == 409:
+                try:
+                    current = self.bitbucket_client.get_pull_request_comment(
+                        self.workspace_slug,
+                        self.repo_slug,
+                        self.pr_num,
+                        comment.id,
+                    )
+                    current_version = current.get("version") if isinstance(current, dict) else None
+                    if not isinstance(current_version, int):
+                        raise ValueError("Bitbucket returned a comment without a valid version")
+                    self.bitbucket_client.update_pull_request_comment(
+                        self.workspace_slug,
+                        self.repo_slug,
+                        self.pr_num,
+                        comment.id,
+                        body,
+                        current_version,
+                    )
+                    return True
+                except Exception as retry_error:
+                    get_logger().exception(
+                        f"Failed to update comment after refreshing its version, error: {retry_error}"
+                    )
+                    return False
+            get_logger().exception(f"Failed to update comment, error: {e}")
+            return False
+        except Exception as e:
+            get_logger().exception(f"Failed to update comment, error: {e}")
+            return False
 
     def remove_initial_comment(self):
         try:
@@ -464,9 +532,43 @@ class BitbucketServerProvider(GitProvider):
         return 0
 
     def get_issue_comments(self):
-        raise NotImplementedError(
-            "Bitbucket provider does not support issue comments yet"
+        comments = []
+        activities = self.bitbucket_client.get_pull_requests_activities(
+            self.workspace_slug,
+            self.repo_slug,
+            self.pr_num,
         )
+        for activity in activities:
+            if not isinstance(activity, dict) or activity.get("action") != "COMMENTED":
+                continue
+            comment = activity.get("comment")
+            if not isinstance(comment, dict):
+                continue
+            if comment.get("parent") or comment.get("anchor") or comment.get("state") == "DELETED":
+                continue
+            body = comment.get("text")
+            comment_id = comment.get("id")
+            version = comment.get("version")
+            if not isinstance(body, str) or not isinstance(comment_id, int) or not isinstance(version, int):
+                continue
+            author = comment.get("author") if isinstance(comment.get("author"), dict) else {}
+            comments.append(SimpleNamespace(
+                body=body,
+                id=comment_id,
+                version=version,
+                user=SimpleNamespace(login=author.get("name") or author.get("slug") or ""),
+            ))
+        return comments
+
+    def get_comment_url(self, comment) -> str:
+        return f"{self._get_pr_web_url()}/overview?commentId={comment.id}"
+
+    def get_latest_commit_url(self) -> str:
+        try:
+            return f"{self._get_repo_web_url()}/commits/{self.pr.fromRef['latestCommit']}"
+        except Exception as e:
+            get_logger().warning(f"Failed to get latest commit URL, error: {e}")
+            return ""
 
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         return None
@@ -575,6 +677,14 @@ class BitbucketServerProvider(GitProvider):
 
     def _get_pr_comments_path(self):
         return f"rest/api/latest/projects/{self.workspace_slug}/repos/{self.repo_slug}/pull-requests/{self.pr_num}/comments"
+
+    def _get_repo_web_url(self) -> str:
+        parsed_url = urlparse(self.pr_url)
+        repo_path = parsed_url.path.rsplit("/pull-requests/", 1)[0]
+        return f"{parsed_url.scheme}://{parsed_url.netloc}{repo_path}"
+
+    def _get_pr_web_url(self) -> str:
+        return f"{self._get_repo_web_url()}/pull-requests/{self.pr_num}"
 
     def _get_merge_base(self):
         return f"rest/api/latest/projects/{self.workspace_slug}/repos/{self.repo_slug}/pull-requests/{self.pr_num}/merge-base"

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -560,7 +560,7 @@ class BitbucketServerProvider(GitProvider):
                 version=version,
                 user=SimpleNamespace(login=author.get("name") or author.get("slug") or ""),
             ))
-        return comments
+        return sorted(comments, key=lambda comment: comment.id)
 
     def get_issue_comments_newest_first(self):
         # The activities feed has no documented ordering, so order by comment id,

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -640,7 +640,19 @@ class TestBitbucketServerProvider:
             (11, 2, "first review", "pr-agent"),
             (12, 5, "second review", "review-bot"),
         ]
-        provider.bitbucket_client.get_pull_requests_activities.assert_called_once_with("AAA", "my-repo", 1)
+        provider.bitbucket_client.get_pull_requests_activities.assert_called_once_with("AAA", "my-repo", 1, limit=100)
+
+    @pytest.mark.parametrize("activity_ids", [(100, 200), (200, 100)])
+    def test_get_issue_comments_newest_first_uses_comment_id(self, activity_ids):
+        provider = self._persistent_provider()
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity("review", comment_id=comment_id)
+            for comment_id in activity_ids
+        ]
+
+        comments = provider.get_issue_comments_newest_first()
+
+        assert [comment.id for comment in comments] == [200, 100]
 
     def test_persistent_review_creates_once_then_updates_the_same_comment(self):
         provider = self._persistent_provider()

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5,9 +6,15 @@ from atlassian.bitbucket import Bitbucket
 from requests.exceptions import HTTPError
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
-from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
+from pr_agent.algo.utils import (
+    PRCodeSuggestionsHeader,
+    PRCodeSuggestionsIdentity,
+    PRReviewHeader,
+    PRReviewIdentity,
+)
 from pr_agent.git_providers import BitbucketServerProvider
 from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 
 
 class TestBitbucketProvider:
@@ -572,6 +579,32 @@ class TestBitbucketServerProvider:
         provider.bitbucket_client = MagicMock()
         return provider
 
+    @staticmethod
+    def _persistent_provider(
+        pr_url="https://git.example.com/bitbucket/projects/AAA/repos/my-repo/pull-requests/1",
+        workspace_slug="AAA",
+    ):
+        provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+        provider.workspace_slug = workspace_slug
+        provider.repo_slug = "my-repo"
+        provider.pr_num = 1
+        provider.pr_url = pr_url
+        provider.pr = SimpleNamespace(fromRef={"latestCommit": "deadbeef12345678"})
+        provider.bitbucket_client = MagicMock()
+        provider.bitbucket_client.get_pull_requests_activities.return_value = []
+        return provider
+
+    @staticmethod
+    def _comment_activity(body, comment_id=7, version=3, **comment_fields):
+        comment = {
+            "id": comment_id,
+            "version": version,
+            "text": body,
+            "author": {"name": "pr-agent"},
+            **comment_fields,
+        }
+        return {"action": "COMMENTED", "comment": comment}
+
     def test_parse_pr_url(self):
         url = "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1"
         workspace_slug, repo_slug, pr_number = BitbucketServerProvider._parse_pr_url(url)
@@ -585,6 +618,171 @@ class TestBitbucketServerProvider:
         assert workspace_slug == "~username"
         assert repo_slug == "my-repo"
         assert pr_number == 1
+
+    def test_get_issue_comments_normalizes_top_level_comments_from_all_activities(self):
+        provider = self._persistent_provider()
+        provider.bitbucket_client.get_pull_requests_activities.return_value = iter([
+            {"action": "OPENED"},
+            {"action": "COMMENTED", "comment": None},
+            self._comment_activity("missing version", version=None),
+            self._comment_activity("reply", comment_id=8, parent={"id": 7}),
+            self._comment_activity("inline", comment_id=9, anchor={"line": 4}),
+            self._comment_activity("deleted", comment_id=10, state="DELETED"),
+            self._comment_activity("first review", comment_id=11, version=2),
+            self._comment_activity("second review", comment_id=12, version=5, author={"slug": "review-bot"}),
+        ])
+
+        comments = provider.get_issue_comments()
+
+        assert provider.is_supported("get_issue_comments") is True
+        assert provider.supports_review_comment_identity() is True
+        assert [(comment.id, comment.version, comment.body, comment.user.login) for comment in comments] == [
+            (11, 2, "first review", "pr-agent"),
+            (12, 5, "second review", "review-bot"),
+        ]
+        provider.bitbucket_client.get_pull_requests_activities.assert_called_once_with("AAA", "my-repo", 1)
+
+    def test_persistent_review_creates_once_then_updates_the_same_comment(self):
+        provider = self._persistent_provider()
+        provider.bitbucket_client.add_pull_request_comment.return_value = {"id": 7, "version": 0}
+        header = "## Team Review 🔍"
+
+        provider.publish_persistent_comment(
+            f"{header}\n\nfirst review",
+            initial_header=header,
+            final_update_message=False,
+            as_thread=True,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+        first_body = provider.bitbucket_client.add_pull_request_comment.call_args.args[3]
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity(first_body),
+        ]
+
+        updated = provider.publish_persistent_comment(
+            f"{header}\n\nsecond review",
+            initial_header=header,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert updated.id == 7
+        provider.bitbucket_client.add_pull_request_comment.assert_called_once()
+        provider.bitbucket_client.update_pull_request_comment.assert_called_once()
+        update_args = provider.bitbucket_client.update_pull_request_comment.call_args.args
+        assert update_args[:4] == ("AAA", "my-repo", 1, 7)
+        assert update_args[5] == 3
+        assert PRReviewIdentity.REGULAR.value in update_args[4]
+        assert "second review" in update_args[4]
+
+    def test_persistent_review_migrates_legacy_heading_to_stable_identity(self):
+        provider = self._persistent_provider()
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity("## PR Reviewer Guide 🔍\n\nprevious review"),
+        ]
+
+        provider.publish_persistent_comment(
+            "## Team Review 🔍\n\nnew review",
+            initial_header="## Team Review 🔍",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        provider.bitbucket_client.add_pull_request_comment.assert_not_called()
+        updated_body = provider.bitbucket_client.update_pull_request_comment.call_args.args[4]
+        assert updated_body.startswith("## Team Review 🔍\n\n")
+        assert PRReviewIdentity.REGULAR.value in updated_body
+
+    def test_edit_comment_retries_once_with_refreshed_version_after_conflict(self):
+        provider = self._persistent_provider()
+        response = MagicMock(status_code=409)
+        conflict = HTTPError("409 Conflict", response=response)
+        provider.bitbucket_client.update_pull_request_comment.side_effect = [conflict, {"version": 5}]
+        provider.bitbucket_client.get_pull_request_comment.return_value = {"id": 7, "version": 4}
+        comment = SimpleNamespace(id=7, version=3, body="previous review")
+
+        assert provider.edit_comment(comment, "new review") is True
+
+        assert provider.bitbucket_client.update_pull_request_comment.call_args_list[0].args[-1] == 3
+        assert provider.bitbucket_client.update_pull_request_comment.call_args_list[1].args[-1] == 4
+        provider.bitbucket_client.get_pull_request_comment.assert_called_once_with("AAA", "my-repo", 1, 7)
+
+    def test_persistent_review_falls_back_to_one_new_comment_when_update_fails(self):
+        provider = self._persistent_provider()
+        existing_body = f"## Team Review 🔍\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity(existing_body),
+        ]
+        provider.bitbucket_client.update_pull_request_comment.side_effect = RuntimeError("update failed")
+        provider.bitbucket_client.add_pull_request_comment.return_value = {"id": 8, "version": 0}
+
+        result = provider.publish_persistent_comment(
+            "## Team Review 🔍\n\nnew review",
+            initial_header="## Team Review 🔍",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert result == {"id": 8, "version": 0}
+        provider.bitbucket_client.update_pull_request_comment.assert_called_once()
+        provider.bitbucket_client.add_pull_request_comment.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "pr_url,workspace_slug,expected_repo_url",
+        [
+            (
+                "https://git.example.com/bitbucket/projects/AAA/repos/my-repo/pull-requests/1",
+                "AAA",
+                "https://git.example.com/bitbucket/projects/AAA/repos/my-repo",
+            ),
+            (
+                "https://git.example.com/bitbucket/users/alice/repos/my-repo/pull-requests/1/overview",
+                "~alice",
+                "https://git.example.com/bitbucket/users/alice/repos/my-repo",
+            ),
+        ],
+    )
+    def test_persistent_comment_links_preserve_project_and_personal_repository_paths(
+        self, pr_url, workspace_slug, expected_repo_url
+    ):
+        provider = self._persistent_provider(pr_url, workspace_slug)
+        comment = SimpleNamespace(id=7)
+
+        assert provider.get_comment_url(comment) == f"{expected_repo_url}/pull-requests/1/overview?commentId=7"
+        assert provider.get_latest_commit_url() == f"{expected_repo_url}/commits/deadbeef12345678"
+
+    def test_improve_history_updates_existing_bitbucket_server_comment(self):
+        provider = self._persistent_provider()
+        existing_body = (
+            f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n"
+            f"{PRCodeSuggestionsIdentity.SUMMARY.value}\n\n"
+            "<!-- abc1234 -->\n\n<table>previous suggestions</table>"
+        )
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity(existing_body),
+        ]
+
+        updated = PRCodeSuggestions.publish_persistent_comment_with_history(
+            provider,
+            f"{PRCodeSuggestionsHeader.SUMMARY.value}\n\n<table>new suggestions</table>",
+            initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+            name="suggestions",
+            final_update_message=False,
+            max_previous_comments=4,
+            identity_marker=PRCodeSuggestionsIdentity.SUMMARY.value,
+            legacy_initial_header=PRCodeSuggestionsHeader.SUMMARY.value,
+        )
+
+        assert updated.id == 7
+        provider.bitbucket_client.add_pull_request_comment.assert_not_called()
+        updated_body = provider.bitbucket_client.update_pull_request_comment.call_args.args[4]
+        assert PRCodeSuggestionsIdentity.SUMMARY.value in updated_body
+        assert "new suggestions" in updated_body
+        assert "Previous suggestions" in updated_body
 
     def test_publish_code_suggestions_reports_success(self):
         provider = self._provider_for_code_suggestions()

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -643,6 +643,18 @@ class TestBitbucketServerProvider:
         provider.bitbucket_client.get_pull_requests_activities.assert_called_once_with("AAA", "my-repo", 1, limit=100)
 
     @pytest.mark.parametrize("activity_ids", [(100, 200), (200, 100)])
+    def test_get_issue_comments_uses_oldest_first_contract(self, activity_ids):
+        provider = self._persistent_provider()
+        provider.bitbucket_client.get_pull_requests_activities.return_value = [
+            self._comment_activity("review", comment_id=comment_id)
+            for comment_id in activity_ids
+        ]
+
+        comments = provider.get_issue_comments()
+
+        assert [comment.id for comment in comments] == [100, 200]
+
+    @pytest.mark.parametrize("activity_ids", [(100, 200), (200, 100)])
     def test_get_issue_comments_newest_first_uses_comment_id(self, activity_ids):
         provider = self._persistent_provider()
         provider.bitbucket_client.get_pull_requests_activities.return_value = [

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -112,6 +112,19 @@ def _azure_devops(monkeypatch) -> AzureDevopsProvider:
     return provider
 
 
+def _bitbucket_server(monkeypatch) -> BitbucketServerProvider:
+    provider = BitbucketServerProvider.__new__(BitbucketServerProvider)
+    provider.workspace_slug = "PRJ"
+    provider.repo_slug = "repo"
+    provider.pr_num = 7
+    provider.bitbucket_client = MagicMock()
+    provider.bitbucket_client.get_pull_requests_activities.return_value = [{
+        "action": "COMMENTED",
+        "comment": {"id": COMMENT_ID, "version": 1, "text": COMMENT_BODY},
+    }]
+    return provider
+
+
 def _bare(provider_type):
     """A provider with no backend wired at all: every call on it must succeed without one."""
     return lambda monkeypatch: provider_type.__new__(provider_type)
@@ -124,7 +137,7 @@ PROVIDERS: dict[str, tuple[type[GitProvider], Callable[[pytest.MonkeyPatch], Git
     "gerrit": (GerritProvider, _gerrit),
     "azure-devops": (AzureDevopsProvider, _azure_devops),
     "bitbucket": (BitbucketProvider, _bare(BitbucketProvider)),
-    "bitbucket-server": (BitbucketServerProvider, _bare(BitbucketServerProvider)),
+    "bitbucket-server": (BitbucketServerProvider, _bitbucket_server),
     "codecommit": (CodeCommitProvider, _bare(CodeCommitProvider)),
     "local": (LocalGitProvider, _bare(LocalGitProvider)),
     "plain-diff": (PlainDiffGitProvider, _bare(PlainDiffGitProvider)),
@@ -173,8 +186,8 @@ METHOD_CONTRACTS = (
         noop_value=[],
         check_supported=_is_comment_sequence,
         tiers=_tiers(
-            supported=("github", "gitlab", "gitea", "gerrit", "azure-devops"),
-            not_implemented=("bitbucket", "bitbucket-server", "codecommit", "local"),
+            supported=("github", "gitlab", "gitea", "gerrit", "azure-devops", "bitbucket-server"),
+            not_implemented=("bitbucket", "codecommit", "local"),
         ),
         # Implementations narrow the base `Iterable` (a paginated list, a list of SDK objects),
         # so the return annotation is checked by behaviour rather than by equality.


### PR DESCRIPTION
Fixes #3051

## Summary

- return top-level pull request comments in deterministic oldest-first order, independent of the Bitbucket activities feed order
- update persistent `/review`, `/improve`, and configured `/describe` comments through the versioned comment API
- keep `/answer` on the latest question and response while persistent comments continue to select the newest match
- retain stable review identities, legacy-header migration, and deployment context in generated links

## Result

Normalized calls for two consecutive persistent review publications:

```
before: creates=2, updates=0
after:  creates=1, updates=1
```

Both oldest-first and newest-first activity feeds now expose the same oldest-first comment list and select the same newest matching persistent comment.

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_bitbucket_provider.py tests/unittest/test_git_provider_method_contract.py tests/unittest/test_pr_reviewer_core.py tests/unittest/test_pr_code_suggestions_core.py` (393 passed)
- `PYTHONPATH=. uv run pytest -q tests/unittest` (3735 passed, 1 skipped, 1 xfailed)
- `uv run ruff check pr_agent/git_providers/bitbucket_server_provider.py tests/unittest/test_bitbucket_provider.py tests/unittest/test_git_provider_method_contract.py` (passed)
