### PR TITLE
chore: unskip E713, E714, E721 ruff rules

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1039,7 +1039,7 @@ def try_fix_yaml(response_text: str,
     response_text_lines_copy = response_text_lines.copy()
     for i in range(0, len(response_text_lines_copy)):
         for key in keys_yaml:
-            if key in response_text_lines_copy[i] and not '|' in response_text_lines_copy[i]:
+            if key in response_text_lines_copy[i] and "|" not in response_text_lines_copy[i]:
                 response_text_lines_copy[i] = response_text_lines_copy[i].replace(f'{key}',
                                                                                   f'{key} |\n        ')
     try:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -313,7 +313,7 @@ class GitProvider(ABC):
             return description
 
     def get_user_description(self) -> str:
-        if hasattr(self, 'user_description') and not (self.user_description is None):
+        if hasattr(self, "user_description") and (self.user_description is not None):
             return self.user_description
 
         description = (self.get_pr_description_full() or "").strip()

--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -61,7 +61,7 @@ class PRAddDocs:
             get_logger().info('Preparing PR documentation...')
             await retry_with_fallback_models(self._prepare_prediction)
             data = self._prepare_pr_code_docs()
-            if (not data) or (not 'Code Documentation' in data):
+            if (not data) or ("Code Documentation" not in data):
                 get_logger().info('No code documentation found for PR.')
                 return
 
@@ -126,8 +126,8 @@ class PRAddDocs:
 
                     body = "**Suggestion:** Proposed documentation\n```suggestion\n" + new_code_snippet + "\n```"
                     docs.append({'body': body, 'relevant_file': relevant_file,
-                                             'relevant_lines_start': relevant_line,
-                                             'relevant_lines_end': relevant_line})
+                                 "relevant_lines_start": relevant_line,
+                                 "relevant_lines_end": relevant_line})
             except Exception:
                 if get_verbosity_level() >= 2:
                     get_logger().info(f"Could not parse code docs: {d}")

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -519,16 +519,16 @@ class PRDescription:
         pr_labels = []
 
         # If the 'PR Type' key is present in the dictionary, split its value by comma and assign it to 'pr_types'
-        if 'labels' in self.data and self.data['labels']:
-            if type(self.data['labels']) == list:
-                pr_labels = self.data['labels']
-            elif type(self.data['labels']) == str:
-                pr_labels = self.data['labels'].split(',')
-        elif 'type' in self.data and self.data['type'] and get_settings().pr_description.publish_labels:
-            if type(self.data['type']) == list:
-                pr_labels = self.data['type']
-            elif type(self.data['type']) == str:
-                pr_labels = self.data['type'].split(',')
+        if "labels" in self.data and self.data["labels"]:
+            if isinstance(self.data["labels"], list):
+                pr_labels = self.data["labels"]
+            elif isinstance(self.data["labels"], str):
+                pr_labels = self.data["labels"].split(",")
+        elif "type" in self.data and self.data["type"] and get_settings().pr_description.publish_labels:
+            if isinstance(self.data["type"], list):
+                pr_labels = self.data["type"]
+            elif isinstance(self.data["type"], str):
+                pr_labels = self.data["type"].split(",")
         pr_labels = [label.strip() for label in pr_labels]
 
         # convert lowercase labels to original case
@@ -620,7 +620,7 @@ class PRDescription:
 
         # Remove the 'PR Title' key from the dictionary
         ai_title = self.data.pop('title', self.vars["title"])
-        if (not get_settings().pr_description.generate_ai_title):
+        if not get_settings().pr_description.generate_ai_title:
             # Assign the original PR title to the 'title' variable
             title = self.vars["title"]
         else:

--- a/pr_agent/tools/pr_generate_labels.py
+++ b/pr_agent/tools/pr_generate_labels.py
@@ -159,11 +159,11 @@ class PRGenerateLabels:
         pr_types = []
 
         # If the 'labels' key is present in the dictionary, split its value by comma and assign it to 'pr_types'
-        if 'labels' in self.data:
-            if type(self.data['labels']) == list:
-                pr_types = self.data['labels']
-            elif type(self.data['labels']) == str:
-                pr_types = self.data['labels'].split(',')
+        if "labels" in self.data:
+            if isinstance(self.data["labels"], list):
+                pr_types = self.data["labels"]
+            elif isinstance(self.data["labels"], str):
+                pr_types = self.data["labels"].split(",")
         pr_types = [label.strip() for label in pr_types]
 
         # convert lowercase labels to original case

--- a/pr_agent/tools/pr_similar_issue.py
+++ b/pr_agent/tools/pr_similar_issue.py
@@ -112,7 +112,7 @@ class PRSimilarIssue:
 
             upsert = True
             pinecone.init(api_key=api_key, environment=environment)
-            if not index_name in pinecone.list_indexes():
+            if index_name not in pinecone.list_indexes():
                 run_from_scratch = True
                 upsert = False
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,7 @@ lint.select = [
   "E",    # Pyflakes
   "F",    # Pyflakes
   "B",    # flake8-bugbear
-  "I001", # isort basic checks
-  "I002", # isort missing-required-import
+  "I",    # isort
 ]
 
 lint.fixable = [
@@ -163,9 +162,6 @@ lint.ignore = [
   "E402", # import not at top of file
   "E501", # line too long
   "E711", # comparison to None
-  "E713", # test for membership with `not ... in`
-  "E714", # test for object identity with `not ... is`
-  "E721", # type comparison with `==`
   "E722", # bare `except`
   "F811", # redefinition of unused name
   "F841", # unused local variable

--- a/tests/unittest/test_git_provider_description_recognition.py
+++ b/tests/unittest/test_git_provider_description_recognition.py
@@ -158,7 +158,7 @@ class TestQuotedHeadersAreNotOurs:
     """A human description that quotes our headers must not be read as generated,
     otherwise get_user_description() returns '' and their text is lost."""
 
-    def test_blockquoted_header_is_not_generated(self):
+    def test_block_quoted_header_is_not_generated(self):
         desc = ("For reference the bot emits:\n\n"
                 "> ### **PR Type**\n> Bug fix\n\nLeave my text alone.")
         assert _make_provider(desc)._is_generated_by_pr_agent(desc.lower()) is False

--- a/tests/unittest/test_pytest_configuration.py
+++ b/tests/unittest/test_pytest_configuration.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 
-
 _PYTEST_COLLECTION_TIMEOUT_SECONDS = 30
 
 


### PR DESCRIPTION
Hello

In pr fix some TODO in ruff rules:
1) https://docs.astral.sh/ruff/rules/not-in-test/
2) https://docs.astral.sh/ruff/rules/not-is-test/
3) https://docs.astral.sh/ruff/rules/type-comparison/

Also:
merge I001 and I002 -> I in selected ruff rules