### PR TITLE
fix: resolve token limits for legacy GPT-5.x _thinking aliases

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1358,8 +1358,9 @@ def get_max_tokens(model):
     logic:
     (1) If the model is in './pr_agent/algo/__init__.py', use the value from there.
     (2) else if 'config.custom_model_max_tokens' is set to a positive value, use it.
-    (3) else, fall back to litellm.get_model_info(model)["max_input_tokens"].
-    (4) else, raise an error.
+    (3) else if it is a GPT-5.x _thinking alias registered under its base name, use that value.
+    (4) else, query LiteLLM for provider-qualified and bare alias bases before the original model.
+    (5) else, raise an error.
 
     For all cases, we further limit the number of tokens to 'config.max_model_tokens' if it is set.
     This aims to improve the algorithmic quality, as the AI model degrades in performance when the input is too long.
@@ -1373,24 +1374,57 @@ def get_max_tokens(model):
         model_base = model_base.removeprefix('openai/').removeprefix('azure/')
     if custom_max_tokens <= 0 and model_base.removesuffix('_thinking') == 'gpt-6-astra':
         model = 'gpt-6-astra'
+    # Normalize GPT-5.x _thinking aliases before token-limit lookup to match
+    # LiteLLMAIHandler request normalization.
+    model_for_max_tokens = model
+    litellm_lookup_models = (model,)
+    if isinstance(model, str):
+        tmp = model
+        while tmp.startswith(("openai/", "azure/")):
+            tmp = tmp.removeprefix("openai/").removeprefix("azure/")
+        if tmp.startswith("gpt-5") and "_thinking" in tmp:
+            model_for_max_tokens = tmp.replace("_thinking", "")
+            settings_get = getattr(settings, "get", None)
+            azure_mode = callable(settings_get) and (
+                settings_get("OPENAI.API_TYPE", None) == "azure"
+                or bool(settings_get("AZURE_AD.CLIENT_ID", None))
+            )
+            if azure_mode or model.startswith("azure/"):
+                provider_prefix = "azure/"
+            else:
+                provider_prefix = "openai/"
+            provider_model = provider_prefix + model_for_max_tokens
+            litellm_lookup_models = tuple(dict.fromkeys((provider_model, model_for_max_tokens, model)))
     if model in MAX_TOKENS:
         max_tokens_model = MAX_TOKENS[model]
     elif custom_max_tokens > 0:
         max_tokens_model = custom_max_tokens
+    elif model_for_max_tokens in MAX_TOKENS:
+        max_tokens_model = MAX_TOKENS[model_for_max_tokens]
     else:
         # Fallback: ask LiteLLM for the model's metadata before giving up.
         max_tokens_model = 0
         import litellm
-        try:
-            model_info = litellm.get_model_info(model)
-        except Exception:
-            get_logger().debug(f"litellm.get_model_info could not resolve model '{model}'")
-            model_info = None
-        if model_info:
-            litellm_max = model_info.get("max_input_tokens")
-            if litellm_max and int(litellm_max) > 0:
-                max_tokens_model = int(litellm_max)
-                get_logger().debug(f"Resolved max_input_tokens for '{model}' from litellm: {max_tokens_model}")
+        # Try provider-qualified and bare bases before the raw alias.
+        for lookup_model in litellm_lookup_models:
+            try:
+                model_info = litellm.get_model_info(lookup_model)
+            except Exception:
+                get_logger().debug(f"litellm.get_model_info could not resolve model '{lookup_model}'")
+                model_info = None
+            if model_info:
+                litellm_max = model_info.get("max_input_tokens")
+                try:
+                    parsed_max_tokens = int(litellm_max)
+                except (TypeError, ValueError, OverflowError):
+                    continue
+                if parsed_max_tokens > 0:
+                    max_tokens_model = parsed_max_tokens
+                    get_logger().debug(
+                        f"Resolved max_input_tokens for '{model}' from litellm "
+                        f"(lookup '{lookup_model}'): {max_tokens_model}"
+                    )
+                    break
 
         if max_tokens_model <= 0:
             get_logger().error(

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -126,6 +126,200 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == expected
 
+    @pytest.mark.parametrize("model", [
+        "gpt-5_thinking",
+        "gpt-5-2025-08-07_thinking",
+        "gpt-5.4-mini_thinking",
+        "gpt-5.6_thinking",
+        "gpt-5.6-sol_thinking",
+        "gpt-5.6-terra_thinking",
+        "gpt-5.6-luna_thinking",
+    ])
+    def test_gpt5_thinking_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        expected = MAX_TOKENS[model.removesuffix("_thinking")]
+        assert get_max_tokens(model) == expected
+
+    @pytest.mark.parametrize("model", [
+        "gpt-5.6_thinking",
+        "openai/gpt-5.6_thinking",
+        "azure/gpt-5.6_thinking",
+    ])
+    def test_gpt5_thinking_alias_preserves_custom_limit(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 7000,
+                "max_model_tokens": 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 7000
+
+    @pytest.mark.parametrize("custom_limit", [
+        pytest.param(0, id="normalized-registry"),
+        pytest.param(9000, id="custom-limit"),
+    ])
+    def test_gpt5_thinking_alias_respects_max_model_tokens_cap(self, monkeypatch, custom_limit):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": custom_limit,
+                "max_model_tokens": 7000
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens("openai/gpt-5.6_thinking") == 7000
+
+    @pytest.mark.parametrize("model", [
+        "openai/gpt-5_thinking",
+        "azure/gpt-5.6_thinking",
+        "openai/gpt-5.6-sol_thinking",
+        "azure/gpt-5.6-terra_thinking",
+        "openai/gpt-5.6-luna_thinking",
+        "azure/openai/gpt-5.6_thinking",
+        "openai/gpt-5-2025-08-07_thinking",
+        "azure/gpt-5-2025-08-07_thinking",
+    ])
+    def test_gpt5_thinking_prefixed_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        # Strip provider prefixes then _thinking suffix to get base key
+        tmp = model
+        while tmp.startswith(("openai/", "azure/")):
+            tmp = tmp.removeprefix("openai/").removeprefix("azure/")
+        base = tmp.removesuffix("_thinking")
+        expected = MAX_TOKENS[base]
+        assert get_max_tokens(model) == expected
+
+    def test_non_gpt5_thinking_model_max_tokens_not_stripped(self, monkeypatch):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        with pytest.raises(Exception):
+            get_max_tokens("gpt-4o_thinking")
+
+    @pytest.mark.parametrize("invalid_limit", ["unknown", None, {}, float("inf"), 0, -1])
+    @pytest.mark.parametrize("raw_resolves", [False, True])
+    def test_thinking_fallback_skips_invalid_token_metadata(self, monkeypatch, invalid_limit, raw_resolves):
+        """Continue past unusable metadata to the raw alias or the unresolved-model error."""
+        settings = type("Settings", (), {
+            "config": type("Config", (), {"custom_model_max_tokens": 0, "max_model_tokens": 32000})(),
+            "get": lambda self, key, default=None: default,
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: settings)
+        model = "openai/gpt-5.9_thinking"
+        lookups = []
+
+        def get_model_info(candidate):
+            lookups.append(candidate)
+            return {"max_input_tokens": "65536" if raw_resolves and candidate == model else invalid_limit}
+
+        monkeypatch.setattr(litellm, "get_model_info", get_model_info)
+        if raw_resolves:
+            assert get_max_tokens(model) == 32000
+        else:
+            with pytest.raises(Exception, match="Ensure .* is defined in MAX_TOKENS"):
+                get_max_tokens(model)
+        assert lookups == ["openai/gpt-5.9", "gpt-5.9", model]
+
+    @pytest.mark.parametrize(
+        ("model", "resolved_model", "expected_lookups", "azure_mode"),
+        [
+            (
+                "gpt-5.9_thinking",
+                "openai/gpt-5.9",
+                ["openai/gpt-5.9"],
+                False,
+            ),
+            (
+                "gpt-5.9_thinking",
+                "gpt-5.9",
+                ["openai/gpt-5.9", "gpt-5.9"],
+                False,
+            ),
+            (
+                "gpt-5.9_thinking",
+                "azure/gpt-5.9",
+                ["azure/gpt-5.9"],
+                True,
+            ),
+            (
+                "openai/gpt-5.9_thinking",
+                "openai/gpt-5.9",
+                ["openai/gpt-5.9"],
+                False,
+            ),
+            (
+                "openai/gpt-5.9_thinking",
+                "azure/gpt-5.9",
+                ["azure/gpt-5.9"],
+                True,
+            ),
+            (
+                "azure/gpt-5.9_thinking",
+                "azure/gpt-5.9",
+                ["azure/gpt-5.9"],
+                False,
+            ),
+            (
+                "azure/openai/gpt-5.9_thinking",
+                "azure/gpt-5.9",
+                ["azure/gpt-5.9"],
+                False,
+            ),
+            (
+                "openai/gpt-5.9_thinking",
+                "openai/gpt-5.9_thinking",
+                ["openai/gpt-5.9", "gpt-5.9", "openai/gpt-5.9_thinking"],
+                False,
+            ),
+        ],
+    )
+    def test_gpt5_thinking_litellm_fallback(
+        self,
+        monkeypatch,
+        model,
+        resolved_model,
+        expected_lookups,
+        azure_mode,
+    ):
+        setting_values = {"OPENAI.API_TYPE": "azure"} if azure_mode else {}
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0
+            })(),
+            "get": lambda self, key, default=None: setting_values.get(key, default),
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        lookups = []
+
+        def mock_get_model_info(m):
+            lookups.append(m)
+            if m == resolved_model:
+                return {"max_input_tokens": 123456}
+            raise Exception("not found")
+
+        monkeypatch.setattr(litellm, "get_model_info", mock_get_model_info)
+        assert get_max_tokens(model) == 123456
+        assert lookups == expected_lookups
+
     @pytest.mark.parametrize(
         ("model", "expected"),
         [

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -7,6 +7,7 @@ from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 from litellm.utils import get_optional_params
 
 import pr_agent.algo.ai_handlers.litellm_ai_handler as litellm_handler
+import pr_agent.algo.utils as utils
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 
 
@@ -62,6 +63,66 @@ class TestLiteLLMReasoningEffort:
     """
 
     # ========== Group 1: Valid Configuration Tests ==========
+
+    @pytest.mark.parametrize("metadata_fallback", [False, True])
+    @pytest.mark.parametrize(("model", "base", "request_model", "azure_mode"), [
+        ("gpt-5.6_thinking", "gpt-5.6", "openai/gpt-5.6", False),
+        ("gpt-5.6_thinking-sol", "gpt-5.6-sol", "openai/gpt-5.6-sol", False),
+        ("azure/gpt-5.6_thinking-terra", "gpt-5.6-terra", "azure/gpt-5.6-terra", False),
+        ("gpt-5.6_thinking-luna_thinking", "gpt-5.6-luna", "openai/gpt-5.6-luna", False),
+        ("openai/gpt-5.6-sol_thinking", "gpt-5.6-sol", "openai/gpt-5.6-sol", False),
+        ("azure/gpt-5.6-terra_thinking", "gpt-5.6-terra", "azure/gpt-5.6-terra", False),
+        ("azure/openai/gpt-5.6-luna_thinking", "gpt-5.6-luna", "azure/gpt-5.6-luna", False),
+        ("openai/azure/gpt-5.6_thinking", "gpt-5.6", "openai/gpt-5.6", False),
+        ("gpt-5.6_thinking", "gpt-5.6", "azure/gpt-5.6", True),
+        ("openai/gpt-5.6-sol_thinking", "gpt-5.6-sol", "azure/gpt-5.6-sol", True),
+    ])
+    async def test_legacy_alias_token_lookup_matches_handler(
+        self, monkeypatch, mock_logger, model, base, request_model, azure_mode, metadata_fallback,
+    ):
+        """Pin both real paths to legacy aliases and explicit expected names, including infix forms."""
+        settings = create_mock_settings("medium")
+        settings.config.custom_model_max_tokens = 0
+        settings.config.max_model_tokens = 0
+        settings.openai = type("OpenAISettings", (), {"api_type": "azure", "key": "test-key"})()
+        setting_values = {"OPENAI.API_TYPE": "azure"} if azure_mode else {}
+        monkeypatch.setattr(settings, "get", lambda key, default=None: setting_values.get(key, default))
+        monkeypatch.setattr(utils, "get_settings", lambda: settings)
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings)
+        for name in ("AWS_USE_IMDS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                     "AWS_SESSION_TOKEN", "AWS_REGION_NAME", "OPENAI_API_KEY"):
+            monkeypatch.delenv(name, raising=False)
+        for name in ("api_key", "openai_key", "azure_key"):
+            monkeypatch.setattr(litellm, name, None)
+        monkeypatch.setattr(litellm_handler.openai, "api_key", None)
+
+        expected_limit = utils.MAX_TOKENS[base]
+        if metadata_fallback:
+            # Force the real lookup through LiteLLM without depending on future model IDs.
+            monkeypatch.delitem(utils.MAX_TOKENS, base)
+        lookups = []
+
+        def get_model_info(lookup_model):
+            lookups.append(lookup_model)
+            if lookup_model == request_model:
+                return {"max_input_tokens": expected_limit}
+            raise ValueError("Unexpected model name")
+
+        monkeypatch.setattr(litellm, "get_model_info", get_model_info)
+        token_limit = utils.get_max_tokens(model)
+        assert token_limit == expected_limit
+        assert lookups == ([request_model] if metadata_fallback else [])
+
+        with patch.object(litellm_handler, "acompletion", new_callable=AsyncMock) as completion:
+            completion.return_value = create_mock_acompletion_response()
+            handler = LiteLLMAIHandler()
+            await handler.chat_completion(model=model, system="system", user="user")
+
+        completion.assert_awaited_once()
+        assert completion.call_args.kwargs["model"] == request_model
+        assert completion.call_args.kwargs["reasoning_effort"] == "medium"
+        if metadata_fallback:
+            assert lookups[0] == completion.call_args.kwargs["model"]
 
     @pytest.mark.asyncio
     async def test_gpt5_valid_reasoning_effort_none(self, monkeypatch, mock_logger):


### PR DESCRIPTION
GPT-5.x models already use config.reasoning_effort without the legacy _thinking suffix, but LiteLLMAIHandler still accepts these aliases for backward compatibility. Token-limit lookup did not recognize them, so PR processing could fail before reaching the handler.

Normalize these aliases during token-limit lookup, accounting for OpenAI and Azure routing while preserving custom token limits and the final max_model_tokens cap.

Reference:
- https://github.com/The-PR-Agent/pr-agent/pull/2355#discussion_r3154845500