### PR TITLE
tests: build file:// URLs with Path.as_uri() to fix Windows failures

### DIFF
--- a/tests/unittest/test_extra_config_url.py
+++ b/tests/unittest/test_extra_config_url.py
@@ -119,14 +119,18 @@ def test_resolve_returns_bare_local_path_without_tempfile(toml_on_disk):
 
 
 def test_resolve_accepts_file_url_scheme(toml_on_disk):
-    path, is_temp = _resolve_extra_config_to_file(f"file://{toml_on_disk}")
+    from pathlib import Path
+    path, is_temp = _resolve_extra_config_to_file(Path(toml_on_disk).as_uri())
     assert path == toml_on_disk
     assert is_temp is False
 
 
 def test_resolve_accepts_file_url_with_localhost_netloc(toml_on_disk):
     # file://localhost/<abs-path> is RFC 8089 form and must resolve same as file://
-    path, is_temp = _resolve_extra_config_to_file(f"file://localhost{toml_on_disk}")
+    from pathlib import Path
+    from urllib.parse import urlparse
+    uri_path = urlparse(Path(toml_on_disk).as_uri()).path  # /abs/path or /C:/abs/path
+    path, is_temp = _resolve_extra_config_to_file(f"file://localhost{uri_path}")
     assert path == toml_on_disk
     assert is_temp is False
 
@@ -135,7 +139,8 @@ def test_resolve_file_url_decodes_percent_encoded_path(tmp_path):
     # A real file at a path containing a space — file:// URL must percent-encode it.
     p = tmp_path / "name with space.toml"
     p.write_bytes(SAMPLE_TOML)
-    url = f"file://{str(p).replace(' ', '%20')}"
+    from pathlib import Path
+    url = Path(p).as_uri()  # Path.as_uri() percent-encodes spaces and is valid on all platforms
     path, is_temp = _resolve_extra_config_to_file(url)
     assert path == str(p), "file:// percent-encoded path must be URL-decoded before stat()"
     assert is_temp is False


### PR DESCRIPTION
## Root cause

Three tests in `test_extra_config_url.py` built `file://` URLs by string-concatenating a raw OS path:

```python
f"file://{toml_on_disk}"
f"file://localhost{toml_on_disk}"
f"file://{str(p).replace(' ', '%20')}"
```

On Windows, `toml_on_disk` is a path like `C:\Users\...`. The first form produces `file://C:\Users\...` where `urlparse()` treats the drive letter as the URI authority, and `url2pathname()` then returns a doubled separator (`C:\\Users\...`). `os.path.isfile()` accepts that normalised path, so `_resolve_extra_config_to_file()` returns it and the exact-string assertions fail.

The three failing cases reported in #3049:
- `test_resolve_accepts_file_url_scheme`
- `test_resolve_accepts_file_url_with_localhost_netloc`
- `test_resolve_file_url_decodes_percent_encoded_path`

## Fix

Use `Path.as_uri()` which produces the correct `file:///C:/Users/...` on Windows and `file:///tmp/...` on Linux/macOS. For the `localhost` variant, extract the path component from the `as_uri()` result so the netloc is always a forward-slash-prefixed absolute path regardless of platform.

## Test evidence

Full suite on Linux (42 tests, 0 failures):
```
42 passed, 2 warnings in 12.03s
```

The 3 targeted tests pass with the fix applied on Linux and are now correct on Windows too (the `Path.as_uri()` output is platform-aware).

Fixes #3049