### PR TITLE
refactor: centralize automatic PR command profiles

### DIFF
--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -27,7 +27,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.azuredevops_provider import AZURE_AGENT_RESPONSE_MARKER, AzureDevopsProvider
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import basic_auth_matches
+from pr_agent.servers.utils import basic_auth_matches, get_pr_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 security = HTTPBasic(auto_error=False)
@@ -209,7 +209,11 @@ async def _perform_commands_azure(commands_conf: str, agent: PRAgent, api_url: s
     if commands_conf == "pr_commands" and get_settings().config.disable_auto_feedback:  # auto commands for PR, and auto feedback is disabled
         get_logger().info(f"Auto feedback is disabled, skipping auto commands for PR {api_url=}", **log_context)
         return
-    commands = get_settings().get(f"azure_devops_server.{commands_conf}")
+    commands = (
+        get_pr_commands("azure_devops_server")
+        if commands_conf == "pr_commands"
+        else get_settings().get(f"azure_devops_server.{commands_conf}")
+    )
     if not commands:
         return
 

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -26,6 +26,7 @@ from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
+from pr_agent.servers.utils import get_pr_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -190,7 +191,11 @@ async def _perform_commands_bitbucket(commands_conf: str, agent: PRAgent, api_ur
     if data.get("event", "") == "pullrequest:created":
         if not should_process_pr_logic(data):
             return
-    commands = get_settings().get(f"bitbucket_app.{commands_conf}", {})
+    commands = (
+        get_pr_commands("bitbucket_app")
+        if commands_conf == "pr_commands"
+        else get_settings().get(f"bitbucket_app.{commands_conf}", {})
+    )
     get_settings().set("config.is_auto_command", True)
     if commands_conf == "push_commands":
         is_valid_push = await _validate_time_from_last_commit_to_pr_update(data)
@@ -366,7 +371,7 @@ async def handle_github_webhooks(background_tasks: BackgroundTasks, request: Req
                     with get_logger().contextualize(**log_context):
                         if get_identity_provider().verify_eligibility("bitbucket",
                                                         sender_id, pr_url) is not Eligibility.NOT_ELIGIBLE:
-                            if get_settings().get("bitbucket_app.pr_commands"):
+                            if get_pr_commands("bitbucket_app"):
                                 await _perform_commands_bitbucket("pr_commands", agent, pr_url, log_context, data)
             elif event == "pullrequest:updated": # PR updated, might be from a push (we will validate this later)
                 pr_url = data["data"]["pullrequest"]["links"]["html"]["href"]

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -21,7 +21,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import verify_signature
+from pr_agent.servers.utils import get_pr_commands, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -177,7 +177,7 @@ async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
             )
         get_settings().set("config.is_auto_command", True)
         if data["eventKey"] == "pr:opened":
-            commands_to_run.extend(_get_commands_list_from_settings('BITBUCKET_SERVER.PR_COMMANDS'))
+            commands_to_run.extend(get_pr_commands("bitbucket_server"))
         else: # Has to be: data["eventKey"] == "pr:from_ref_updated" or "repo:refs_changed"
             if not get_settings().get("BITBUCKET_SERVER.HANDLE_PUSH_TRIGGER"):
                 get_logger().info(f"Push trigger is disabled, skipping push commands for PR {pr_url}", **log_context)

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -13,7 +13,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import verify_signature
+from pr_agent.servers.utils import get_pr_commands, verify_signature
 
 # Setup logging and router
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
@@ -133,7 +133,11 @@ async def _perform_commands_gitea(commands_conf: str, agent: PRAgent, body: dict
         return
     if not should_process_pr_logic(body): # Here we already updated the configuration with the repo settings
         return {}
-    commands = get_settings().get(f"gitea.{commands_conf}")
+    commands = (
+        get_pr_commands("gitea")
+        if commands_conf == "pr_commands"
+        else get_settings().get(f"gitea.{commands_conf}")
+    )
     if not commands:
         get_logger().info("New PR, but no auto commands configured")
         return

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -19,7 +19,7 @@ from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import DefaultDictWithTimeout, verify_signature
+from pr_agent.servers.utils import DefaultDictWithTimeout, get_pr_commands, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -521,7 +521,11 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         return
     if not should_process_pr_logic(body): # Here we already updated the configuration with the repo settings
         return {}
-    commands = get_settings().get(f"github_app.{commands_conf}")
+    commands = (
+        get_pr_commands("github_app")
+        if commands_conf == "pr_commands"
+        else get_settings().get(f"github_app.{commands_conf}")
+    )
     if not commands:
         get_logger().info(f"No {commands_conf} configured, skipping auto commands")
         return

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -22,6 +22,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
+from pr_agent.servers.utils import get_pr_commands
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -71,7 +72,11 @@ async def _perform_commands_gitlab(commands_conf: str, agent: PRAgent, api_url: 
         return
     if not should_process_pr_logic(data): # Here we already updated the configurations
         return
-    commands = get_settings().get(f"gitlab.{commands_conf}", {})
+    commands = (
+        get_pr_commands("gitlab")
+        if commands_conf == "pr_commands"
+        else get_settings().get(f"gitlab.{commands_conf}", {})
+    )
     get_settings().set("config.is_auto_command", True)
     for command in commands:
         try:

--- a/pr_agent/servers/utils.py
+++ b/pr_agent/servers/utils.py
@@ -3,9 +3,42 @@ import hmac
 import secrets
 import time
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from fastapi import HTTPException
+
+from pr_agent.config_loader import get_settings
+
+# custom_merge_loader bypasses Dynaconf token expansion, so TOML references such as
+# @get would remain strings. Keep the shared profiles immutable and copy only defaults.
+_STANDARD_PR_COMMANDS = (
+    "/describe --pr_description.final_update_message=false",
+    "/review",
+    "/improve",
+)
+_PLAIN_PR_COMMANDS = ("/describe", "/review", "/improve")
+_COMMITTABLE_PR_COMMANDS = (
+    "/describe --pr_description.final_update_message=false",
+    "/review",
+    "/improve --pr_code_suggestions.commitable_code_suggestions=true",
+)
+_DEFAULT_PR_COMMANDS_BY_PROVIDER = {
+    "github_app": _STANDARD_PR_COMMANDS,
+    "gitlab": _STANDARD_PR_COMMANDS,
+    "gitea": _PLAIN_PR_COMMANDS,
+    "azure_devops_server": _PLAIN_PR_COMMANDS,
+    "bitbucket_app": _COMMITTABLE_PR_COMMANDS,
+    "bitbucket_server": _COMMITTABLE_PR_COMMANDS,
+}
+_MISSING = object()
+
+
+def get_pr_commands(provider: str) -> Sequence[str]:
+    """Return an explicit provider override or a fresh copy of its default profile."""
+    configured = get_settings().get(f"{provider}.pr_commands", _MISSING)
+    if configured is not _MISSING:
+        return configured
+    return list(_DEFAULT_PR_COMMANDS_BY_PROVIDER[provider])
 
 
 def verify_signature(payload_body, secret_token, signature_header):

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -308,11 +308,6 @@ override_deployment_type = true
 # settings for "pull_request" event
 handle_pr_actions = ['opened', 'reopened', 'ready_for_review']
 feedback_on_draft_pr = false
-pr_commands = [
-    "/describe --pr_description.final_update_message=false",
-    "/review",
-    "/improve",
-]
 # A submitted GitHub review can optionally trigger these commands. The empty default preserves current behavior.
 review_states = ["changes_requested"]
 review_author_types = ["User"]
@@ -343,11 +338,6 @@ publish_improve_as_thread = false
 publish_code_suggestions_as_review = false
 # Resolve the bot's own inline threads that a later push left on an outdated diff version.
 resolve_outdated_inline_threads = false
-pr_commands = [
-    "/describe --pr_description.final_update_message=false",
-    "/review",
-    "/improve",
-]
 handle_push_trigger = false
 push_commands = [
     "/describe",
@@ -370,22 +360,12 @@ url = "https://gitea.com"
 # above, else derived from the PR's html_url.
 # web_url = ""
 handle_push_trigger = false
-pr_commands = [
-    "/describe",
-    "/review",
-    "/improve",
-]
 push_commands = [
     "/describe",
     "/review",
 ]
 
 [bitbucket_app]
-pr_commands = [
-    "/describe --pr_description.final_update_message=false",
-    "/review",
-    "/improve --pr_code_suggestions.commitable_code_suggestions=true",
-]
 avoid_full_files = false
 request_timeout = 30 # positive seconds for connection and response-read inactivity timeouts
 
@@ -412,11 +392,6 @@ webhook_password = ""
 # URL to the BitBucket Server instance
 # url = "https://git.bitbucket.com"
 url = ""
-pr_commands = [
-    "/describe --pr_description.final_update_message=false",
-    "/review",
-    "/improve --pr_code_suggestions.commitable_code_suggestions=true",
-]
 
 [litellm]
 # use_client = false
@@ -551,11 +526,6 @@ default_comment_status = "closed"
 
 [azure_devops_server]
 agent_identity = "" # empty: discover the identity from earlier agent comments on the PR
-pr_commands = [
-    "/describe",
-    "/review",
-    "/improve",
-]
 
 [push_outputs] # push tool outputs to external sinks without calling git-provider APIs (disabled by default)
 enable = false

--- a/tests/unittest/test_pr_command_profiles.py
+++ b/tests/unittest/test_pr_command_profiles.py
@@ -118,7 +118,7 @@ def test_explicit_pr_command_overrides_are_preserved(monkeypatch, override):
 
 def test_provider_sections_no_longer_duplicate_pr_command_defaults():
     configuration_path = Path(__file__).parents[2] / "pr_agent/settings/configuration.toml"
-    configuration = tomllib.loads(configuration_path.read_text())
+    configuration = tomllib.loads(configuration_path.read_text(encoding="utf-8"))
 
     for provider in DEFAULT_PR_COMMANDS:
         assert "pr_commands" not in configuration[provider]

--- a/tests/unittest/test_pr_command_profiles.py
+++ b/tests/unittest/test_pr_command_profiles.py
@@ -65,6 +65,11 @@ class _RecordingAgent:
         self.commands.append(command)
 
 
+class _IdentityProvider:
+    def verify_eligibility(self, *_args):
+        return Eligibility.ELIGIBLE
+
+
 class _Request:
     def __init__(self, payload):
         self.headers = {"authorization": "JWT e30.eyJpc3MiOiJjbGllbnQifQ.signature"}
@@ -79,13 +84,13 @@ class _Request:
 
 @pytest.mark.parametrize(("provider", "expected"), DEFAULT_PR_COMMANDS.items())
 def test_default_pr_command_profiles_match_existing_provider_behavior(monkeypatch, provider, expected):
-    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(server_utils, "get_settings", _Settings)
 
     assert server_utils.get_pr_commands(provider) == expected
 
 
 def test_default_pr_commands_are_fresh_lists(monkeypatch):
-    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(server_utils, "get_settings", _Settings)
 
     first = server_utils.get_pr_commands("github_app")
     second = server_utils.get_pr_commands("github_app")
@@ -220,7 +225,7 @@ async def _dispatch_default_pr_commands(provider, monkeypatch, agent):
 @pytest.mark.parametrize("provider", DEFAULT_PR_COMMANDS)
 async def test_each_webhook_dispatches_its_default_profile(provider, monkeypatch):
     agent = _RecordingAgent()
-    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(server_utils, "get_settings", _Settings)
 
     with request_cycle_context({}):
         context["settings"] = copy.deepcopy(global_settings)
@@ -250,7 +255,7 @@ async def test_bitbucket_app_default_profile_passes_the_early_gate(monkeypatch):
     async def perform_commands(*args):
         calls.append(args)
 
-    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(server_utils, "get_settings", _Settings)
     monkeypatch.setattr(bitbucket_app, "is_bot_user", lambda _data: False)
     monkeypatch.setattr(bitbucket_app, "should_process_pr_logic", lambda _data: True)
     monkeypatch.setattr(bitbucket_app, "get_fork_safe_secret_provider", lambda: secret_provider)
@@ -259,7 +264,7 @@ async def test_bitbucket_app_default_profile_passes_the_early_gate(monkeypatch):
     monkeypatch.setattr(
         bitbucket_app,
         "get_identity_provider",
-        lambda: type("IdentityProvider", (), {"verify_eligibility": lambda self, *args: Eligibility.ELIGIBLE})(),
+        _IdentityProvider,
     )
     monkeypatch.setattr(bitbucket_app, "_perform_commands_bitbucket", perform_commands)
     endpoint = next(route.endpoint for route in bitbucket_app.router.routes if route.path == "/webhook")

--- a/tests/unittest/test_pr_command_profiles.py
+++ b/tests/unittest/test_pr_command_profiles.py
@@ -1,0 +1,276 @@
+import copy
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+from dynaconf.loaders import env_loader
+from starlette.background import BackgroundTasks
+from starlette_context import context, request_cycle_context
+
+from pr_agent.config_loader import get_settings, global_settings
+from pr_agent.git_providers.utils import _apply_repo_settings_file
+from pr_agent.identity_providers.identity_provider import Eligibility
+from pr_agent.servers import (
+    azuredevops_server_webhook,
+    bitbucket_app,
+    bitbucket_server_webhook,
+    gitea_app,
+    github_app,
+    gitlab_webhook,
+)
+from pr_agent.servers import (
+    utils as server_utils,
+)
+
+DEFAULT_PR_COMMANDS = {
+    "github_app": [
+        "/describe --pr_description.final_update_message=false",
+        "/review",
+        "/improve",
+    ],
+    "gitlab": [
+        "/describe --pr_description.final_update_message=false",
+        "/review",
+        "/improve",
+    ],
+    "gitea": ["/describe", "/review", "/improve"],
+    "azure_devops_server": ["/describe", "/review", "/improve"],
+    "bitbucket_app": [
+        "/describe --pr_description.final_update_message=false",
+        "/review",
+        "/improve --pr_code_suggestions.commitable_code_suggestions=true",
+    ],
+    "bitbucket_server": [
+        "/describe --pr_description.final_update_message=false",
+        "/review",
+        "/improve --pr_code_suggestions.commitable_code_suggestions=true",
+    ],
+}
+
+
+class _Settings:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key.lower(), default)
+
+
+class _RecordingAgent:
+    def __init__(self):
+        self.commands = []
+
+    async def handle_request(self, _url, command, notify=None):
+        self.commands.append(command)
+
+
+class _Request:
+    def __init__(self, payload):
+        self.headers = {"authorization": "JWT e30.eyJpc3MiOiJjbGllbnQifQ.signature"}
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def body(self):
+        return json.dumps(self._payload).encode()
+
+
+@pytest.mark.parametrize(("provider", "expected"), DEFAULT_PR_COMMANDS.items())
+def test_default_pr_command_profiles_match_existing_provider_behavior(monkeypatch, provider, expected):
+    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+
+    assert server_utils.get_pr_commands(provider) == expected
+
+
+def test_default_pr_commands_are_fresh_lists(monkeypatch):
+    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+
+    first = server_utils.get_pr_commands("github_app")
+    second = server_utils.get_pr_commands("github_app")
+    first.append("/ask")
+
+    assert second == DEFAULT_PR_COMMANDS["github_app"]
+
+
+def test_missing_dynaconf_key_uses_the_default_profile(monkeypatch):
+    settings = copy.deepcopy(global_settings)
+    settings.github_app.pop("pr_commands", None)
+    monkeypatch.setattr(server_utils, "get_settings", lambda: settings)
+
+    assert server_utils.get_pr_commands("github_app") == DEFAULT_PR_COMMANDS["github_app"]
+
+
+@pytest.mark.parametrize("override", [[], "", ["/custom"]])
+def test_explicit_pr_command_overrides_are_preserved(monkeypatch, override):
+    configured = copy.deepcopy(override)
+    settings = _Settings({"github_app.pr_commands": configured})
+    monkeypatch.setattr(server_utils, "get_settings", lambda: settings)
+
+    assert server_utils.get_pr_commands("github_app") is configured
+
+
+def test_provider_sections_no_longer_duplicate_pr_command_defaults():
+    configuration_path = Path(__file__).parents[2] / "pr_agent/settings/configuration.toml"
+    configuration = tomllib.loads(configuration_path.read_text())
+
+    for provider in DEFAULT_PR_COMMANDS:
+        assert "pr_commands" not in configuration[provider]
+
+
+def test_repo_pr_commands_override_the_default_profile(tmp_path):
+    repo_settings = tmp_path / ".pr_agent.toml"
+    repo_settings.write_text('[github_app]\npr_commands = ["/repo"]\n')
+
+    with request_cycle_context({}):
+        context["settings"] = copy.deepcopy(global_settings)
+        _apply_repo_settings_file(str(repo_settings))
+
+        assert server_utils.get_pr_commands("github_app") == ["/repo"]
+
+
+def test_environment_pr_commands_win_over_repo_settings(tmp_path, monkeypatch):
+    repo_settings = tmp_path / ".pr_agent.toml"
+    repo_settings.write_text('[github_app]\npr_commands = ["/repo"]\n')
+    monkeypatch.setenv("GITHUB_APP__PR_COMMANDS", '["/environment"]')
+
+    with request_cycle_context({}):
+        context["settings"] = copy.deepcopy(global_settings)
+        env_loader.load(get_settings())
+        _apply_repo_settings_file(str(repo_settings))
+
+        assert server_utils.get_pr_commands("github_app") == ["/environment"]
+
+
+async def _dispatch_default_pr_commands(provider, monkeypatch, agent):
+    if provider == "github_app":
+        monkeypatch.setattr(github_app, "prepare_command", lambda command: command)
+        monkeypatch.setattr(github_app, "should_process_pr_logic", lambda _body: True)
+        await github_app._perform_auto_commands_github(
+            "pr_commands",
+            agent,
+            {"action": "opened", "pull_request": {"draft": False}},
+            "https://example.test/pr/1",
+            {},
+        )
+    elif provider == "gitlab":
+        monkeypatch.setattr(gitlab_webhook, "prepare_command", lambda command: command)
+        monkeypatch.setattr(gitlab_webhook, "should_process_pr_logic", lambda _body: True)
+        await gitlab_webhook._perform_commands_gitlab(
+            "pr_commands",
+            agent,
+            "https://example.test/pr/1",
+            {},
+            {"object_attributes": {"title": "Ready MR"}},
+        )
+    elif provider == "gitea":
+        monkeypatch.setattr(gitea_app, "apply_repo_settings", lambda _url: None)
+        monkeypatch.setattr(gitea_app, "prepare_command", lambda command: command)
+        monkeypatch.setattr(gitea_app, "should_process_pr_logic", lambda _body: True)
+        await gitea_app._perform_commands_gitea(
+            "pr_commands",
+            agent,
+            {},
+            "https://example.test/pr/1",
+        )
+    elif provider == "bitbucket_app":
+        monkeypatch.setattr(bitbucket_app, "apply_repo_settings", lambda _url: None)
+        monkeypatch.setattr(bitbucket_app, "prepare_command", lambda command: command)
+        monkeypatch.setattr(bitbucket_app, "should_process_pr_logic", lambda _body: True)
+        await bitbucket_app._perform_commands_bitbucket(
+            "pr_commands",
+            agent,
+            "https://example.test/pr/1",
+            {},
+            {"event": "pullrequest:created"},
+        )
+    elif provider == "azure_devops_server":
+        monkeypatch.setattr(azuredevops_server_webhook, "apply_repo_settings", lambda _url: None)
+        monkeypatch.setattr(azuredevops_server_webhook, "prepare_command", lambda command: command)
+        await azuredevops_server_webhook._perform_commands_azure(
+            "pr_commands",
+            agent,
+            "https://example.test/pr/1",
+            {},
+        )
+    else:
+        monkeypatch.setattr(bitbucket_server_webhook, "apply_repo_settings", lambda _url: None)
+        monkeypatch.setattr(bitbucket_server_webhook, "should_process_pr_logic", lambda _body: True)
+        recorded = []
+
+        async def record_commands(commands, _url, _log_context):
+            recorded.extend(commands)
+
+        monkeypatch.setattr(bitbucket_server_webhook, "_run_commands_sequentially", record_commands)
+        payload = {
+            "eventKey": "pr:opened",
+            "pullRequest": {
+                "id": 1,
+                "toRef": {"repository": {"slug": "repo", "project": {"key": "project"}}},
+            },
+        }
+        background_tasks = BackgroundTasks()
+        response = await bitbucket_server_webhook.handle_webhook(background_tasks, _Request(payload))
+        assert response.status_code == 200
+        await background_tasks()
+        agent.commands.extend(recorded)
+
+
+@pytest.mark.parametrize("provider", DEFAULT_PR_COMMANDS)
+async def test_each_webhook_dispatches_its_default_profile(provider, monkeypatch):
+    agent = _RecordingAgent()
+    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+
+    with request_cycle_context({}):
+        context["settings"] = copy.deepcopy(global_settings)
+        await _dispatch_default_pr_commands(provider, monkeypatch, agent)
+
+    assert agent.commands == DEFAULT_PR_COMMANDS[provider]
+
+
+async def test_bitbucket_app_default_profile_passes_the_early_gate(monkeypatch):
+    calls = []
+    payload = {
+        "event": "pullrequest:created",
+        "data": {
+            "actor": {"type": "user", "account_id": "account"},
+            "pullrequest": {"links": {"html": {"href": "https://example.test/pr/1"}}},
+        },
+    }
+    secret_provider = type(
+        "SecretProvider",
+        (),
+        {"get_secret": lambda self, _key: json.dumps({"shared_secret": "secret"})},
+    )()
+
+    async def get_bearer_token(_shared_secret, _client_key):
+        return "bearer"
+
+    async def perform_commands(*args):
+        calls.append(args)
+
+    monkeypatch.setattr(server_utils, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(bitbucket_app, "is_bot_user", lambda _data: False)
+    monkeypatch.setattr(bitbucket_app, "should_process_pr_logic", lambda _data: True)
+    monkeypatch.setattr(bitbucket_app, "get_fork_safe_secret_provider", lambda: secret_provider)
+    monkeypatch.setattr(bitbucket_app, "get_bearer_token", get_bearer_token)
+    monkeypatch.setattr(bitbucket_app.jwt, "decode", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        bitbucket_app,
+        "get_identity_provider",
+        lambda: type("IdentityProvider", (), {"verify_eligibility": lambda self, *args: Eligibility.ELIGIBLE})(),
+    )
+    monkeypatch.setattr(bitbucket_app, "_perform_commands_bitbucket", perform_commands)
+    endpoint = next(route.endpoint for route in bitbucket_app.router.routes if route.path == "/webhook")
+    background_tasks = BackgroundTasks()
+
+    with request_cycle_context({}):
+        context["settings"] = copy.deepcopy(global_settings)
+        get_settings().set("BITBUCKET.BASE_URL", "https://example.test/app")
+        result = await endpoint(background_tasks, _Request(payload))
+        await background_tasks()
+
+    assert result == "OK"
+    assert len(calls) == 1
+    assert calls[0][0] == "pr_commands"


### PR DESCRIPTION
## Summary

- centralize the three existing automatic PR command profiles as immutable Python defaults
- fall back only when a provider key is absent, preserving explicit empty and custom overrides
- route all six webhook implementations and the Bitbucket Cloud early gate through the resolver

## Testing

- full unit suite
- focused webhook and settings suite
- pre-commit hooks on the complete change

## Scope

This keeps command selection separate from the fail-fast execution work in #2952. If that lands first, this branch can be rebased around its loop changes.

Closes #3041