### PR TITLE
fix(improve): report exhausted suggestion publication retries

### DIFF
--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -37,6 +37,11 @@ For example, you can present suggestions with verified replacement ranges as com
 
 Suggestions whose replacement ranges cannot be verified remain regular comments without an apply action.
 
+If batch publication fails, `/improve` retries each suggestion individually. If every retry fails,
+it reports a failure instead of silently removing the progress comment. With
+`config.propagate_tool_errors=true`, the publication error is also raised to the caller.
+If any individual retry succeeds, the existing partial-recovery behavior is preserved.
+
 ![improve](https://codium.ai/images/pr_agent/improve.png){width=512}
 
 ### Automatic triggering

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -40,6 +40,9 @@ Suggestions whose replacement ranges cannot be verified remain regular comments 
 If batch publication fails, `/improve` retries each suggestion individually. If every retry fails,
 it reports a failure instead of silently removing the progress comment. With
 `config.propagate_tool_errors=true`, the publication error is also raised to the caller.
+Regular fallback comments and coverage notices are published before the error is reported.
+When this fallback output succeeds, it is retained without an additional failure banner;
+error propagation still follows `config.propagate_tool_errors`.
 If any individual retry succeeds, the existing partial-recovery behavior is preserved.
 
 ![improve](https://codium.ai/images/pr_agent/improve.png){width=512}

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -362,9 +362,10 @@ class PRCodeSuggestions:
             if get_settings().config.publish_output:
                 if self.progress_response:
                     self.git_provider.remove_comment(self.progress_response)
-                elif not self._output_published:
+                if not self._output_published:
                     try:
-                        self.git_provider.remove_initial_comment()
+                        if not self.progress_response:
+                            self.git_provider.remove_initial_comment()
                         self.git_provider.publish_comment("Failed to generate code suggestions for PR")
                     except Exception as e:
                         get_logger().exception(f"Failed to update persistent review, error: {e}")
@@ -1086,7 +1087,10 @@ class PRCodeSuggestions:
                 get_logger().info("Failed to publish code suggestions, trying to publish each suggestion separately")
                 for code_suggestion in code_suggestions:
                     if self.git_provider.publish_code_suggestions([code_suggestion]):
+                        is_successful = True
                         self._output_published = True
+                if not is_successful:
+                    raise RuntimeError("Failed to publish code suggestions after individual retries")
         if coverage_footer and not supports_suggestions_artifact:
             fallback_comments.append(coverage_footer.strip())
         if fallback_comments:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -1089,13 +1089,13 @@ class PRCodeSuggestions:
                     if self.git_provider.publish_code_suggestions([code_suggestion]):
                         is_successful = True
                         self._output_published = True
-                if not is_successful:
-                    raise RuntimeError("Failed to publish code suggestions after individual retries")
         if coverage_footer and not supports_suggestions_artifact:
             fallback_comments.append(coverage_footer.strip())
         if fallback_comments:
             self.git_provider.publish_comment("\n\n---\n\n".join(fallback_comments))
             self._output_published = True
+        if code_suggestions and not is_successful:
+            raise RuntimeError("Failed to publish code suggestions after individual retries")
         return
 
     def _get_diff_file(self, relevant_file):

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -743,7 +743,8 @@ def test_dedent_code_uses_patch_when_head_file_is_partial():
 
 
 @pytest.mark.asyncio
-async def test_push_inline_code_suggestions_falls_back_to_individual_publish_calls():
+@pytest.mark.parametrize("retry_results", [(True, True), (True, False), (False, True)])
+async def test_push_inline_code_suggestions_falls_back_to_individual_publish_calls(retry_results):
     git_provider = MagicMock()
     git_provider.diff_files = [
         FilePatchInfo(
@@ -759,7 +760,7 @@ async def test_push_inline_code_suggestions_falls_back_to_individual_publish_cal
             filename="worker.py",
         ),
     ]
-    git_provider.publish_code_suggestions.side_effect = [False, True, True]
+    git_provider.publish_code_suggestions.side_effect = [False, *retry_results]
     tool = _make_tool(git_provider)
     data = {"code_suggestions": [
         _valid_suggestion(

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -13,6 +13,7 @@ _TRACKED_SETTINGS = (
     "config.publish_output",
     "config.publish_output_progress",
     "config.is_auto_command",
+    "config.propagate_tool_errors",
     "pr_code_suggestions.commitable_code_suggestions",
     "pr_code_suggestions.dual_publishing_score_threshold",
     "pr_code_suggestions.persistent_comment",
@@ -391,5 +392,61 @@ async def test_run_retains_progress_handle_when_check_run_cleanup_fails(monkeypa
         provider.remove_comment.assert_called_once_with(progress_comment)
         # The handle is retained so a later cancellation or error handler can retry removal
         assert tool.progress_response is progress_comment
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_errors", [False, True])
+@pytest.mark.parametrize("show_progress", [False, True])
+@pytest.mark.parametrize("supports_artifact", [False, True])
+async def test_run_reports_exhausted_inline_publication_retries(
+    monkeypatch, propagate_errors, show_progress, supports_artifact
+):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.get_files.return_value = [object()]
+        provider.diff_files = []
+        provider.is_supported.return_value = False
+        provider.supports_code_suggestions_artifact.return_value = supports_artifact
+        provider.publish_code_suggestions_artifact.return_value = False
+        provider.publish_code_suggestions.return_value = False
+        tool = _make_tool(provider)
+        tool._validate_suggestion = MagicMock(return_value=(True, "", True))
+        tool.dedent_code = MagicMock(side_effect=lambda _file, _line, code: code)
+        suggestion = {
+            "relevant_file": "app.py",
+            "relevant_lines_start": 1,
+            "relevant_lines_end": 1,
+            "suggestion_content": "Use the helper.",
+            "existing_code": "old()",
+            "improved_code": "new()",
+            "label": "maintainability",
+        }
+        monkeypatch.setattr(
+            pr_code_suggestions_module,
+            "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": [suggestion]}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.config.publish_output_progress = show_progress
+        settings.config.propagate_tool_errors = propagate_errors
+        settings.pr_code_suggestions.commitable_code_suggestions = True
+
+        if propagate_errors:
+            with pytest.raises(RuntimeError, match="Failed to publish code suggestions"):
+                await tool.run()
+        else:
+            await tool.run()
+
+        assert provider.publish_code_suggestions.call_count == (1 if supports_artifact else 2)
+        assert tool._output_published is False
+        published_comments = [call.args[0] for call in provider.publish_comment.call_args_list]
+        assert published_comments[-1] == "Failed to generate code suggestions for PR"
+        if show_progress:
+            assert published_comments[0] == "Preparing suggestions..."
+            provider.remove_comment.assert_called_once_with(provider.publish_comment.return_value)
     finally:
         restore_settings(settings_snapshot)

--- a/tests/unittest/test_pr_code_suggestions_lifecycle.py
+++ b/tests/unittest/test_pr_code_suggestions_lifecycle.py
@@ -450,3 +450,68 @@ async def test_run_reports_exhausted_inline_publication_retries(
             provider.remove_comment.assert_called_once_with(provider.publish_comment.return_value)
     finally:
         restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_errors", [False, True])
+@pytest.mark.parametrize(("supports_artifact", "fallback_kind"), [
+    (False, "anchor"), (True, "anchor"), (False, "syntax"),
+    (False, "truncated"), (False, "coverage"),
+])
+async def test_failed_inline_retries_preserve_fallback_output(
+    monkeypatch, propagate_errors, supports_artifact, fallback_kind
+):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.get_files.return_value = [object()]
+        provider.is_supported.return_value = False
+        provider.supports_code_suggestions_artifact.return_value = supports_artifact
+        provider.publish_code_suggestions_artifact.return_value = False
+        provider.publish_code_suggestions.return_value = False
+        tool = _make_tool(provider)
+        tool._validate_suggestion = MagicMock(side_effect=[
+            (True, "", True),
+            (False, "unverified range", False) if fallback_kind == "anchor" else (True, "", True),
+        ])
+        tool._validate_python_replacement_syntax = MagicMock(side_effect=[True, False])
+        tool.dedent_code = MagicMock(side_effect=lambda _file, _line, code: code)
+        tool._get_suggestions_coverage_footer = MagicMock(
+            return_value="\n\nCoverage notice" if fallback_kind == "coverage" else ""
+        )
+        suggestion = {
+            "relevant_file": "app.py", "relevant_lines_start": 1, "relevant_lines_end": 1,
+            "suggestion_content": "Inline suggestion.", "existing_code": "old()",
+            "improved_code": "new()", "label": "maintainability",
+        }
+        suggestions = [suggestion]
+        if fallback_kind != "coverage":
+            fallback = {**suggestion, "suggestion_content": "Fallback suggestion."}
+            if fallback_kind == "truncated":
+                fallback["_is_truncated"] = True
+            suggestions.append(fallback)
+        monkeypatch.setattr(
+            pr_code_suggestions_module, "retry_with_fallback_models",
+            AsyncMock(return_value={"code_suggestions": suggestions}),
+        )
+        _configure_published_run()
+        settings = get_settings()
+        settings.config.propagate_tool_errors = propagate_errors
+        settings.pr_code_suggestions.commitable_code_suggestions = True
+
+        if propagate_errors:
+            with pytest.raises(RuntimeError, match="Failed to publish code suggestions"):
+                await tool.run()
+        else:
+            await tool.run()
+
+        comments = [call.args[0] for call in provider.publish_comment.call_args_list]
+        assert len(comments) == 2
+        assert comments[0] == "Preparing suggestions..."
+        expected = "Coverage notice" if fallback_kind == "coverage" else "Fallback suggestion."
+        assert expected in comments[1]
+        assert "Failed to generate code suggestions" not in comments[1]
+        assert tool._output_published is True
+        provider.remove_comment.assert_called_once_with(provider.publish_comment.return_value)
+    finally:
+        restore_settings(settings_snapshot)


### PR DESCRIPTION
## Summary

Closes #3056.

When batch publication and every individual retry returned `False`, `/improve` completed without a failure result. Track whether any retry succeeds and report exhausted retries after publishing applicable fallback comments and the coverage footer. Successful fallback output is retained without an extra failure banner; when nothing was published, the existing handler publishes its failure notice after removing the progress comment. Error propagation still raises when `config.propagate_tool_errors=true`.

Successful individual retries retain the current partial-recovery behavior. The `/improve` guide documents the failure and fallback behavior.

## Validation

- Reproduced all eight original lifecycle combinations: ordinary/artifact publication, progress on/off, and error propagation on/off.
- Added ten mixed-output regressions covering anchor, artifact, syntax, truncated, and coverage fallbacks with error propagation on/off. All ten failed before the review correction and pass afterward.
- `PYTHONPATH=. uv run --frozen pytest tests/unittest -q --color=no`: **3,635 passed, 1 skipped, 1 xfailed**.
- Focused core, lifecycle, and rendering tests: **168 passed**.
- Ruff, pre-commit, and `git diff --check`: passed.

Tests use fake providers and model results; no live provider or model calls were needed. Implemented and validated with OpenAI Codex. These are local validation results; two GitHub workflows currently await maintainer approval.

## Scope

The shared `/improve` publication path covers provider-independent inline retries and artifact fallback. Existing dual publishing keeps its already-published summary when inline publication fails. The separate `/add_docs` retry loop also ignores individual return values; its command-specific failure handling remains a follow-up, outside this `/improve` issue. No provider API contracts or configuration defaults change here.