### PR TITLE
fix(polling): bound active workers across polling iterations

### DIFF
--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -23,7 +23,7 @@ behavior, not Requests-specific environment settings.
 
 ## Sizing a self-hosted webhook server
 
-The GitHub, GitLab and Gitea webhook servers (the `github_app`, `gitlab_webhook` and `gitea_app` Docker targets) run under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. The other deployments — Bitbucket, Azure DevOps, GitHub polling, and the Lambda variants — run a single process and are unaffected by this section.
+The GitHub, GitLab and Gitea webhook servers (the `github_app`, `gitlab_webhook` and `gitea_app` Docker targets) run under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. The other deployments — Bitbucket, Azure DevOps, GitHub polling, and the Lambda variants — do not use this gunicorn worker configuration.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -39,6 +39,24 @@ If the container is OOMKilled during startup, lower the worker count:
 ```bash
 GUNICORN_WORKERS=2
 ```
+
+## GitHub polling workers
+
+GitHub polling uses one polling process and a separate child process for each
+accepted comment. At most 10 of these child workers may be active across all
+polling iterations. If an earlier batch still fills the limit, accepted work
+waits for a free slot without blocking the event loop. This can delay the next
+notification poll under sustained load.
+
+The existing per-batch limit is unchanged: only the first 10 queued comments in
+a batch are accepted; excess work is logged and dropped. Waiting work is held in
+memory only. Notification acknowledgement is unchanged, so shutdown or startup
+failures do not guarantee redelivery. Dispatch interruptions log the remaining
+count. A worker startup failure stops polling rather than risking further
+dispatch with an untracked child; inspect the failure before restarting.
+Completed children are joined without waiting and closed each iteration;
+live children are not terminated on cancellation. This is not a durable queue,
+a model-call deadline, or a host-wide memory limit.
 
 !!! note "Docker Hub namespace migration"
     Releases **`0.34.2` and later** are published under [`pragent/pr-agent`](https://hub.docker.com/r/pragent/pr-agent). Older releases (up to and including `v0.31`) remain at the legacy [`codiumai/pr-agent`](https://hub.docker.com/r/codiumai/pr-agent) namespace as a frozen archive — no new images are pushed there. The examples on this site reference the new namespace; if you are pinning to a release before `0.34.2`, swap `pragent/pr-agent` for `codiumai/pr-agent` in your `image:` / `docker pull` / `uses: docker://` references.

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -21,6 +21,11 @@ setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL"
 NOTIFICATION_URL = "https://api.github.com/notifications"
 DEFAULT_POLLING_REQUEST_TIMEOUT = 10
 MAX_POLLING_REQUEST_TIMEOUT = 60
+POLLING_CAPACITY_CHECK_INTERVAL = 0.25
+
+
+class _PollingWorkerStartError(RuntimeError):
+    """Stop dispatch when child startup leaves process state uncertain."""
 
 
 def _get_polling_request_timeout() -> float:
@@ -196,23 +201,50 @@ async def is_valid_notification(notification, headers, handled_ids, session, use
         return False, handled_ids
 
 
-def _start_queued_processes(task_queue, max_allowed_parallel_tasks):
-    """Start at most max_allowed_parallel_tasks queued jobs and clear the queue.
+def _reap_finished_processes(active_processes):
+    """Release completed workers without waiting for live ones."""
+    for process in active_processes[:]:
+        if not process.is_alive():
+            process.join(timeout=0)
+            process.close()
+            active_processes.remove(process)
 
-    Do not join the started processes; let the polling loop move on to the next
-    iteration without waiting for them to complete.
-    """
-    processes = []
-    for i, (func, args) in enumerate(task_queue):
-        if i >= max_allowed_parallel_tasks:
-            get_logger().error(
-                f"Dropping {len(task_queue) - max_allowed_parallel_tasks} tasks from polling session")
-            break
-        process = multiprocessing.Process(target=func, args=args)
-        processes.append(process)
-        process.start()
-    task_queue.clear()
-    return processes
+
+async def _start_queued_processes(task_queue, max_allowed_parallel_tasks, active_processes):
+    """Keep the batch limit, waiting for capacity shared across polling iterations."""
+    if max_allowed_parallel_tasks <= 0:
+        raise ValueError("The polling process limit must be positive")
+    overflow = len(task_queue) - max_allowed_parallel_tasks
+    if overflow > 0:
+        get_logger().error(f"Dropping {overflow} tasks from polling session")
+        for _ in range(overflow):
+            task_queue.pop()
+
+    try:
+        while task_queue:
+            _reap_finished_processes(active_processes)
+            if len(active_processes) >= max_allowed_parallel_tasks:
+                await asyncio.sleep(POLLING_CAPACITY_CHECK_INTERVAL)
+                continue
+            func, args = task_queue[0]
+            process = multiprocessing.Process(target=func, args=args)
+            try:
+                process.start()
+            except BaseException as exc:
+                # Treat a PID-bearing child as potentially dispatched; never retry its task.
+                if process.pid is not None:
+                    active_processes.append(process)
+                    task_queue.popleft()
+                else:
+                    process.close()
+                if isinstance(exc, Exception):
+                    raise _PollingWorkerStartError("Polling worker startup failed; stopping dispatch") from exc
+                raise
+            active_processes.append(process)
+            task_queue.popleft()
+    finally:
+        if task_queue:
+            get_logger().error(f"Polling dispatch stopped with {len(task_queue)} tasks not dispatched")
 
 
 async def polling_loop():
@@ -239,8 +271,11 @@ async def polling_loop():
     if not token:
         raise ValueError("User token must be set to get notifications")
 
+    active_processes = []
     async with aiohttp.ClientSession() as session:
         while True:
+            task_queue = deque()
+            dispatch_started = False
             try:
                 await asyncio.sleep(5)
                 headers = {
@@ -264,7 +299,6 @@ async def polling_loop():
                         if not notifications:
                             continue
                         get_logger().info(f"Received {len(notifications)} notifications")
-                        task_queue = deque()
                         for notification in notifications:
                             if not notification:
                                 continue
@@ -288,14 +322,21 @@ async def polling_loop():
 
                         max_allowed_parallel_tasks = 10
                         if task_queue:
-                            _start_queued_processes(task_queue, max_allowed_parallel_tasks)
+                            dispatch_started = True
+                            await _start_queued_processes(task_queue, max_allowed_parallel_tasks, active_processes)
 
                     elif response.status != 304:
                         print(f"Failed to fetch notifications. Status code: {response.status}")
 
+            except _PollingWorkerStartError:
+                raise
             except Exception as e:
                 get_logger().error(f"Polling exception during processing of a notification: {e}",
                                    artifact={"traceback": traceback.format_exc()})
+            finally:
+                if task_queue and not dispatch_started:
+                    get_logger().error(f"Polling dispatch stopped with {len(task_queue)} tasks not dispatched")
+                _reap_finished_processes(active_processes)
 
 
 if __name__ == '__main__':

--- a/tests/unittest/test_github_polling.py
+++ b/tests/unittest/test_github_polling.py
@@ -1,27 +1,447 @@
+import asyncio
+import multiprocessing
+import random
+import time
 from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from pr_agent.servers import github_polling
 
 
-def test_start_queued_processes_respects_parallel_limit(monkeypatch):
-    created_processes = []
+@pytest.fixture
+def workers(monkeypatch):
+    created = []
 
     class FakeProcess:
         def __init__(self, target, args):
             self.target = target
             self.args = args
-            self.started = False
-            created_processes.append(self)
+            self.pid = None
+            self.alive = False
+            self.closed = False
+            self.joined = False
+            created.append(self)
 
         def start(self):
-            self.started = True
+            self.pid = len(created)
+            self.alive = True
+            assert sum(p.alive for p in created) <= 10
 
-    monkeypatch.setattr(github_polling.multiprocessing, "Process", FakeProcess)
+        def is_alive(self):
+            assert not self.closed
+            return self.alive
 
-    task_queue = deque((lambda: None, ()) for _ in range(12))
-    processes = github_polling._start_queued_processes(task_queue, 10)
+        def join(self, timeout):
+            assert timeout == 0
+            assert not self.alive
+            self.joined = True
 
-    assert len(created_processes) == 10
-    assert len(processes) == 10
-    assert all(process.started for process in processes)
-    assert not task_queue
+        def close(self):
+            assert not self.alive
+            self.closed = True
+
+    # Replace the module reference, not multiprocessing.Process process-wide.
+    monkeypatch.setattr(github_polling, "multiprocessing", SimpleNamespace(Process=FakeProcess))
+    monkeypatch.setattr(github_polling, "get_logger", MagicMock())
+    return created, FakeProcess
+
+
+def _queue(size):
+    return deque((time.sleep, (i,)) for i in range(size))
+
+
+@pytest.mark.asyncio
+async def test_start_queued_processes_respects_parallel_limit(workers):
+    created, _ = workers
+    active = []
+    queue = _queue(12)
+    await github_polling._start_queued_processes(queue, 10, active)
+    assert len(created) == len(active) == 10
+    assert all(process.alive for process in active)
+    assert [process.args for process in active] == [(i,) for i in range(10)]
+    assert not queue
+
+
+@pytest.mark.asyncio
+async def test_next_batch_waits_without_dropping_accepted_work(workers, monkeypatch):
+    created, _ = workers
+    active = []
+    await github_polling._start_queued_processes(_queue(10), 10, active)
+    waiting = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_for_capacity(delay):
+        assert delay == 0.25
+        waiting.set()
+        await release.wait()
+
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=wait_for_capacity))
+    queue = _queue(3)
+    task = asyncio.create_task(github_polling._start_queued_processes(queue, 10, active))
+    try:
+        await asyncio.wait_for(waiting.wait(), 2)
+        assert len(created) == 10
+        assert len(queue) == 3
+        for process in created[:3]:
+            process.alive = False
+        release.set()
+        await asyncio.wait_for(task, 2)
+        assert len(created) == 13
+        assert len(active) == 10
+        assert all(p.joined and p.closed for p in created[:3])
+        assert not queue
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_capacity_wait_does_not_start_or_discard_work(workers, monkeypatch):
+    created, _ = workers
+    active = []
+    await github_polling._start_queued_processes(_queue(10), 10, active)
+    entered = asyncio.Event()
+
+    async def wait_for_capacity(delay):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=wait_for_capacity))
+    queue = _queue(2)
+    task = asyncio.create_task(github_polling._start_queued_processes(queue, 10, active))
+    try:
+        await asyncio.wait_for(entered.wait(), 2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            _ = await task
+        assert len(created) == len(active) == 10
+        assert len(queue) == 2
+        github_polling.get_logger().error.assert_called_once_with(
+            "Polling dispatch stopped with 2 tasks not dispatched"
+        )
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("partial_start", [False, True])
+async def test_start_failure_keeps_previous_workers_tracked(workers, monkeypatch, partial_start):
+    created, process_type = workers
+    start = process_type.start
+
+    def fail_second(process):
+        if len(created) == 2:
+            if partial_start:
+                start(process)
+            raise OSError("Cannot start worker")
+        start(process)
+
+    monkeypatch.setattr(process_type, "start", fail_second)
+    active = []
+    queue = _queue(3)
+    with pytest.raises(github_polling._PollingWorkerStartError, match="startup failed") as failure:
+        await github_polling._start_queued_processes(queue, 10, active)
+    assert isinstance(failure.value.__cause__, OSError)
+    assert active == (created if partial_start else created[:1])
+    assert created[0].alive
+    assert created[1].closed is (not partial_start)
+    expected_remaining = 1 if partial_start else 2
+    assert len(queue) == expected_remaining
+    github_polling.get_logger().error.assert_called_once_with(
+        f"Polling dispatch stopped with {expected_remaining} tasks not dispatched"
+    )
+    assert len(created) == 2
+
+
+@pytest.mark.asyncio
+async def test_many_batches_keep_the_active_limit(workers, monkeypatch):
+    created, _ = workers
+    active = []
+    rng = random.Random(42)
+    accepted = 0
+
+    async def complete_workers(delay):
+        for process in active[:3]:
+            process.alive = False
+
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=complete_workers))
+    for _ in range(100):
+        size = rng.randint(1, 12)
+        accepted += min(size, 10)
+        await github_polling._start_queued_processes(_queue(size), 10, active)
+        assert len(active) <= 10
+        for process in active[:rng.randint(0, len(active))]:
+            process.alive = False
+    assert len(created) == accepted
+    for process in active:
+        process.alive = False
+    github_polling._reap_finished_processes(active)
+    assert not active
+    assert all(p.joined and p.closed for p in created)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("idle_response", [304, 200, 500, OSError("poll failed")])
+async def test_polling_loop_reaps_workers_on_idle_and_failed_polls(workers, monkeypatch, idle_response):
+    created, _ = workers
+    settings = SimpleNamespace(
+        github=SimpleNamespace(deployment_type="user", user_token="test-token"), set=MagicMock()
+    )
+    monkeypatch.setattr(github_polling, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        github_polling,
+        "get_git_provider",
+        lambda: lambda: SimpleNamespace(get_user_id=lambda: "bot"),
+    )
+    monkeypatch.setattr(github_polling, "mark_notification_as_read", AsyncMock())
+    monkeypatch.setattr(github_polling, "is_valid_notification", AsyncMock(return_value=(
+        True, set(), {"id": 2}, "@bot /review", "https://example.test/pull/1", "@bot"
+    )))
+    finished = asyncio.Event()
+    polls = 0
+    sleeps = 0
+
+    class Response:
+        def __init__(self, status):
+            self.status = status
+            self.headers = {}
+
+        async def __aenter__(self):
+            if isinstance(self.status, Exception):
+                raise self.status
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def json(self):
+            return [{"id": 1}] if polls == 1 else []
+
+    class Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def get(self, *args, **kwargs):
+            nonlocal polls
+            polls += 1
+            return Response(200 if polls == 1 else idle_response)
+
+    async def sleep(delay):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 2:
+            created[0].alive = False
+        if sleeps == 3:
+            finished.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(github_polling, "aiohttp", SimpleNamespace(ClientSession=Session))
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=sleep))
+    task = asyncio.create_task(github_polling.polling_loop())
+    try:
+        await asyncio.wait_for(finished.wait(), 2)
+        assert len(created) == 1
+        assert created[0].joined and created[0].closed
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_reap_real_spawned_worker(monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(github_polling, "multiprocessing", SimpleNamespace(Process=ctx.Process))
+    active = []
+    await github_polling._start_queued_processes(deque([(time.sleep, (0,))]), 1, active)
+    process = active[0]
+    try:
+        await asyncio.to_thread(process.join, 5)
+        assert not process.is_alive()
+        github_polling._reap_finished_processes(active)
+        assert not active
+        with pytest.raises(ValueError, match="closed"):
+            process.is_alive()
+    finally:
+        if active:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+            process.close()
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_shares_capacity_between_batches(workers, monkeypatch):
+    created, _ = workers
+    settings = SimpleNamespace(
+        github=SimpleNamespace(deployment_type="user", user_token="test-token"), set=MagicMock()
+    )
+    monkeypatch.setattr(github_polling, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        github_polling,
+        "get_git_provider",
+        lambda: lambda: SimpleNamespace(get_user_id=lambda: "bot"),
+    )
+    monkeypatch.setattr(github_polling, "mark_notification_as_read", AsyncMock())
+    monkeypatch.setattr(github_polling, "is_valid_notification", AsyncMock(return_value=(
+        True, set(), {"id": 2}, "@bot /review", "https://example.test/pull/1", "@bot"
+    )))
+    waiting = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    polls = 0
+
+    class Session:
+        status = 200
+        headers = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def get(self, *args, **kwargs):
+            nonlocal polls
+            polls += 1
+            return self
+
+        async def json(self):
+            return [{"id": i} for i in range(10 if polls == 1 else 2)]
+
+    async def sleep(delay):
+        if delay == 0.25:
+            waiting.set()
+            await release.wait()
+        elif polls == 2:
+            finished.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(github_polling, "aiohttp", SimpleNamespace(ClientSession=Session))
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=sleep))
+    task = asyncio.create_task(github_polling.polling_loop())
+    try:
+        await asyncio.wait_for(waiting.wait(), 2)
+        assert len(created) == 10
+        assert polls == 2
+        for process in created[:2]:
+            process.alive = False
+        release.set()
+        await asyncio.wait_for(finished.wait(), 2)
+        assert len(created) == 12
+        assert sum(process.alive for process in created) == 10
+    finally:
+        task.cancel()
+        result, = await asyncio.gather(task, return_exceptions=True)
+    assert isinstance(result, asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_logs_accepted_work_cancelled_before_dispatch(workers, monkeypatch):
+    created, _ = workers
+    settings = SimpleNamespace(
+        github=SimpleNamespace(deployment_type="user", user_token="test-token"), set=MagicMock()
+    )
+    monkeypatch.setattr(github_polling, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        github_polling,
+        "get_git_provider",
+        lambda: lambda: SimpleNamespace(get_user_id=lambda: "bot"),
+    )
+    monkeypatch.setattr(github_polling, "mark_notification_as_read", AsyncMock())
+    entered_second = asyncio.Event()
+    validation_calls = 0
+
+    async def validate(*args, **kwargs):
+        nonlocal validation_calls
+        validation_calls += 1
+        if validation_calls == 1:
+            return True, set(), {"id": 2}, "@bot /review", "https://example.test/pull/1", "@bot"
+        entered_second.set()
+        await asyncio.Event().wait()
+        raise AssertionError("Second validation should remain blocked")
+
+    monkeypatch.setattr(github_polling, "is_valid_notification", validate)
+
+    class Session:
+        status = 200
+        headers = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def get(self, *args, **kwargs):
+            return self
+
+        async def json(self):
+            return [{"id": 1}, {"id": 2}]
+
+    async def sleep(delay):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(github_polling, "aiohttp", SimpleNamespace(ClientSession=Session))
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=sleep))
+    task = asyncio.create_task(github_polling.polling_loop())
+    await asyncio.wait_for(entered_second.wait(), 2)
+    task.cancel()
+    result, = await asyncio.gather(task, return_exceptions=True)
+
+    assert isinstance(result, asyncio.CancelledError)
+    assert not created
+    github_polling.get_logger().error.assert_any_call(
+        "Polling dispatch stopped with 1 tasks not dispatched"
+    )
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_stops_after_worker_start_failure(workers, monkeypatch):
+    _, process_type = workers
+    settings = SimpleNamespace(
+        github=SimpleNamespace(deployment_type="user", user_token="test-token"), set=MagicMock()
+    )
+    monkeypatch.setattr(github_polling, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        github_polling,
+        "get_git_provider",
+        lambda: lambda: SimpleNamespace(get_user_id=lambda: "bot"),
+    )
+    monkeypatch.setattr(github_polling, "mark_notification_as_read", AsyncMock())
+    monkeypatch.setattr(github_polling, "is_valid_notification", AsyncMock(return_value=(
+        True, set(), {"id": 2}, "@bot /review", "https://example.test/pull/1", "@bot"
+    )))
+    start = MagicMock(side_effect=OSError("Cannot start worker"))
+    monkeypatch.setattr(process_type, "start", start)
+
+    class Session:
+        status = 200
+        headers = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def get(self, *args, **kwargs):
+            return self
+
+        async def json(self):
+            return [{"id": 1}]
+
+    async def sleep(delay):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(github_polling, "aiohttp", SimpleNamespace(ClientSession=Session))
+    monkeypatch.setattr(github_polling, "asyncio", SimpleNamespace(sleep=sleep))
+    with pytest.raises(github_polling._PollingWorkerStartError, match="startup failed"):
+        await asyncio.wait_for(github_polling.polling_loop(), timeout=2)
+    start.assert_called_once()


### PR DESCRIPTION
## Summary

Apply the existing ten-worker GitHub polling limit across polling iterations, not just within each batch. Track active child processes, reap completed workers, and wait asynchronously when earlier work already consumes the available capacity.

## Behavior

- Preserve the existing per-batch policy: accept the first ten queued comments and log/drop excess work.
- Wait for shared capacity instead of discarding already accepted work because earlier workers are still active.
- Track started children and reap completed workers without waiting for live ones.
- Treat a PID-bearing startup failure as potentially dispatched, remove that task from the pending queue, and stop polling rather than risk duplicate dispatch or an uncertain worker state.
- Log accepted-but-undispatched work when dispatch is interrupted or cancellation happens before dispatch starts.
- Propagate cancellation without terminating live review workers.

Waiting work remains memory-only and notification acknowledgement is unchanged; this does not add durable delivery.

## Validation

- Focused tests cover repeated batches, cross-iteration capacity sharing, idle/error cleanup, startup failures, cancellation during capacity waits, cancellation before dispatch, and a real spawned child.
- GitHub Advanced Security findings raised against the added tests are resolved in the current head.

This change is independent of #2624 and the separate async HTTP fallback PR.