### PR TITLE
fix(polling): avoid blocking HTTP in notification fallback

### DIFF
--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -9,6 +9,18 @@ There are several ways to use PR-Agent:
 - [Azure DevOps integration](./azure.md)
 - [Gitea integration](./gitea.md)
 
+## GitHub polling HTTP requests
+
+When GitHub polling needs to look back through PR comments, it reuses the polling
+HTTP session rather than blocking the event loop with a synchronous request.
+`github.polling_request_timeout` sets the total timeout for this fallback request
+(default: 10 seconds; positive values are capped at 60). Invalid values use the
+default with a warning. Set it in the host configuration or through
+`GITHUB__POLLING_REQUEST_TIMEOUT`; repository settings do not control this limit.
+This does not change the other polling requests or the sequential notification
+scan. The fallback now follows the existing aiohttp session's proxy and TLS
+behavior, not Requests-specific environment settings.
+
 ## Sizing a self-hosted webhook server
 
 The GitHub, GitLab and Gitea webhook servers (the `github_app`, `gitlab_webhook` and `gitea_app` Docker targets) run under gunicorn with multiple worker processes, so that a worker busy handling a request cannot block the health check served by another. The other deployments — Bitbucket, Azure DevOps, GitHub polling, and the Lambda variants — run a single process and are unaffected by this section.

--- a/pr_agent/servers/github_polling.py
+++ b/pr_agent/servers/github_polling.py
@@ -1,11 +1,11 @@
 import asyncio
+import math
 import multiprocessing
 import traceback
 from collections import deque
 from datetime import datetime, timezone
 
 import aiohttp
-import requests
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.ai_handlers.litellm_helpers import (
@@ -13,12 +13,47 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     drain_litellm_callbacks,
     litellm_callbacks_registered,
 )
-from pr_agent.config_loader import get_settings
+from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 NOTIFICATION_URL = "https://api.github.com/notifications"
+DEFAULT_POLLING_REQUEST_TIMEOUT = 10
+MAX_POLLING_REQUEST_TIMEOUT = 60
+
+
+def _get_polling_request_timeout() -> float:
+    """Bound the timeout for notification fallback requests."""
+    value = global_settings.get("github.polling_request_timeout", DEFAULT_POLLING_REQUEST_TIMEOUT)
+    try:
+        timeout = float(value) if not isinstance(value, bool) else 0.0
+    except (TypeError, ValueError, OverflowError):
+        timeout = 0.0
+    if not math.isfinite(timeout) or timeout <= 0:
+        get_logger().warning(
+            f"Invalid github.polling_request_timeout; using {DEFAULT_POLLING_REQUEST_TIMEOUT} seconds"
+        )
+        return float(DEFAULT_POLLING_REQUEST_TIMEOUT)
+    if timeout > MAX_POLLING_REQUEST_TIMEOUT:
+        get_logger().warning(f"Capping github.polling_request_timeout at {MAX_POLLING_REQUEST_TIMEOUT} seconds")
+    return min(timeout, float(MAX_POLLING_REQUEST_TIMEOUT))
+
+
+async def _fetch_comment_history(session, url, headers) -> list:
+    """Fetch fallback comments without retaining a response or blocking the event loop."""
+    async with session.get(
+        url,
+        headers=headers,
+        timeout=aiohttp.ClientTimeout(total=_get_polling_request_timeout()),
+        allow_redirects=True,
+        max_redirects=30,
+    ) as response:
+        response.raise_for_status()
+        comments = await response.json(content_type=None)
+    if not isinstance(comments, list):
+        raise ValueError("Expected a list of pull request comments")
+    return comments
 
 
 async def mark_notification_as_read(headers, notification, session):
@@ -135,8 +170,7 @@ async def is_valid_notification(notification, headers, handled_ids, session, use
                         else: # we could not find the user tag in the latest comment. Check previous comments
                             # get all comments in the PR
                             requests_url = f"{pr_url}/comments".replace("pulls", "issues")
-                            comments_response = requests.get(requests_url, headers=headers)
-                            comments = comments_response.json()[::-1]
+                            comments = (await _fetch_comment_history(session, requests_url, headers))[::-1]
                             max_comment_to_scan = 4
                             for comment in comments[:max_comment_to_scan]:
                                 if 'user' in comment and 'login' in comment['user']:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -281,6 +281,7 @@ enable_help_text=false
 # The type of deployment to create. Valid values are 'app' or 'user'.
 deployment_type = "user"
 ratelimit_retries = 5
+polling_request_timeout = 10 # total seconds for comment-history fallback; positive values capped at 60
 base_url = "https://api.github.com"
 publish_inline_comments_fallback_with_verification = true
 try_fix_invalid_inline_comments = true

--- a/tests/unittest/test_github_polling_notifications.py
+++ b/tests/unittest/test_github_polling_notifications.py
@@ -1,0 +1,225 @@
+import asyncio
+import json
+import tomllib
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+import requests
+from aiohttp import web
+
+from pr_agent.servers import github_polling
+
+
+@pytest.fixture(autouse=True)
+def isolate_notification_io(monkeypatch):
+    monkeypatch.setattr(
+        github_polling, "global_settings", SimpleNamespace(get=lambda key, default: default)
+    )
+    monkeypatch.setattr(github_polling, "get_logger", MagicMock())
+
+    def reject_sync_http(*args, **kwargs):
+        raise AssertionError("Notification fallback must not use synchronous HTTP")
+
+    monkeypatch.setattr(requests, "get", reject_sync_http)
+
+
+def _comment(comment_id=2, body="@bot /review", user="human"):
+    return {"id": comment_id, "body": body, "user": {"login": user}}
+
+
+def _notification(base_url):
+    return {
+        "reason": "mention",
+        "subject": {
+            "type": "PullRequest",
+            "url": f"{base_url}/repos/owner/repo/pulls/1",
+            "latest_comment_url": f"{base_url}/latest",
+        },
+    }
+
+
+@asynccontextmanager
+async def _server(fallback, latest=None):
+    async def latest_handler(request):
+        return web.json_response(latest if latest is not None else _comment(99, "Other discussion"))
+
+    app = web.Application()
+    app.router.add_get("/latest", latest_handler)
+    app.router.add_get("/repos/owner/repo/issues/1/comments", fallback)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        host, port = runner.addresses[0]
+        yield f"http://{host}:{port}"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_fallback_reuses_session_and_preserves_selection():
+    selected = _comment(2)
+    seen = []
+
+    async def fallback(request):
+        seen.append(request.headers["Authorization"])
+        return web.Response(
+            text=json.dumps([_comment(1, "@bot /ask old"), selected, _comment(3, ""), _comment(4, user="bot")]),
+            content_type="text/plain",
+        )
+
+    connector = aiohttp.TCPConnector(limit=1)
+    async with _server(fallback) as url, aiohttp.ClientSession(connector=connector) as session:
+        # Check that the consumed latest-comment response releases the only
+        # connection before fallback.
+        handled = set()
+        result = await github_polling.is_valid_notification(
+            _notification(url), {"Authorization": "Bearer test-token"}, handled, session, "bot"
+        )
+    assert result == (True, handled, selected, "@bot /review", f"{url}/repos/owner/repo/pulls/1", "@bot")
+    assert handled == {99}
+    assert seen == ["Bearer test-token"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("latest", [_comment(), _comment(2, "@bot /ask question")])
+async def test_latest_mention_does_not_fetch_history(latest):
+    calls = []
+
+    async def fallback(request):
+        calls.append(request.path)
+        return web.json_response([])
+
+    async with _server(fallback, latest) as url, aiohttp.ClientSession() as session:
+        result = await github_polling.is_valid_notification(_notification(url), {}, set(), session, "bot")
+    assert result[0] is True
+    assert result[2] == latest
+    assert not calls
+
+
+@pytest.mark.asyncio
+async def test_fallback_still_scans_only_four_comments():
+    async def fallback(request):
+        return web.json_response([_comment()] + [_comment(i, "No mention") for i in range(3, 7)])
+
+    async with _server(fallback) as url, aiohttp.ClientSession() as session:
+        handled = set()
+        assert await github_polling.is_valid_notification(_notification(url), {}, handled, session, "bot") == (
+            False, handled
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [(401, "[]"), (403, "[]"), (429, "[]"), (500, "[]"), (200, "not json"), (200, "{}"), (200, "null")],
+)
+async def test_bad_fallback_response_is_rejected_and_connection_reusable(status, body):
+    async def fallback(request):
+        return web.Response(status=status, text=body)
+
+    connector = aiohttp.TCPConnector(limit=1)
+    async with _server(fallback) as url, aiohttp.ClientSession(connector=connector) as session:
+        handled = set()
+        assert await github_polling.is_valid_notification(_notification(url), {}, handled, session, "bot") == (
+            False, handled
+        )
+        async with session.get(f"{url}/latest", timeout=aiohttp.ClientTimeout(total=2)) as response:
+            assert response.status == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_stalled_fallback_yields_and_releases_connection(monkeypatch, cancel):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    monkeypatch.setattr(github_polling, "_get_polling_request_timeout", lambda: 2 if cancel else 0.05)
+
+    async def fallback(request):
+        entered.set()
+        await release.wait()
+        return web.json_response([])
+
+    connector = aiohttp.TCPConnector(limit=1)
+    async with _server(fallback) as url, aiohttp.ClientSession(connector=connector) as session:
+        handled = set()
+        task = asyncio.create_task(
+            github_polling.is_valid_notification(_notification(url), {}, handled, session, "bot")
+        )
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=2)
+            # Check that the event loop remains free while HTTP is stalled.
+            if cancel:
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    _ = await task
+            else:
+                assert await asyncio.wait_for(task, timeout=2) == (False, handled)
+            async with session.get(f"{url}/latest", timeout=aiohttp.ClientTimeout(total=2)) as response:
+                assert response.status == 200
+        finally:
+            release.set()
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_fallback_has_explicit_timeout_and_redirect_limit(monkeypatch):
+    calls = []
+
+    class Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        async def json(self, **kwargs):
+            return _comment(99, "Other discussion") if len(calls) == 1 else [_comment()]
+
+    class Session:
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return Response()
+
+    result = await github_polling.is_valid_notification(
+        _notification("https://example.test"), {}, set(), Session(), "bot"
+    )
+    assert result[0] is True
+    kwargs = calls[1][1]
+    assert kwargs["timeout"].total == 10
+    assert kwargs["allow_redirects"] is True
+    assert kwargs["max_redirects"] == 30
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(10, 10), ("2.5", 2.5), (60, 60), (600, 60), (None, 10), (True, 10), (False, 10),
+     (0, 10), (-1, 10), ("bad", 10), ([], 10), (float("nan"), 10), (float("inf"), 10)],
+)
+def test_polling_timeout_validation(monkeypatch, value, expected):
+    monkeypatch.setattr(github_polling, "global_settings", SimpleNamespace(get=lambda key, default: value))
+    assert github_polling._get_polling_request_timeout() == expected
+
+
+def test_timeout_ignores_request_scoped_settings(monkeypatch):
+    monkeypatch.setattr(github_polling, "global_settings", SimpleNamespace(get=lambda key, default: 12))
+    monkeypatch.setattr(github_polling, "get_settings", lambda **kwargs: SimpleNamespace(get=lambda key, default: 60))
+    assert github_polling._get_polling_request_timeout() == 12
+
+
+def test_polling_timeout_default_matches_shipped_configuration():
+    config_path = Path(github_polling.__file__).parents[1] / "settings" / "configuration.toml"
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert config["github"]["polling_request_timeout"] == github_polling.DEFAULT_POLLING_REQUEST_TIMEOUT


### PR DESCRIPTION
## Summary

Replace the synchronous comment-history fallback in GitHub polling with the existing aiohttp session so slow fallback I/O does not block the polling event loop.

Add a bounded host-level `github.polling_request_timeout`: 10 seconds by default, capped at 60, with invalid values falling back safely.

## Behavior

- Preserve reverse ordering, the four-comment scan, notification acknowledgement, deduplication, and return values.
- Read the timeout from host `global_settings`, preventing repository/request-scoped settings from changing this safeguard.
- Raise HTTP errors and require a JSON list while still accepting valid JSON with a nonstandard Content-Type.
- Release responses on success, failure, timeout, and cancellation.
- Preserve cancellation propagation and reuse the polling session's existing proxy/TLS behavior.

Worker management and polling concurrency behavior are unchanged.

## Validation

- Focused tests cover fallback selection, malformed/error responses, timeout validation, cancellation, connection reuse, redirects, and host-vs-request settings isolation.
- The GitHub Advanced Security finding raised against the added cancellation test is resolved in the current head.