### PR TITLE
fix: surface description publication failures

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1013,7 +1013,7 @@ class AzureDevopsProvider(GitProvider):
             raise RuntimeError("Azure DevOps comment author cannot be verified")
         return any(value in stable_identities for value in values)
 
-    def publish_description(self, pr_title: str, pr_body: str):
+    def publish_description(self, pr_title: str, pr_body: str) -> None:
         if len(pr_body) > MAX_PR_DESCRIPTION_AZURE_LENGTH:
 
             usage_guide_text='<details> <summary><strong>✨ Describe tool usage guide:</strong></summary><hr>'
@@ -1046,6 +1046,7 @@ class AzureDevopsProvider(GitProvider):
             get_logger().exception(
                 f"Could not update pull request {self.pr_num} description: {e}"
             )
+            raise
 
     def remove_initial_comment(self):
         try:

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -690,19 +690,17 @@ class BitbucketProvider(GitProvider):
         return ""  # not implemented yet
 
     # bitbucket does not support labels
-    def publish_description(self, pr_title: str, description: str):
+    def publish_description(self, pr_title: str, description: str) -> None:
         payload_dict = {"description": description}
         if pr_title is not None:
             payload_dict["title"] = pr_title
         payload = json.dumps(payload_dict)
 
         response = requests.request("PUT", self.bitbucket_pull_request_api_url, headers=self.headers, data=payload)
-        try:
-            if response.status_code != 200:
-                get_logger().info(f"Failed to update description, error code: {response.status_code}")
-        except:
-            pass
-        return response
+        if response.status_code != 200:
+            message = f"Failed to update description, error code: {response.status_code}"
+            get_logger().error(message)
+            raise RuntimeError(message)
 
     # bitbucket does not support labels
     def publish_labels(self, pr_types: list):

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -697,7 +697,7 @@ class BitbucketProvider(GitProvider):
         payload = json.dumps(payload_dict)
 
         response = requests.request("PUT", self.bitbucket_pull_request_api_url, headers=self.headers, data=payload)
-        if response.status_code != 200:
+        if not 200 <= response.status_code < 300:
             message = f"Failed to update description, error code: {response.status_code}"
             get_logger().error(message)
             raise RuntimeError(message)

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -258,7 +258,12 @@ class GitProvider(ABC):
         pass
 
     @abstractmethod
-    def publish_description(self, pr_title: str, pr_body: str):
+    def publish_description(self, pr_title: str, pr_body: str) -> None:
+        """Publish the pull request title and description.
+
+        Implementations must raise when the remote update fails so callers do
+        not continue through a false-success path.
+        """
         # pr_title may be None, which means "leave the existing title unchanged"
         # and update only the description. Implementations must not write the
         # title in that case.

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -789,7 +789,7 @@ class GiteaProvider(GitProvider):
 
         if not response:
             self.logger.error("Failed to publish PR description")
-            return None
+            raise RuntimeError("Failed to publish PR description")
 
         self.logger.info("PR description published successfully")
         if self.enabled_pr:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -890,7 +890,7 @@ class GitLabProvider(GitProvider):
             self.git_files = [c.get('new_path') for c in raw_changes if c.get('new_path')]
         return self.git_files
 
-    def publish_description(self, pr_title: str, pr_body: str):
+    def publish_description(self, pr_title: str, pr_body: str) -> None:
         try:
             if pr_title is not None:
                 self.mr.title = pr_title
@@ -898,6 +898,7 @@ class GitLabProvider(GitProvider):
             self.mr.save()
         except Exception as e:
             get_logger().exception(f"Could not update merge request {self.id_mr} description: {e}")
+            raise
 
     def get_latest_commit_url(self):
         try:

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -210,7 +210,16 @@ class PRDescription:
                     # anywhere in the body without depending on visible section
                     # headers that a human might quote.
                     pr_body = '<!-- pr-agent-generated -->\n' + pr_body
-                    self.git_provider.publish_description(title_to_publish, pr_body)
+                    try:
+                        self.git_provider.publish_description(title_to_publish, pr_body)
+                    except Exception:
+                        try:
+                            self.git_provider.publish_comment("Failed to update PR description")
+                        except Exception as publication_error:
+                            get_logger().exception(
+                                f"Failed to publish PR description failure result, error: {publication_error}"
+                            )
+                        raise
 
                     # publish final update message
                     if (get_settings().pr_description.final_update_message and not get_settings().config.get('is_auto_command', False)):

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -15,6 +15,18 @@ from pr_agent.git_providers.azuredevops_provider import (
 from pr_agent.log import get_logger
 
 
+def test_publish_description_propagates_update_failure():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.workspace_slug = "my-project"
+    provider.repo_slug = "my-repo"
+    provider.pr_num = 1
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.update_pull_request.side_effect = RuntimeError("permission denied")
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        provider.publish_description("AI title", "Updated description")
+
+
 class TestAzureDevopsProviderRepoContext:
     def test_get_repo_file_content_reads_from_target_commit(self):
         # Repo-context files must be read from the PR target (base) commit, matching

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -68,6 +68,18 @@ class TestBitbucketProvider:
 
         assert provider.edit_comment(comment, "updated body") is False
 
+    def test_publish_description_raises_on_non_success_response(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.bitbucket_pull_request_api_url = "https://api.bitbucket.org/pullrequests/1"
+        provider.headers = {"Authorization": "Bearer token"}
+        response = MagicMock(status_code=500)
+
+        with (
+            patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response),
+            pytest.raises(RuntimeError, match="error code: 500"),
+        ):
+            provider.publish_description("AI title", "Updated description")
+
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
         workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -80,6 +80,16 @@ class TestBitbucketProvider:
         ):
             provider.publish_description("AI title", "Updated description")
 
+    @pytest.mark.parametrize("status_code", [200, 201, 204])
+    def test_publish_description_accepts_success_response(self, status_code):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.bitbucket_pull_request_api_url = "https://api.bitbucket.org/pullrequests/1"
+        provider.headers = {"Authorization": "Bearer token"}
+        response = MagicMock(status_code=status_code)
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response):
+            provider.publish_description("AI title", "Updated description")
+
     def test_parse_pr_url(self):
         url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
         workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)

--- a/tests/unittest/test_gitea_provider.py
+++ b/tests/unittest/test_gitea_provider.py
@@ -59,6 +59,21 @@ def test_gitea_edit_comment_returns_false_on_failure():
     assert provider.edit_comment({"id": 42}, "updated body") is False
 
 
+def test_gitea_publish_description_raises_when_update_returns_no_response():
+    provider = GiteaProvider.__new__(GiteaProvider)
+    provider.repo_api = MagicMock()
+    provider.repo_api.edit_pull_request.return_value = None
+    provider.owner = "owner"
+    provider.repo = "repo"
+    provider.pr_number = 1
+    provider.issue_number = None
+    provider.enabled_pr = True
+    provider.logger = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Failed to publish PR description"):
+        provider.publish_description("AI title", "Updated description")
+
+
 def test_gitea_get_issue_comments_returns_empty_list_when_no_comments():
     provider = GiteaProvider.__new__(GiteaProvider)
     provider.enabled_issue = False

--- a/tests/unittest/test_gitlab_provider.py
+++ b/tests/unittest/test_gitlab_provider.py
@@ -369,6 +369,14 @@ class TestGitLabProvider:
         assert gitlab_provider.mr.description == "Updated description"
         gitlab_provider.mr.save.assert_called_once()
 
+    def test_publish_description_propagates_save_failure(self, gitlab_provider):
+        gitlab_provider.mr = MagicMock()
+        gitlab_provider.mr.save.side_effect = RuntimeError("permission denied")
+        gitlab_provider.id_mr = 1
+
+        with pytest.raises(RuntimeError, match="permission denied"):
+            gitlab_provider.publish_description("AI title", "Updated description")
+
     @pytest.mark.parametrize("configured", [True, False])
     def test_should_publish_review_as_thread_reflects_config(self, gitlab_provider, configured):
         with patch("pr_agent.git_providers.gitlab_provider.get_settings",

--- a/tests/unittest/test_pr_description_lifecycle.py
+++ b/tests/unittest/test_pr_description_lifecycle.py
@@ -15,6 +15,14 @@ _TRACKED_SETTINGS = (
     "config.publish_output",
     "config.is_auto_command",
     "config.propagate_tool_errors",
+    "pr_description.enable_help_comment",
+    "pr_description.enable_help_text",
+    "pr_description.enable_semantic_files_types",
+    "pr_description.final_update_message",
+    "pr_description.generate_ai_title",
+    "pr_description.publish_description_as_comment",
+    "pr_description.publish_labels",
+    "pr_description.use_description_markers",
 )
 
 
@@ -135,5 +143,48 @@ async def test_run_neutralizes_progress_comment_before_delete(monkeypatch):
             ),
             call.remove_comment(progress_comment),
         ]
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_tool_errors", [False, True])
+async def test_run_reports_description_publication_failure(monkeypatch, propagate_tool_errors):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        progress_comment = MagicMock(name="progress_comment")
+        provider.publish_comment.return_value = progress_comment
+        provider.publish_description.side_effect = RuntimeError("permission denied")
+        provider.is_supported.return_value = False
+        description = _make_description(provider)
+        description.prediction = "generated"
+        description._prepare_data = MagicMock()
+        description._prepare_pr_answer = MagicMock(return_value=("AI title", "Description", "", []))
+
+        monkeypatch.setattr(pr_description_module, "extract_and_cache_pr_tickets", AsyncMock())
+        monkeypatch.setattr(pr_description_module, "retry_with_fallback_models", AsyncMock())
+        _configure_published_run()
+        settings = get_settings()
+        settings.config.propagate_tool_errors = propagate_tool_errors
+        settings.pr_description.enable_help_comment = False
+        settings.pr_description.enable_help_text = False
+        settings.pr_description.enable_semantic_files_types = False
+        settings.pr_description.final_update_message = True
+        settings.pr_description.generate_ai_title = True
+        settings.pr_description.publish_description_as_comment = False
+        settings.pr_description.publish_labels = False
+        settings.pr_description.use_description_markers = False
+
+        if propagate_tool_errors:
+            with pytest.raises(RuntimeError, match="permission denied"):
+                await description.run()
+        else:
+            assert await description.run() == ""
+
+        provider.publish_description.assert_called_once()
+        assert call("Failed to update PR description") in provider.publish_comment.call_args_list
+        assert not any("updated to latest commit" in str(published) for published in provider.publish_comment.call_args_list)
+        provider.remove_comment.assert_called_once_with(progress_comment)
     finally:
         restore_settings(settings_snapshot)


### PR DESCRIPTION
## Summary

- define `publish_description()` as an exception-on-failure provider contract
- propagate confirmed GitLab and Azure DevOps SDK failures, and reject unsuccessful Bitbucket Cloud and Gitea responses
- report a visible publication failure from `/describe` and skip the final "updated" success message
- cover the four provider boundaries and both `propagate_tool_errors` lifecycle modes

Closes #3057.

## Validation

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_pr_description_lifecycle.py tests/unittest/test_gitlab_provider.py tests/unittest/test_azure_devops_provider.py tests/unittest/test_bitbucket_provider.py tests/unittest/test_gitea_provider.py` — **396 passed**
- targeted new regressions — **6 passed**
- `uv run ruff check` on all changed Python files — passed
- Python AST compilation and `git diff --check` — passed

The full unit suite's first failure on this Windows host is the existing `tests/unittest/test_artifacts.py::TestResolveArtifactPath::test_root_workspace_does_not_reject_valid_paths`; it reproduces unchanged on a clean `f3b385e` worktree. Pre-commit could not initialize because fetching `pre-commit-hooks` failed twice with a GitHub port 443 connection error; its relevant Python checks were covered manually above.