### PR TITLE
fix(github): read ignore_bot_pr from the [github] section where it is set

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -332,7 +332,7 @@ def get_log_context(body, event, action, build_number):
 def is_bot_user(sender, sender_type):
     try:
         # logic to ignore PRs opened by bot
-        if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        if get_settings().get("GITHUB.IGNORE_BOT_PR", False) and sender_type == "Bot":
             if 'pr-agent' not in sender:
                 get_logger().info(f"Ignoring PR from '{sender=}' because it is a bot")
             return True

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -332,7 +332,10 @@ def get_log_context(body, event, action, build_number):
 def is_bot_user(sender, sender_type):
     try:
         # logic to ignore PRs opened by bot
-        if get_settings().get("GITHUB.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        ignore_bot_pr = get_settings().get("GITHUB_APP.IGNORE_BOT_PR", None)
+        if ignore_bot_pr is None:
+            ignore_bot_pr = get_settings().get("GITHUB.IGNORE_BOT_PR", False)
+        if ignore_bot_pr and sender_type == "Bot":
             if 'pr-agent' not in sender:
                 get_logger().info(f"Ignoring PR from '{sender=}' because it is a bot")
             return True

--- a/tests/unittest/test_github_app_auth.py
+++ b/tests/unittest/test_github_app_auth.py
@@ -45,3 +45,30 @@ class TestGithubAppAuth:
         finally:
             for name, value in original.items():
                 settings.set(name, value)
+
+    def test_is_bot_user_reads_github_section_setting(self):
+        """is_bot_user must honor `ignore_bot_pr` from the [github] section
+        (#3017): configuration.toml sets it under [github], so reading
+        GITHUB_APP.IGNORE_BOT_PR left the guard permanently off."""
+        from pr_agent.servers.github_app import is_bot_user
+
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR", None)
+        settings.set("GITHUB.IGNORE_BOT_PR", True)
+        try:
+            assert is_bot_user("some-bot[bot]", "Bot") is True
+            assert is_bot_user("human", "User") is False
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)
+
+    def test_is_bot_user_off_when_setting_unset(self):
+        """With the setting off, bot senders are not filtered."""
+        from pr_agent.servers.github_app import is_bot_user
+
+        settings = get_settings()
+        original = settings.get("GITHUB.IGNORE_BOT_PR", None)
+        settings.set("GITHUB.IGNORE_BOT_PR", False)
+        try:
+            assert is_bot_user("some-bot[bot]", "Bot") is False
+        finally:
+            settings.set("GITHUB.IGNORE_BOT_PR", original)


### PR DESCRIPTION
`configuration.toml` sets `ignore_bot_pr` under `[github]`, but `is_bot_user()` in `github_app.py` read `GITHUB_APP.IGNORE_BOT_PR` — a key that exists nowhere — so the setting silently defaulted to `False` and the bot-PR guard never fired.

One-line fix: read `GITHUB.IGNORE_BOT_PR`, the section where the default ships as `true`.

Tests: 2 new cases in `test_github_app_auth.py` verify the guard fires for bot senders when the `[github]` setting is on and stays off otherwise. The firing case fails on old code; all 3 pass with the fix. Ruff clean.

Fixes #3017