### PR TITLE
fix(diff): exclude file headers from numbered hunks

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -13,6 +13,20 @@ RE_HUNK_HEADER = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
 
 
+def to_hunk_only_patch(patch_str: str) -> str:
+    """Drop unified-diff file metadata before the first hunk.
+
+    ``FilePatchInfo.patch`` consumers expect hunk-only patches and may otherwise
+    treat ``---``/``+++`` file headers as changed source lines. Returns an empty
+    string when the diff has no textual hunk, for example a rename-only change.
+    """
+    lines = patch_str.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.startswith("@@"):
+            return "".join(lines[i:])
+    return ""
+
+
 def extend_patch(original_file_str, patch_str, patch_extra_lines_before=0,
                  patch_extra_lines_after=0, filename: str = "", new_file_str="") -> str:
     if not patch_str or (patch_extra_lines_before == 0 and patch_extra_lines_after == 0) or not original_file_str:
@@ -386,6 +400,9 @@ __old hunk__
             section_header, size1, size2, start1, start2 = extract_hunk_headers(match)
 
         elif skip_hunk:
+            continue
+        elif match is None:
+            # Ignore unified-diff file metadata before the first valid hunk.
             continue
         elif line.startswith('+'):
             new_content_lines.append(line)

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -26,7 +26,11 @@ from pydantic import BaseModel
 from starlette_context import context
 
 from pr_agent.algo import MAX_TOKENS
-from pr_agent.algo.git_patch_processing import extract_hunk_headers, extract_hunk_lines_from_patch
+from pr_agent.algo.git_patch_processing import (
+    extract_hunk_headers,
+    extract_hunk_lines_from_patch,
+    to_hunk_only_patch,
+)
 from pr_agent.algo.run_details import get_run_details
 from pr_agent.algo.token_handler import TokenEncoder
 from pr_agent.algo.types import FilePatchInfo
@@ -911,7 +915,7 @@ def convert_str_to_datetime(date_str):
 def load_large_diff(filename, new_file_content_str: str, original_file_content_str: str, show_warning: bool = True) -> str:
     """
     Generate a patch for a modified file by comparing the original content of the file with the new content provided as
-    input.
+    input. The returned patch starts at its first hunk and excludes unified-diff file metadata.
     """
     if not original_file_content_str and not new_file_content_str:
         return ""
@@ -923,8 +927,7 @@ def load_large_diff(filename, new_file_content_str: str, original_file_content_s
                                     new_file_content_str.splitlines(keepends=True))
         if get_verbosity_level() >= 2 and show_warning:
             get_logger().info(f"File was modified, but no patch was found. Manually creating patch: {filename}.")
-        patch = ''.join(diff)
-        return patch
+        return to_hunk_only_patch(''.join(diff))
     except Exception as e:
         get_logger().exception(f"Failed to generate patch for file: {filename}")
         return ""

--- a/pr_agent/git_providers/diff_parsing.py
+++ b/pr_agent/git_providers/diff_parsing.py
@@ -1,8 +1,14 @@
 from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
+from pr_agent.algo.git_patch_processing import to_hunk_only_patch as _to_hunk_only_patch
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.log import get_logger
+
+
+def to_hunk_only_patch(patch_str: str) -> str:
+    """Keep the existing provider-layer import path for callers."""
+    return _to_hunk_only_patch(patch_str)
 
 
 def _strip_prefix(path: str | None) -> str | None:
@@ -11,21 +17,6 @@ def _strip_prefix(path: str | None) -> str | None:
     if path.startswith(("a/", "b/")):
         return path[2:]
     return path
-
-
-def to_hunk_only_patch(patch_str: str) -> str:
-    """Drop file-header lines ('diff --git', 'index', '---', '+++') that precede
-    the first '@@' hunk header.
-
-    Platform providers (GitHub, GitLab, ...) store hunk-only patches, and the
-    shared hunk/line-number converter treats any '+'/'-' line as content. Left
-    in, the '---'/'+++' headers would be emitted as a bogus leading hunk with
-    invalid line numbers. Returns "" when there is no hunk (e.g. rename-only)."""
-    lines = patch_str.splitlines(keepends=True)
-    for i, line in enumerate(lines):
-        if line.startswith("@@"):
-            return "".join(lines[i:])
-    return ""
 
 
 def parse_unified_diff(diff_text: str) -> list[FilePatchInfo]:

--- a/pr_agent/mosaico/diff_provider.py
+++ b/pr_agent/mosaico/diff_provider.py
@@ -10,6 +10,7 @@ are read from MOSAICO.INPUT on the (context) settings.
 import re
 from typing import List, Optional
 
+from pr_agent.algo.git_patch_processing import to_hunk_only_patch
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
@@ -30,10 +31,9 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
     """Parse a supplied unified diff (git format) into a list of FilePatchInfo.
 
     Splits on ``diff --git a/<f> b/<f>`` headers; per file: filename = the b/ path,
-    patch = that file's section verbatim (the @@ hunk body pr-agent's hunk processing
-    consumes), edit_type inferred from new/deleted/rename file modes, and head/base
-    file content reconstructed best-effort from +/-/context lines. Degrades gracefully:
-    a blob with no ``diff --git`` header yields []."""
+    patch = that file's hunk body, edit_type inferred from new/deleted/rename file
+    modes, and head/base file content reconstructed best-effort from +/-/context
+    lines. Degrades gracefully: a blob with no ``diff --git`` header yields []."""
     if not diff_text or not isinstance(diff_text, str):
         return []
 
@@ -51,8 +51,6 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
         m = _DIFF_GIT_RE.match(header)
         a_path = m.group("a") if m else ""
         b_path = m.group("b") if m else ""
-
-        patch = "".join(section)
 
         edit_type = EDIT_TYPE.MODIFIED
         old_filename = None
@@ -96,7 +94,7 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
         files.append(FilePatchInfo(
             base_file="".join(base_lines),
             head_file="".join(head_lines),
-            patch=patch,
+            patch=to_hunk_only_patch("".join(section)),
             filename=filename,
             edit_type=edit_type,
             old_filename=old_filename,

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -870,7 +870,7 @@ class TestBitbucketServerProvider:
             FilePatchInfo(
                 'file\nwith\nmultiple \nlines\nto\nemulate\na\nreal\nfile\n',
                 'file\nwith\nmultiple \nlines\nto\nemulate\na\nfake\nfile\n',
-                '--- \n+++ \n@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n+fake\n file\n',
+                '@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n+fake\n file\n',
                 'Readme.md',
                 edit_type=EDIT_TYPE.MODIFIED,
             )
@@ -930,7 +930,7 @@ class TestBitbucketServerProvider:
             FilePatchInfo(
                 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n',
                 'file\nwith\nsome\nlines\nto\nemulate\na\nfake\ntest\n',
-                '--- \n+++ \n@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n-file\n+fake\n+test\n',
+                '@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n-file\n+fake\n+test\n',
                 'Readme.md',
                 edit_type=EDIT_TYPE.MODIFIED,
             )
@@ -1007,7 +1007,7 @@ class TestBitbucketServerProvider:
             FilePatchInfo(
                 'file\nwith\nmultiple\nlines\nto\nemulate\na\nreal\nfile',
                 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile',
-                '--- \n+++ \n@@ -1,9 +1,9 @@\n-file\n-with\n-multiple\n+readme\n+without\n+some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
+                '@@ -1,9 +1,9 @@\n-file\n-with\n-multiple\n+readme\n+without\n+some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
                 'Readme.md',
                 edit_type=EDIT_TYPE.MODIFIED,
             )
@@ -1029,7 +1029,7 @@ class TestBitbucketServerProvider:
             FilePatchInfo(
                 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile',
                 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile',
-                '--- \n+++ \n@@ -1,9 +1,9 @@\n-file\n-with\n+readme\n+without\n some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
+                '@@ -1,9 +1,9 @@\n-file\n-with\n+readme\n+without\n some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
                 'Readme.md',
                 edit_type=EDIT_TYPE.MODIFIED,
             )
@@ -1051,7 +1051,7 @@ class TestBitbucketServerProvider:
             FilePatchInfo(
                 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile',
                 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile',
-                '--- \n+++ \n@@ -1,9 +1,9 @@\n-file\n-with\n+readme\n+without\n some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
+                '@@ -1,9 +1,9 @@\n-file\n-with\n+readme\n+without\n some\n lines\n to\n-emulate\n+simulate\n a\n real\n file\n',
                 'Readme.md',
                 edit_type=EDIT_TYPE.MODIFIED,
             )

--- a/tests/unittest/test_extend_patch.py
+++ b/tests/unittest/test_extend_patch.py
@@ -183,8 +183,6 @@ class TestLoadLargeDiff:
                                 old content 2""")
 
         patch_expected="""\
---- 
-+++ 
 @@ -1,3 +1,3 @@
 -
                                  old content 1
@@ -198,7 +196,7 @@ class TestLoadLargeDiff:
         assert load_large_diff("test.py", "", "") == ""
         assert load_large_diff("test.py", None, None) == ""
         assert (load_large_diff("test.py", "content\n", "") ==
-                '--- \n+++ \n@@ -1 +1 @@\n-\n+content\n')
+                '@@ -1 +1 @@\n-\n+content\n')
 
 class TestOmittedHunkCount:
     def test_omitted_count_is_parsed_as_one(self):

--- a/tests/unittest/test_hunk_header_parse_guard.py
+++ b/tests/unittest/test_hunk_header_parse_guard.py
@@ -1,4 +1,4 @@
-"""Parse a patch without crashing on a '@@' line that is not a unified hunk header."""
+"""Guard numbered diff rendering around malformed hunks and file metadata."""
 from pr_agent.algo.git_patch_processing import (
     decouple_and_convert_to_hunks_with_lines_numbers,
     extract_hunk_lines_from_patch,
@@ -7,6 +7,16 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 COMBINED = "@@@ -1,2 -1,2 +1,2 @@@\n- a\n +b\n  c"
 NORMAL = "@@ -1,2 +1,2 @@\n ctx\n-old\n+new"
+WITH_FILE_HEADERS = (
+    "diff --git a/m.py b/m.py\n"
+    "index 1111111..2222222 100644\n"
+    "--- a/m.py\n"
+    "+++ b/m.py\n"
+    "@@ -1,2 +1,2 @@\n"
+    " ctx\n"
+    "-old\n"
+    "+new"
+)
 
 
 def _file():
@@ -27,6 +37,13 @@ def test_decouple_still_renders_a_normal_hunk():
 
     assert "__new hunk__" in out
     assert "+new" in out
+
+
+def test_decouple_ignores_file_headers_before_the_first_hunk():
+    expected = decouple_and_convert_to_hunks_with_lines_numbers(NORMAL, _file())
+    actual = decouple_and_convert_to_hunks_with_lines_numbers(WITH_FILE_HEADERS, _file())
+
+    assert actual == expected
 
 
 def test_a_valid_hunk_after_an_invalid_header_is_still_rendered():

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -39,13 +39,25 @@ class TestParseUnifiedDiff:
         assert added.filename == "added.py"
         assert added.edit_type == EDIT_TYPE.ADDED
         assert "def hello():" in added.patch
-        assert added.patch.startswith("diff --git a/added.py b/added.py")
+        assert added.patch.startswith("@@")
 
         assert existing.filename == "existing.py"
         assert existing.edit_type == EDIT_TYPE.MODIFIED
-        # patch preserved verbatim for the section
+        assert existing.patch.startswith("@@")
         assert "-x = 1" in existing.patch
         assert "+x = 2" in existing.patch
+        for diff_file in files:
+            assert "diff --git" not in diff_file.patch
+            assert "--- " not in diff_file.patch
+            assert "+++ " not in diff_file.patch
+
+    def test_crlf_input_stores_hunk_only_patch(self):
+        files = parse_unified_diff(TWO_FILE_DIFF.replace("\n", "\r\n"))
+
+        assert len(files) == 2
+        assert all(diff_file.patch.startswith("@@") for diff_file in files)
+        assert all("\r\n" in diff_file.patch for diff_file in files)
+        assert all("diff --git" not in diff_file.patch for diff_file in files)
 
     def test_head_base_reconstruction(self):
         files = parse_unified_diff(TWO_FILE_DIFF)
@@ -75,6 +87,7 @@ class TestParseUnifiedDiff:
         assert files[0].edit_type == EDIT_TYPE.RENAMED
         assert files[0].filename == "new.py"
         assert files[0].old_filename == "old.py"
+        assert files[0].patch == ""
 
 
 class TestProviderRegistration:

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import pr_agent.tools.pr_code_suggestions as pr_code_suggestions_module
-from pr_agent.algo.pr_processing import retry_with_fallback_models
+from pr_agent.algo.pr_processing import pr_generate_extended_diff, retry_with_fallback_models
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.algo.utils import PRCodeSuggestionsHeader, PRCodeSuggestionsIdentity
+from pr_agent.algo.utils import PRCodeSuggestionsHeader, PRCodeSuggestionsIdentity, load_large_diff
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import AzureDevopsProvider
 from pr_agent.git_providers.git_provider import GitProvider, IncrementalPR
@@ -65,6 +65,39 @@ code_suggestions:
     assert len(data["code_suggestions"]) == 1
     assert data["code_suggestions"][0]["one_sentence_summary"] == "Avoid duplicated work"
     assert data["code_suggestions"][0]["improved_code"] == "new()"
+
+
+@pytest.mark.asyncio
+async def test_convert_to_decoupled_uses_normalized_diff_and_keeps_ai_summary():
+    settings_snapshot = snapshot_settings(("config.enable_ai_metadata",))
+    token_handler = MagicMock(prompt_tokens=0)
+    token_handler.count_tokens.return_value = 1
+    file = FilePatchInfo(
+        base_file="old\n",
+        head_file="new\n",
+        patch=load_large_diff("app.py", "new\n", "old\n"),
+        filename="app.py",
+        ai_file_summary={"long_summary": "Keep the existing summary."},
+    )
+    try:
+        get_settings().set("config.enable_ai_metadata", True)
+        patches, _, _ = pr_generate_extended_diff(
+            [{"language": "Python", "files": [file]}],
+            token_handler,
+            add_line_numbers_to_hunks=False,
+        )
+    finally:
+        restore_settings(settings_snapshot)
+    tool = _make_tool()
+    tool.token_handler = token_handler
+
+    result = await tool.convert_to_decoupled_with_line_numbers(patches, "gpt-4o-mini")
+
+    assert len(result) == 1
+    assert "### AI-generated changes summary:" in result[0]
+    assert "Keep the existing summary." in result[0]
+    assert not any(line.startswith(("---", "+++")) for line in result[0].splitlines())
+    assert "1 +new" in result[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #3032, extending the same header-normalization behavior to generated and supplied diffs.

## Summary

- normalize patches from `load_large_diff` and MOSAICO before they reach prompt rendering
- ignore metadata before the first valid hunk in the shared numbered-hunk renderer
- keep the existing `to_hunk_only_patch` import path compatible and cover the affected provider paths

## Result

File headers such as `--- a/app.py` and `+++ b/app.py` are no longer included as changed source lines. The first real added line remains `1 +new`.

## Testing

- focused diff, provider, and code-suggestion tests: 211 passed
- full unit suite: 3726 passed, 1 skipped, 1 xfailed
- Ruff on the changed files: passed
