### PR TITLE
fix(review): keep the persistent review when the agent identity is unproven

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from github import AppAuthentication, Auth, Github, GithubException
+from github import AppAuthentication, Auth, Github, GithubException, GithubIntegration
 from github.Issue import Issue
 from retry.api import retry_call
 from starlette_context import context
@@ -433,17 +433,70 @@ class GithubProvider(GitProvider):
         return True
 
     def supports_review_finding_state(self) -> bool:
-        deployment_type = getattr(self, "deployment_type", None)
-        if deployment_type is None:
-            deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
+        deployment_type = self._deployment_type()
         # User deployments resolve the authenticated account through the API.
-        # App deployments require a login grounded in a trusted provider response.
+        # App deployments resolve their own `<slug>[bot]` login through the app JWT.
         if deployment_type == "user":
             return True
         if deployment_type == "app":
-            cached_login = getattr(self, "github_user_id", None)
-            return isinstance(cached_login, str) and bool(cached_login.strip())
+            return bool(self._agent_login())
         return False
+
+    def _deployment_type(self) -> str:
+        deployment_type = getattr(self, "deployment_type", None)
+        if deployment_type is None:
+            deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
+        return deployment_type
+
+    def _resolve_app_login(self) -> str:
+        """Return the app's own `<slug>[bot]` login, or "" when it cannot be resolved.
+
+        An app authenticates the API with an installation token, which cannot call
+        `GET /user`. The app's slug comes from the app JWT instead, so the identity does
+        not depend on PR-Agent having already commented on the pull request.
+        """
+        cached = getattr(self, "_app_login", None)
+        if isinstance(cached, str):
+            return cached
+        self._app_login = ""
+        try:
+            integration = GithubIntegration(
+                integration_id=str(get_settings().github.app_id),
+                private_key=get_settings().github.private_key,
+                base_url=self.base_url,
+            )
+            slug = (getattr(integration.get_app(), "slug", "") or "").strip()
+            if slug:
+                self._app_login = f"{slug}[bot]"
+        except Exception as e:
+            get_logger().warning(f"Could not resolve the GitHub App login: {e}")
+        return self._app_login
+
+    def _resolve_user_login(self) -> str:
+        """Return the authenticated login, falling back to the Actions bot identity.
+
+        The workflow token cannot call `GET /user`, but every comment it posts is
+        authored by `github-actions[bot]`.
+        """
+        try:
+            login = self.get_user_id()
+        except Exception as e:
+            get_logger().warning(f"Could not resolve the GitHub user login: {e}")
+            login = ""
+        if isinstance(login, str) and login.strip():
+            return login.strip()
+        if os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true":
+            return "github-actions[bot]"
+        return ""
+
+    def _agent_login(self) -> str:
+        """Login PR-Agent posts as, or "" when this deployment cannot establish one."""
+        cached = getattr(self, "github_user_id", None)
+        if isinstance(cached, str) and cached.strip():
+            return cached.strip()
+        if self._deployment_type() == "app":
+            return self._resolve_app_login()
+        return self._resolve_user_login()
 
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
         if isinstance(comment, dict):
@@ -457,22 +510,12 @@ class GithubProvider(GitProvider):
         if not isinstance(login, str) or not login.strip():
             raise RuntimeError("GitHub comment author cannot be verified")
 
-        deployment_type = getattr(self, "deployment_type", None)
-        if deployment_type is None:
-            deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
-        if deployment_type not in {"user", "app"}:
+        if self._deployment_type() not in {"user", "app"}:
             raise RuntimeError("Unsupported GitHub deployment identity")
 
-        agent_login = getattr(self, "github_user_id", None)
-        if not isinstance(agent_login, str) or not agent_login.strip():
-            if deployment_type == "app":
-                raise RuntimeError("GitHub App identity cannot be verified")
-            try:
-                agent_login = self.get_user_id()
-            except Exception as error:
-                raise RuntimeError("GitHub user identity cannot be verified") from error
-        if not isinstance(agent_login, str) or not agent_login.strip():
-            raise RuntimeError("GitHub user identity cannot be verified")
+        agent_login = self._agent_login()
+        if not agent_login:
+            raise RuntimeError("GitHub identity cannot be verified")
         return login.casefold() == agent_login.casefold()
 
     def _publish_check_run(self, text: str, name: str) -> bool:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -456,9 +456,8 @@ class GithubProvider(GitProvider):
         not depend on PR-Agent having already commented on the pull request.
         """
         cached = getattr(self, "_app_login", None)
-        if isinstance(cached, str):
+        if isinstance(cached, str) and cached:
             return cached
-        self._app_login = ""
         try:
             integration = GithubIntegration(
                 integration_id=str(get_settings().github.app_id),
@@ -467,16 +466,30 @@ class GithubProvider(GitProvider):
             )
             slug = (getattr(integration.get_app(), "slug", "") or "").strip()
             if slug:
+                # Only a success is cached. Caching the failure too would let one timed-out
+                # `GET /app` demote every later command in the same request, which is the
+                # behaviour this change exists to remove.
                 self._app_login = f"{slug}[bot]"
+                return self._app_login
         except Exception as e:
             get_logger().warning(f"Could not resolve the GitHub App login: {e}")
-        return self._app_login
+        return ""
 
     def _resolve_user_login(self) -> str:
         """Return the authenticated login, falling back to the Actions bot identity.
 
-        The workflow token cannot call `GET /user`, but every comment it posts is
-        authored by `github-actions[bot]`.
+        The workflow token cannot call `GET /user`, but every comment it posts is authored by
+        `github-actions[bot]`.
+
+        This fallback is a deliberate widening, and the one place where the identity is assumed
+        rather than read: inside a GitHub Actions run the workflow token is the only credential
+        PR-Agent has, so a comment marked as PR-Agent's and authored by `github-actions[bot]`
+        will be edited. Anything else in the same workflow that posts under the workflow token -
+        another action, another step - shares that identity. The exposure is bounded by the
+        identity marker (the comment must already carry PR-Agent's own marker) and by the fact
+        that GitHub reserves the `[bot]` suffix, so no human account can hold this login. It
+        applies only when `GITHUB_ACTIONS=true` and `GET /user` failed; a deployment that can
+        resolve its real login never reaches it.
         """
         try:
             login = self.get_user_id()

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -325,6 +325,11 @@ class PRReviewer:
                     persistent_write_failed = not self._persistent_publish_succeeded(result)
                     if persistent_write_failed:
                         review_failed = True
+                elif self._persistent_review_comment_exists() is False:
+                    # There is no review comment to replace, so creating one cannot overwrite
+                    # a comment PR-Agent did not author. An identity this deployment cannot
+                    # resolve is not a reason to demote the canonical review.
+                    self.git_provider.publish_persistent_comment(pr_review, **persistent_args)
                 else:
                     # An unverified provider identity must never update a canonical review.
                     self.git_provider.publish_comment(
@@ -448,6 +453,27 @@ class PRReviewer:
             and implementation is not GitProvider.supports_review_finding_state
         )
 
+    def _persistent_review_comment_exists(self) -> Optional[bool]:
+        """Whether a comment already carries the full-review identity.
+
+        Returns None when the provider's comments could not be read at all, so a caller
+        that must not overwrite an existing review can stay conservative.
+        """
+        provider = getattr(self, "git_provider", None)
+        if provider is None:
+            return None
+        try:
+            for _comment, _body in GitProvider._iter_persistent_comments(
+                provider,
+                get_pr_review_comment_identifiers(full=True, incremental=False),
+                identity_marker=PRReviewIdentity.REGULAR.value,
+            ):
+                return True
+            return False
+        except Exception as error:
+            get_logger().warning(f"Could not read the existing review comments: {error}")
+            return None
+
     def _review_comment_authorship_available(self) -> bool:
         provider = getattr(self, "git_provider", None)
         if provider is None:
@@ -538,7 +564,12 @@ class PRReviewer:
         for issue in issues:
             finding = cls._review_finding_from_issue(issue)
             if finding is None:
-                return None
+                # A key issue without a file or a body cannot be tracked across runs, but the
+                # review summary still renders it; dropping the entry keeps the lifecycle state
+                # of every other finding instead of discarding the whole review.
+                get_logger().debug("Skipping a key issue that carries no trackable location",
+                                   artifact={"issue": issue})
+                continue
             findings.append(finding)
         return findings
 
@@ -611,12 +642,19 @@ class PRReviewer:
             max_findings = int(get_settings().pr_reviewer.num_max_findings)
         except (TypeError, ValueError):
             max_findings = 0
+        reported_issues = data["review"].get("key_issues_to_review")
+        dropped_findings = (
+            isinstance(reported_issues, list)
+            and len(current_findings) < len(reported_issues)
+        )
         allow_resolution = (
             bool(self.prediction)
             and not bool(getattr(self.incremental, "is_incremental", False))
             and not bool(self.remaining_files_list)
             and parsed.valid
             and current_findings is not None
+            # a dropped finding is not an absent one, so this run cannot resolve anything
+            and not dropped_findings
             and len(current_findings) < max_findings
         )
         result = reconcile_review_findings(

--- a/tests/unittest/test_review_persistent_comment_authorship.py
+++ b/tests/unittest/test_review_persistent_comment_authorship.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock
 import pytest
 from github import GithubException
 
-import pr_agent.tools.pr_reviewer as reviewer_module
 from pr_agent.algo.review_finding_state import append_review_state, reconcile_review_findings
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, add_pr_review_identity
@@ -164,9 +163,9 @@ def _github_provider(monkeypatch, deployment_type, comments, bot_login, user_log
 
 
 def _wire_reviewer(monkeypatch, provider):
-    monkeypatch.setattr(reviewer_module, "get_git_provider_with_context", lambda url: provider)
-    monkeypatch.setattr(reviewer_module, "build_repo_context", lambda git_provider: "")
-    monkeypatch.setattr(reviewer_module, "get_skills_context", lambda: "")
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.get_git_provider_with_context", lambda url: provider)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.build_repo_context", lambda git_provider: "")
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.get_skills_context", lambda: "")
 
     async def no_tickets(git_provider, vars):
         return None
@@ -174,9 +173,9 @@ def _wire_reviewer(monkeypatch, provider):
     async def direct_model(f, model_type=None):
         return await f("gpt-4o")
 
-    monkeypatch.setattr(reviewer_module, "extract_and_cache_pr_tickets", no_tickets)
-    monkeypatch.setattr(reviewer_module, "get_pr_diff", lambda *args, **kwargs: (DIFF, []))
-    monkeypatch.setattr(reviewer_module, "retry_with_fallback_models", direct_model)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", no_tickets)
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.get_pr_diff", lambda *args, **kwargs: (DIFF, []))
+    monkeypatch.setattr("pr_agent.tools.pr_reviewer.retry_with_fallback_models", direct_model)
 
 
 @pytest.fixture
@@ -352,3 +351,66 @@ def test_unusable_key_issues_are_dropped_without_discarding_the_rest():
 def test_missing_key_issue_collection_still_fails_closed():
     assert PRReviewer._review_findings_from_data({"review": {}}) is None
     assert PRReviewer._review_findings_from_data({"review": {"key_issues_to_review": {"a": 1}}}) is None
+
+
+# --------------------------------------------------------------------------------------
+# A failed app-login resolution must not poison the rest of the request.
+#
+# `github_app` runs several commands against one provider instance. Caching the empty result
+# of a timed-out `GET /app` would demote every command after the first, which is the exact
+# behaviour this change exists to remove.
+# --------------------------------------------------------------------------------------
+def test_a_transient_app_login_failure_is_retried(monkeypatch):
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.deployment_type = "app"
+    monkeypatch.setattr(get_settings(), "github", SimpleNamespace(
+        app_id="1", private_key="key", deployment_type="app"), raising=False)
+    attempts = []
+
+    def integration(**kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("connection reset")
+        return SimpleNamespace(get_app=lambda: SimpleNamespace(slug="pr-agent"))
+
+    monkeypatch.setattr("pr_agent.git_providers.github_provider.GithubIntegration", integration)
+
+    assert provider._resolve_app_login() == ""
+    assert provider._resolve_app_login() == "pr-agent[bot]"
+    assert len(attempts) == 2
+
+
+def test_a_resolved_app_login_is_cached(monkeypatch):
+    """Control: the successful answer is still resolved once per provider instance."""
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.deployment_type = "app"
+    monkeypatch.setattr(get_settings(), "github", SimpleNamespace(
+        app_id="1", private_key="key", deployment_type="app"), raising=False)
+    attempts = []
+
+    def integration(**kwargs):
+        attempts.append(1)
+        return SimpleNamespace(get_app=lambda: SimpleNamespace(slug="pr-agent"))
+
+    monkeypatch.setattr("pr_agent.git_providers.github_provider.GithubIntegration", integration)
+
+    assert provider._resolve_app_login() == "pr-agent[bot]"
+    assert provider._resolve_app_login() == "pr-agent[bot]"
+    assert len(attempts) == 1
+
+
+def test_an_app_that_never_resolves_stays_unproven(monkeypatch):
+    """Control: the conservative outcome is unchanged when the JWT route is unavailable."""
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.deployment_type = "app"
+    monkeypatch.setattr(get_settings(), "github", SimpleNamespace(
+        app_id="1", private_key="key", deployment_type="app"), raising=False)
+    monkeypatch.setattr("pr_agent.git_providers.github_provider.GithubIntegration",
+                        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("no private key")))
+
+    assert provider._agent_login() == ""
+    with pytest.raises(RuntimeError):
+        provider.is_comment_authored_by_pr_agent(SimpleNamespace(user=SimpleNamespace(login="someone")))

--- a/tests/unittest/test_review_persistent_comment_authorship.py
+++ b/tests/unittest/test_review_persistent_comment_authorship.py
@@ -1,0 +1,354 @@
+"""The persistent review must survive an identity PR-Agent cannot prove up front.
+
+`persistent_comment` (default true) promises that "every new review request will edit the
+previous one". Verifying that PR-Agent authored the comment it is about to edit protects a
+comment it did not write; it must not cost the persistent review in deployments where the
+identity is merely unresolved:
+
+- a GitHub App running an automatic command publishes no progress comment, so no earlier
+  comment has taught the provider its own login;
+- a GitHub Actions token cannot call `GET /user`;
+- Azure DevOps ships `agent_identity = ""`.
+
+Creating the first review comment overwrites nothing, so an unverified identity is not a
+reason to demote it. Editing an existing comment still requires proof of authorship.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from github import GithubException
+
+import pr_agent.tools.pr_reviewer as reviewer_module
+from pr_agent.algo.review_finding_state import append_review_state, reconcile_review_findings
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity, add_pr_review_identity
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.azuredevops_provider import AzureDevopsProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+PR_URL = "https://github.com/org/repo/pull/1"
+HEAD_FILE = "def retry():\n    attempts = 0\n    while attempts < 3:\n        pass\n"
+PATCH = "@@ -1,3 +1,4 @@\n def retry():\n     attempts = 0\n+    while attempts < 3:\n+        pass\n"
+DIFF = "## File: 'src/app.py'\n\n" + PATCH
+STANDALONE_HEADING = "## Standalone PR Review"
+
+REVIEW_YAML = """review:
+  estimated_effort_to_review_[1-5]: |
+    2
+  relevant_tests: |
+    No
+  key_issues_to_review:
+    - relevant_file: |
+        src/app.py
+      issue_header: |
+        Possible Bug
+      issue_content: |
+        The retry loop never increments `attempts`, so it spins forever.
+      start_line: 3
+      end_line: 4
+  security_concerns: |
+    No
+"""
+
+# The prompt asks every key issue for a file, but a model that summarises one finding
+# without a location is ordinary. The review summary renders such an entry.
+REVIEW_YAML_ISSUE_WITHOUT_FILE = """review:
+  estimated_effort_to_review_[1-5]: |
+    2
+  relevant_tests: |
+    No
+  key_issues_to_review:
+    - relevant_file: |
+        src/app.py
+      issue_header: |
+        Possible Bug
+      issue_content: |
+        The retry loop never increments `attempts`, so it spins forever.
+      start_line: 3
+      end_line: 4
+    - relevant_file: ""
+      issue_header: |
+        Missing tests
+      issue_content: |
+        The PR adds retry logic without any test exercising the failure path.
+      start_line: 0
+      end_line: 0
+  security_concerns: |
+    No
+"""
+
+
+class FakeAIHandler:
+    response = REVIEW_YAML
+    main_pr_language = None
+
+    async def chat_completion(self, model, system, user, temperature=0.2, img_path=None):
+        return self.response, "stop"
+
+
+class FakeComment:
+    _next_id = 1000
+
+    def __init__(self, body, login):
+        FakeComment._next_id += 1
+        self.id = FakeComment._next_id
+        self.body = body
+        self.user = SimpleNamespace(login=login, type="Bot")
+        self.html_url = f"{PR_URL}#issuecomment-{self.id}"
+        self.edits = []
+        self.deleted = False
+
+    def edit(self, body):
+        self.edits.append(body)
+        self.body = body
+
+    def delete(self):
+        self.deleted = True
+
+
+class FakePR:
+    def __init__(self, comments, bot_login):
+        self.title = "Add retry loop"
+        self.body = "Adds a retry loop."
+        self.head = SimpleNamespace(ref="feature/retry", sha="abc123")
+        self.comments = list(comments)
+        self.created = []
+        self.bot_login = bot_login
+
+    def get_issue_comments(self):
+        return list(self.comments)
+
+    def create_issue_comment(self, body):
+        comment = FakeComment(body, self.bot_login)
+        self.comments.append(comment)
+        self.created.append(comment)
+        return comment
+
+
+def _stub_pr_data(provider, pr):
+    provider.pr = pr
+    provider.repo = "org/repo"
+    provider.pr_num = 1
+    provider.pr_url = PR_URL
+    provider.last_commit_id = SimpleNamespace(sha="abc123", html_url="https://github.com/org/repo/commit/abc123")
+    provider.diff_files = [FilePatchInfo(base_file="def retry():\n    attempts = 0\n", head_file=HEAD_FILE,
+                                         patch=PATCH, filename="src/app.py", edit_type=EDIT_TYPE.MODIFIED)]
+    provider.get_languages = lambda: {"Python": 100}
+    provider.get_files = lambda: ["src/app.py"]
+    provider.get_diff_files = lambda: provider.diff_files
+    provider.get_num_of_files = lambda: 1
+    provider.get_commit_messages = lambda: ""
+    provider.get_pr_description = lambda full=True, split_changes_walkthrough=False: ("Adds a retry loop.", [])
+    provider.get_pr_branch = lambda: "feature/retry"
+
+
+def _github_provider(monkeypatch, deployment_type, comments, bot_login, user_login=None):
+    """A real GithubProvider whose PyGithub client is faked.
+
+    user_login=None models a token that cannot call `GET /user`, which is what an
+    installation token (including the Actions GITHUB_TOKEN) answers with.
+    """
+    client = MagicMock()
+    if user_login is None:
+        client.get_user.side_effect = GithubException(403, {"message": "Resource not accessible by integration"}, None)
+    else:
+        client.get_user.return_value = SimpleNamespace(raw_data={"login": user_login})
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: client)
+    provider = GithubProvider(pr_url=None)
+    provider.deployment_type = deployment_type
+    provider.github_client = client
+    _stub_pr_data(provider, FakePR(comments, bot_login))
+    return provider
+
+
+def _wire_reviewer(monkeypatch, provider):
+    monkeypatch.setattr(reviewer_module, "get_git_provider_with_context", lambda url: provider)
+    monkeypatch.setattr(reviewer_module, "build_repo_context", lambda git_provider: "")
+    monkeypatch.setattr(reviewer_module, "get_skills_context", lambda: "")
+
+    async def no_tickets(git_provider, vars):
+        return None
+
+    async def direct_model(f, model_type=None):
+        return await f("gpt-4o")
+
+    monkeypatch.setattr(reviewer_module, "extract_and_cache_pr_tickets", no_tickets)
+    monkeypatch.setattr(reviewer_module, "get_pr_diff", lambda *args, **kwargs: (DIFF, []))
+    monkeypatch.setattr(reviewer_module, "retry_with_fallback_models", direct_model)
+
+
+@pytest.fixture
+def review_settings(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings.config, "publish_output", True)
+    monkeypatch.setattr(settings.config, "publish_output_progress", True)
+    monkeypatch.setattr(settings.config, "git_provider", "github")
+    monkeypatch.setattr(settings.config, "is_auto_command", False, raising=False)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_comment", True)
+    monkeypatch.setattr(settings.pr_reviewer, "persistent_finding_state", True, raising=False)
+    monkeypatch.setattr(settings.pr_reviewer, "final_update_message", False)
+    monkeypatch.setattr(settings.pr_reviewer, "enable_review_labels_effort", False)
+    monkeypatch.setattr(settings.pr_reviewer, "enable_review_labels_security", False)
+    monkeypatch.setattr(settings.pr_reviewer, "inline_key_issues", False, raising=False)
+    monkeypatch.setattr(settings.github, "publish_as_check_run", False, raising=False)
+    monkeypatch.setattr(settings.azure_devops_server, "agent_identity", "", raising=False)
+    monkeypatch.setattr(FakeAIHandler, "response", REVIEW_YAML)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    return settings
+
+
+def _previous_persistent_review(body_text="previous review body"):
+    finding = {"path": "src/app.py", "body": "**Possible Issue**\n\nOld wording of the finding.",
+               "line_start": 3, "line_end": 4}
+    state = reconcile_review_findings(None, [finding], allow_resolution=False, head_sha="0ld5ha").state
+    body = (f"{PRReviewHeader.REGULAR.value} 🔍\n\n{PRReviewIdentity.REGULAR.value}\n\n"
+            f"<table><tr><td>{body_text}</td></tr></table>")
+    return append_review_state(body, state)
+
+
+async def test_github_app_auto_review_creates_the_persistent_review(monkeypatch, review_settings):
+    """An automatic App command has no earlier comment to learn its login from."""
+    review_settings.set("CONFIG.IS_AUTO_COMMAND", True)
+    provider = _github_provider(monkeypatch, "app", comments=[], bot_login="pr-agent[bot]")
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    created = provider.pr.created
+    assert len(created) == 1
+    body = created[0].body
+    assert not body.startswith(STANDALONE_HEADING)
+    assert body.startswith(PRReviewHeader.REGULAR.value)
+    assert PRReviewIdentity.REGULAR.value in body
+
+
+async def test_github_actions_rerun_edits_the_previous_review(monkeypatch, review_settings):
+    """Under Actions the token cannot resolve itself, but its comment login is known."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    review_settings.set("CONFIG.IS_AUTO_COMMAND", True)
+    previous = FakeComment(_previous_persistent_review(), "github-actions[bot]")
+    provider = _github_provider(monkeypatch, "user", comments=[previous],
+                                bot_login="github-actions[bot]", user_login=None)
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    assert [c for c in provider.pr.created if not c.deleted] == []
+    assert len(previous.edits) == 1
+    assert not previous.body.startswith(STANDALONE_HEADING)
+
+
+async def test_review_with_a_fileless_key_issue_still_updates_the_persistent_review(monkeypatch, review_settings):
+    """One unusable key issue must not discard the lifecycle state of the others."""
+    monkeypatch.setattr(FakeAIHandler, "response", REVIEW_YAML_ISSUE_WITHOUT_FILE)
+    previous = FakeComment(_previous_persistent_review(), "reviewer-bot")
+    provider = _github_provider(monkeypatch, "user", comments=[previous],
+                                bot_login="reviewer-bot", user_login="reviewer-bot")
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    assert not any(c.body.startswith(STANDALONE_HEADING) for c in provider.pr.created)
+    assert len(previous.edits) == 1
+    assert "Missing tests" in previous.body
+
+
+async def test_azure_devops_without_configured_identity_creates_the_persistent_review(
+    monkeypatch, review_settings
+):
+    """`agent_identity` is empty by default and there is no comment to overwrite."""
+    monkeypatch.setattr(review_settings.config, "git_provider", "azure")
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.incremental = SimpleNamespace(is_incremental=False)
+    provider._threads_cache = None
+    calls = {"persistent": [], "plain": []}
+    _stub_pr_data(provider, FakePR([], "pr-agent"))
+    provider.get_issue_comments = lambda: []
+    provider.get_issue_comments_newest_first = lambda: []
+    provider.publish_comment = lambda body, is_temporary=False, **kw: (
+        calls["plain"].append(body) or SimpleNamespace(id=1))
+    provider.publish_persistent_comment = lambda body, *a, **kw: calls["persistent"].append(body)
+    provider.publish_persistent_comment_full = lambda body, *a, **kw: (
+        calls["persistent"].append(body) or SimpleNamespace(id=2))
+    provider.remove_comment = lambda comment: None
+    provider.is_supported = lambda capability: True
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    assert not any(body.startswith(STANDALONE_HEADING) for body in calls["plain"])
+    assert len(calls["persistent"]) == 1
+
+
+async def test_control_github_pat_rerun_edits_the_previous_review(monkeypatch, review_settings):
+    """A resolvable identity keeps the pre-existing behaviour untouched."""
+    previous = FakeComment(_previous_persistent_review(), "reviewer-bot")
+    provider = _github_provider(monkeypatch, "user", comments=[previous],
+                                bot_login="reviewer-bot", user_login="reviewer-bot")
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    assert [c for c in provider.pr.created if not c.deleted] == []
+    assert len(previous.edits) == 1
+    assert PRReviewIdentity.REGULAR.value in previous.body
+    assert "pr-agent-review-state:v1" in previous.body
+
+
+async def test_forged_review_comment_is_never_edited(monkeypatch, review_settings):
+    """A comment carrying the identity marker but written by somebody else stays untouched."""
+    review_settings.set("CONFIG.IS_AUTO_COMMAND", True)
+    forged_body = add_pr_review_identity("forged review", PRReviewIdentity.REGULAR.value)
+    forged = FakeComment(forged_body, "impostor")
+    provider = _github_provider(monkeypatch, "app", comments=[forged], bot_login="pr-agent[bot]")
+    provider.github_client.get_user.side_effect = GithubException(403, {"message": "no"}, None)
+    monkeypatch.setattr(GithubProvider, "_resolve_app_login", lambda self: "")
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    assert forged.body == forged_body
+    assert forged.edits == []
+    created = [c.body for c in provider.pr.created if not c.deleted]
+    assert len(created) == 1
+    assert created[0].startswith(STANDALONE_HEADING)
+
+
+async def test_unreadable_comments_do_not_create_a_second_review(monkeypatch, review_settings):
+    """When the comment list cannot be read, PR-Agent cannot know what it would replace."""
+    review_settings.set("CONFIG.IS_AUTO_COMMAND", True)
+    provider = _github_provider(monkeypatch, "app", comments=[], bot_login="pr-agent[bot]")
+    monkeypatch.setattr(GithubProvider, "_resolve_app_login", lambda self: "")
+
+    def unreadable():
+        raise GithubException(502, {"message": "Server Error"}, None)
+
+    provider.pr.get_issue_comments = unreadable
+    _wire_reviewer(monkeypatch, provider)
+
+    await PRReviewer(PR_URL, ai_handler=FakeAIHandler).run()
+
+    created = [c.body for c in provider.pr.created if not c.deleted]
+    assert len(created) == 1
+    assert created[0].startswith(STANDALONE_HEADING)
+
+
+def test_unusable_key_issues_are_dropped_without_discarding_the_rest():
+    data = {"review": {"key_issues_to_review": [
+        {"relevant_file": "src/app.py", "issue_header": "Possible Bug",
+         "issue_content": "Real finding.", "start_line": 3, "end_line": 4},
+        {"relevant_file": "", "issue_header": "Missing tests", "issue_content": "No location."},
+        {"relevant_file": "src/app.py", "issue_header": "Empty", "issue_content": ""},
+    ]}}
+
+    findings = PRReviewer._review_findings_from_data(data)
+
+    assert [finding["path"] for finding in findings] == ["src/app.py"]
+    assert "Real finding." in findings[0]["body"]
+
+
+def test_missing_key_issue_collection_still_fails_closed():
+    assert PRReviewer._review_findings_from_data({"review": {}}) is None
+    assert PRReviewer._review_findings_from_data({"review": {"key_issues_to_review": {"a": 1}}}) is None


### PR DESCRIPTION
Closes #3071.

## Description

`persistent_comment` (default `true`) promises that "every new review request will edit the previous one".
Since #2722 the reviewer refuses to touch a review comment unless the provider can *prove* PR-Agent authored
it, and demotes the result to a `## Standalone PR Review` comment otherwise. In three ordinary deployments the
identity is merely *unresolved* rather than *foreign*, so the promise is broken on every run.

### Root cause

`PRReviewer.run()` reaches the demotion whenever `_review_finding_state_in_play()` is true (any provider that
overrides `supports_review_finding_state`) but `_review_comment_authorship_available()` is false:

| Trigger | Why the identity is unknown |
|---|---|
| GitHub App, any automatic command (`pr_commands`, `push_commands`, `review_commands`) | In app mode the login was only ever cached by `publish_comment`, i.e. by the *"Preparing review…"* progress comment — which `config.is_auto_command` suppresses. |
| GitHub Actions, every rerun | `deployment_type=user` with `GITHUB_TOKEN`; `GET /user` answers 403 *"Resource not accessible by integration"*, so `is_comment_authored_by_pr_agent` raises and the run is treated as a provider read failure. |
| Azure DevOps, shipped configuration | `supports_review_finding_state()` is `bool(_configured_stable_agent_identities())` and `configuration.toml` ships `agent_identity = ""`. |
| Any provider, when one key issue lacks a file or body | `_review_findings_from_data` returned `None` for the whole collection, blocking the state and demoting the review. |

### The fix

Three changes, each addressing one link in that chain:

1. **`github_provider.py` — resolve the identity instead of giving up.** App deployments read their own
   `<slug>[bot]` login from the app JWT (`GithubIntegration.get_app()`), which does not depend on having
   commented before. User deployments that cannot call `GET /user` fall back to `github-actions[bot]` when
   `GITHUB_ACTIONS=true`, which is the login the workflow token posts as.
2. **`pr_reviewer.py` — separate creating from updating.** When no comment carries the full-review identity,
   creating one cannot overwrite a comment PR-Agent did not author, so the review is published persistently.
   The demotion is kept for the case it was written for: a comment already exists and authorship is unproven.
3. **`pr_reviewer.py` — drop an untrackable key issue instead of the whole collection.** A finding with no
   file or body is skipped for lifecycle purposes and still rendered in the summary. Because a dropped
   finding is not an absent one, that run is barred from resolving anything.

## Behaviour change

| Situation | Before | After |
|---|---|---|
| App auto command, fresh PR | new `## Standalone PR Review` comment each run | the persistent review, created once and edited afterwards |
| Actions rerun | a second standalone comment per run | the previous review is edited in place |
| Azure DevOps, default config | standalone comment | persistent review |
| One fileless key issue | whole review demoted, state frozen | review updated, that one finding not tracked |
| **Comment exists, authorship unproven (forged marker)** | standalone comment, original untouched | **unchanged** |
| Provider comments unreadable | standalone comment | **unchanged** (cannot know what it would replace) |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3694 passed, 1 skipped, 1 xfailed, 94 warnings in 58.24s
```

New file `tests/unittest/test_review_persistent_comment_authorship.py` (9 tests), each written first and
proven to fail without the fix (8 failed / 1 passed before, 9 passed after). It drives the real
`PRReviewer.run()` against a real `GithubProvider` and a real `AzureDevopsProvider`; only the PyGithub client,
the diff and the model are faked. It covers the four triggers, a resolvable-identity control, and two
security edge cases:

- `test_forged_review_comment_is_never_edited` — a human-authored comment carrying the identity marker is
  left untouched and the result is still a standalone comment.
- `test_unreadable_comments_do_not_create_a_second_review` — a provider read failure stays conservative.

The pre-existing authorship tests in `tests/unittest/test_pr_reviewer_finding_state.py`, including
`test_review_run_does_not_edit_forged_persistent_comment_without_authorship`, pass unchanged.

Also checked: `ruff check` clean on every file touched.

## Risk / compatibility

The forgery protection introduced by #2722 is preserved exactly: the only newly-allowed write is *creating*
a comment when none exists. Deployments that already resolved their identity take the same path as before.
`GithubIntegration.get_app()` is called at most once per provider instance and only in app mode; any failure
is logged and degrades to the previous behaviour.

