### PR TITLE
fix(log): attach structured payloads without reformatting the message

### DIFF
--- a/pr_agent/log/__init__.py
+++ b/pr_agent/log/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import sys
 from enum import Enum
+from string import Formatter
 
 from loguru import logger
 
@@ -66,5 +67,83 @@ def setup_logger(level: str = "INFO", fmt: LoggingFormat = LoggingFormat.CONSOLE
     return logger
 
 
+_LOG_METHODS = ("trace", "debug", "info", "success", "warning", "error", "critical", "exception")
+
+
+def _is_template_for(message, payload: dict) -> bool:
+    """Whether the message reads as a loguru template these keywords are meant to fill.
+
+    An already-interpolated message carries braces from data, whose field names do not match
+    the payload; a real template names every field it uses.
+    """
+    try:
+        fields = [name for _, name, _, _ in Formatter().parse(str(message)) if name]
+    except ValueError:
+        return False  # unbalanced braces: never a template
+    if not fields:
+        return False
+    return all(name.split(".")[0].split("[")[0] in payload for name in fields)
+
+
+class StructuredLogger:
+    """loguru proxy that attaches a keyword payload without re-formatting the message.
+
+    loguru formats the message with `str.format(*args, **kwargs)` as soon as a keyword
+    argument is passed. The codebase passes `artifact=` (and friends) to carry structured
+    data, so a message that already interpolated an exception - every PyGithub error renders
+    the provider's JSON - used to raise `KeyError` from inside the `except` block reporting
+    it. Binding the payload instead puts it in `record["extra"]`, which is where the JSON
+    sink already reads it from, and leaves the message untouched.
+
+    Explicit templating keeps working: positional arguments are passed straight through, and
+    a message whose fields are all named in the payload is still formatted.
+    """
+
+    def __init__(self, wrapped):
+        self._logger = wrapped
+
+    def __getattr__(self, name):
+        return getattr(self._logger, name)
+
+    def _emit(self, method: str, message, args: tuple, payload: dict):
+        target = self._logger.opt(depth=2)  # report the caller, not this proxy
+        if payload and not args and not _is_template_for(message, payload):
+            return getattr(target.bind(**payload), method)(message)
+        return getattr(target, method)(message, *args, **payload)
+
+    def trace(self, message, *args, **kwargs):
+        return self._emit("trace", message, args, kwargs)
+
+    def debug(self, message, *args, **kwargs):
+        return self._emit("debug", message, args, kwargs)
+
+    def info(self, message, *args, **kwargs):
+        return self._emit("info", message, args, kwargs)
+
+    def success(self, message, *args, **kwargs):
+        return self._emit("success", message, args, kwargs)
+
+    def warning(self, message, *args, **kwargs):
+        return self._emit("warning", message, args, kwargs)
+
+    def error(self, message, *args, **kwargs):
+        return self._emit("error", message, args, kwargs)
+
+    def critical(self, message, *args, **kwargs):
+        return self._emit("critical", message, args, kwargs)
+
+    def exception(self, message, *args, **kwargs):
+        return self._emit("exception", message, args, kwargs)
+
+    def log(self, level, message, *args, **kwargs):
+        target = self._logger.opt(depth=2)
+        if kwargs and not args and not _is_template_for(message, kwargs):
+            return target.bind(**kwargs).log(level, message)
+        return target.log(level, message, *args, **kwargs)
+
+
+_structured_logger = StructuredLogger(logger)
+
+
 def get_logger(*args, **kwargs):
-    return logger
+    return _structured_logger

--- a/pr_agent/log/__init__.py
+++ b/pr_agent/log/__init__.py
@@ -67,9 +67,6 @@ def setup_logger(level: str = "INFO", fmt: LoggingFormat = LoggingFormat.CONSOLE
     return logger
 
 
-_LOG_METHODS = ("trace", "debug", "info", "success", "warning", "error", "critical", "exception")
-
-
 def _is_template_for(message, payload: dict) -> bool:
     """Whether the message reads as a loguru template these keywords are meant to fill.
 

--- a/tests/unittest/test_config_override_value_parsing.py
+++ b/tests/unittest/test_config_override_value_parsing.py
@@ -1,0 +1,92 @@
+"""A `--key=value` override must reach the tool whatever the value looks like.
+
+`update_settings_from_args` tries to read the value as YAML and falls back to the raw string.
+The fallback logs at DEBUG - the level every webhook server runs at, because
+`configuration.toml` ships `log_level="DEBUG"` - so the log call is on the hot path for any
+value YAML rejects.
+"""
+import pytest
+
+import pr_agent.agent.pr_agent as agent_module
+from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.config_loader import get_settings
+from pr_agent.log import setup_logger
+
+PR_URL = "https://github.com/org/repo/pull/1"
+
+# None of these can start a YAML plain scalar, so each takes the raw-string fallback.
+UNPARSEABLE_VALUES = [
+    "`{}` is preferred over dict()",
+    "*Always* check {placeholders} in f-strings",
+    "@decorator usage: verify {kwargs} handling",
+    "%s and {0} are both positional",
+    "&anchor {name} lookups",
+    "unbalanced { brace",
+]
+
+
+@pytest.fixture
+def debug_logging():
+    """The level every webhook server passes to setup_logger."""
+    setup_logger(level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
+    yield
+    setup_logger(level="INFO")
+
+
+@pytest.fixture
+def review_tool(monkeypatch):
+    ran = {}
+
+    class FakeReviewTool:
+        def __init__(self, pr_url, ai_handler=None, args=None):
+            ran["args"] = args
+
+        async def run(self):
+            ran["ran"] = True
+
+    monkeypatch.setitem(agent_module.command2class, "review", FakeReviewTool)
+    monkeypatch.setattr(agent_module, "apply_repo_settings", lambda pr_url: None)
+    return ran
+
+
+@pytest.mark.parametrize("value", UNPARSEABLE_VALUES)
+def test_an_unparseable_value_is_stored_as_the_raw_string(monkeypatch, debug_logging, value):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    update_settings_from_args([f"--pr_reviewer.extra_instructions={value}"])
+
+    assert settings.pr_reviewer.extra_instructions == value
+
+
+def test_a_parseable_value_is_still_converted(monkeypatch, debug_logging):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 3)
+
+    update_settings_from_args(["--pr_reviewer.num_max_findings=5"])
+
+    assert settings.pr_reviewer.num_max_findings == 5
+
+
+async def test_a_braced_instruction_reaches_the_tool(monkeypatch, debug_logging, review_tool):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    handled = await agent_module.PRAgent().handle_request(
+        PR_URL, '/review --pr_reviewer.extra_instructions="`{}` is preferred over dict()"')
+
+    assert handled is True
+    assert review_tool.get("ran") is True
+    assert settings.pr_reviewer.extra_instructions == "`{}` is preferred over dict()"
+
+
+async def test_a_plain_instruction_reaches_the_tool(monkeypatch, debug_logging, review_tool):
+    """Control: the same request with a value YAML accepts always worked."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    handled = await agent_module.PRAgent().handle_request(
+        PR_URL, '/review --pr_reviewer.extra_instructions="focus on the retry loop"')
+
+    assert handled is True
+    assert review_tool.get("ran") is True

--- a/tests/unittest/test_logging_structured_payloads.py
+++ b/tests/unittest/test_logging_structured_payloads.py
@@ -1,0 +1,162 @@
+"""A structured payload must never make the log call itself raise.
+
+loguru formats the message with `str.format(*args, **kwargs)` as soon as a keyword argument
+is passed, so `get_logger().error(f"... {e}", artifact=...)` re-formats text that already
+carries the exception. Every PyGithub error renders as `<status> <json body>` and LiteLLM
+wraps the provider's JSON, so the braces in that text turn the handler into the failure.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from github import GithubException
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.log import get_logger
+from pr_agent.servers.utils import RateLimitExceeded
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+from pr_agent.tools.pr_description import PRDescription
+
+RATE_LIMITED = GithubException(
+    403,
+    {"message": "API rate limit exceeded for installation ID 1.",
+     "documentation_url": "https://docs.github.com/rest#rate-limiting"},
+    None,
+)
+NOT_ACCESSIBLE = GithubException(
+    403, {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com"}, None,
+)
+
+
+@pytest.fixture
+def captured_records():
+    records = []
+    handler_id = get_logger().add(lambda message: records.append(message.record), level="TRACE")
+    yield records
+    get_logger().remove(handler_id)
+
+
+@pytest.mark.parametrize("message", [
+    'Failed: 403 {"message": "API rate limit exceeded"}',
+    "Failed to parse config override PR_REVIEWER.EXTRA_INSTRUCTIONS=`{}` preferred",
+    "Unbalanced brace { in the model answer",
+    "Value {0} and {placeholder} came from the model",
+])
+def test_a_braced_message_with_a_payload_does_not_raise(captured_records, message):
+    get_logger().error(message, artifact={"traceback": "..."})
+
+    assert captured_records[-1]["message"] == message
+    assert captured_records[-1]["extra"]["artifact"] == {"traceback": "..."}
+
+
+def test_positional_templating_still_formats(captured_records):
+    get_logger().info("Cleaned up temp repo at {}", "/tmp/repo")
+
+    assert captured_records[-1]["message"] == "Cleaned up temp repo at /tmp/repo"
+
+
+def test_named_templating_still_formats(captured_records):
+    get_logger().error("Azure failed to publish, error: {error}", error="boom")
+
+    assert captured_records[-1]["message"] == "Azure failed to publish, error: boom"
+    assert captured_records[-1]["extra"]["error"] == "boom"
+
+
+def test_payload_without_a_placeholder_is_still_bound(captured_records):
+    get_logger().info("PR-Agent request handler started", analytics=True)
+
+    assert captured_records[-1]["extra"]["analytics"] is True
+
+
+def test_the_caller_module_is_still_recorded(captured_records):
+    get_logger().warning("a message with a { brace", artifact={"k": "v"})
+
+    assert captured_records[-1]["name"] == __name__
+
+
+# --------------------------------------------------------------------------------------
+# The three handlers whose contract the formatting failure broke.
+# --------------------------------------------------------------------------------------
+@pytest.fixture
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+
+@pytest.fixture
+def publishing(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings.config, "publish_output", True)
+    monkeypatch.setattr(settings.config, "publish_output_progress", True)
+    monkeypatch.setattr(settings.config, "is_auto_command", False, raising=False)
+    monkeypatch.setattr(settings.config, "propagate_tool_errors", False, raising=False)
+    return settings
+
+
+def test_a_rate_limited_diff_fetch_is_retried(monkeypatch, no_sleep):
+    """The handler converts the 403 into RateLimitExceeded, which `retry_call` retries."""
+    get_settings().set("GITHUB.RATELIMIT_RETRIES", 3)
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.pr = MagicMock()
+    attempts = []
+
+    def rate_limited():
+        attempts.append(1)
+        raise RATE_LIMITED
+
+    provider.pr.get_files.side_effect = rate_limited
+
+    with pytest.raises(RateLimitExceeded):
+        provider.get_diff_files()
+    assert len(attempts) == 3
+
+
+async def test_describe_swallows_a_provider_error(publishing):
+    """`propagate_tool_errors` is false by default, so `run()` logs and returns."""
+    provider = MagicMock()
+    provider.publish_comment.side_effect = NOT_ACCESSIBLE
+    tool = PRDescription.__new__(PRDescription)
+    tool.git_provider = provider
+    tool.pr_id = "org/repo/1"
+
+    await tool.run()
+
+
+async def test_improve_reports_a_provider_error_to_the_pr(publishing):
+    provider = MagicMock()
+    provider.supports_code_suggestion_state = lambda: False
+    provider.get_files.side_effect = RATE_LIMITED
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.pr_url = "https://github.com/org/repo/pull/1"
+    tool.progress_response = None
+
+    await tool.run()
+
+    provider.publish_comment.assert_called_once_with("Failed to generate code suggestions for PR")
+
+
+async def test_one_unreadable_ticket_link_keeps_the_others(monkeypatch):
+    """A 404 on one linked issue must not discard every extracted ticket."""
+    from types import SimpleNamespace
+
+    from pr_agent.tools.ticket_pr_compliance_check import extract_tickets
+
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.repo = "org/repo"
+    provider.repo_obj = MagicMock()
+
+    def get_issue(number):
+        if number == 1:
+            raise GithubException(404, {"message": "Not Found"}, None)
+        return SimpleNamespace(number=number, title="Issue", body="Body", labels=[])
+
+    provider.repo_obj.get_issue.side_effect = get_issue
+    provider.get_user_description = lambda: "Fixes #1 and closes #2"
+    provider.get_pr_branch = lambda: "fix/retry"
+    provider.fetch_sub_issues = lambda issue_url: []
+
+    tickets = await extract_tickets(provider)
+
+    assert [ticket["ticket_id"] for ticket in tickets] == [2]


### PR DESCRIPTION

Closes #3073.

## Description

`get_logger().error(f"Failed: {e}", artifact={...})` re-formats a message that already
interpolated the exception. loguru calls `str.format(*args, **kwargs)` as soon as any keyword
argument is passed, so a brace in the interpolated text raises `KeyError` / `IndexError` /
`ValueError` from inside the handler that was reporting the original failure.

Braces are the norm, not the exception:

```
>>> str(GithubException(403, {"message": "API rate limit exceeded ..."}, None))
'403 {"message": "API rate limit exceeded for installation ID 1.", "documentation_url": "..."}'
>>> str(litellm.BadRequestError(message='OpenAIException - {"error": {"message": "bad"}}', ...))
'litellm.BadRequestError: OpenAIException - {"error": {"message": "bad"}}'
```

### Root cause

The payload keywords (`artifact=`, `exc_info=`, `analytics=`, …) are how this codebase carries
structured data, and loguru cannot receive them without also treating the message as a template.
51 call sites pass a payload together with an interpolated message; 13 of them interpolate text
that routinely contains braces.

### The fix

One change at the logging boundary rather than 51 call sites. `get_logger()` now returns a
`StructuredLogger` proxy that **binds** the payload instead of passing it as format arguments:

- payload present, no positional arguments, message is not a template for that payload
  → `logger.bind(**payload).error(message)`; the message is never formatted and the payload
  still lands in `record["extra"]`, exactly where the JSON sink already reads it from;
- positional arguments present → passed straight through, so `get_logger().info("at {}", path)`
  is unchanged;
- every field in the message is named in the payload → still formatted, so
  `get_logger().error("failed: {error}", error=e)` is unchanged.

`opt(depth=2)` keeps the caller's module, function and line in the record.

## Behaviour change

| Call | Before | After |
|---|---|---|
| `error(f"Failed: {e}", artifact=…)` where `str(e)` has a brace | raises `KeyError` | logged; payload in `extra` |
| `info("at {}", path)` | formatted | formatted |
| `error("failed: {error}", error=e)` | formatted | formatted |
| `info("started", analytics=True)` | logged | logged |

Three contracts this restores, each covered by a test:

- **the GitHub rate-limit retry** — `get_diff_files` converts a 403 into `RateLimitExceeded` so
  `retry_call` retries `GITHUB.RATELIMIT_RETRIES` times; it used to raise `KeyError` on the first attempt;
- **`/describe` honouring `propagate_tool_errors=false`** — a provider error is logged and swallowed;
- **`/improve` reporting failure** — the PR gets "Failed to generate code suggestions for PR"
  instead of a dangling "Preparing suggestions…" comment;
- **ticket extraction** — one unreadable issue link no longer discards every other extracted ticket.

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3697 passed, 1 skipped, 1 xfailed, 91 warnings in 52.56s
```

New file `tests/unittest/test_logging_structured_payloads.py` (12 tests), written first:
9 failed / 3 passed before the fix, 12 passed after. Covers the four brace shapes, both
templating forms that must keep working, payload binding, caller attribution, and the four
handler contracts above.

Also checked: `ruff check` clean on both files.

## Risk / compatibility

`StructuredLogger` forwards every other attribute (`bind`, `opt`, `contextualize`, `add`,
`remove`, `level`) to loguru, so `get_logger().opt(exception=True).warning(...)` and
`get_logger().contextualize(...)` are untouched. No call site changed, and the full suite
passes unmodified.
