### PR TITLE
fix(config): keep a `--key=value` override that YAML cannot parse

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -972,7 +972,10 @@ def _fix_key_value(key: str, value: str):
     try:
         value = yaml.safe_load(value)
     except Exception as e:
-        get_logger().debug(f"Failed to parse YAML for config override {key}={value}", exc_info=e)
+        # The message stays literal: loguru formats it whenever a payload is passed, and an
+        # override value is free text that routinely contains braces.
+        get_logger().debug("Failed to parse a config override as YAML; keeping the raw string",
+                           artifact={"key": key, "error": str(e)})
     return key, value
 
 

--- a/tests/unittest/test_config_override_value_parsing.py
+++ b/tests/unittest/test_config_override_value_parsing.py
@@ -1,0 +1,92 @@
+"""A `--key=value` override must reach the tool whatever the value looks like.
+
+`update_settings_from_args` tries to read the value as YAML and falls back to the raw string.
+The fallback logs at DEBUG - the level every webhook server runs at, because
+`configuration.toml` ships `log_level="DEBUG"` - so the log call is on the hot path for any
+value YAML rejects.
+"""
+import pytest
+
+import pr_agent.agent.pr_agent as agent_module
+from pr_agent.algo.utils import update_settings_from_args
+from pr_agent.config_loader import get_settings
+from pr_agent.log import setup_logger
+
+PR_URL = "https://github.com/org/repo/pull/1"
+
+# None of these can start a YAML plain scalar, so each takes the raw-string fallback.
+UNPARSEABLE_VALUES = [
+    "`{}` is preferred over dict()",
+    "*Always* check {placeholders} in f-strings",
+    "@decorator usage: verify {kwargs} handling",
+    "%s and {0} are both positional",
+    "&anchor {name} lookups",
+    "unbalanced { brace",
+]
+
+
+@pytest.fixture
+def debug_logging():
+    """The level every webhook server passes to setup_logger."""
+    setup_logger(level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
+    yield
+    setup_logger(level="INFO")
+
+
+@pytest.fixture
+def review_tool(monkeypatch):
+    ran = {}
+
+    class FakeReviewTool:
+        def __init__(self, pr_url, ai_handler=None, args=None):
+            ran["args"] = args
+
+        async def run(self):
+            ran["ran"] = True
+
+    monkeypatch.setitem(agent_module.command2class, "review", FakeReviewTool)
+    monkeypatch.setattr(agent_module, "apply_repo_settings", lambda pr_url: None)
+    return ran
+
+
+@pytest.mark.parametrize("value", UNPARSEABLE_VALUES)
+def test_an_unparseable_value_is_stored_as_the_raw_string(monkeypatch, debug_logging, value):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    update_settings_from_args([f"--pr_reviewer.extra_instructions={value}"])
+
+    assert settings.pr_reviewer.extra_instructions == value
+
+
+def test_a_parseable_value_is_still_converted(monkeypatch, debug_logging):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "num_max_findings", 3)
+
+    update_settings_from_args(["--pr_reviewer.num_max_findings=5"])
+
+    assert settings.pr_reviewer.num_max_findings == 5
+
+
+async def test_a_braced_instruction_reaches_the_tool(monkeypatch, debug_logging, review_tool):
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    handled = await agent_module.PRAgent().handle_request(
+        PR_URL, '/review --pr_reviewer.extra_instructions="`{}` is preferred over dict()"')
+
+    assert handled is True
+    assert review_tool.get("ran") is True
+    assert settings.pr_reviewer.extra_instructions == "`{}` is preferred over dict()"
+
+
+async def test_a_plain_instruction_reaches_the_tool(monkeypatch, debug_logging, review_tool):
+    """Control: the same request with a value YAML accepts always worked."""
+    settings = get_settings()
+    monkeypatch.setattr(settings.pr_reviewer, "extra_instructions", "")
+
+    handled = await agent_module.PRAgent().handle_request(
+        PR_URL, '/review --pr_reviewer.extra_instructions="focus on the retry loop"')
+
+    assert handled is True
+    assert review_tool.get("ran") is True


### PR DESCRIPTION


Closes #3075.

## Description

`update_settings_from_args` reads each `--section.key=value` argument as YAML and falls back to the
raw string when that fails. The fallback logs the failure:

```python
get_logger().debug(f"Failed to parse YAML for config override {key}={value}", exc_info=e)
```

loguru formats the message with `str.format(**kwargs)` because `exc_info=` is a keyword argument,
so a value that YAML rejects *and* contains a brace makes the log call raise. `PRAgent._handle_request`
catches it and returns `False`: the command is dropped, the user gets the 👀 reaction and nothing else.

### Root cause

Two independent problems in one line:

1. the message interpolates `value`, which is arbitrary user text, and is then re-formatted;
2. `exc_info=` is not a loguru option (loguru attaches an exception through `opt(exception=…)`),
   so it never did what it looks like — it only added an extra field whose presence triggers the formatting.

The call is `debug`, so it only runs when the level is DEBUG — which is the shipped default:
`configuration.toml` has `log_level="DEBUG"` and every webhook server passes it to `setup_logger`.

### The fix

Keep the message literal and move the context into the payload, where nothing formats it:

```python
get_logger().debug("Failed to parse a config override as YAML; keeping the raw string",
                   artifact={"key": key, "error": str(e)})
```

The value no longer reaches the message at all, which also keeps a potentially sensitive override
out of the log line.

## Behaviour change

| Argument | Before | After |
|---|---|---|
| ``--pr_reviewer.extra_instructions="`{}` is preferred"`` | command dropped, returns `False` | applied as the raw string |
| `--pr_reviewer.num_max_findings=5` | parsed as `5` | parsed as `5` |
| `--pr_reviewer.extra_instructions="focus on retries"` | applied | applied |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3694 passed, 1 skipped, 1 xfailed, 91 warnings in 49.30s
```

New file `tests/unittest/test_config_override_value_parsing.py` (9 tests), written first:
6 failed / 3 passed before the fix, 9 passed after. Six value shapes YAML rejects, a parseable
value that must still be converted, and both ends of `PRAgent.handle_request`.

Also checked: `ruff check` clean on both files.

## Risk / compatibility

One log line changes text; no parsing behaviour changes. Values YAML accepts take exactly the same
path as before.
