### PR TITLE
fix(review): keep the persistent state marker inside its HTML comment

### DIFF
--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -159,6 +159,10 @@ def serialize_review_state(state: Mapping[str, Any]) -> str:
     if not _is_valid_state(state):
         raise ValueError("Invalid review finding state")
     payload = json.dumps(state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    # An HTML comment ends at the first "-->" or "--!>", and a finding quotes whatever the
+    # diff contains. Escaping the ">" keeps the marker one comment; json.loads decodes the
+    # escape, so the finding round-trips unchanged.
+    payload = payload.replace("-->", "--\\u003e").replace("--!>", "--!\\u003e")
     return f"<!-- pr-agent-review-state:v{STATE_SCHEMA_VERSION}\n{payload}\n-->"
 
 

--- a/tests/unittest/test_review_state_marker_escaping.py
+++ b/tests/unittest/test_review_state_marker_escaping.py
@@ -63,7 +63,9 @@ def test_the_finding_round_trips_unchanged(body):
     parsed = parse_review_state(rendered)
 
     assert parsed.valid and parsed.present
-    assert parsed.state["findings"][0]["body"] == body.replace("\n\n", " ").replace("\n", " ")
+    # Compare whitespace-insensitively: this test is about the escaping surviving the round
+    # trip, not about how normalize_finding stores line breaks.
+    assert " ".join(parsed.state["findings"][0]["body"].split()) == " ".join(body.split())
 
 
 def test_a_finding_without_an_arrow_is_untouched():

--- a/tests/unittest/test_review_state_marker_escaping.py
+++ b/tests/unittest/test_review_state_marker_escaping.py
@@ -1,0 +1,76 @@
+"""The persistent state marker must stay a comment whatever a finding says.
+
+The marker is an HTML comment wrapping JSON. HTML comments do not nest and end at the first
+`-->` (or `--!>`), so a finding that quotes an arrow - a mermaid edge, an XML comment, prose -
+would close the marker early and spill the rest of the JSON into the rendered review.
+"""
+from html.parser import HTMLParser
+
+import pytest
+
+from pr_agent.algo.review_finding_state import (
+    append_review_state,
+    parse_review_state,
+    reconcile_review_findings,
+    serialize_review_state,
+)
+
+REVIEW = "## PR Reviewer Guide 🔍\n\n<!-- pr-agent:review:full -->\n\n<table><tr><td>body</td></tr></table>"
+
+
+class _VisibleText(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.chunks = []
+
+    def handle_data(self, data):
+        self.chunks.append(data)
+
+
+def _visible(html: str) -> str:
+    parser = _VisibleText()
+    parser.feed(html)
+    return "".join(parser.chunks)
+
+
+def _state_for(body: str):
+    finding = {"path": "docs/flow.md", "body": body, "line_start": 3, "line_end": 3}
+    return reconcile_review_findings(None, [finding], allow_resolution=False, head_sha="abc123").state
+
+
+@pytest.mark.parametrize("body", [
+    "**Possible Issue**\n\nThe edge `A --> B` is drawn twice.",
+    "The comment `<!-- keep -->` is duplicated.",
+    "An abrupt close --!> also ends a comment.",
+    "Arrows everywhere: --> --> -->",
+])
+def test_the_marker_stays_hidden(body):
+    rendered = append_review_state(REVIEW, _state_for(body))
+
+    visible = _visible(rendered)
+    assert "schema_version" not in visible
+    assert "finding_id" not in visible
+
+
+@pytest.mark.parametrize("body", [
+    "**Possible Issue**\n\nThe edge `A --> B` is drawn twice.",
+    "The comment `<!-- keep -->` is duplicated.",
+    "An abrupt close --!> also ends a comment.",
+])
+def test_the_finding_round_trips_unchanged(body):
+    rendered = append_review_state(REVIEW, _state_for(body))
+
+    parsed = parse_review_state(rendered)
+
+    assert parsed.valid and parsed.present
+    assert parsed.state["findings"][0]["body"] == body.replace("\n\n", " ").replace("\n", " ")
+
+
+def test_a_finding_without_an_arrow_is_untouched():
+    """Control: the ordinary payload keeps its exact serialisation."""
+    state = _state_for("**Possible Issue**\n\nThe retry loop never ends.")
+
+    marker = serialize_review_state(state)
+
+    assert "\\u003e" not in marker
+    assert parse_review_state(f"{REVIEW}\n\n{marker}").valid


### PR DESCRIPTION


Closes #3077.

## Description

`serialize_review_state` wraps the lifecycle JSON in `<!-- pr-agent-review-state:v1 … -->`. HTML
comments do not nest and end at the **first** `-->` (or `--!>`), and each finding's `body` is the
model's own text. A finding quoting a mermaid edge, an XML comment or plain prose with an arrow
closes the marker early, and everything after it — `"finding_id"`, `"head_sha"`, `"schema_version"`
and a stray `-->` — renders as visible text in the review comment.

### The fix

Escape the `>` of both comment terminators inside the JSON payload:

```python
payload = payload.replace("-->", "-->").replace("--!>", "--!>")
```

JSON permits `\uXXXX`, so `json.loads` decodes it and the finding round-trips byte-identical.
`parse_review_state` needs no change, and a payload without an arrow is serialised exactly as before.

## Behaviour change

| Finding body | Before | After |
|---|---|---|
| ``The edge `A --> B` is drawn twice.`` | state JSON visible in the PR | marker stays hidden |
| ``The comment `<!-- keep -->` is duplicated.`` | state JSON visible | marker stays hidden |
| `An abrupt close --!> also ends a comment.` | state JSON visible | marker stays hidden |
| `The retry loop never ends.` | hidden | hidden, byte-identical serialisation |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3685 passed, 1 skipped, 1 xfailed, 91 warnings in 48.75s
```

New file `tests/unittest/test_review_state_marker_escaping.py` (8 tests), written first and proven
to fail without the fix. It parses the rendered comment with `html.parser` and asserts no state key
is visible, then asserts each finding round-trips through `parse_review_state` unchanged. The
control asserts an ordinary payload contains no escape at all.

Cross-checked against GitHub's renderer: `cmarkgfm.github_flavored_markdown_to_html` on the
unfixed output leaks the JSON, and on the fixed output does not.

Also checked: `ruff check` clean.

## Risk / compatibility

A marker written by an older version still parses: the escape only affects payloads that contain an
arrow, and `parse_review_state` decodes JSON either way. Nothing about the schema or version changes.
