### PR TITLE
fix(review): flatten chunked findings fields the model returned as a list

### DIFF
--- a/pr_agent/algo/review_merge.py
+++ b/pr_agent/algo/review_merge.py
@@ -158,7 +158,10 @@ def _merge_findings_text(values: List[Any]) -> Any:
         seen.add(fingerprint)
         reported.append(text)
     if not reported:
-        return _first_non_empty(values)
+        # Every chunk reported nothing. Return the canonical "No" rather than one chunk's raw
+        # value: a chunk answering ["No"] would otherwise reach the renderer as a list, which
+        # is_value_no does not recognise, and the review would show a concern reading "- No".
+        return "No"
     return "\n\n".join(reported)
 
 

--- a/pr_agent/algo/review_merge.py
+++ b/pr_agent/algo/review_merge.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import re
 from typing import Any, Callable, Hashable, List, Optional
 
-from pr_agent.algo.utils import is_value_no
+from pr_agent.algo.utils import as_review_text, is_value_no
 from pr_agent.log import get_logger
 
 MAX_EFFORT = 5
@@ -126,12 +126,31 @@ def _worst_of(order: tuple) -> Callable[[List[Any]], Any]:
     return merge
 
 
+def _reported_text(value: Any) -> str:
+    """Flatten one chunk's answer to text, or "" when that chunk reported nothing.
+
+    The field is declared as a string, but a model listing several findings answers with a
+    list or a mapping, which the review renderer already accepts.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple, set)):
+        entries = [entry for entry in (_reported_text(item) for item in value) if entry]
+        if not entries:
+            return ""
+        if len(entries) == 1:
+            return entries[0]
+        return "\n".join(f"- {entry}" for entry in entries)
+    text = as_review_text(value)
+    return "" if is_value_no(text) else text
+
+
 def _merge_findings_text(values: List[Any]) -> Any:
     """Union the chunks that reported something; 'No' only when every chunk said no."""
     reported, seen = [], set()
     for value in values:
-        text = str(value if value is not None else "").strip()
-        if is_value_no(text):
+        text = _reported_text(value)
+        if not text:
             continue
         fingerprint = _normalize_text(text)
         if fingerprint in seen:

--- a/tests/unittest/test_review_merge_field_shapes.py
+++ b/tests/unittest/test_review_merge_field_shapes.py
@@ -8,6 +8,7 @@ Python list repr into the PR.
 import pytest
 
 from pr_agent.algo.review_merge import merge_review_chunks
+from pr_agent.algo.utils import is_value_no
 
 
 def _merged(*chunk_values, field="security_concerns"):
@@ -43,10 +44,18 @@ def test_a_mapping_is_rendered_as_text():
     assert "{'" not in merged
 
 
-def test_a_list_saying_no_is_still_no():
-    merged = _merged(["No"], "No")
+@pytest.mark.parametrize("chunks", [
+    (["No"], "No"),
+    (["No"], ["No"]),
+    ("No", "No"),
+    ([], ""),
+    ([None], None),
+])
+def test_nothing_reported_merges_to_a_value_the_renderer_suppresses(chunks):
+    """`is_value_no` only recognises a string, so the merged value must be one."""
+    merged = _merged(*chunks)
 
-    assert "- No" not in str(merged)
+    assert is_value_no(merged), f"the review would render a concern reading {merged!r}"
 
 
 def test_plain_strings_are_unchanged():

--- a/tests/unittest/test_review_merge_field_shapes.py
+++ b/tests/unittest/test_review_merge_field_shapes.py
@@ -1,0 +1,69 @@
+"""Merging chunked reviews must render the same shapes the single-call review accepts.
+
+`security_concerns` and `insights_from_user_answers` are declared as strings, but a model
+enumerating several findings answers with a list; `convert_to_markdown_v2` has rendered that
+since #2899. The chunk merger still stringified the value, so a chunked review printed a
+Python list repr into the PR.
+"""
+import pytest
+
+from pr_agent.algo.review_merge import merge_review_chunks
+
+
+def _merged(*chunk_values, field="security_concerns"):
+    return merge_review_chunks([{"review": {field: value}} for value in chunk_values])["review"][field]
+
+
+def test_a_list_from_one_chunk_is_rendered_as_text():
+    merged = _merged(["SQL injection in the query builder"], "No")
+
+    assert "SQL injection in the query builder" in merged
+    assert "['" not in merged and "']" not in merged
+
+
+def test_entries_from_several_chunks_are_unioned():
+    merged = _merged(["SQL injection in the query builder"], ["Missing CSRF token"])
+
+    assert "SQL injection in the query builder" in merged
+    assert "Missing CSRF token" in merged
+    assert "['" not in merged
+
+
+def test_a_multi_entry_list_becomes_bullets():
+    merged = _merged(["First concern", "Second concern"], "No")
+
+    assert "- First concern" in merged
+    assert "- Second concern" in merged
+
+
+def test_a_mapping_is_rendered_as_text():
+    merged = _merged({"auth": "token logged in plaintext"}, "No")
+
+    assert "token logged in plaintext" in merged
+    assert "{'" not in merged
+
+
+def test_a_list_saying_no_is_still_no():
+    merged = _merged(["No"], "No")
+
+    assert "- No" not in str(merged)
+
+
+def test_plain_strings_are_unchanged():
+    """Control: the shape the prompt asks for keeps its exact behaviour."""
+    assert _merged("SQL injection", "No") == "SQL injection"
+    assert _merged("No", "No") == "No"
+
+
+def test_two_different_strings_are_still_unioned():
+    merged = _merged("First concern", "Second concern")
+
+    assert merged == "First concern\n\nSecond concern"
+
+
+@pytest.mark.parametrize("field", ["security_concerns", "insights_from_user_answers"])
+def test_both_findings_fields_flatten(field):
+    merged = _merged(["A finding"], "No", field=field)
+
+    assert "A finding" in merged
+    assert "['" not in merged


### PR DESCRIPTION
Closes #3079.

## Description

`security_concerns` and `insights_from_user_answers` are declared as strings in the prompt, but a
model enumerating several findings answers with a list. `convert_to_markdown_v2` has accepted that
since #2899 (`as_review_text`). The chunk merger used by `enable_large_pr_chunking` still did

```python
text = str(value if value is not None else "").strip()
```

so a chunk answering with a list was merged as `"['SQL injection in the query builder']"` and the
renderer faithfully printed the repr into the PR.

### The fix

A `_reported_text` helper flattens one chunk's answer before de-duplication:

- a list, tuple or set drops the entries that report nothing and becomes bullets (or the single
  entry unchanged);
- anything else goes through the shared `as_review_text`, so a mapping renders as `key: value`;
- `"No"` — at any nesting level — still counts as "nothing reported", so a merged review only says
  `No` when every chunk did.

## Behaviour change

| Chunk answers | Before | After |
|---|---|---|
| `["SQL injection"]`, `"No"` | `['SQL injection']` | `SQL injection` |
| `["First"]`, `["Second"]` | `['First']\n\n['Second']` | `First\n\nSecond` |
| `["First", "Second"]` | `['First', 'Second']` | `- First`<br>`- Second` |
| `{"auth": "token logged"}` | `{'auth': 'token logged'}` | `auth: token logged` |
| `["No"]` | reported as a concern | nothing reported |
| `"SQL injection"`, `"No"` | `SQL injection` | `SQL injection` |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3694 passed, 1 skipped, 1 xfailed, 91 warnings in 48.93s
```

New file `tests/unittest/test_review_merge_field_shapes.py` (9 tests), written first and proven to
fail without the fix (4 failed before, 9 passed after). Covers both fields, single and multi-entry
lists, mappings, a list saying `No`, and two string controls that must stay byte-identical.

Also checked: `ruff check` clean on both files.

## Risk / compatibility

Only reachable with `pr_reviewer.enable_large_pr_chunking = true` (off by default). String answers —
the shape the prompt asks for — take the same path as before.
