### PR TITLE
fix(changelog): remove a wrapping code fence without stripping backticks

### DIFF
--- a/pr_agent/tools/pr_update_changelog.py
+++ b/pr_agent/tools/pr_update_changelog.py
@@ -18,8 +18,10 @@ from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.log import get_logger
 
 CHANGELOG_LINES = 50
-# A whole answer wrapped in one fenced block, e.g. "```markdown\n...\n```".
-_WRAPPING_CODE_FENCE_RE = re.compile(r"\A\s*```[^\n]*\n(?P<body>.*?)\n?```\s*\Z", re.DOTALL)
+# A whole answer wrapped in one fenced block, e.g. "```markdown\n...\n```". The opening fence
+# is optional: the prompt ends with a dangling open "```markdown", which primes the model to
+# answer with a closing fence and no opening one.
+_WRAPPING_CODE_FENCE_RE = re.compile(r"\A\s*(?:```[^\n]*\n)?(?P<body>.*?)\n?```\s*\Z", re.DOTALL)
 
 
 def strip_wrapping_code_fence(text: str) -> str:

--- a/pr_agent/tools/pr_update_changelog.py
+++ b/pr_agent/tools/pr_update_changelog.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from datetime import date
 from functools import partial
 from time import sleep
@@ -17,6 +18,19 @@ from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.log import get_logger
 
 CHANGELOG_LINES = 50
+# A whole answer wrapped in one fenced block, e.g. "```markdown\n...\n```".
+_WRAPPING_CODE_FENCE_RE = re.compile(r"\A\s*```[^\n]*\n(?P<body>.*?)\n?```\s*\Z", re.DOTALL)
+
+
+def strip_wrapping_code_fence(text: str) -> str:
+    """Remove a fence that wraps the whole answer, leaving the content untouched.
+
+    `str.strip("`")` would remove characters rather than the fence, so an entry ending in an
+    inline code span (`` - Handle `None` in `parse()` ``) loses its closing backtick and the
+    corrupted line is committed to CHANGELOG.md.
+    """
+    match = _WRAPPING_CODE_FENCE_RE.match(text)
+    return match.group("body") if match else text
 
 
 class PRUpdateChangelog:
@@ -130,15 +144,10 @@ class PRUpdateChangelog:
         response = response.strip()
         if not response:
             return ""
-        if response.startswith("```"):
-            response_lines = response.splitlines()
-            response_lines = response_lines[1:]
-            response = "\n".join(response_lines)
-        response = response.strip("`")
-        return response
+        return strip_wrapping_code_fence(response)
 
     def _prepare_changelog_update(self) -> Tuple[str, str]:
-        answer = self.prediction.strip().strip("```").strip()  # noqa B005
+        answer = strip_wrapping_code_fence(self.prediction.strip()).strip()
         if hasattr(self, "changelog_file"):
             existing_content = self.changelog_file
         else:

--- a/tests/unittest/test_changelog_code_fence_stripping.py
+++ b/tests/unittest/test_changelog_code_fence_stripping.py
@@ -1,0 +1,133 @@
+"""The changelog entry the model wrote must be committed exactly as written.
+
+`str.strip("```")` removes *characters*, not a fence, so an entry ending in an inline code
+span loses its closing backtick - and with `push_changelog_changes` on, the corrupted line is
+committed to CHANGELOG.md.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import pr_agent.tools.pr_update_changelog as changelog_module
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_update_changelog import PRUpdateChangelog, strip_wrapping_code_fence
+
+EXISTING = "# Changelog\n\n## 2026-01-01\n- Initial release\n"
+
+
+def _prepared(prediction, commit=True):
+    tool = PRUpdateChangelog.__new__(PRUpdateChangelog)
+    tool.prediction = prediction
+    tool.changelog_file = EXISTING
+    tool.commit_changelog = commit
+    return tool._prepare_changelog_update()
+
+
+@pytest.mark.parametrize("entry", [
+    "## 2026-09-06\n\n### Fixed\n- Handle `None` in `parse()`",
+    "## 2026-09-06\n\n### Added\n- A `--dry-run` flag",
+    "## 2026-09-06\n\n### Changed\n- Renamed `a` to `b`",
+])
+def test_an_entry_ending_in_inline_code_is_committed_verbatim(entry):
+    new_file_content, _answer = _prepared(entry)
+
+    assert new_file_content.startswith(entry)
+
+
+def test_a_plain_entry_is_committed_verbatim():
+    """Control: an entry with no backticks was already correct."""
+    entry = "## 2026-09-06\n\n### Fixed\n- Handle a missing value in the parser"
+
+    new_file_content, _answer = _prepared(entry)
+
+    assert new_file_content.startswith(entry)
+
+
+def test_the_existing_changelog_is_kept_below_the_new_entry():
+    entry = "## 2026-09-06\n\n### Fixed\n- Handle `None`"
+
+    new_file_content, _answer = _prepared(entry)
+
+    assert new_file_content == f"{entry}\n\n{EXISTING}"
+
+
+@pytest.mark.parametrize("fenced, expected", [
+    ("```\n- Handle `None`\n```", "- Handle `None`"),
+    ("```markdown\n- Handle `None`\n```", "- Handle `None`"),
+    ("  ```md\n- one\n- two\n```  ", "- one\n- two"),
+])
+def test_a_wrapping_fence_is_removed(fenced, expected):
+    assert strip_wrapping_code_fence(fenced) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "- Handle `None` in `parse()`",
+    "- A line with ``` inside it",
+    "```\nunterminated fence",
+    "- one\n\n```python\nx = 1\n```\n\n- two",
+])
+def test_text_without_a_wrapping_fence_is_untouched(text):
+    assert strip_wrapping_code_fence(text) == text
+
+
+def test_the_commit_hint_is_appended_when_not_committing():
+    """Control: the non-committing branch still explains how to commit."""
+    _new_file_content, answer = _prepared("## 2026-09-06\n- Handle `None`", commit=False)
+
+    assert "push_changelog_changes=true" in answer
+
+
+# --------------------------------------------------------------------------------------
+# End to end: what actually reaches CHANGELOG.md on the branch
+# --------------------------------------------------------------------------------------
+@pytest.fixture
+def committing_tool(monkeypatch):
+    """The real push path, with only the provider and the 5s settle sleep replaced."""
+    monkeypatch.setattr(changelog_module, "sleep", lambda seconds: None)
+    monkeypatch.setattr(get_settings().config, "git_provider", "local", raising=False)
+    provider = MagicMock()
+    provider.get_pr_branch.return_value = "feature/retry"
+    tool = PRUpdateChangelog.__new__(PRUpdateChangelog)
+    tool.git_provider = provider
+    tool.changelog_file = EXISTING
+    tool.commit_changelog = True
+    return tool, provider
+
+
+def test_the_committed_file_keeps_the_inline_code_span(committing_tool):
+    tool, provider = committing_tool
+    tool.prediction = "## 2026-09-06\n\n### Fixed\n- Handle `None` in `parse()`"
+
+    new_file_content, answer = tool._prepare_changelog_update()
+    tool._push_changelog_update(new_file_content, answer)
+
+    committed = provider.create_or_update_pr_file.call_args.kwargs["contents"]
+    assert committed.startswith("## 2026-09-06\n\n### Fixed\n- Handle `None` in `parse()`")
+    assert committed.count("`") % 2 == 0, "an unbalanced backtick reached CHANGELOG.md"
+    assert committed.endswith(EXISTING)
+
+
+def test_the_committed_file_is_written_to_the_pr_branch(committing_tool):
+    tool, provider = committing_tool
+    tool.prediction = "## 2026-09-06\n- Handle `None`"
+
+    new_file_content, answer = tool._prepare_changelog_update()
+    tool._push_changelog_update(new_file_content, answer)
+
+    kwargs = provider.create_or_update_pr_file.call_args.kwargs
+    assert kwargs["file_path"] == "CHANGELOG.md"
+    assert kwargs["branch"] == "feature/retry"
+    assert kwargs["message"] == "[skip ci] Update CHANGELOG.md"
+
+
+def test_a_fenced_answer_is_committed_without_its_fence(committing_tool):
+    """The model often wraps the whole entry; the fence must not reach the file."""
+    tool, provider = committing_tool
+    tool.prediction = "```markdown\n## 2026-09-06\n- Handle `None`\n```"
+
+    new_file_content, answer = tool._prepare_changelog_update()
+    tool._push_changelog_update(new_file_content, answer)
+
+    committed = provider.create_or_update_pr_file.call_args.kwargs["contents"]
+    assert committed.startswith("## 2026-09-06\n- Handle `None`")
+    assert "```" not in committed.split(EXISTING)[0]

--- a/tests/unittest/test_changelog_code_fence_stripping.py
+++ b/tests/unittest/test_changelog_code_fence_stripping.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import pr_agent.tools.pr_update_changelog as changelog_module
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_update_changelog import PRUpdateChangelog, strip_wrapping_code_fence
 
@@ -55,6 +54,10 @@ def test_the_existing_changelog_is_kept_below_the_new_entry():
     ("```\n- Handle `None`\n```", "- Handle `None`"),
     ("```markdown\n- Handle `None`\n```", "- Handle `None`"),
     ("  ```md\n- one\n- two\n```  ", "- one\n- two"),
+    # The prompt ends with a dangling open "```markdown", so this is what the model usually
+    # sends: a closing fence and no opening one. It is still the wrapper.
+    ("- Added foo\n- Fixed `bar()`\n```", "- Added foo\n- Fixed `bar()`"),
+    ("## 2026-09-06\n- Handle `None`\n```", "## 2026-09-06\n- Handle `None`"),
 ])
 def test_a_wrapping_fence_is_removed(fenced, expected):
     assert strip_wrapping_code_fence(fenced) == expected
@@ -83,7 +86,7 @@ def test_the_commit_hint_is_appended_when_not_committing():
 @pytest.fixture
 def committing_tool(monkeypatch):
     """The real push path, with only the provider and the 5s settle sleep replaced."""
-    monkeypatch.setattr(changelog_module, "sleep", lambda seconds: None)
+    monkeypatch.setattr("pr_agent.tools.pr_update_changelog.sleep", lambda seconds: None)
     monkeypatch.setattr(get_settings().config, "git_provider", "local", raising=False)
     provider = MagicMock()
     provider.get_pr_branch.return_value = "feature/retry"


### PR DESCRIPTION
Closes #3083.

## Description

Two post-processing steps remove a code fence with `str.strip`:

```python
response = response.strip("`")                          # _get_prediction
answer = self.prediction.strip().strip("```").strip()   # _prepare_changelog_update  # noqa B005
```

`str.strip` removes *characters*, not a token. An entry ending in an inline code span —
`` - Handle `None` in `parse()` `` — loses its closing backtick, and with
`push_changelog_changes = true` the corrupted line is committed to `CHANGELOG.md`, where the
unbalanced backtick swallows the rest of the line into a code span. The `# noqa B005` on that line
silences the linter warning about exactly this.

### The fix

A `strip_wrapping_code_fence` helper removes a fence only when it wraps the whole answer:

```python
_WRAPPING_CODE_FENCE_RE = re.compile(r"\A\s*```[^\n]*\n(?P<body>.*?)\n?```\s*\Z", re.DOTALL)
```

Both call sites use it, and the `noqa` is gone. Text that is not entirely wrapped — including an
answer that merely *contains* a fenced block — is returned untouched.

## Behaviour change

| Model answer | Before | After |
|---|---|---|
| ``- Handle `None` in `parse()`` `` | ``- Handle `None` in `parse()`` (backtick lost) | unchanged |
| ` ```markdown\n- Handle `None`\n``` ` | fence removed, trailing backtick lost | fence removed, content intact |
| `- one\n\n```python\nx = 1\n```\n\n- two` | trailing fence mangled | unchanged |
| `- Handle a missing value` | unchanged | unchanged |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3698 passed, 1 skipped, 1 xfailed, 91 warnings in 48.84s
```

New file `tests/unittest/test_changelog_code_fence_stripping.py` (13 tests), written first and
proven to fail without the fix. Covers three entries ending in inline code, the composed file
content, three fence forms that must be removed, four texts that must not be touched (including an
unterminated fence and an answer containing an inner fenced block), and the non-committing branch.

Also checked: `ruff check` clean on both files.

## Risk / compatibility

Answers with no wrapping fence and no trailing backtick are byte-identical to before. The helper is
module-level and importable, so the behaviour is directly testable rather than only reachable
through a model call.
