### PR TITLE
fix(review): keep a finding's line breaks in the resolved section

### DIFF
--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -67,8 +67,9 @@ def normalize_finding(finding: Mapping[str, Any]) -> dict[str, Any] | None:
     if not path or not body:
         return None
 
-    body = _WHITESPACE_RE.sub(" ", body)
-    finding_id = key_issue_fingerprint(path, body.lower())
+    # The fingerprint ignores whitespace so re-wrapped prose stays the same finding, but the
+    # body is what the resolved section renders, so it keeps the line breaks the reviewer used.
+    finding_id = key_issue_fingerprint(path, _WHITESPACE_RE.sub(" ", body).lower())
     start = _as_line(
         finding.get("line_start")
         or finding.get("relevant_lines_start")

--- a/tests/unittest/test_resolved_finding_rendering.py
+++ b/tests/unittest/test_resolved_finding_rendering.py
@@ -1,0 +1,60 @@
+"""A resolved finding must read the way it read while it was active.
+
+The reviewer renders a key issue as a header, a blank line and the model's text, which often
+contains a fenced code block. Normalisation collapsed every newline, so the resolved section
+printed the whole finding - fence included - on one line.
+"""
+from pr_agent.algo.review_finding_state import (
+    _render_resolved_section,
+    normalize_finding,
+    reconcile_review_findings,
+)
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+ISSUE = {
+    "relevant_file": "src/app.py",
+    "issue_header": "Possible Bug",
+    "issue_content": "The loop never ends:\n```suggestion\nwhile attempts < 3:\n    attempts += 1\n```",
+    "start_line": 3,
+    "end_line": 4,
+}
+
+
+def _resolved_section_for(issue):
+    finding = PRReviewer._review_finding_from_issue(issue)
+    active = reconcile_review_findings(None, [finding], allow_resolution=False, head_sha="aaa111").state
+    resolved = reconcile_review_findings(active, [], allow_resolution=True, head_sha="bbb222").state
+    return _render_resolved_section(resolved)
+
+
+def test_a_resolved_finding_keeps_its_code_block():
+    rendered = _resolved_section_for(ISSUE)
+
+    assert "```text\nwhile attempts < 3:\n    attempts += 1\n```" in rendered
+
+
+def test_a_resolved_finding_keeps_its_header_on_its_own_line():
+    rendered = _resolved_section_for(ISSUE)
+
+    assert "**Possible Issue**\n\nThe loop never ends:" in rendered
+
+
+def test_the_fingerprint_still_ignores_whitespace():
+    """Re-wrapped prose is the same finding, so the lifecycle survives a reflow."""
+    one_line = normalize_finding({"path": "src/app.py", "body": "The loop never   ends here."})
+    wrapped = normalize_finding({"path": "src/app.py", "body": "The loop never\nends here."})
+
+    assert one_line["finding_id"] == wrapped["finding_id"]
+
+
+def test_the_body_keeps_its_own_line_breaks():
+    finding = normalize_finding({"path": "src/app.py", "body": "First line.\n\nSecond line."})
+
+    assert finding["body"] == "First line.\n\nSecond line."
+
+
+def test_a_single_line_finding_is_unchanged():
+    """Control: prose without line breaks is stored exactly as before."""
+    finding = normalize_finding({"path": "src/app.py", "body": "The retry loop never ends."})
+
+    assert finding["body"] == "The retry loop never ends."


### PR DESCRIPTION
Closes #3085.

## Description

`PRReviewer._review_finding_from_issue` deliberately builds a finding body as
`**Header**\n\n<content>` and rewrites a ```` ```suggestion ```` fence to ```` ```text ```` so the
code renders as a block. `normalize_finding` then stored the body after
`_WHITESPACE_RE.sub(" ", body)`, and `_render_resolved_section` prints what was stored — so once a
finding is resolved, the header, the prose and the whole code block appear on a single line:

```
**Possible Issue** The loop never ends: ```text while attempts < 3: attempts += 1 ```
```

### Root cause

One value served two purposes. Collapsing whitespace is right for the **fingerprint** — re-wrapped
prose must stay the same finding across runs — but wrong for the **display body**.

### The fix

Collapse only for the fingerprint, and store the body as written:

```python
finding_id = key_issue_fingerprint(path, _WHITESPACE_RE.sub(" ", body).lower())
```

`finding_id` is unchanged for every existing finding, so state written by an older version still
reconciles; the stored body simply gains its line breaks back on the next run.

## Behaviour change

| Stored / rendered | Before | After |
|---|---|---|
| body with a code block | one line | the reviewer's own layout |
| header and text | glued together | separated by a blank line |
| `finding_id` | collapsed-text hash | **unchanged** |
| single-line body | unchanged | unchanged |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3690 passed, 1 skipped, 1 xfailed, 91 warnings in 51.33s
```

New file `tests/unittest/test_resolved_finding_rendering.py` (5 tests), written first and proven to
fail without the fix (3 failed / 2 passed before, 5 passed after). It builds a finding through the
reviewer's own `_review_finding_from_issue`, resolves it through `reconcile_review_findings`, and
asserts the rendered section keeps the fence and the header. Two further tests pin the properties
that must not change: the fingerprint still ignores whitespace, and a single-line body is stored
exactly as before.

Also checked: `ruff check` clean on both files.

## Risk / compatibility

Backward compatible with existing markers: identity is computed from the same collapsed text, so a
finding tracked by an older version is still recognised.
