### PR TITLE
feat(models): add OpenAI GPT-6 Astra support

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -649,6 +649,18 @@ reasoning_effort = "medium" # "none", "minimal", "low", "medium", "high", "xhigh
 
 With the OpenAI models that support reasoning effort (eg: gpt-5.6-terra), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to any supported value based on your usage. Available values depend on the model and provider.
 
+To use [GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra):
+
+```toml
+[config]
+model = "gpt-6-astra"
+reasoning_effort = "medium" # "low", "medium", "high", "xhigh", "max"
+```
+
+PR-Agent omits temperature for GPT-6 Astra and maps `none` or `minimal` reasoning effort to `low`.
+Its 1,050,000-token context window remains subject to `config.max_model_tokens`.
+The existing Chat Completions path is used; access depends on your OpenAI account.
+
 ### Anthropic models
 
 ```toml
@@ -687,13 +699,15 @@ built-in defaults.
 max_output_tokens = 0 # 0 = unset (default)
 ```
 
-By default PR-Agent does not send an output token limit (`max_tokens`) on model calls, so the
+By default PR-Agent does not send an output token limit on model calls, so the
 provider's own default applies. On some providers that default is low — for example, AWS Bedrock
 (Converse API) can cap Claude reasoning models at 4096 output tokens, and since reasoning tokens
 count against that budget, the visible answer can come back empty or truncated. Set
-`config.max_output_tokens` to a positive value (e.g. `16000`) to send it as `max_tokens` on every
-completion call. When Claude extended thinking is enabled, `extended_thinking_max_output_tokens`
-takes precedence.
+`config.max_output_tokens` to a positive value (e.g. `16000`) to send it to LiteLLM as
+`max_completion_tokens` for GPT-6 Astra or `max_tokens` for other models. Use a value supported by
+the selected model; GPT-6 Astra supports at most 128,000 output tokens, including reasoning tokens.
+PR-Agent does not automatically clamp this setting to the model's output limit.
+When Claude extended thinking is enabled, `extended_thinking_max_output_tokens` takes precedence.
 For models with small context windows, keep in mind that prompt and completion tokens share the
 model's context window: size `config.max_model_tokens` so the packed prompt leaves room for the
 configured output limit.

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -315,6 +315,7 @@ MAX_TOKENS = {
     'gpt-5.6-sol': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
     'gpt-5.6-terra': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
     'gpt-5.6-luna': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
+    'gpt-6-astra': 1050000,  # 1.05M, but may be limited by config.max_model_tokens
     'o1-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-mini-2024-09-12': 128000,  # 128K, but may be limited by config.max_model_tokens
     'o1-preview': 128000,  # 128K, but may be limited by config.max_model_tokens

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -814,7 +814,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 model_base = model
                 while model_base.startswith(('openai/', 'azure/')):
                     model_base = model_base.removeprefix('openai/').removeprefix('azure/')
-                if model_base.startswith('gpt-5'):
+                is_gpt6_astra = model_base.removesuffix('_thinking') == 'gpt-6-astra'
+                if model_base.startswith('gpt-5') or is_gpt6_astra:
                     # Use configured reasoning_effort or default to MEDIUM
                     config_effort = get_settings().config.reasoning_effort
                     try:
@@ -828,11 +829,16 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 f"Using default '{effort}'. Valid values: {[e.value for e in ReasoningEffort]}"
                             )
 
+                    if is_gpt6_astra and effort in (ReasoningEffort.NONE.value, ReasoningEffort.MINIMAL.value):
+                        get_logger().info(f"GPT-6 Astra does not support reasoning_effort='{effort}'; using 'low'")
+                        effort = ReasoningEffort.LOW.value
+
                     thinking_kwargs_gpt5 = {
                         "reasoning_effort": effort,
                         "allowed_openai_params": ["reasoning_effort"],
                     }
-                    get_logger().info(f"Using reasoning_effort='{effort}' for GPT-5 model")
+                    model_family = "GPT-6 Astra" if is_gpt6_astra else "GPT-5"
+                    get_logger().info(f"Using reasoning_effort='{effort}' for {model_family} model")
                     # Routing priority: Azure mode > explicit provider prefix in user config > openai/
                     # default. This preserves an explicit "azure/" the user wrote in config even when
                     # self.azure is false, and avoids stacking when self.azure already added "azure/".
@@ -965,7 +971,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 except (TypeError, ValueError):
                     max_output_tokens = 0
                 if max_output_tokens > 0:
-                    kwargs.setdefault("max_tokens", max_output_tokens)
+                    output_limit_param = "max_completion_tokens" if is_gpt6_astra else "max_tokens"
+                    kwargs.setdefault(output_limit_param, max_output_tokens)
 
                 if get_settings().litellm.get("enable_callbacks", False):
                     kwargs = self.add_litellm_callbacks(kwargs)

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -1341,6 +1341,13 @@ def get_max_tokens(model):
     """
     settings = get_settings()
     custom_max_tokens = _as_int(settings.config.custom_model_max_tokens)
+    # Resolve GPT-6 Astra aliases before diff token accounting, just as the handler does.
+    # Preserve explicit custom limits for provider aliases that were not in the registry.
+    model_base = model
+    while model_base.startswith(('openai/', 'azure/')):
+        model_base = model_base.removeprefix('openai/').removeprefix('azure/')
+    if custom_max_tokens <= 0 and model_base.removesuffix('_thinking') == 'gpt-6-astra':
+        model = 'gpt-6-astra'
     if model in MAX_TOKENS:
         max_tokens_model = MAX_TOKENS[model]
     elif custom_max_tokens > 0:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -38,7 +38,8 @@ max_description_tokens = 500
 max_commits_tokens = 500
 max_model_tokens = 32000 # Limits the maximum number of tokens that can be used by any model, regardless of the model's default capabilities.
 custom_model_max_tokens=-1 # for models not in the default list
-max_output_tokens = 0 # Output token limit sent as max_tokens on model calls; 0 = unset (the provider's own default applies)
+# Sent as max_completion_tokens for GPT-6 Astra, otherwise max_tokens; use a limit supported by the model.
+max_output_tokens = 0 # 0 = unset (the provider's own default applies)
 model_token_count_estimate_factor=0.3 # factor to increase the token count estimate, in order to reduce likelihood of model failure due to too many tokens - applicable only when requesting an accurate estimate.
 # patch extension logic
 patch_extension_skip_types =[".md",".txt"]

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -95,6 +95,37 @@ class TestGetMaxTokens:
 
         assert get_max_tokens(model) == 1050000
 
+    @pytest.mark.parametrize("prefix", ["", "openai/", "azure/", "azure/openai/"])
+    @pytest.mark.parametrize("suffix", ["", "_thinking"])
+    @pytest.mark.parametrize("cap", [0, 32000])
+    def test_gpt6_astra_model_max_tokens(self, monkeypatch, prefix, suffix, cap):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": cap,
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+        monkeypatch.setattr(litellm, "get_model_info", lambda *args, **kwargs: pytest.fail("Static lookup expected"))
+
+        assert get_max_tokens(f"{prefix}gpt-6-astra{suffix}") == (cap or 1050000)
+
+    @pytest.mark.parametrize("model", [
+        "openai/gpt-6-astra", "azure/gpt-6-astra", "azure/openai/gpt-6-astra_thinking",
+        "gpt-6-astra_thinking",
+    ])
+    @pytest.mark.parametrize("cap, expected", [(0, 128000), (32000, 32000)])
+    def test_gpt6_astra_alias_preserves_custom_limit(self, monkeypatch, model, cap, expected):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 128000,
+                "max_model_tokens": cap,
+            })()
+        })()
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == expected
+
     @pytest.mark.parametrize(
         ("model", "expected"),
         [

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -860,6 +860,69 @@ class TestLiteLLMReasoningEffort:
                 )
 
 
+class TestLiteLLMReasoningEffortGPT6:
+    @pytest.mark.parametrize("provider", ["openai", "azure"])
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_litellm_forwards_astra_reasoning(self, monkeypatch, provider, effort):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        params = get_optional_params(
+            model="gpt-6-astra",
+            custom_llm_provider=provider,
+            reasoning_effort=effort,
+            allowed_openai_params=["reasoning_effort"],
+            max_completion_tokens=4096,
+        )
+        assert params["reasoning_effort"] == effort
+        assert params["max_completion_tokens"] == 4096
+        assert "max_tokens" not in params
+        assert "temperature" not in params
+
+    @pytest.mark.parametrize("prefix", ["", "openai/", "azure/", "azure/openai/"])
+    @pytest.mark.parametrize("suffix", ["", "_thinking"])
+    @pytest.mark.parametrize("azure", [False, True])
+    @pytest.mark.parametrize("effort, expected", [
+        ("low", "low"), ("medium", "medium"), ("high", "high"),
+        ("xhigh", "xhigh"), ("max", "max"), ("none", "low"), ("minimal", "low"),
+        (None, "medium"), ("invalid", "medium"),
+    ])
+    async def test_astra_request(self, monkeypatch, prefix, suffix, azure, effort, expected):
+        fake_settings = create_mock_settings(effort)
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        for name in ("AWS_USE_IMDS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                     "AWS_SESSION_TOKEN", "AWS_REGION_NAME", "OPENAI_API_KEY"):
+            monkeypatch.delenv(name, raising=False)
+
+        with patch.object(litellm_handler, "acompletion", new_callable=AsyncMock) as completion:
+            completion.return_value = create_mock_acompletion_response()
+            handler = LiteLLMAIHandler()
+            handler.azure = azure
+            result = await handler.chat_completion(
+                model=f"{prefix}gpt-6-astra{suffix}", system="system", user="user",
+            )
+
+        kwargs = completion.call_args.kwargs
+        provider = "azure/" if azure or prefix.startswith("azure/") else "openai/"
+        assert kwargs["model"] == provider + "gpt-6-astra"
+        assert kwargs["reasoning_effort"] == expected
+        assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
+        assert "temperature" not in kwargs
+        assert kwargs["messages"] == [{"role": "system", "content": "system"}, {"role": "user", "content": "user"}]
+        assert result == ("test", "stop")
+
+    async def test_astra_output_limit(self, monkeypatch):
+        fake_settings = create_mock_settings("max")
+        fake_settings.config.get = lambda key, default=None: 4096 if key == "max_output_tokens" else default
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+
+        with patch.object(litellm_handler, "acompletion", new_callable=AsyncMock) as completion:
+            completion.return_value = create_mock_acompletion_response()
+            await LiteLLMAIHandler().chat_completion(model="gpt-6-astra", system="system", user="user")
+
+        kwargs = completion.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 4096
+        assert "max_tokens" not in kwargs
+
+
 class TestLiteLLMReasoningEffortGemini:
     """Gemini 2.5 reasoning_effort handling via the SUPPORT_REASONING_EFFORT_MODELS path.
 


### PR DESCRIPTION
Register Astra's context window and handle its reasoning and output parameters while preserving model defaults and custom token limits.

Cover provider aliases and request parameters with regression tests.

References:
- https://openai.com/index/gpt-6-astra/
- https://developers.openai.com/api/docs/models/gpt-6-astra