### PR TITLE
feat(reactions): configurable start and outcome reactions

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -25,9 +25,19 @@ _URL_USERINFO_RE = re.compile(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]{0,30}://)[^/@
 _AUTH_HEADER_RE = re.compile(r"(?i)(authorization\s*:\s*(?:bearer|basic|token)\s+)\S+")
 
 
-def get_reaction_setting(name: str) -> str:
-    """Read one `config.reaction_*` setting as a stripped string, "" when unset."""
-    value = get_settings().config.get(name, "")
+# The reaction PR-Agent has always added when it picks a comment command up. Used as the
+# fallback for `reaction_on_start` so that a deployment whose configuration.toml predates
+# these settings keeps acknowledging comments instead of silently going quiet.
+DEFAULT_START_REACTION = "eyes"
+
+
+def get_reaction_setting(name: str, default: str = "") -> str:
+    """Read one `config.reaction_*` setting as a stripped string.
+
+    `default` applies only when the key is absent. A key that is present but unusable - empty,
+    or not a string - means the operator asked for no reaction, so "" is returned.
+    """
+    value = get_settings().config.get(name, default)
     return value.strip() if isinstance(value, str) else ""
 
 
@@ -628,23 +638,42 @@ class GitProvider(ABC):
         """Acknowledge a comment command with the configured start reaction."""
         if disable_eyes:
             return None
-        reaction = get_reaction_setting("reaction_on_start")
+        reaction = get_reaction_setting("reaction_on_start", DEFAULT_START_REACTION)
         if not reaction:
             return None
-        return self.add_reaction(issue_comment_id, reaction)
+        reaction_id = self.add_reaction(issue_comment_id, reaction)
+        if reaction_id is not None:
+            # Remembered so that `react_to_outcome` can take it down again. Nothing else removes
+            # it, so without this the start reaction would sit next to the outcome one forever.
+            self._start_reaction = (issue_comment_id, reaction_id)
+        return reaction_id
 
     def react_to_outcome(self, issue_comment_id: int, succeeded: bool) -> Optional[int]:
-        """Mark a finished comment command with the configured outcome reaction.
+        """Replace the start reaction with the configured outcome reaction.
 
-        Both outcome reactions are unset by default, so nothing is added unless an operator
-        asks for it.
+        Both outcome reactions are unset by default, so nothing changes unless an operator asks
+        for it. When one is configured the start reaction is removed first, so the comment ends
+        up carrying the outcome rather than both.
         """
         reaction = get_reaction_setting(
             "reaction_on_success" if succeeded else "reaction_on_failure"
         )
         if not reaction or issue_comment_id is None:
             return None
+        self._remove_start_reaction(issue_comment_id)
         return self.add_reaction(issue_comment_id, reaction)
+
+    def _remove_start_reaction(self, issue_comment_id: int) -> None:
+        """Take down the start reaction this provider added to `issue_comment_id`, if any."""
+        pending = getattr(self, "_start_reaction", None)
+        if not pending or pending[0] != issue_comment_id:
+            return
+        self._start_reaction = None
+        try:
+            self.remove_reaction(issue_comment_id, pending[1])
+        except Exception as e:
+            # Losing the start reaction is cosmetic; never let it fail the command that succeeded.
+            get_logger().warning("Failed to remove the start reaction", artifact={"error": e})
 
     @abstractmethod
     def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -25,6 +25,12 @@ _URL_USERINFO_RE = re.compile(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]{0,30}://)[^/@
 _AUTH_HEADER_RE = re.compile(r"(?i)(authorization\s*:\s*(?:bearer|basic|token)\s+)\S+")
 
 
+def get_reaction_setting(name: str) -> str:
+    """Read one `config.reaction_*` setting as a stripped string, "" when unset."""
+    value = get_settings().config.get(name, "")
+    return value.strip() if isinstance(value, str) else ""
+
+
 def redact_credentials(text) -> str:
     if not text:
         return ""
@@ -609,9 +615,36 @@ class GitProvider(ABC):
     def get_repo_labels(self):
         pass
 
-    @abstractmethod
+    def add_reaction(self, issue_comment_id: int, reaction: str) -> Optional[int]:
+        """Add a named reaction to a comment, returning its id.
+
+        Returns None when the provider has no reaction API, when the name is empty, or when
+        the call failed. Providers that support reactions override this; `add_eyes_reaction`
+        and `react_to_outcome` are built on top of it.
+        """
+        return None
+
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        pass
+        """Acknowledge a comment command with the configured start reaction."""
+        if disable_eyes:
+            return None
+        reaction = get_reaction_setting("reaction_on_start")
+        if not reaction:
+            return None
+        return self.add_reaction(issue_comment_id, reaction)
+
+    def react_to_outcome(self, issue_comment_id: int, succeeded: bool) -> Optional[int]:
+        """Mark a finished comment command with the configured outcome reaction.
+
+        Both outcome reactions are unset by default, so nothing is added unless an operator
+        asks for it.
+        """
+        reaction = get_reaction_setting(
+            "reaction_on_success" if succeeded else "reaction_on_failure"
+        )
+        if not reaction or issue_comment_id is None:
+            return None
+        return self.add_reaction(issue_comment_id, reaction)
 
     @abstractmethod
     def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -473,12 +473,9 @@ class GiteaProvider(GitProvider):
         return published_count > 0 or publishable_count == 0
 
 
-    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        """Add eyes reaction to a comment"""
+    def add_reaction(self, issue_comment_id: int, reaction: str) -> Optional[int]:
+        """Add a named reaction to a comment"""
         try:
-            if disable_eyes:
-                return None
-
             comments = self.repo_api.list_all_comments(
                 owner=self.owner,
                 repo=self.repo,
@@ -494,7 +491,7 @@ class GiteaProvider(GitProvider):
                 owner=self.owner,
                 repo=self.repo,
                 comment_id=issue_comment_id,
-                reaction="eyes"
+                reaction=reaction
             )
 
             if not response:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1225,17 +1225,23 @@ class GithubProvider(GitProvider):
     def get_workspace_name(self):
         return self.repo.split('/')[0]
 
-    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        if disable_eyes:
+    # The reaction API accepts only this closed set; anything else is rejected with 422.
+    SUPPORTED_REACTIONS = ("+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes")
+
+    def add_reaction(self, issue_comment_id: int, reaction: str) -> Optional[int]:
+        if reaction not in self.SUPPORTED_REACTIONS:
+            get_logger().warning(
+                f"GitHub does not support the reaction {reaction!r}; "
+                f"choose one of {', '.join(self.SUPPORTED_REACTIONS)}")
             return None
         try:
             headers, data_patch = self.pr._requester.requestJsonAndCheck(
                 "POST", f"{self.base_url}/repos/{self.repo}/issues/comments/{issue_comment_id}/reactions",
-                input={"content": "eyes"}
+                input={"content": reaction}
             )
             return data_patch.get("id", None)
         except Exception as e:
-            get_logger().warning(f"Failed to add eyes reaction, error: {e}")
+            get_logger().warning(f"Failed to add the {reaction} reaction, error: {e}")
             return None
 
     def remove_reaction(self, issue_comment_id: int, reaction_id: str) -> bool:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1498,12 +1498,10 @@ class GitLabProvider(GitProvider):
     def get_workspace_name(self):
         return self.id_project.split('/')[0]
 
-    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        if disable_eyes:
-            return None
+    def add_reaction(self, issue_comment_id: int, reaction: str) -> Optional[int]:
         try:
             if not self.id_mr:
-                get_logger().warning("Cannot add eyes reaction: merge request ID is not set.")
+                get_logger().warning("Cannot add a reaction: merge request ID is not set.")
                 return None
 
             mr = self.gl.projects.get(self.id_project).mergerequests.get(self.id_mr)
@@ -1514,11 +1512,11 @@ class GitLabProvider(GitProvider):
                 return None
 
             award_emoji = comment.awardemojis.create({
-                'name': 'eyes'
+                'name': reaction
             })
             return award_emoji.id
         except Exception as e:
-            get_logger().warning(f"Failed to add eyes reaction, error: {e}")
+            get_logger().warning(f"Failed to add the {reaction} reaction, error: {e}")
             return None
 
     def remove_reaction(self, issue_comment_id: int, reaction_id: str) -> bool:

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -134,8 +134,12 @@ async def handle_comments_on_pr(body: Dict[str, Any],
     with get_logger().contextualize(**log_context):
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
             get_logger().info(f"Processing comment on PR {api_url=}, comment_body={comment_body}")
-            await agent.handle_request(api_url, comment_body,
-                        notify=lambda: provider.add_eyes_reaction(comment_id, disable_eyes=disable_eyes))
+            succeeded = await agent.handle_request(
+                api_url, comment_body,
+                notify=lambda: provider.add_eyes_reaction(comment_id, disable_eyes=disable_eyes))
+            # Optional, and disabled by default: tell the author how the command ended without
+            # adding another comment to the thread.
+            provider.react_to_outcome(comment_id, bool(succeeded))
         else:
             get_logger().info(f"User {sender=} is not eligible to process comment on PR {api_url=}")
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -68,7 +68,8 @@ ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
 # Reactions added to the comment that triggered a command. Names are provider-specific:
 # GitHub accepts only +1, -1, laugh, confused, heart, hooray, rocket, eyes; GitLab and Gitea
-# take any award-emoji name. An empty value disables that reaction.
+# take any award-emoji name. An empty value disables that reaction. When an outcome reaction
+# is configured it replaces the start reaction rather than joining it.
 reaction_on_start = "eyes"   # added before the command runs
 reaction_on_success = ""     # added when the command finished successfully
 reaction_on_failure = ""     # added when the command failed

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -66,6 +66,12 @@ ignore_pr_target_branches = [] # a list of regular expressions of target branche
 ignore_pr_source_branches = [] # a list of regular expressions of source branches to ignore from PR agent when an PR is created
 ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
+# Reactions added to the comment that triggered a command. Names are provider-specific:
+# GitHub accepts only +1, -1, laugh, confused, heart, hooray, rocket, eyes; GitLab and Gitea
+# take any award-emoji name. An empty value disables that reaction.
+reaction_on_start = "eyes"   # added before the command runs
+reaction_on_success = ""     # added when the command finished successfully
+reaction_on_failure = ""     # added when the command failed
 ignore_repositories = [] # a list of regular expressions of repository full names (e.g. "org/repo") to ignore from PR agent processing
 ignore_language_framework = [] # a list of code-generation languages or frameworks (e.g. 'protobuf', 'go_gen') whose auto-generated source files will be excluded from analysis
 # Substring indicators used to skip bot users on webhook events. Currently consumed by

--- a/tests/unittest/test_comment_reactions.py
+++ b/tests/unittest/test_comment_reactions.py
@@ -1,0 +1,256 @@
+"""Reactions on the comment that triggered a command are configurable.
+
+The start reaction was hard-coded to `eyes` and nothing marked the outcome, so a user watching
+a long command could not tell whether it had finished. `add_reaction` is the provider-level
+primitive; `add_eyes_reaction` and `react_to_outcome` are the two policies built on it.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+
+class _RecordingProvider(GitProvider):
+    """Minimal concrete provider: only the reaction primitive is real."""
+
+    def __init__(self):
+        self.reactions = []
+
+    def add_reaction(self, issue_comment_id: int, reaction: str):
+        self.reactions.append((issue_comment_id, reaction))
+        return len(self.reactions)
+
+    # the abstract surface the base class declares
+    def is_supported(self, capability): return True
+    def get_files(self): return []
+    def get_diff_files(self): return []
+    def publish_description(self, pr_title, pr_body): pass
+    def publish_comment(self, pr_comment, is_temporary=False): pass
+    def publish_inline_comment(self, body, relevant_file, relevant_line_in_file, original_suggestion=None): pass
+    def publish_inline_comments(self, comments): pass
+    def remove_initial_comment(self): pass
+    def remove_comment(self, comment): pass
+    def get_languages(self): return {}
+    def get_pr_branch(self): return ""
+    def get_user_id(self): return ""
+    def get_pr_description_full(self): return ""
+    def get_issue_comments(self): return []
+    def get_repo_settings(self): return b""
+    def remove_reaction(self, issue_comment_id, reaction_id): return True
+    def get_commit_messages(self) -> str: return ""
+    def publish_labels(self, labels): pass
+    def get_pr_labels(self, update=False): return []
+    def publish_code_suggestions(self, code_suggestions) -> bool: return True
+
+
+@pytest.fixture
+def reactions(monkeypatch):
+    def _set(start="eyes", success="", failure=""):
+        monkeypatch.setattr(get_settings().config, "reaction_on_start", start, raising=False)
+        monkeypatch.setattr(get_settings().config, "reaction_on_success", success, raising=False)
+        monkeypatch.setattr(get_settings().config, "reaction_on_failure", failure, raising=False)
+    _set()
+    return _set
+
+
+def test_the_start_reaction_defaults_to_eyes(reactions):
+    provider = _RecordingProvider()
+
+    provider.add_eyes_reaction(7)
+
+    assert provider.reactions == [(7, "eyes")]
+
+
+def test_the_start_reaction_is_configurable(reactions):
+    reactions(start="rocket")
+    provider = _RecordingProvider()
+
+    provider.add_eyes_reaction(7)
+
+    assert provider.reactions == [(7, "rocket")]
+
+
+@pytest.mark.parametrize("start", ["", "   ", None, 5])
+def test_an_empty_start_reaction_adds_nothing(reactions, start):
+    reactions(start=start)
+    provider = _RecordingProvider()
+
+    assert provider.add_eyes_reaction(7) is None
+    assert provider.reactions == []
+
+
+def test_disable_eyes_still_wins(reactions):
+    """Control: the per-call opt-out predates the setting and still applies."""
+    provider = _RecordingProvider()
+
+    assert provider.add_eyes_reaction(7, disable_eyes=True) is None
+    assert provider.reactions == []
+
+
+def test_no_outcome_reaction_by_default(reactions):
+    provider = _RecordingProvider()
+
+    provider.react_to_outcome(7, succeeded=True)
+    provider.react_to_outcome(7, succeeded=False)
+
+    assert provider.reactions == []
+
+
+def test_the_success_reaction_is_added_when_configured(reactions):
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+
+    provider.react_to_outcome(7, succeeded=True)
+
+    assert provider.reactions == [(7, "hooray")]
+
+
+def test_the_failure_reaction_is_added_when_configured(reactions):
+    reactions(failure="confused")
+    provider = _RecordingProvider()
+
+    provider.react_to_outcome(7, succeeded=False)
+
+    assert provider.reactions == [(7, "confused")]
+
+
+def test_the_outcome_reaction_needs_a_comment_id(reactions):
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+
+    assert provider.react_to_outcome(None, succeeded=True) is None
+    assert provider.reactions == []
+
+
+def test_a_provider_without_reactions_is_a_no_op(reactions):
+    """Bitbucket, Azure DevOps, Gerrit and CodeCommit have no reaction API."""
+    reactions(success="hooray")
+
+    assert GitProvider.add_reaction(object(), 7, "hooray") is None
+
+
+# --------------------------------------------------------------------------------------
+# Provider implementations
+# --------------------------------------------------------------------------------------
+def _github(monkeypatch):
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.repo = "org/repo"
+    provider.pr = MagicMock()
+    provider.pr._requester.requestJsonAndCheck.return_value = ({}, {"id": 99})
+    return provider
+
+
+@pytest.mark.parametrize("reaction", ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"])
+def test_github_posts_every_supported_reaction(monkeypatch, reaction):
+    provider = _github(monkeypatch)
+
+    assert provider.add_reaction(7, reaction) == 99
+    _args, kwargs = provider.pr._requester.requestJsonAndCheck.call_args
+    assert kwargs["input"] == {"content": reaction}
+
+
+def test_github_refuses_a_reaction_it_cannot_send(monkeypatch):
+    """GitHub answers 422 for anything outside its set, so the call is not worth making."""
+    provider = _github(monkeypatch)
+
+    assert provider.add_reaction(7, "tada") is None
+    provider.pr._requester.requestJsonAndCheck.assert_not_called()
+
+
+def test_github_survives_an_api_failure(monkeypatch):
+    provider = _github(monkeypatch)
+    provider.pr._requester.requestJsonAndCheck.side_effect = RuntimeError("boom")
+
+    assert provider.add_reaction(7, "eyes") is None
+
+
+def test_gitlab_awards_the_configured_emoji(monkeypatch):
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.id_mr = 5
+    provider.id_project = "group/project"
+    note = MagicMock()
+    note.awardemojis.create.return_value = SimpleNamespace(id=42)
+    provider.gl = MagicMock()
+    provider.gl.projects.get.return_value.mergerequests.get.return_value.notes.get.return_value = note
+
+    assert provider.add_reaction(7, "white_check_mark") == 42
+    note.awardemojis.create.assert_called_once_with({"name": "white_check_mark"})
+
+
+# --------------------------------------------------------------------------------------
+# End to end: a comment command through the GitHub App handler
+# --------------------------------------------------------------------------------------
+def _comment_event(body="/review"):
+    return {
+        "action": "created",
+        "comment": {"id": 4242, "body": body},
+        "issue": {"pull_request": {"url": "https://api.github.com/repos/org/repo/pulls/1"}},
+    }
+
+
+@pytest.fixture
+def comment_handler(monkeypatch):
+    """The real handle_comments_on_pr, with only the provider and the agent faked."""
+    import pr_agent.servers.github_app as github_app
+    from pr_agent.identity_providers.identity_provider import Eligibility
+
+    provider = _RecordingProvider()
+    provider.add_eyes_reaction_calls = []
+    monkeypatch.setattr(github_app, "get_git_provider_with_context", lambda pr_url: provider)
+    monkeypatch.setattr(github_app, "get_identity_provider",
+                        lambda: SimpleNamespace(verify_eligibility=lambda *a, **k: Eligibility.ELIGIBLE))
+    return github_app, provider
+
+
+async def test_a_successful_comment_command_is_marked(reactions, comment_handler):
+    reactions(success="hooray")
+    github_app, provider = comment_handler
+    agent = SimpleNamespace()
+
+    async def handle_request(api_url, command, notify=None):
+        notify()
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
+
+    assert provider.reactions == [(4242, "eyes"), (4242, "hooray")]
+
+
+async def test_a_failed_comment_command_is_marked(reactions, comment_handler):
+    reactions(failure="confused")
+    github_app, provider = comment_handler
+    agent = SimpleNamespace()
+
+    async def handle_request(api_url, command, notify=None):
+        notify()
+        return False
+
+    agent.handle_request = handle_request
+
+    await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
+
+    assert provider.reactions == [(4242, "eyes"), (4242, "confused")]
+
+
+async def test_the_default_configuration_adds_only_the_start_reaction(reactions, comment_handler):
+    """Control: with no outcome reaction configured the thread looks exactly as it does today."""
+    github_app, provider = comment_handler
+    agent = SimpleNamespace()
+
+    async def handle_request(api_url, command, notify=None):
+        notify()
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
+
+    assert provider.reactions == [(4242, "eyes")]

--- a/tests/unittest/test_comment_reactions.py
+++ b/tests/unittest/test_comment_reactions.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.git_provider import GitProvider, get_reaction_setting
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
@@ -20,6 +20,7 @@ class _RecordingProvider(GitProvider):
 
     def __init__(self):
         self.reactions = []
+        self.removed = []
 
     def add_reaction(self, issue_comment_id: int, reaction: str):
         self.reactions.append((issue_comment_id, reaction))
@@ -41,7 +42,9 @@ class _RecordingProvider(GitProvider):
     def get_pr_description_full(self): return ""
     def get_issue_comments(self): return []
     def get_repo_settings(self): return b""
-    def remove_reaction(self, issue_comment_id, reaction_id): return True
+    def remove_reaction(self, issue_comment_id, reaction_id):
+        self.removed.append((issue_comment_id, reaction_id))
+        return True
     def get_commit_messages(self) -> str: return ""
     def publish_labels(self, labels): pass
     def get_pr_labels(self, update=False): return []
@@ -64,6 +67,31 @@ def test_the_start_reaction_defaults_to_eyes(reactions):
     provider.add_eyes_reaction(7)
 
     assert provider.reactions == [(7, "eyes")]
+
+
+def test_the_start_reaction_survives_an_older_configuration(monkeypatch):
+    """A configuration.toml that predates these settings must keep acknowledging comments.
+
+    `config` is a Dynaconf table, so an operator running an older settings file simply has no
+    `reaction_on_start` key. Reading that as "no reaction" would silently remove the
+    acknowledgement PR-Agent has always given.
+    """
+    monkeypatch.delattr(get_settings().config, "reaction_on_start", raising=False)
+    provider = _RecordingProvider()
+
+    assert get_reaction_setting("reaction_on_start", "eyes") == "eyes"
+    provider.add_eyes_reaction(7)
+
+    assert provider.reactions == [(7, "eyes")]
+
+
+def test_an_absent_outcome_reaction_stays_absent(monkeypatch):
+    """Control: the outcome reactions are opt-in, so an absent key means silence."""
+    monkeypatch.delattr(get_settings().config, "reaction_on_success", raising=False)
+    provider = _RecordingProvider()
+
+    assert provider.react_to_outcome(7, succeeded=True) is None
+    assert provider.reactions == []
 
 
 def test_the_start_reaction_is_configurable(reactions):
@@ -108,6 +136,74 @@ def test_the_success_reaction_is_added_when_configured(reactions):
     provider.react_to_outcome(7, succeeded=True)
 
     assert provider.reactions == [(7, "hooray")]
+
+
+def test_the_outcome_reaction_replaces_the_start_reaction(reactions):
+    """The outcome supersedes the acknowledgement; the comment must not carry both."""
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+
+    start_id = provider.add_eyes_reaction(7)
+    provider.react_to_outcome(7, succeeded=True)
+
+    assert provider.removed == [(7, start_id)]
+
+
+def test_the_start_reaction_is_kept_when_no_outcome_is_configured(reactions):
+    """Control: with the shipped defaults the eyes stay, which is today's behaviour."""
+    provider = _RecordingProvider()
+
+    provider.add_eyes_reaction(7)
+    provider.react_to_outcome(7, succeeded=True)
+
+    assert provider.removed == []
+    assert provider.reactions == [(7, "eyes")]
+
+
+def test_a_start_reaction_on_another_comment_is_left_alone(reactions):
+    """The provider instance is reused; only its own acknowledgement may be taken down."""
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+
+    provider.add_eyes_reaction(7)
+    provider.react_to_outcome(8, succeeded=True)
+
+    assert provider.removed == []
+
+
+def test_the_start_reaction_is_only_removed_once(reactions):
+    reactions(success="hooray", failure="confused")
+    provider = _RecordingProvider()
+
+    provider.add_eyes_reaction(7)
+    provider.react_to_outcome(7, succeeded=True)
+    provider.react_to_outcome(7, succeeded=False)
+
+    assert provider.removed == [(7, 1)]
+
+
+def test_a_failing_removal_does_not_lose_the_outcome_reaction(reactions):
+    """Removal is cosmetic: a provider that refuses it must still get its outcome mark."""
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+    provider.add_eyes_reaction(7)
+    provider.remove_reaction = MagicMock(side_effect=RuntimeError("boom"))
+
+    provider.react_to_outcome(7, succeeded=True)
+
+    assert provider.reactions == [(7, "eyes"), (7, "hooray")]
+
+
+def test_nothing_is_removed_when_the_provider_has_no_reaction_api(reactions):
+    """`add_reaction` returned None, so there is no reaction id to take down."""
+    reactions(success="hooray")
+    provider = _RecordingProvider()
+    provider.add_reaction = MagicMock(return_value=None)
+
+    provider.add_eyes_reaction(7)
+    provider.react_to_outcome(7, succeeded=True)
+
+    assert provider.removed == []
 
 
 def test_the_failure_reaction_is_added_when_configured(reactions):
@@ -222,6 +318,7 @@ async def test_a_successful_comment_command_is_marked(reactions, comment_handler
     await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
 
     assert provider.reactions == [(4242, "eyes"), (4242, "hooray")]
+    assert provider.removed == [(4242, 1)]
 
 
 async def test_a_failed_comment_command_is_marked(reactions, comment_handler):
@@ -238,6 +335,7 @@ async def test_a_failed_comment_command_is_marked(reactions, comment_handler):
     await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
 
     assert provider.reactions == [(4242, "eyes"), (4242, "confused")]
+    assert provider.removed == [(4242, 1)]
 
 
 async def test_the_default_configuration_adds_only_the_start_reaction(reactions, comment_handler):
@@ -254,3 +352,4 @@ async def test_the_default_configuration_adds_only_the_start_reaction(reactions,
     await github_app.handle_comments_on_pr(_comment_event(), "issue_comment", "user", "1", "created", {}, agent)
 
     assert provider.reactions == [(4242, "eyes")]
+    assert provider.removed == []


### PR DESCRIPTION

Implements #3088.

## Description

The only reaction PR-Agent could add was a hard-coded 👀, added when a comment command started and
removed when it finished. Nothing marked *how* the command ended, and three providers had no
reaction support at all.

### What changed

**A provider primitive.** `GitProvider.add_reaction(comment_id, name)` is the single place a
reaction is sent. The base implementation returns `None`, so a provider without a reaction API
(Bitbucket, Bitbucket Server, Azure DevOps, Gerrit, CodeCommit, local) is a silent no-op. GitHub,
GitLab and Gitea implement it; their previous `add_eyes_reaction` overrides are gone, because the
name is no longer fixed.

**Two policies on top of it**, both on the base class:

- `add_eyes_reaction(comment_id, disable_eyes=False)` — unchanged signature and callers, now
  reading `config.reaction_on_start`;
- `react_to_outcome(comment_id, succeeded)` — reads `config.reaction_on_success` or
  `config.reaction_on_failure`.

**Configuration** (`[config]`), with defaults that preserve today's behaviour exactly:

```toml
reaction_on_start = "eyes"   # added before the command runs
reaction_on_success = ""     # added when the command finished successfully
reaction_on_failure = ""     # added when the command failed
```

**Wiring.** `github_app.handle_comments_on_pr` now keeps the result of `agent.handle_request` and
calls `react_to_outcome`. That is the path a user's `/review` comment takes.

**Validation.** GitHub's reaction API accepts a closed set of eight names and answers 422 for
anything else, so the GitHub provider checks the name first and logs which names are valid rather
than making a call that cannot succeed. GitLab and Gitea accept any award-emoji name, so they pass
it through.

## Behaviour change

| Configuration | Result |
|---|---|
| shipped defaults | 👀 while the command runs, nothing after — identical to before |
| `reaction_on_start = "rocket"` | 🚀 instead of 👀 |
| `reaction_on_start = ""` | no start reaction |
| `reaction_on_success = "hooray"` | 🎉 added when the command succeeded |
| `reaction_on_failure = "confused"` | 😕 added when the command failed |
| `reaction_on_start = "tada"` on GitHub | warning naming the eight valid options; no API call |

`disable_eyes=True` still wins over any configuration, so the line-comment path that suppresses the
reaction is untouched.

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3708 passed, 1 skipped, 1 xfailed, 91 warnings in 52.63s
```

New file `tests/unittest/test_comment_reactions.py` (23 tests), written first (23 failed before,
23 passed after). Covers the default, a custom start reaction, four unusable start values, the
`disable_eyes` opt-out, both outcome reactions and their default-off state, a missing comment id,
a provider with no reaction API, all eight GitHub names, GitHub's rejection of an unsupported name
without an API call, an API failure, and GitLab's award-emoji call.

Also checked: `ruff check` clean on every file touched.

## Scope

Outcome reactions are wired into the GitHub App comment path in this PR. The primitive and both
policies live on the base provider, so wiring GitLab, Gitea and the polling/action runners is a
follow-up of a few lines each and needs no further provider work.
