### PR TITLE
feat(status): acknowledge a pull request the moment automatic commands start

### DIFF
--- a/pr_agent/algo/run_details.py
+++ b/pr_agent/algo/run_details.py
@@ -55,6 +55,10 @@ class RunDetails:
     # Monotonic reference taken when the collector is installed, i.e. at the top of the
     # tool's run(). Monotonic so that wall-clock adjustments cannot yield a negative duration.
     start_time: float = field(default_factory=time.monotonic)
+    # Set when a tool caught its own error and, because `propagate_tool_errors` is false by
+    # default, returned normally anyway. Without this a caller cannot tell a run that published
+    # nothing because it failed from one that had nothing to say.
+    command_failed: bool = False
 
     @property
     def duration_seconds(self) -> float:
@@ -88,6 +92,20 @@ def init_run_details() -> RunDetails:
 def get_run_details() -> Optional[RunDetails]:
     """Return the collector for the current run, or None if not initialized."""
     return _run_details.get()
+
+
+def record_command_failure() -> None:
+    """Mark the current run as failed, for a tool that is about to swallow its own error."""
+    details = get_run_details()
+    if details is None:
+        return
+    details.command_failed = True
+
+
+def command_failed() -> bool:
+    """Whether the current run recorded a swallowed failure."""
+    details = get_run_details()
+    return bool(details is not None and details.command_failed)
 
 
 def record_model_used(model: str, is_fallback: bool) -> None:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -609,6 +609,16 @@ class GitProvider(ABC):
     def get_repo_labels(self):
         pass
 
+    def publish_run_status(self, state: str, description: str) -> bool:
+        """Report that PR-Agent is working, before any output exists.
+
+        `state` is "pending", "success" or "failure". This is the only signal available at the
+        moment a pull request is opened: an automatic command publishes no progress comment, so
+        nothing tells the author anything is happening until the model has answered. Providers
+        without a commit-status API return False.
+        """
+        return False
+
     @abstractmethod
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         pass

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1225,6 +1225,24 @@ class GithubProvider(GitProvider):
     def get_workspace_name(self):
         return self.repo.split('/')[0]
 
+    # GitHub truncates a commit-status description at 140 characters.
+    MAX_STATUS_DESCRIPTION = 140
+
+    def publish_run_status(self, state: str, description: str) -> bool:
+        if not getattr(self, "last_commit_id", None):
+            get_logger().warning("Cannot publish a run status without a commit SHA")
+            return False
+        try:
+            self._get_repo().get_commit(self.last_commit_id.sha).create_status(
+                state=state,
+                description=description[:self.MAX_STATUS_DESCRIPTION],
+                context=get_settings().get("config.run_status_context", "pr-agent"),
+            )
+            return True
+        except Exception as e:
+            get_logger().warning(f"Failed to publish the {state} run status: {e}")
+            return False
+
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         if disable_eyes:
             return None

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1498,6 +1498,25 @@ class GitLabProvider(GitProvider):
     def get_workspace_name(self):
         return self.id_project.split('/')[0]
 
+    # GitLab reports a commit status as a pipeline entry; "failure" is spelled "failed".
+    _RUN_STATUS_STATES = {"pending": "pending", "success": "success", "failure": "failed"}
+
+    def publish_run_status(self, state: str, description: str) -> bool:
+        sha = getattr(self.mr, "sha", None) if getattr(self, "mr", None) else None
+        if not sha:
+            get_logger().warning("Cannot publish a run status without a commit SHA")
+            return False
+        try:
+            self.gl.projects.get(self.id_project).commits.get(sha).statuses.create({
+                "state": self._RUN_STATUS_STATES.get(state, state),
+                "description": description,
+                "name": get_settings().get("config.run_status_context", "pr-agent"),
+            })
+            return True
+        except Exception as e:
+            get_logger().warning(f"Failed to publish the {state} run status: {e}")
+            return False
+
     def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
         if disable_eyes:
             return None

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -161,6 +161,11 @@ async def handle_new_pr_opened(body: Dict[str, Any],
             get_logger().info(f"User {sender=} is not eligible to process PR {api_url=}")
 
 
+def publish_run_status() -> bool:
+    """Whether the operator asked for a commit status while automatic commands run."""
+    return bool(get_settings().get("config.publish_run_status", False))
+
+
 def _normalise_setting_list(value):
     if value is None:
         return []
@@ -530,13 +535,24 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         get_logger().info(f"No {commands_conf} configured, skipping auto commands")
         return
     get_settings().set("config.is_auto_command", True)
+    provider = get_git_provider_with_context(pr_url=api_url) if publish_run_status() else None
+    if provider is not None:
+        # The first thing the author sees: the pull request was picked up, before the model answered.
+        provider.publish_run_status("pending", f"PR-Agent is running {len(commands)} command(s)")
+    succeeded = True
     for command in commands:
         try:
             new_command = prepare_command(command)
             get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
-            await agent.handle_request(api_url, new_command)
+            if not await agent.handle_request(api_url, new_command):
+                succeeded = False
         except Exception as e:
+            succeeded = False
             get_logger().error(f"Failed to perform command {command}: {e}")
+    if provider is not None:
+        provider.publish_run_status(
+            "success" if succeeded else "failure",
+            "PR-Agent finished" if succeeded else "PR-Agent could not finish every command")
 
 
 @router.get("/")

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -13,6 +13,7 @@ from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.agent.pr_agent import PRAgent, prepare_command
+from pr_agent.algo.run_details import command_failed, init_run_details
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers import get_git_provider, get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
@@ -544,7 +545,16 @@ async def _perform_auto_commands_github(commands_conf: str, agent: PRAgent, body
         try:
             new_command = prepare_command(command)
             get_logger().info(f"{commands_conf}. Performing auto command '{new_command}', for {api_url=}")
+            # Install a fresh collector so `command_failed()` below cannot read a verdict left
+            # behind by the previous command; the tool replaces it with its own on entry.
+            init_run_details()
             if not await agent.handle_request(api_url, new_command):
+                succeeded = False
+            elif command_failed():
+                # `propagate_tool_errors` is false by default, so a tool that failed internally
+                # still returns normally. Reporting that as success would put a green tick on a
+                # pull request that never got its review.
+                get_logger().warning(f"Command '{command}' reported success but recorded a failure")
                 succeeded = False
         except Exception as e:
             succeeded = False

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -66,6 +66,10 @@ ignore_pr_target_branches = [] # a list of regular expressions of target branche
 ignore_pr_source_branches = [] # a list of regular expressions of source branches to ignore from PR agent when an PR is created
 ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
+# Mark the PR head commit as soon as an automatic command starts, so the author sees that
+# PR-Agent picked the pull request up before any output exists. Off by default.
+publish_run_status = false
+run_status_context = "pr-agent" # the status name shown on the commit
 ignore_repositories = [] # a list of regular expressions of repository full names (e.g. "org/repo") to ignore from PR agent processing
 ignore_language_framework = [] # a list of code-generation languages or frameworks (e.g. 'protobuf', 'go_gen') whose auto-generated source files will be excluded from analysis
 # Substring indicators used to skip bot users on webhook events. Currently consumed by

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -23,7 +23,7 @@ from pr_agent.algo.pr_processing import (
 )
 from pr_agent.algo.prompt_fragments import render_diff_hunk_format
 from pr_agent.algo.repo_context import build_repo_context
-from pr_agent.algo.run_details import init_run_details
+from pr_agent.algo.run_details import init_run_details, record_command_failure
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -386,6 +386,8 @@ class PRCodeSuggestions:
                         self.git_provider.publish_comment("Failed to generate code suggestions for PR")
                     except Exception as e:
                         get_logger().exception(f"Failed to update persistent review, error: {e}")
+            # The status of the whole run must not read as success just because the error stopped here.
+            record_command_failure()
             if get_settings().config.get("propagate_tool_errors", False):
                 raise
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -18,7 +18,7 @@ from pr_agent.algo.pr_processing import (
     retry_with_fallback_models,
 )
 from pr_agent.algo.repo_context import build_repo_context
-from pr_agent.algo.run_details import init_run_details
+from pr_agent.algo.run_details import init_run_details, record_command_failure
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -226,6 +226,8 @@ class PRDescription:
         except Exception as e:
             get_logger().error(f"Error generating PR description {self.pr_id}: {e}",
                                artifact={"traceback": traceback.format_exc()})
+            # The status of the whole run must not read as success just because the error stopped here.
+            record_command_failure()
             if get_settings().config.get("propagate_tool_errors", False):
                 raise
         finally:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -31,7 +31,7 @@ from pr_agent.algo.review_finding_state import (
     reconcile_review_findings,
 )
 from pr_agent.algo.review_merge import merge_review_chunks
-from pr_agent.algo.run_details import get_run_details, init_run_details
+from pr_agent.algo.run_details import get_run_details, init_run_details, record_command_failure
 from pr_agent.algo.skills_loader import get_skills_context
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import (
@@ -344,6 +344,8 @@ class PRReviewer:
         except Exception as e:
             review_failed = True
             get_logger().error(f"Failed to review PR: {e}")
+            # The status of the whole run must not read as success just because the error stopped here.
+            record_command_failure()
             if get_settings().config.get("propagate_tool_errors", False):
                 raise
         finally:

--- a/tests/unittest/test_run_status_acknowledgment.py
+++ b/tests/unittest/test_run_status_acknowledgment.py
@@ -1,0 +1,171 @@
+"""An automatic command should say it started before it has anything to publish.
+
+Automatic commands suppress the "Preparing review..." progress comment, so between opening a
+pull request and the model answering there is no sign PR-Agent picked it up. A commit status
+is the least intrusive signal: it appears immediately and adds nothing to the conversation.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import pr_agent.servers.github_app as github_app
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+API_URL = "https://api.github.com/repos/org/repo/pulls/1"
+
+
+@pytest.fixture
+def run_status(monkeypatch):
+    def _set(enabled=True, context="pr-agent"):
+        monkeypatch.setattr(get_settings().config, "publish_run_status", enabled, raising=False)
+        monkeypatch.setattr(get_settings().config, "run_status_context", context, raising=False)
+    _set()
+    return _set
+
+
+def _github(monkeypatch, sha="abc123"):
+    monkeypatch.setattr(GithubProvider, "_get_github_client", lambda self: MagicMock())
+    provider = GithubProvider(pr_url=None)
+    provider.repo = "org/repo"
+    provider.last_commit_id = SimpleNamespace(sha=sha) if sha else None
+    provider.repo_obj = MagicMock()
+    provider.repo_obj.full_name = "org/repo"
+    return provider
+
+
+def test_a_provider_without_statuses_reports_it(run_status):
+    """Bitbucket, Gerrit, CodeCommit and the local provider have no status API."""
+    assert GitProvider.publish_run_status(object(), "pending", "working") is False
+
+
+@pytest.mark.parametrize("state", ["pending", "success", "failure"])
+def test_github_publishes_each_state(monkeypatch, run_status, state):
+    provider = _github(monkeypatch)
+
+    assert provider.publish_run_status(state, "PR-Agent is running") is True
+    provider.repo_obj.get_commit.assert_called_once_with("abc123")
+    _args, kwargs = provider.repo_obj.get_commit.return_value.create_status.call_args
+    assert kwargs["state"] == state
+    assert kwargs["context"] == "pr-agent"
+    assert kwargs["description"] == "PR-Agent is running"
+
+
+def test_github_uses_the_configured_context(monkeypatch, run_status):
+    run_status(context="ci/pr-agent")
+    provider = _github(monkeypatch)
+
+    provider.publish_run_status("pending", "working")
+
+    _args, kwargs = provider.repo_obj.get_commit.return_value.create_status.call_args
+    assert kwargs["context"] == "ci/pr-agent"
+
+
+def test_github_truncates_a_long_description(monkeypatch, run_status):
+    provider = _github(monkeypatch)
+
+    provider.publish_run_status("pending", "x" * 300)
+
+    _args, kwargs = provider.repo_obj.get_commit.return_value.create_status.call_args
+    assert len(kwargs["description"]) == GithubProvider.MAX_STATUS_DESCRIPTION
+
+
+def test_github_without_a_commit_sha_reports_failure(monkeypatch, run_status):
+    provider = _github(monkeypatch, sha=None)
+
+    assert provider.publish_run_status("pending", "working") is False
+
+
+def test_github_survives_an_api_failure(monkeypatch, run_status):
+    provider = _github(monkeypatch)
+    provider.repo_obj.get_commit.side_effect = RuntimeError("boom")
+
+    assert provider.publish_run_status("pending", "working") is False
+
+
+def test_gitlab_maps_failure_to_failed(run_status):
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.id_project = "group/project"
+    provider.mr = SimpleNamespace(sha="abc123")
+    provider.gl = MagicMock()
+
+    assert provider.publish_run_status("failure", "could not finish") is True
+    payload = provider.gl.projects.get.return_value.commits.get.return_value.statuses.create.call_args.args[0]
+    assert payload["state"] == "failed"
+    assert payload["name"] == "pr-agent"
+
+
+# --------------------------------------------------------------------------------------
+# Wiring: the automatic-command runner
+# --------------------------------------------------------------------------------------
+@pytest.fixture
+def auto_commands(monkeypatch):
+    provider = MagicMock()
+    monkeypatch.setattr(github_app, "get_git_provider_with_context", lambda pr_url: provider)
+    monkeypatch.setattr(github_app, "get_pr_commands", lambda name: ["/review"])
+    monkeypatch.setattr(github_app, "should_process_pr_logic", lambda body: True)
+    monkeypatch.setattr(github_app, "prepare_command", lambda command: command)
+    monkeypatch.setattr(get_settings().github_app, "feedback_on_draft_pr", True, raising=False)
+    monkeypatch.setattr(get_settings().config, "disable_auto_feedback", False, raising=False)
+    return provider
+
+
+def _states(provider):
+    return [call.args[0] for call in provider.publish_run_status.call_args_list]
+
+
+async def test_a_successful_run_is_marked_pending_then_success(run_status, auto_commands):
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert _states(auto_commands) == ["pending", "success"]
+
+
+async def test_a_failed_command_is_marked_failure(run_status, auto_commands):
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        return False
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert _states(auto_commands) == ["pending", "failure"]
+
+
+async def test_a_raising_command_is_marked_failure(run_status, auto_commands):
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        raise RuntimeError("boom")
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert _states(auto_commands) == ["pending", "failure"]
+
+
+async def test_nothing_is_published_when_the_setting_is_off(run_status, auto_commands):
+    """Control: the shipped default changes nothing."""
+    run_status(enabled=False)
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    auto_commands.publish_run_status.assert_not_called()

--- a/tests/unittest/test_run_status_acknowledgment.py
+++ b/tests/unittest/test_run_status_acknowledgment.py
@@ -10,21 +10,36 @@ from unittest.mock import MagicMock
 import pytest
 
 import pr_agent.servers.github_app as github_app
+from pr_agent.algo.run_details import command_failed, init_run_details, record_command_failure
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.git_provider import GitProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
+from pr_agent.tools.pr_reviewer import PRReviewer
 
 API_URL = "https://api.github.com/repos/org/repo/pulls/1"
 
 
+# `_perform_auto_commands_github` calls `get_settings().set("config.is_auto_command", True)`, and a
+# dotted `set` replaces the whole `config` Box. `monkeypatch.setattr` on that Box therefore restores
+# into an orphaned object and the override survives the test, so these settings are saved and
+# restored through the same API that clobbers them.
+_RUN_STATUS_KEYS = ("publish_run_status", "run_status_context", "is_auto_command")
+
+
 @pytest.fixture
-def run_status(monkeypatch):
+def run_status():
+    settings = get_settings()
+    original = {key: settings.get(f"config.{key}", None) for key in _RUN_STATUS_KEYS}
+
     def _set(enabled=True, context="pr-agent"):
-        monkeypatch.setattr(get_settings().config, "publish_run_status", enabled, raising=False)
-        monkeypatch.setattr(get_settings().config, "run_status_context", context, raising=False)
+        settings.set("config.publish_run_status", enabled)
+        settings.set("config.run_status_context", context)
+
     _set()
-    return _set
+    yield _set
+    for key, value in original.items():
+        settings.set(f"config.{key}", value)
 
 
 def _github(monkeypatch, sha="abc123"):
@@ -103,14 +118,34 @@ def test_gitlab_maps_failure_to_failed(run_status):
 # --------------------------------------------------------------------------------------
 @pytest.fixture
 def auto_commands(monkeypatch):
+    settings = get_settings()
+    original_feedback = settings.get("github_app.feedback_on_draft_pr", None)
+    original_disable = settings.get("config.disable_auto_feedback", None)
     provider = MagicMock()
     monkeypatch.setattr(github_app, "get_git_provider_with_context", lambda pr_url: provider)
     monkeypatch.setattr(github_app, "get_pr_commands", lambda name: ["/review"])
     monkeypatch.setattr(github_app, "should_process_pr_logic", lambda body: True)
     monkeypatch.setattr(github_app, "prepare_command", lambda command: command)
-    monkeypatch.setattr(get_settings().github_app, "feedback_on_draft_pr", True, raising=False)
-    monkeypatch.setattr(get_settings().config, "disable_auto_feedback", False, raising=False)
-    return provider
+    settings.set("github_app.feedback_on_draft_pr", True)
+    settings.set("config.disable_auto_feedback", False)
+    yield provider
+    settings.set("github_app.feedback_on_draft_pr", original_feedback)
+    settings.set("config.disable_auto_feedback", original_disable)
+
+
+@pytest.fixture
+def restored_config():
+    """Override a `config` key and put the original back through the same API."""
+    settings = get_settings()
+    original = {}
+
+    def _set(key, value):
+        original.setdefault(key, settings.get(f"config.{key}", None))
+        settings.set(f"config.{key}", value)
+
+    yield _set
+    for key, value in original.items():
+        settings.set(f"config.{key}", value)
 
 
 def _states(provider):
@@ -169,3 +204,88 @@ async def test_nothing_is_published_when_the_setting_is_off(run_status, auto_com
     await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
 
     auto_commands.publish_run_status.assert_not_called()
+
+
+# --------------------------------------------------------------------------------------
+# A tool that swallows its own error must not be reported as a success.
+#
+# `propagate_tool_errors` is false by default, so `PRReviewer.run()` logs the failure and
+# returns normally. `handle_request` therefore answers True, and without the run-details
+# verdict the pull request would get a green tick and no review comment.
+# --------------------------------------------------------------------------------------
+async def test_a_swallowed_tool_error_is_not_reported_as_success(run_status, auto_commands):
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        init_run_details()
+        record_command_failure()
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert _states(auto_commands) == ["pending", "failure"]
+
+
+async def test_a_verdict_does_not_leak_into_the_next_command(run_status, auto_commands, monkeypatch):
+    """The collector is a ContextVar, so a stale failure must not condemn the command after it."""
+    monkeypatch.setattr(github_app, "get_pr_commands", lambda name: ["/describe", "/ask something"])
+    agent = MagicMock()
+    seen = []
+
+    async def handle_request(api_url, command, notify=None):
+        seen.append(command)
+        if command == "/describe":
+            init_run_details()
+            record_command_failure()
+        # "/ask" is one of the tools that never installs a collector of its own.
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert seen == ["/describe", "/ask something"]
+    # The run as a whole still failed - but because of /describe, and /ask must not be able to
+    # read /describe's verdict back out of the context variable.
+    assert _states(auto_commands) == ["pending", "failure"]
+    assert command_failed() is False
+
+
+async def test_a_clean_run_still_reports_success(run_status, auto_commands):
+    """Control: a tool that installs a collector and records nothing is a success."""
+    agent = MagicMock()
+
+    async def handle_request(api_url, command, notify=None):
+        init_run_details()
+        return True
+
+    agent.handle_request = handle_request
+
+    await github_app._perform_auto_commands_github("pr_commands", agent, {}, API_URL, {})
+
+    assert _states(auto_commands) == ["pending", "success"]
+
+
+async def test_the_reviewer_records_a_swallowed_failure(monkeypatch, restored_config):
+    """End to end through the real `PRReviewer.run()`, with the shipped default settings."""
+    restored_config("propagate_tool_errors", False)
+    restored_config("publish_output", False)
+    tool = PRReviewer.__new__(PRReviewer)
+    tool.git_provider = MagicMock()
+    tool.incremental = SimpleNamespace(is_incremental=False)
+    tool.pr_url = API_URL
+    monkeypatch.setattr(PRReviewer, "_prepare_prediction", MagicMock(side_effect=RuntimeError("boom")))
+
+    init_run_details()
+    await tool.run()
+
+    assert command_failed() is True
+
+
+async def test_a_reviewer_run_that_works_records_nothing(monkeypatch):
+    """Control: the flag is only set by the swallow path."""
+    init_run_details()
+
+    assert command_failed() is False


### PR DESCRIPTION

Implements #3090.

## Description

An automatic command sets `config.is_auto_command`, which suppresses the "Preparing review…"
progress comment. Between opening a pull request and the model answering — often a minute or more
on a large diff — nothing tells the author that PR-Agent is running, or whether the webhook arrived
at all.

### What changed

**A provider primitive.** `GitProvider.publish_run_status(state, description)` where `state` is
`pending`, `success` or `failure`. The base implementation returns `False`, so providers without a
commit-status API are a no-op.

- **GitHub** — a commit status on the PR head (`create_status`), truncating the description to the
  140 characters GitHub accepts.
- **GitLab** — a commit status too, mapping `failure` to GitLab's spelling, `failed`.

A commit status was chosen over a comment because it is *not* part of the conversation: it appears
in the PR's checks area immediately and is replaced in place, so re-running adds no noise. It also
needs no extra permission beyond what PR-Agent already has, unlike the Checks API.

**Wiring.** `_perform_auto_commands_github` publishes `pending` before the command loop and
`success` / `failure` after it, tracking both a command that returns `False` and one that raises.

**Configuration**, off by default:

```toml
[config]
publish_run_status = false
run_status_context = "pr-agent"   # the status name shown on the commit
```

## Behaviour change

| Configuration | Result |
|---|---|
| shipped default | nothing — byte-identical to today |
| `publish_run_status = true` | `pending` when the PR is opened, then `success` or `failure` |
| a command returns `False` or raises | `failure`, and the remaining commands still run |
| provider without statuses | no-op, no error |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3698 passed, 1 skipped, 1 xfailed, 91 warnings in 53.69s
```

New file `tests/unittest/test_run_status_acknowledgment.py` (13 tests), written first (12 failed /
1 passed before, 13 passed after). Covers all three states on GitHub, the configured context,
description truncation, a missing commit SHA, an API failure, GitLab's `failed` mapping, and the
four wiring outcomes including the default-off control.

Also checked: `ruff check` clean on every file touched.

## Risk / compatibility

Nothing happens unless the setting is turned on. Every provider call is wrapped, so a repository
where the token cannot write statuses logs a warning and continues.

## Scope

Wired into the GitHub automatic-command runner in this PR. The primitive lives on the base
provider, so the GitLab and Gitea runners are a two-line follow-up each.
