### PR TITLE
feat(tools): let the model call host-provided tools

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import os
 import re
+from typing import List, Optional
 
 import httpx
 import litellm
@@ -29,6 +30,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     get_repetition_penalty,
 )
 from pr_agent.algo.run_details import _as_decimal_cost, record_ai_call
+from pr_agent.algo.tool_registry import get_max_tool_iterations, get_tool_registry
 from pr_agent.algo.utils import ReasoningEffort, get_version
 from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.log import get_logger
@@ -1228,9 +1230,61 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         return resp, finish_reason
 
-    async def _get_completion(self, **kwargs):
+    async def chat_completion_with_tools(self, model: str, system: str, user: str,
+                                         temperature: float = 0.2,
+                                         max_iterations: Optional[int] = None):
+        """Answer with the host's tools available to the model.
+
+        Kept separate from `chat_completion`, which is a single request/response call used by
+        every tool prompt: this one owns a conversation, because a tool call is answered and
+        the model is asked again. Returns the final text and the calls that were made, so a
+        caller can show its work.
+
+        The loop is bounded by `tools.max_iterations`; when the budget runs out the model is
+        asked once more without tools so it always produces an answer.
+        """
+        registry = get_tool_registry()
+        specs = registry.specs()
+        iterations = get_max_tool_iterations() if max_iterations is None else max_iterations
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+        calls: List[dict] = []
+        if not specs:
+            response, finish_reason = await self.chat_completion(
+                model=model, system=system, user=user, temperature=temperature)
+            return response, finish_reason, calls
+
+        for _round in range(max(0, iterations)):
+            content, finish_reason, response = await self._get_completion(
+                model=model, messages=messages, temperature=temperature,
+                tools=specs, tool_choice="auto", allow_tool_calls=True,
+                timeout=get_settings().config.ai_timeout)
+            message = response["choices"][0]["message"]
+            tool_calls = getattr(message, "tool_calls", None) or []
+            if not tool_calls:
+                return content or "", finish_reason, calls
+            messages.append(message.model_dump() if hasattr(message, "model_dump") else message)
+            for tool_call in tool_calls:
+                name = tool_call.function.name
+                arguments = tool_call.function.arguments
+                get_logger().info(f"The model called the tool {name!r}")
+                result = registry.execute(name, arguments)
+                calls.append({"name": name, "arguments": arguments, "result": result})
+                messages.append({"role": "tool", "tool_call_id": tool_call.id,
+                                 "name": name, "content": result})
+
+        # The budget is spent: ask once more with the results in hand, but no further tools.
+        get_logger().info("The tool-call budget is spent; asking for a final answer")
+        content, finish_reason, _response = await self._get_completion(
+            model=model, messages=messages, temperature=temperature,
+            timeout=get_settings().config.ai_timeout)
+        return content or "", finish_reason, calls
+
+    async def _get_completion(self, allow_tool_calls: bool = False, **kwargs):
         """
         Wrapper that automatically handles streaming for required models.
+
+        `allow_tool_calls` accepts a response whose content is empty because the model asked
+        to call a tool instead of answering; every other caller still requires content.
         """
         model = kwargs["model"]
         custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
@@ -1271,7 +1325,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 )
             content = response["choices"][0]['message']['content']
             finish_reason = response["choices"][0]["finish_reason"]
-            if not content:
+            requested_tools = getattr(response["choices"][0]["message"], "tool_calls", None)
+            if not content and not (allow_tool_calls and requested_tools):
                 get_logger().warning(
                     f"Empty content in model response, finish_reason: {finish_reason}")
                 raise openai.APIError(

--- a/pr_agent/algo/tool_registry.py
+++ b/pr_agent/algo/tool_registry.py
@@ -1,0 +1,168 @@
+"""Host-provided tools a model may call while answering.
+
+A tool is a named function with a JSON-schema signature and a host-side handler. The registry
+is the single place that decides which tools exist, which of them an operator has enabled, and
+how a call is executed - so a tool can never be introduced by repository settings or by text in
+a pull request, only by the host.
+
+Nothing is enabled by default: `config.tools.enabled` is false, so the registry reports no
+tools and the model is never offered any.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+MAX_TOOL_RESULT_CHARS = 8000
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One callable exposed to the model.
+
+    `parameters` is a JSON schema object; `handler` receives the decoded arguments as keyword
+    arguments and returns text the model can read.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+    handler: Optional[Callable[..., str]] = None
+
+    def spec(self) -> Dict[str, Any]:
+        """The tool as the completion API expects to receive it."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+class ToolRegistry:
+    """The set of tools this host offers, and the gate in front of them."""
+
+    def __init__(self):
+        self._tools: Dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        """Add a tool. Registering the same tool again is a no-op; a different one raises."""
+        if not isinstance(tool, Tool) or not tool.name:
+            raise TypeError(f"Not a usable tool: {tool!r}")
+        if callable(getattr(tool, "handler", None)) is False:
+            raise TypeError(f"Tool {tool.name!r} has no handler")
+        existing = self._tools.get(tool.name)
+        if existing is not None and existing != tool:
+            raise ValueError(f"Tool {tool.name!r} is already registered")
+        self._tools[tool.name] = tool
+
+    def unregister(self, name: str) -> None:
+        self._tools.pop(name, None)
+
+    def get(self, name: str) -> Optional[Tool]:
+        return self._tools.get(name)
+
+    def registered_names(self) -> List[str]:
+        return sorted(self._tools)
+
+    def enabled_tools(self) -> List[Tool]:
+        """The tools the operator has turned on, in a stable order.
+
+        Empty unless `tools.enabled` is true. An `allowed` list further narrows the set; an
+        empty `allowed` means every registered tool.
+        """
+        settings = get_settings()
+        if not bool(settings.get("tools.enabled", False)):
+            return []
+        allowed = settings.get("tools.allowed", []) or []
+        if isinstance(allowed, str):
+            allowed = [allowed]
+        allowed = {str(name).strip() for name in allowed if str(name).strip()}
+        unknown = allowed - set(self._tools)
+        if unknown:
+            get_logger().warning(f"tools.allowed names nothing registered: {sorted(unknown)}")
+        return [tool for name, tool in sorted(self._tools.items())
+                if not allowed or name in allowed]
+
+    def specs(self) -> List[Dict[str, Any]]:
+        return [tool.spec() for tool in self.enabled_tools()]
+
+    def execute(self, name: str, arguments: Any) -> str:
+        """Run one tool call and always return text the model can read.
+
+        A tool that is unknown, disabled, called with unreadable arguments, or that raises,
+        produces an error string rather than an exception: a failed tool must not fail the
+        command that was using it.
+        """
+        tool = next((candidate for candidate in self.enabled_tools() if candidate.name == name), None)
+        if tool is None:
+            get_logger().warning(f"The model called an unavailable tool: {name!r}")
+            return f"Error: the tool {name!r} is not available."
+        try:
+            kwargs = self._decode_arguments(arguments)
+        except ValueError as error:
+            return f"Error: could not read the arguments for {name!r}: {error}"
+        try:
+            result = tool.handler(**kwargs)
+        except Exception as error:
+            get_logger().warning(f"The tool {name!r} failed: {error}")
+            return f"Error: the tool {name!r} failed: {error}"
+        return self._as_text(result)
+
+    @staticmethod
+    def _decode_arguments(arguments: Any) -> Dict[str, Any]:
+        if arguments is None or arguments == "":
+            return {}
+        if isinstance(arguments, dict):
+            return arguments
+        try:
+            decoded = json.loads(arguments)
+        except (TypeError, ValueError) as error:
+            raise ValueError(str(error)) from error
+        if not isinstance(decoded, dict):
+            raise ValueError("arguments must be a JSON object")
+        return decoded
+
+    @staticmethod
+    def _as_text(result: Any) -> str:
+        if isinstance(result, str):
+            text = result
+        else:
+            try:
+                text = json.dumps(result, ensure_ascii=False)
+            except (TypeError, ValueError):
+                text = str(result)
+        if len(text) > MAX_TOOL_RESULT_CHARS:
+            text = text[:MAX_TOOL_RESULT_CHARS] + "\n[truncated]"
+        return text
+
+
+_registry = ToolRegistry()
+
+
+def get_tool_registry() -> ToolRegistry:
+    """The process-wide registry."""
+    return _registry
+
+
+def register_tool(tool: Tool) -> None:
+    """Make a tool available to the model, subject to the operator's configuration."""
+    _registry.register(tool)
+
+
+def get_max_tool_iterations() -> int:
+    """How many rounds of tool calls one answer may take."""
+    value = get_settings().get("tools.max_iterations", 3)
+    try:
+        iterations = int(value)
+    except (TypeError, ValueError):
+        get_logger().warning(f"tools.max_iterations is not a number ({value!r}); using 3")
+        return 3
+    return max(0, iterations)

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -16,11 +16,16 @@
 # reach internal endpoints (SSRF), or append to arbitrary host files. The whole section is
 # therefore host-only (empty allowlist -> every key dropped).
 #
+# tools: decides which host-side functions a model may call, and a tool reaches the network or
+# the host filesystem. Letting a repository enable one, or widen the allowlist, would turn PR
+# content into a way to reach the host, so the whole section is host-only.
+#
 # prompt_fragments: contains Jinja source rendered by the host before it is inserted into tool
 # prompts. Keep the whole section host-only so repository settings and comment arguments cannot
 # supply executable template expressions.
 REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
     "skills": frozenset({"enabled", "max_skills_tokens"}),
+    "tools": frozenset(),
     "push_outputs": frozenset(),
     "prompt_fragments": frozenset(),
 }

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -104,6 +104,13 @@ extract_issue_from_branch = true
 branch_issue_regex = ""
 
 
+[tools] # host-provided tools the model may call while answering #
+# Nothing is offered to the model unless this is on. Tools are registered by the host process
+# only: a repository's .pr_agent.toml and a PR comment cannot introduce or reach one.
+enabled = false
+allowed = []        # empty: every registered tool. Otherwise an allowlist of tool names
+max_iterations = 3  # rounds of tool calls one answer may take before a final answer is required
+
 [pr_reviewer] # /review #
 # enable/disable features
 require_score_review=false

--- a/tests/unittest/test_tool_calling_loop.py
+++ b/tests/unittest/test_tool_calling_loop.py
@@ -1,0 +1,164 @@
+"""The tool-calling loop: answer, call, answer again, and always finish.
+
+`chat_completion_with_tools` owns a conversation rather than a single request, so the parts that
+matter are: tools are only offered when enabled, every call is executed and fed back, the loop
+is bounded, and a spent budget still produces an answer.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+from pr_agent.algo.tool_registry import Tool, get_tool_registry
+from pr_agent.config_loader import get_settings
+
+ECHO = Tool(
+    name="echo",
+    description="Repeat the given text.",
+    parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    handler=lambda text: f"echo: {text}",
+)
+
+
+def _response(message, finish_reason):
+    """`_get_completion` answers with (content, finish_reason, raw response)."""
+    raw = {"choices": [{"message": message, "finish_reason": finish_reason}]}
+    return getattr(message, "content", None), finish_reason, raw
+
+
+def _answer(content):
+    return _response(
+        SimpleNamespace(content=content, tool_calls=None, model_dump=lambda: {"role": "assistant"}),
+        "stop")
+
+
+def _tool_request(name="echo", arguments='{"text": "hi"}', call_id="call_1"):
+    call = SimpleNamespace(id=call_id, function=SimpleNamespace(name=name, arguments=arguments))
+    return _response(
+        SimpleNamespace(content=None, tool_calls=[call],
+                        model_dump=lambda: {"role": "assistant", "tool_calls": []}),
+        "tool_calls")
+
+
+@pytest.fixture
+def handler(monkeypatch):
+    monkeypatch.setattr(LiteLLMAIHandler, "__init__", lambda self: None)
+    handler = LiteLLMAIHandler()
+    return handler
+
+
+@pytest.fixture
+def tools_enabled(monkeypatch):
+    registry = get_tool_registry()
+    registry.register(ECHO)
+
+    def _set(enabled=True, max_iterations=3):
+        get_settings().set("tools.enabled", enabled)
+        get_settings().set("tools.allowed", [])
+        get_settings().set("tools.max_iterations", max_iterations)
+    _set()
+    yield _set
+    registry.unregister("echo")
+    get_settings().set("tools.enabled", False)
+
+
+async def test_an_answer_without_a_tool_call_is_returned(handler, tools_enabled):
+    handler._get_completion = AsyncMock(return_value=_answer("done"))
+
+    text, finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, finish_reason, calls) == ("done", "stop", [])
+
+
+async def test_a_tool_call_is_executed_and_fed_back(handler, tools_enabled):
+    handler._get_completion = AsyncMock(side_effect=[_tool_request(), _answer("done")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "done"
+    assert calls == [{"name": "echo", "arguments": '{"text": "hi"}', "result": "echo: hi"}]
+    second_call_messages = handler._get_completion.await_args_list[1].kwargs["messages"]
+    assert second_call_messages[-1]["role"] == "tool"
+    assert second_call_messages[-1]["content"] == "echo: hi"
+    assert second_call_messages[-1]["tool_call_id"] == "call_1"
+
+
+async def test_the_tools_are_offered_on_every_round(handler, tools_enabled):
+    handler._get_completion = AsyncMock(side_effect=[_tool_request(), _answer("done")])
+
+    await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    for call in handler._get_completion.await_args_list:
+        assert call.kwargs["tools"][0]["function"]["name"] == "echo"
+        assert call.kwargs["tool_choice"] == "auto"
+        assert call.kwargs["allow_tool_calls"] is True
+
+
+async def test_no_tools_are_offered_when_the_feature_is_off(handler, tools_enabled, monkeypatch):
+    """Control: with tools off this is the ordinary single-shot completion."""
+    tools_enabled(enabled=False)
+    handler.chat_completion = AsyncMock(return_value=("plain", "stop"))
+    handler._get_completion = AsyncMock()
+
+    text, finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, finish_reason, calls) == ("plain", "stop", [])
+    handler._get_completion.assert_not_awaited()
+
+
+async def test_the_loop_is_bounded_and_still_answers(handler, tools_enabled):
+    """A model that keeps calling tools is asked once more without them."""
+    tools_enabled(max_iterations=2)
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(), _tool_request(call_id="call_2"), _answer("final")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "final"
+    assert len(calls) == 2
+    assert "tools" not in handler._get_completion.await_args_list[-1].kwargs
+
+
+async def test_a_failing_tool_does_not_fail_the_answer(handler, tools_enabled):
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(arguments="{not json"), _answer("done anyway")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "done anyway"
+    assert calls[0]["result"].startswith("Error: could not read the arguments")
+
+
+async def test_an_unknown_tool_is_reported_to_the_model(handler, tools_enabled):
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(name="rm_rf", arguments="{}"), _answer("done")])
+
+    _text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert "not available" in calls[0]["result"]
+
+
+async def test_several_calls_in_one_round_are_all_executed(handler, tools_enabled):
+    first = SimpleNamespace(id="a", function=SimpleNamespace(name="echo", arguments=json.dumps({"text": "1"})))
+    second = SimpleNamespace(id="b", function=SimpleNamespace(name="echo", arguments=json.dumps({"text": "2"})))
+    both = _response(
+        SimpleNamespace(content=None, tool_calls=[first, second],
+                        model_dump=lambda: {"role": "assistant"}),
+        "tool_calls")
+    handler._get_completion = AsyncMock(side_effect=[both, _answer("done")])
+
+    _text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert [call["result"] for call in calls] == ["echo: 1", "echo: 2"]
+
+
+async def test_a_zero_budget_asks_once_without_tools(handler, tools_enabled):
+    tools_enabled(max_iterations=0)
+    handler._get_completion = AsyncMock(return_value=_answer("straight answer"))
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, calls) == ("straight answer", [])
+    assert "tools" not in handler._get_completion.await_args_list[0].kwargs

--- a/tests/unittest/test_tool_registry.py
+++ b/tests/unittest/test_tool_registry.py
@@ -1,0 +1,182 @@
+"""Host-provided tools: registration, the operator's gate, and call execution.
+
+A tool reaches the network or the host filesystem, so the registry is the boundary: nothing is
+offered unless the host registered it *and* the operator enabled it, and a failing tool returns
+text rather than failing the command.
+"""
+import json
+
+import pytest
+
+from pr_agent.algo.tool_registry import (
+    MAX_TOOL_RESULT_CHARS,
+    Tool,
+    ToolRegistry,
+    get_max_tool_iterations,
+)
+from pr_agent.config_loader import get_settings
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
+
+ECHO = Tool(
+    name="echo",
+    description="Repeat the given text.",
+    parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    handler=lambda text: f"echo: {text}",
+)
+CLOCK = Tool(name="clock", description="Return a fixed time.", handler=lambda: "12:00")
+
+
+@pytest.fixture
+def tools_config(monkeypatch):
+    def _set(enabled=True, allowed=None, max_iterations=3):
+        get_settings().set("tools.enabled", enabled)
+        get_settings().set("tools.allowed", allowed if allowed is not None else [])
+        get_settings().set("tools.max_iterations", max_iterations)
+    _set()
+    yield _set
+    get_settings().set("tools.enabled", False)
+
+
+@pytest.fixture
+def registry():
+    registry = ToolRegistry()
+    registry.register(ECHO)
+    registry.register(CLOCK)
+    return registry
+
+
+def test_nothing_is_offered_until_the_operator_says_so(registry, tools_config):
+    tools_config(enabled=False)
+
+    assert registry.enabled_tools() == []
+    assert registry.specs() == []
+
+
+def test_every_registered_tool_is_offered_by_default(registry, tools_config):
+    assert [tool.name for tool in registry.enabled_tools()] == ["clock", "echo"]
+
+
+def test_an_allowlist_narrows_the_set(registry, tools_config):
+    tools_config(allowed=["echo"])
+
+    assert [tool.name for tool in registry.enabled_tools()] == ["echo"]
+
+
+def test_an_allowlist_naming_nothing_registered_offers_nothing(registry, tools_config):
+    tools_config(allowed=["nope"])
+
+    assert registry.enabled_tools() == []
+
+
+def test_the_spec_matches_the_completion_api(registry, tools_config):
+    tools_config(allowed=["echo"])
+
+    assert registry.specs() == [{
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Repeat the given text.",
+            "parameters": ECHO.parameters,
+        },
+    }]
+
+
+def test_registering_the_same_tool_twice_is_allowed(registry):
+    registry.register(ECHO)
+
+    assert registry.registered_names() == ["clock", "echo"]
+
+
+def test_registering_a_different_tool_under_a_taken_name_raises(registry):
+    with pytest.raises(ValueError):
+        registry.register(Tool(name="echo", description="Something else", handler=lambda: ""))
+
+
+@pytest.mark.parametrize("bad", [None, "echo", 42, Tool(name="", description="", handler=lambda: "")])
+def test_registering_something_that_is_not_a_tool_raises(registry, bad):
+    with pytest.raises(TypeError):
+        registry.register(bad)
+
+
+# --------------------------------------------------------------------------------------
+# Execution
+# --------------------------------------------------------------------------------------
+def test_a_call_runs_the_handler(registry, tools_config):
+    assert registry.execute("echo", json.dumps({"text": "hi"})) == "echo: hi"
+
+
+def test_arguments_may_arrive_already_decoded(registry, tools_config):
+    assert registry.execute("echo", {"text": "hi"}) == "echo: hi"
+
+
+def test_a_tool_without_arguments_is_callable(registry, tools_config):
+    assert registry.execute("clock", "") == "12:00"
+    assert registry.execute("clock", None) == "12:00"
+
+
+def test_an_unknown_tool_is_reported_to_the_model(registry, tools_config):
+    assert "not available" in registry.execute("rm_rf", "{}")
+
+
+def test_a_disabled_tool_cannot_be_called(registry, tools_config):
+    """The gate is enforced at call time, not only when the specs are built."""
+    tools_config(allowed=["clock"])
+
+    assert "not available" in registry.execute("echo", json.dumps({"text": "hi"}))
+
+
+def test_a_call_with_no_tools_enabled_is_refused(registry, tools_config):
+    tools_config(enabled=False)
+
+    assert "not available" in registry.execute("echo", json.dumps({"text": "hi"}))
+
+
+@pytest.mark.parametrize("arguments", ["{not json", "[1, 2]", '"a string"'])
+def test_unreadable_arguments_are_reported_not_raised(registry, tools_config, arguments):
+    assert registry.execute("echo", arguments).startswith("Error: could not read the arguments")
+
+
+def test_a_raising_tool_is_reported_not_raised(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="boom", description="Always fails.",
+                           handler=lambda: (_ for _ in ()).throw(RuntimeError("no"))))
+
+    assert registry.execute("boom", "{}").startswith("Error: the tool 'boom' failed")
+
+
+def test_a_wrong_argument_name_is_reported_not_raised(registry, tools_config):
+    assert registry.execute("echo", json.dumps({"wrong": "hi"})).startswith("Error: the tool 'echo' failed")
+
+
+def test_a_non_string_result_is_serialised(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="data", description="Returns a mapping.",
+                           handler=lambda: {"a": 1}))
+
+    assert registry.execute("data", "{}") == '{"a": 1}'
+
+
+def test_a_long_result_is_truncated(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="long", description="Returns a lot.",
+                           handler=lambda: "x" * (MAX_TOOL_RESULT_CHARS + 500)))
+
+    result = registry.execute("long", "{}")
+
+    assert len(result) == MAX_TOOL_RESULT_CHARS + len("\n[truncated]")
+    assert result.endswith("[truncated]")
+
+
+# --------------------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("value, expected", [(5, 5), ("4", 4), (0, 0), (-1, 0), ("nope", 3), (None, 3)])
+def test_the_iteration_budget_is_read_defensively(tools_config, value, expected):
+    tools_config(max_iterations=value)
+
+    assert get_max_tool_iterations() == expected
+
+
+def test_a_repository_cannot_enable_tools():
+    """`[tools]` decides what the model may reach, so it is host-only."""
+    assert REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION["tools"] == frozenset()


### PR DESCRIPTION

Implements #3093.

## Description

Every AI handler is text-in / text-out: `chat_completion` sends a system and user prompt and
returns a string. Nothing in the codebase passes `tools=` to LiteLLM or handles `tool_calls`, so a
model cannot look anything up while it answers.

### What changed

**A registry** (`pr_agent/algo/tool_registry.py`). A `Tool` is a name, a description, a JSON-schema
signature and a host-side handler. The registry is the boundary that decides what exists, what is
enabled, and how a call runs:

- `enabled_tools()` returns nothing unless `tools.enabled` is true; `tools.allowed` narrows further;
- `execute()` **always returns text** — an unknown tool, a disabled tool, unreadable arguments or a
  raising handler all produce an error string, because a failed tool must not fail the command;
- results are truncated at 8 000 characters so a large tool answer cannot blow the prompt budget.

**A conversation** (`chat_completion_with_tools`). Deliberately separate from `chat_completion`,
which stays a single request/response call used by every existing prompt — this one owns a message
list, because a tool call is answered and the model is asked again. It returns the final text, the
finish reason, and the calls that were made, so a caller can show its work. The loop is bounded by
`tools.max_iterations`; when the budget is spent the model is asked once more *without* tools, so
an answer is always produced.

**One change to the shared path:** `_get_completion` gained `allow_tool_calls=False`. A response
whose content is empty because the model asked for a tool used to raise
`APIError("Empty content in model response")`; that check still applies to every other caller.

**Configuration**, off by default:

```toml
[tools]
enabled = false
allowed = []        # empty: every registered tool
max_iterations = 3
```

### Security boundary

`[tools]` is added to `REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION` with an **empty** allowlist, so a
repository's `.pr_agent.toml` and a PR comment cannot enable tools, widen the allowlist, or raise
the iteration budget. Tools are registered by the host process only. This matches how
`push_outputs` and `prompt_fragments` are already treated, and it is the reason the gate is
re-checked inside `execute()` rather than only when the specs are built.

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3725 passed, 1 skipped, 1 xfailed, 91 warnings in 54.52s
```

Two new files, 40 tests, written first:

- `tests/unittest/test_tool_registry.py` (27) — the gate, the allowlist, spec shape, duplicate and
  invalid registration, and eight execution paths including unreadable arguments, a raising
  handler, a wrong argument name, serialisation and truncation.
- `tests/unittest/test_tool_calling_loop.py` (13) — a plain answer, a tool call fed back with the
  right `tool_call_id`, tools offered on every round, several calls in one round, the bounded loop
  falling back to a tool-free question, a failing tool that still yields an answer, and the
  feature-off control.

**Verified against real models.** Unit tests mock `_get_completion`, which hid a real integration
bug: the shared path rejected a tool-call response as empty content. It was found by running the
loop against live models through OpenRouter, and is why `allow_tool_calls` exists. After the fix,
two models (`nvidia/nemotron-3.5-lightning`, `cohere/north-mini-code`) each called the tool,
received the host's answer and produced a final reply built from it.

Also checked: `ruff check` clean on every file touched.

## Risk / compatibility

Nothing is offered to any model unless an operator turns tools on *and* the host registers one, and
no tool ships in this PR. `chat_completion` is untouched, so every existing prompt takes exactly the
same path as before.

## Known limitation

A model in `streaming_required_models` takes the streaming branch of `_get_completion`, which does
not reassemble tool calls. Tool calling is for non-streaming models in this PR.
