### PR TITLE
feat(tools): a web-search tool the model can call

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import os
 import re
+from typing import List, Optional
 
 import httpx
 import litellm
@@ -29,6 +30,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     get_repetition_penalty,
 )
 from pr_agent.algo.run_details import _as_decimal_cost, record_ai_call
+from pr_agent.algo.tool_registry import get_max_tool_iterations, get_tool_registry
 from pr_agent.algo.utils import ReasoningEffort, get_version
 from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.log import get_logger
@@ -1228,9 +1230,61 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         return resp, finish_reason
 
-    async def _get_completion(self, **kwargs):
+    async def chat_completion_with_tools(self, model: str, system: str, user: str,
+                                         temperature: float = 0.2,
+                                         max_iterations: Optional[int] = None):
+        """Answer with the host's tools available to the model.
+
+        Kept separate from `chat_completion`, which is a single request/response call used by
+        every tool prompt: this one owns a conversation, because a tool call is answered and
+        the model is asked again. Returns the final text and the calls that were made, so a
+        caller can show its work.
+
+        The loop is bounded by `tools.max_iterations`; when the budget runs out the model is
+        asked once more without tools so it always produces an answer.
+        """
+        registry = get_tool_registry()
+        specs = registry.specs()
+        iterations = get_max_tool_iterations() if max_iterations is None else max_iterations
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+        calls: List[dict] = []
+        if not specs:
+            response, finish_reason = await self.chat_completion(
+                model=model, system=system, user=user, temperature=temperature)
+            return response, finish_reason, calls
+
+        for _round in range(max(0, iterations)):
+            content, finish_reason, response = await self._get_completion(
+                model=model, messages=messages, temperature=temperature,
+                tools=specs, tool_choice="auto", allow_tool_calls=True,
+                timeout=get_settings().config.ai_timeout)
+            message = response["choices"][0]["message"]
+            tool_calls = getattr(message, "tool_calls", None) or []
+            if not tool_calls:
+                return content or "", finish_reason, calls
+            messages.append(message.model_dump() if hasattr(message, "model_dump") else message)
+            for tool_call in tool_calls:
+                name = tool_call.function.name
+                arguments = tool_call.function.arguments
+                get_logger().info(f"The model called the tool {name!r}")
+                result = registry.execute(name, arguments)
+                calls.append({"name": name, "arguments": arguments, "result": result})
+                messages.append({"role": "tool", "tool_call_id": tool_call.id,
+                                 "name": name, "content": result})
+
+        # The budget is spent: ask once more with the results in hand, but no further tools.
+        get_logger().info("The tool-call budget is spent; asking for a final answer")
+        content, finish_reason, _response = await self._get_completion(
+            model=model, messages=messages, temperature=temperature,
+            timeout=get_settings().config.ai_timeout)
+        return content or "", finish_reason, calls
+
+    async def _get_completion(self, allow_tool_calls: bool = False, **kwargs):
         """
         Wrapper that automatically handles streaming for required models.
+
+        `allow_tool_calls` accepts a response whose content is empty because the model asked
+        to call a tool instead of answering; every other caller still requires content.
         """
         model = kwargs["model"]
         custom_llm_provider = str(kwargs.get("custom_llm_provider") or "").strip().lower()
@@ -1271,7 +1325,8 @@ class LiteLLMAIHandler(BaseAiHandler):
                 )
             content = response["choices"][0]['message']['content']
             finish_reason = response["choices"][0]["finish_reason"]
-            if not content:
+            requested_tools = getattr(response["choices"][0]["message"], "tool_calls", None)
+            if not content and not (allow_tool_calls and requested_tools):
                 get_logger().warning(
                     f"Empty content in model response, finish_reason: {finish_reason}")
                 raise openai.APIError(

--- a/pr_agent/algo/tool_registry.py
+++ b/pr_agent/algo/tool_registry.py
@@ -1,0 +1,168 @@
+"""Host-provided tools a model may call while answering.
+
+A tool is a named function with a JSON-schema signature and a host-side handler. The registry
+is the single place that decides which tools exist, which of them an operator has enabled, and
+how a call is executed - so a tool can never be introduced by repository settings or by text in
+a pull request, only by the host.
+
+Nothing is enabled by default: `config.tools.enabled` is false, so the registry reports no
+tools and the model is never offered any.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+MAX_TOOL_RESULT_CHARS = 8000
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One callable exposed to the model.
+
+    `parameters` is a JSON schema object; `handler` receives the decoded arguments as keyword
+    arguments and returns text the model can read.
+    """
+
+    name: str
+    description: str
+    parameters: Dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+    handler: Optional[Callable[..., str]] = None
+
+    def spec(self) -> Dict[str, Any]:
+        """The tool as the completion API expects to receive it."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+class ToolRegistry:
+    """The set of tools this host offers, and the gate in front of them."""
+
+    def __init__(self):
+        self._tools: Dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        """Add a tool. Registering the same tool again is a no-op; a different one raises."""
+        if not isinstance(tool, Tool) or not tool.name:
+            raise TypeError(f"Not a usable tool: {tool!r}")
+        if callable(getattr(tool, "handler", None)) is False:
+            raise TypeError(f"Tool {tool.name!r} has no handler")
+        existing = self._tools.get(tool.name)
+        if existing is not None and existing != tool:
+            raise ValueError(f"Tool {tool.name!r} is already registered")
+        self._tools[tool.name] = tool
+
+    def unregister(self, name: str) -> None:
+        self._tools.pop(name, None)
+
+    def get(self, name: str) -> Optional[Tool]:
+        return self._tools.get(name)
+
+    def registered_names(self) -> List[str]:
+        return sorted(self._tools)
+
+    def enabled_tools(self) -> List[Tool]:
+        """The tools the operator has turned on, in a stable order.
+
+        Empty unless `tools.enabled` is true. An `allowed` list further narrows the set; an
+        empty `allowed` means every registered tool.
+        """
+        settings = get_settings()
+        if not bool(settings.get("tools.enabled", False)):
+            return []
+        allowed = settings.get("tools.allowed", []) or []
+        if isinstance(allowed, str):
+            allowed = [allowed]
+        allowed = {str(name).strip() for name in allowed if str(name).strip()}
+        unknown = allowed - set(self._tools)
+        if unknown:
+            get_logger().warning(f"tools.allowed names nothing registered: {sorted(unknown)}")
+        return [tool for name, tool in sorted(self._tools.items())
+                if not allowed or name in allowed]
+
+    def specs(self) -> List[Dict[str, Any]]:
+        return [tool.spec() for tool in self.enabled_tools()]
+
+    def execute(self, name: str, arguments: Any) -> str:
+        """Run one tool call and always return text the model can read.
+
+        A tool that is unknown, disabled, called with unreadable arguments, or that raises,
+        produces an error string rather than an exception: a failed tool must not fail the
+        command that was using it.
+        """
+        tool = next((candidate for candidate in self.enabled_tools() if candidate.name == name), None)
+        if tool is None:
+            get_logger().warning(f"The model called an unavailable tool: {name!r}")
+            return f"Error: the tool {name!r} is not available."
+        try:
+            kwargs = self._decode_arguments(arguments)
+        except ValueError as error:
+            return f"Error: could not read the arguments for {name!r}: {error}"
+        try:
+            result = tool.handler(**kwargs)
+        except Exception as error:
+            get_logger().warning(f"The tool {name!r} failed: {error}")
+            return f"Error: the tool {name!r} failed: {error}"
+        return self._as_text(result)
+
+    @staticmethod
+    def _decode_arguments(arguments: Any) -> Dict[str, Any]:
+        if arguments is None or arguments == "":
+            return {}
+        if isinstance(arguments, dict):
+            return arguments
+        try:
+            decoded = json.loads(arguments)
+        except (TypeError, ValueError) as error:
+            raise ValueError(str(error)) from error
+        if not isinstance(decoded, dict):
+            raise ValueError("arguments must be a JSON object")
+        return decoded
+
+    @staticmethod
+    def _as_text(result: Any) -> str:
+        if isinstance(result, str):
+            text = result
+        else:
+            try:
+                text = json.dumps(result, ensure_ascii=False)
+            except (TypeError, ValueError):
+                text = str(result)
+        if len(text) > MAX_TOOL_RESULT_CHARS:
+            text = text[:MAX_TOOL_RESULT_CHARS] + "\n[truncated]"
+        return text
+
+
+_registry = ToolRegistry()
+
+
+def get_tool_registry() -> ToolRegistry:
+    """The process-wide registry."""
+    return _registry
+
+
+def register_tool(tool: Tool) -> None:
+    """Make a tool available to the model, subject to the operator's configuration."""
+    _registry.register(tool)
+
+
+def get_max_tool_iterations() -> int:
+    """How many rounds of tool calls one answer may take."""
+    value = get_settings().get("tools.max_iterations", 3)
+    try:
+        iterations = int(value)
+    except (TypeError, ValueError):
+        get_logger().warning(f"tools.max_iterations is not a number ({value!r}); using 3")
+        return 3
+    return max(0, iterations)

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -16,11 +16,16 @@
 # reach internal endpoints (SSRF), or append to arbitrary host files. The whole section is
 # therefore host-only (empty allowlist -> every key dropped).
 #
+# tools: decides which host-side functions a model may call, and a tool reaches the network or
+# the host filesystem. Letting a repository enable one, or widen the allowlist, would turn PR
+# content into a way to reach the host, so the whole section is host-only.
+#
 # prompt_fragments: contains Jinja source rendered by the host before it is inserted into tool
 # prompts. Keep the whole section host-only so repository settings and comment arguments cannot
 # supply executable template expressions.
 REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
     "skills": frozenset({"enabled", "max_skills_tokens"}),
+    "tools": frozenset(),
     "push_outputs": frozenset(),
     "prompt_fragments": frozenset(),
 }

--- a/pr_agent/config_security.py
+++ b/pr_agent/config_security.py
@@ -16,6 +16,8 @@
 # reach internal endpoints (SSRF), or append to arbitrary host files. The whole section is
 # therefore host-only (empty allowlist -> every key dropped).
 #
+# web_search: holds the API key of a third-party search provider and the endpoint it is sent to.
+#
 # tools: decides which host-side functions a model may call, and a tool reaches the network or
 # the host filesystem. Letting a repository enable one, or widen the allowlist, would turn PR
 # content into a way to reach the host, so the whole section is host-only.
@@ -26,6 +28,7 @@
 REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION = {
     "skills": frozenset({"enabled", "max_skills_tokens"}),
     "tools": frozenset(),
+    "web_search": frozenset(),
     "push_outputs": frozenset(),
     "prompt_fragments": frozenset(),
 }

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -111,6 +111,13 @@ enabled = false
 allowed = []        # empty: every registered tool. Otherwise an allowlist of tool names
 max_iterations = 3  # rounds of tool calls one answer may take before a final answer is required
 
+[web_search] # the web_search tool, offered only when [tools] is on #
+# Host-only, like [tools]: the key reaches a third party, so a repository cannot set it.
+provider = ""    # "exa" or "tavily"; empty means the tool is not registered at all
+api_key = ""     # keep this in .secrets.toml, not here
+result_count = 3
+timeout = 10
+
 [pr_reviewer] # /review #
 # enable/disable features
 require_score_review=false

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -104,6 +104,13 @@ extract_issue_from_branch = true
 branch_issue_regex = ""
 
 
+[tools] # host-provided tools the model may call while answering #
+# Nothing is offered to the model unless this is on. Tools are registered by the host process
+# only: a repository's .pr_agent.toml and a PR comment cannot introduce or reach one.
+enabled = false
+allowed = []        # empty: every registered tool. Otherwise an allowlist of tool names
+max_iterations = 3  # rounds of tool calls one answer may take before a final answer is required
+
 [pr_reviewer] # /review #
 # enable/disable features
 require_score_review=false

--- a/pr_agent/tools/model_tools/__init__.py
+++ b/pr_agent/tools/model_tools/__init__.py
@@ -1,0 +1,19 @@
+"""Tools the host can offer to the model.
+
+Importing a module here does not enable anything: registration only makes a tool known, and
+`[tools]` still decides whether it is offered. `register_builtin_tools()` is the one entry point
+a server or the CLI calls at start-up.
+"""
+
+from pr_agent.log import get_logger
+
+
+def register_builtin_tools() -> None:
+    """Register the tools that ship with PR-Agent, skipping any that are not configured."""
+    from pr_agent.tools.model_tools.web_search import register_web_search_tool
+
+    for register in (register_web_search_tool,):
+        try:
+            register()
+        except Exception as e:
+            get_logger().warning(f"Could not register a built-in tool: {e}")

--- a/pr_agent/tools/model_tools/web_search.py
+++ b/pr_agent/tools/model_tools/web_search.py
@@ -1,0 +1,140 @@
+"""A web-search tool the model can call while reviewing.
+
+A review often turns on something outside the diff: whether an API is deprecated, what a CVE
+covers, what a library's current version does. This tool gives the model one bounded way to ask,
+through a search provider the operator configured.
+
+The provider is chosen by the host. Both supported providers take a POST with a JSON body and an
+API key, so a new one is a few lines below rather than a new dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import requests
+
+from pr_agent.algo.tool_registry import Tool, register_tool
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+WEB_SEARCH_TOOL_NAME = "web_search"
+DEFAULT_RESULT_COUNT = 3
+MAX_RESULT_COUNT = 10
+DEFAULT_TIMEOUT_SECONDS = 10
+MAX_SNIPPET_CHARS = 500
+
+_PROVIDERS = {
+    "exa": {
+        "url": "https://api.exa.ai/search",
+        "auth_header": "x-api-key",
+        "body": lambda query, count: {"query": query, "numResults": count, "contents": {"text": True}},
+        "results_key": "results",
+        "fields": ("title", "url", "text"),
+    },
+    "tavily": {
+        "url": "https://api.tavily.com/search",
+        "auth_header": "Authorization",
+        "auth_prefix": "Bearer ",
+        "body": lambda query, count: {"query": query, "max_results": count},
+        "results_key": "results",
+        "fields": ("title", "url", "content"),
+    },
+}
+
+
+def get_web_search_settings() -> Dict[str, Any]:
+    """The configured provider and key, or an empty mapping when search is not set up."""
+    settings = get_settings()
+    provider = str(settings.get("web_search.provider", "") or "").strip().lower()
+    api_key = str(settings.get("web_search.api_key", "") or "").strip()
+    if not provider or not api_key:
+        return {}
+    if provider not in _PROVIDERS:
+        get_logger().warning(
+            f"web_search.provider {provider!r} is not supported; "
+            f"choose one of {', '.join(sorted(_PROVIDERS))}")
+        return {}
+    return {"provider": provider, "api_key": api_key}
+
+
+def _result_count() -> int:
+    value = get_settings().get("web_search.result_count", DEFAULT_RESULT_COUNT)
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        get_logger().warning(f"web_search.result_count is not a number ({value!r}); using {DEFAULT_RESULT_COUNT}")
+        return DEFAULT_RESULT_COUNT
+    return max(1, min(MAX_RESULT_COUNT, count))
+
+
+def _timeout() -> int:
+    value = get_settings().get("web_search.timeout", DEFAULT_TIMEOUT_SECONDS)
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+    return max(1, timeout)
+
+
+def _format(results: List[dict], fields) -> str:
+    title_key, url_key, text_key = fields
+    lines = []
+    for index, result in enumerate(results, start=1):
+        if not isinstance(result, dict):
+            continue
+        title = str(result.get(title_key) or "").strip() or "(no title)"
+        url = str(result.get(url_key) or "").strip()
+        snippet = " ".join(str(result.get(text_key) or "").split())[:MAX_SNIPPET_CHARS]
+        lines.append(f"{index}. {title}\n   {url}\n   {snippet}".rstrip())
+    return "\n".join(lines) if lines else "No results."
+
+
+def search_the_web(query: str) -> str:
+    """Search the web and return the top results as text the model can cite."""
+    query = str(query or "").strip()
+    if not query:
+        return "Error: the query is empty."
+    configured = get_web_search_settings()
+    if not configured:
+        return "Error: web search is not configured on this host."
+    provider = _PROVIDERS[configured["provider"]]
+    headers = {"Content-Type": "application/json",
+               provider["auth_header"]: provider.get("auth_prefix", "") + configured["api_key"]}
+    try:
+        response = requests.post(provider["url"], json=provider["body"](query, _result_count()),
+                                 headers=headers, timeout=_timeout(), allow_redirects=False)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as e:
+        # Log the type only: a search error can echo the URL, which carries the key.
+        get_logger().warning(f"The web search failed: {type(e).__name__}")
+        return f"Error: the web search failed ({type(e).__name__})."
+    results = payload.get(provider["results_key"]) if isinstance(payload, dict) else None
+    if not isinstance(results, list):
+        return "No results."
+    return _format(results, provider["fields"])
+
+
+WEB_SEARCH_TOOL = Tool(
+    name=WEB_SEARCH_TOOL_NAME,
+    description=(
+        "Search the web for current information the pull request does not contain, such as "
+        "whether an API is deprecated, what a CVE covers, or how a library behaves. "
+        "Returns the top results with their URLs."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {"query": {"type": "string", "description": "What to search for"}},
+        "required": ["query"],
+    },
+    handler=search_the_web,
+)
+
+
+def register_web_search_tool() -> bool:
+    """Register the tool when a provider and key are configured; report whether it was."""
+    if not get_web_search_settings():
+        return False
+    register_tool(WEB_SEARCH_TOOL)
+    return True

--- a/tests/unittest/test_tool_calling_loop.py
+++ b/tests/unittest/test_tool_calling_loop.py
@@ -1,0 +1,164 @@
+"""The tool-calling loop: answer, call, answer again, and always finish.
+
+`chat_completion_with_tools` owns a conversation rather than a single request, so the parts that
+matter are: tools are only offered when enabled, every call is executed and fed back, the loop
+is bounded, and a spent budget still produces an answer.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+from pr_agent.algo.tool_registry import Tool, get_tool_registry
+from pr_agent.config_loader import get_settings
+
+ECHO = Tool(
+    name="echo",
+    description="Repeat the given text.",
+    parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    handler=lambda text: f"echo: {text}",
+)
+
+
+def _response(message, finish_reason):
+    """`_get_completion` answers with (content, finish_reason, raw response)."""
+    raw = {"choices": [{"message": message, "finish_reason": finish_reason}]}
+    return getattr(message, "content", None), finish_reason, raw
+
+
+def _answer(content):
+    return _response(
+        SimpleNamespace(content=content, tool_calls=None, model_dump=lambda: {"role": "assistant"}),
+        "stop")
+
+
+def _tool_request(name="echo", arguments='{"text": "hi"}', call_id="call_1"):
+    call = SimpleNamespace(id=call_id, function=SimpleNamespace(name=name, arguments=arguments))
+    return _response(
+        SimpleNamespace(content=None, tool_calls=[call],
+                        model_dump=lambda: {"role": "assistant", "tool_calls": []}),
+        "tool_calls")
+
+
+@pytest.fixture
+def handler(monkeypatch):
+    monkeypatch.setattr(LiteLLMAIHandler, "__init__", lambda self: None)
+    handler = LiteLLMAIHandler()
+    return handler
+
+
+@pytest.fixture
+def tools_enabled(monkeypatch):
+    registry = get_tool_registry()
+    registry.register(ECHO)
+
+    def _set(enabled=True, max_iterations=3):
+        get_settings().set("tools.enabled", enabled)
+        get_settings().set("tools.allowed", [])
+        get_settings().set("tools.max_iterations", max_iterations)
+    _set()
+    yield _set
+    registry.unregister("echo")
+    get_settings().set("tools.enabled", False)
+
+
+async def test_an_answer_without_a_tool_call_is_returned(handler, tools_enabled):
+    handler._get_completion = AsyncMock(return_value=_answer("done"))
+
+    text, finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, finish_reason, calls) == ("done", "stop", [])
+
+
+async def test_a_tool_call_is_executed_and_fed_back(handler, tools_enabled):
+    handler._get_completion = AsyncMock(side_effect=[_tool_request(), _answer("done")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "done"
+    assert calls == [{"name": "echo", "arguments": '{"text": "hi"}', "result": "echo: hi"}]
+    second_call_messages = handler._get_completion.await_args_list[1].kwargs["messages"]
+    assert second_call_messages[-1]["role"] == "tool"
+    assert second_call_messages[-1]["content"] == "echo: hi"
+    assert second_call_messages[-1]["tool_call_id"] == "call_1"
+
+
+async def test_the_tools_are_offered_on_every_round(handler, tools_enabled):
+    handler._get_completion = AsyncMock(side_effect=[_tool_request(), _answer("done")])
+
+    await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    for call in handler._get_completion.await_args_list:
+        assert call.kwargs["tools"][0]["function"]["name"] == "echo"
+        assert call.kwargs["tool_choice"] == "auto"
+        assert call.kwargs["allow_tool_calls"] is True
+
+
+async def test_no_tools_are_offered_when_the_feature_is_off(handler, tools_enabled, monkeypatch):
+    """Control: with tools off this is the ordinary single-shot completion."""
+    tools_enabled(enabled=False)
+    handler.chat_completion = AsyncMock(return_value=("plain", "stop"))
+    handler._get_completion = AsyncMock()
+
+    text, finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, finish_reason, calls) == ("plain", "stop", [])
+    handler._get_completion.assert_not_awaited()
+
+
+async def test_the_loop_is_bounded_and_still_answers(handler, tools_enabled):
+    """A model that keeps calling tools is asked once more without them."""
+    tools_enabled(max_iterations=2)
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(), _tool_request(call_id="call_2"), _answer("final")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "final"
+    assert len(calls) == 2
+    assert "tools" not in handler._get_completion.await_args_list[-1].kwargs
+
+
+async def test_a_failing_tool_does_not_fail_the_answer(handler, tools_enabled):
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(arguments="{not json"), _answer("done anyway")])
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert text == "done anyway"
+    assert calls[0]["result"].startswith("Error: could not read the arguments")
+
+
+async def test_an_unknown_tool_is_reported_to_the_model(handler, tools_enabled):
+    handler._get_completion = AsyncMock(
+        side_effect=[_tool_request(name="rm_rf", arguments="{}"), _answer("done")])
+
+    _text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert "not available" in calls[0]["result"]
+
+
+async def test_several_calls_in_one_round_are_all_executed(handler, tools_enabled):
+    first = SimpleNamespace(id="a", function=SimpleNamespace(name="echo", arguments=json.dumps({"text": "1"})))
+    second = SimpleNamespace(id="b", function=SimpleNamespace(name="echo", arguments=json.dumps({"text": "2"})))
+    both = _response(
+        SimpleNamespace(content=None, tool_calls=[first, second],
+                        model_dump=lambda: {"role": "assistant"}),
+        "tool_calls")
+    handler._get_completion = AsyncMock(side_effect=[both, _answer("done")])
+
+    _text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert [call["result"] for call in calls] == ["echo: 1", "echo: 2"]
+
+
+async def test_a_zero_budget_asks_once_without_tools(handler, tools_enabled):
+    tools_enabled(max_iterations=0)
+    handler._get_completion = AsyncMock(return_value=_answer("straight answer"))
+
+    text, _finish_reason, calls = await handler.chat_completion_with_tools("gpt-4o", "sys", "usr")
+
+    assert (text, calls) == ("straight answer", [])
+    assert "tools" not in handler._get_completion.await_args_list[0].kwargs

--- a/tests/unittest/test_tool_registry.py
+++ b/tests/unittest/test_tool_registry.py
@@ -1,0 +1,182 @@
+"""Host-provided tools: registration, the operator's gate, and call execution.
+
+A tool reaches the network or the host filesystem, so the registry is the boundary: nothing is
+offered unless the host registered it *and* the operator enabled it, and a failing tool returns
+text rather than failing the command.
+"""
+import json
+
+import pytest
+
+from pr_agent.algo.tool_registry import (
+    MAX_TOOL_RESULT_CHARS,
+    Tool,
+    ToolRegistry,
+    get_max_tool_iterations,
+)
+from pr_agent.config_loader import get_settings
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
+
+ECHO = Tool(
+    name="echo",
+    description="Repeat the given text.",
+    parameters={"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    handler=lambda text: f"echo: {text}",
+)
+CLOCK = Tool(name="clock", description="Return a fixed time.", handler=lambda: "12:00")
+
+
+@pytest.fixture
+def tools_config(monkeypatch):
+    def _set(enabled=True, allowed=None, max_iterations=3):
+        get_settings().set("tools.enabled", enabled)
+        get_settings().set("tools.allowed", allowed if allowed is not None else [])
+        get_settings().set("tools.max_iterations", max_iterations)
+    _set()
+    yield _set
+    get_settings().set("tools.enabled", False)
+
+
+@pytest.fixture
+def registry():
+    registry = ToolRegistry()
+    registry.register(ECHO)
+    registry.register(CLOCK)
+    return registry
+
+
+def test_nothing_is_offered_until_the_operator_says_so(registry, tools_config):
+    tools_config(enabled=False)
+
+    assert registry.enabled_tools() == []
+    assert registry.specs() == []
+
+
+def test_every_registered_tool_is_offered_by_default(registry, tools_config):
+    assert [tool.name for tool in registry.enabled_tools()] == ["clock", "echo"]
+
+
+def test_an_allowlist_narrows_the_set(registry, tools_config):
+    tools_config(allowed=["echo"])
+
+    assert [tool.name for tool in registry.enabled_tools()] == ["echo"]
+
+
+def test_an_allowlist_naming_nothing_registered_offers_nothing(registry, tools_config):
+    tools_config(allowed=["nope"])
+
+    assert registry.enabled_tools() == []
+
+
+def test_the_spec_matches_the_completion_api(registry, tools_config):
+    tools_config(allowed=["echo"])
+
+    assert registry.specs() == [{
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Repeat the given text.",
+            "parameters": ECHO.parameters,
+        },
+    }]
+
+
+def test_registering_the_same_tool_twice_is_allowed(registry):
+    registry.register(ECHO)
+
+    assert registry.registered_names() == ["clock", "echo"]
+
+
+def test_registering_a_different_tool_under_a_taken_name_raises(registry):
+    with pytest.raises(ValueError):
+        registry.register(Tool(name="echo", description="Something else", handler=lambda: ""))
+
+
+@pytest.mark.parametrize("bad", [None, "echo", 42, Tool(name="", description="", handler=lambda: "")])
+def test_registering_something_that_is_not_a_tool_raises(registry, bad):
+    with pytest.raises(TypeError):
+        registry.register(bad)
+
+
+# --------------------------------------------------------------------------------------
+# Execution
+# --------------------------------------------------------------------------------------
+def test_a_call_runs_the_handler(registry, tools_config):
+    assert registry.execute("echo", json.dumps({"text": "hi"})) == "echo: hi"
+
+
+def test_arguments_may_arrive_already_decoded(registry, tools_config):
+    assert registry.execute("echo", {"text": "hi"}) == "echo: hi"
+
+
+def test_a_tool_without_arguments_is_callable(registry, tools_config):
+    assert registry.execute("clock", "") == "12:00"
+    assert registry.execute("clock", None) == "12:00"
+
+
+def test_an_unknown_tool_is_reported_to_the_model(registry, tools_config):
+    assert "not available" in registry.execute("rm_rf", "{}")
+
+
+def test_a_disabled_tool_cannot_be_called(registry, tools_config):
+    """The gate is enforced at call time, not only when the specs are built."""
+    tools_config(allowed=["clock"])
+
+    assert "not available" in registry.execute("echo", json.dumps({"text": "hi"}))
+
+
+def test_a_call_with_no_tools_enabled_is_refused(registry, tools_config):
+    tools_config(enabled=False)
+
+    assert "not available" in registry.execute("echo", json.dumps({"text": "hi"}))
+
+
+@pytest.mark.parametrize("arguments", ["{not json", "[1, 2]", '"a string"'])
+def test_unreadable_arguments_are_reported_not_raised(registry, tools_config, arguments):
+    assert registry.execute("echo", arguments).startswith("Error: could not read the arguments")
+
+
+def test_a_raising_tool_is_reported_not_raised(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="boom", description="Always fails.",
+                           handler=lambda: (_ for _ in ()).throw(RuntimeError("no"))))
+
+    assert registry.execute("boom", "{}").startswith("Error: the tool 'boom' failed")
+
+
+def test_a_wrong_argument_name_is_reported_not_raised(registry, tools_config):
+    assert registry.execute("echo", json.dumps({"wrong": "hi"})).startswith("Error: the tool 'echo' failed")
+
+
+def test_a_non_string_result_is_serialised(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="data", description="Returns a mapping.",
+                           handler=lambda: {"a": 1}))
+
+    assert registry.execute("data", "{}") == '{"a": 1}'
+
+
+def test_a_long_result_is_truncated(tools_config):
+    registry = ToolRegistry()
+    registry.register(Tool(name="long", description="Returns a lot.",
+                           handler=lambda: "x" * (MAX_TOOL_RESULT_CHARS + 500)))
+
+    result = registry.execute("long", "{}")
+
+    assert len(result) == MAX_TOOL_RESULT_CHARS + len("\n[truncated]")
+    assert result.endswith("[truncated]")
+
+
+# --------------------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("value, expected", [(5, 5), ("4", 4), (0, 0), (-1, 0), ("nope", 3), (None, 3)])
+def test_the_iteration_budget_is_read_defensively(tools_config, value, expected):
+    tools_config(max_iterations=value)
+
+    assert get_max_tool_iterations() == expected
+
+
+def test_a_repository_cannot_enable_tools():
+    """`[tools]` decides what the model may reach, so it is host-only."""
+    assert REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION["tools"] == frozenset()

--- a/tests/unittest/test_web_search_tool.py
+++ b/tests/unittest/test_web_search_tool.py
@@ -1,0 +1,174 @@
+"""The web-search tool: configuration, request shape, and containment.
+
+Search reaches a third party with the host's API key, so what matters is that the tool does not
+exist unless the host configured it, that a failure is reported to the model rather than raised,
+and that nothing logs the key.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.algo.tool_registry import ToolRegistry
+from pr_agent.config_loader import get_settings
+from pr_agent.config_security import REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION
+from pr_agent.tools.model_tools.web_search import (
+    WEB_SEARCH_TOOL,
+    MAX_SNIPPET_CHARS,
+    get_web_search_settings,
+    register_web_search_tool,
+    search_the_web,
+)
+
+EXA_PAYLOAD = {"results": [
+    {"title": "Deprecation notice", "url": "https://example.test/a", "text": "The API was removed in v3."},
+    {"title": "Migration guide", "url": "https://example.test/b", "text": "Use the new client instead."},
+]}
+TAVILY_PAYLOAD = {"results": [
+    {"title": "CVE-2026-1", "url": "https://example.test/cve", "content": "Affects versions below 2.1."},
+]}
+
+
+@pytest.fixture
+def search_config(monkeypatch):
+    def _set(provider="exa", api_key="secret-key", result_count=3, timeout=10):
+        get_settings().set("web_search.provider", provider)
+        get_settings().set("web_search.api_key", api_key)
+        get_settings().set("web_search.result_count", result_count)
+        get_settings().set("web_search.timeout", timeout)
+    _set()
+    yield _set
+    get_settings().set("web_search.provider", "")
+    get_settings().set("web_search.api_key", "")
+
+
+@pytest.fixture
+def post(monkeypatch):
+    call = MagicMock()
+    call.return_value = MagicMock(json=lambda: EXA_PAYLOAD, raise_for_status=lambda: None)
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post", call)
+    return call
+
+
+def test_the_tool_is_not_registered_without_a_provider(search_config):
+    search_config(provider="")
+
+    assert register_web_search_tool() is False
+
+
+def test_the_tool_is_not_registered_without_a_key(search_config):
+    search_config(api_key="")
+
+    assert register_web_search_tool() is False
+
+
+def test_an_unsupported_provider_is_refused(search_config):
+    search_config(provider="altavista")
+
+    assert get_web_search_settings() == {}
+    assert register_web_search_tool() is False
+
+
+def test_the_tool_is_registered_when_configured(search_config):
+    assert register_web_search_tool() is True
+
+
+def test_the_registered_tool_is_still_gated_by_the_tools_section(search_config):
+    """Control: configuring search does not by itself offer it to the model."""
+    registry = ToolRegistry()
+    registry.register(WEB_SEARCH_TOOL)
+    get_settings().set("tools.enabled", False)
+
+    assert registry.enabled_tools() == []
+
+
+def test_a_search_returns_titles_urls_and_snippets(search_config, post):
+    result = search_the_web("is the v2 api deprecated")
+
+    assert "1. Deprecation notice" in result
+    assert "https://example.test/a" in result
+    assert "The API was removed in v3." in result
+    assert "2. Migration guide" in result
+
+
+def test_exa_receives_the_query_and_the_key(search_config, post):
+    search_the_web("is the v2 api deprecated")
+
+    _args, kwargs = post.call_args
+    assert post.call_args.args[0] == "https://api.exa.ai/search"
+    assert kwargs["json"]["query"] == "is the v2 api deprecated"
+    assert kwargs["json"]["numResults"] == 3
+    assert kwargs["headers"]["x-api-key"] == "secret-key"
+    assert kwargs["allow_redirects"] is False
+
+
+def test_tavily_uses_its_own_shape(search_config, monkeypatch):
+    search_config(provider="tavily")
+    call = MagicMock(return_value=MagicMock(json=lambda: TAVILY_PAYLOAD, raise_for_status=lambda: None))
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post", call)
+
+    result = search_the_web("CVE-2026-1")
+
+    assert call.call_args.args[0] == "https://api.tavily.com/search"
+    assert call.call_args.kwargs["json"]["max_results"] == 3
+    assert call.call_args.kwargs["headers"]["Authorization"] == "Bearer secret-key"
+    assert "Affects versions below 2.1." in result
+
+
+@pytest.mark.parametrize("count, expected", [(1, 1), (7, 7), (99, 10), (0, 1), ("4", 4), ("nope", 3)])
+def test_the_result_count_is_bounded(search_config, post, count, expected):
+    search_config(result_count=count)
+
+    search_the_web("anything")
+
+    assert post.call_args.kwargs["json"]["numResults"] == expected
+
+
+def test_a_long_snippet_is_truncated(search_config, monkeypatch):
+    payload = {"results": [{"title": "Long", "url": "https://example.test/x", "text": "y" * 2000}]}
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post",
+                        MagicMock(return_value=MagicMock(json=lambda: payload, raise_for_status=lambda: None)))
+
+    result = search_the_web("anything")
+
+    assert "y" * MAX_SNIPPET_CHARS in result
+    assert "y" * (MAX_SNIPPET_CHARS + 1) not in result
+
+
+def test_an_empty_query_is_refused(search_config, post):
+    assert search_the_web("   ").startswith("Error: the query is empty")
+    post.assert_not_called()
+
+
+def test_an_unconfigured_host_reports_it_to_the_model(search_config, post):
+    search_config(provider="")
+
+    assert search_the_web("anything").startswith("Error: web search is not configured")
+    post.assert_not_called()
+
+
+def test_a_network_failure_is_reported_not_raised(search_config, monkeypatch):
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post",
+                        MagicMock(side_effect=RuntimeError("connection reset")))
+
+    assert search_the_web("anything").startswith("Error: the web search failed")
+
+
+def test_the_key_never_reaches_the_log(search_config, monkeypatch, caplog):
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post",
+                        MagicMock(side_effect=RuntimeError("https://api.exa.ai?key=secret-key")))
+
+    message = search_the_web("anything")
+
+    assert "secret-key" not in message
+
+
+def test_an_unreadable_payload_is_reported(search_config, monkeypatch):
+    monkeypatch.setattr("pr_agent.tools.model_tools.web_search.requests.post",
+                        MagicMock(return_value=MagicMock(json=lambda: ["not", "a", "mapping"],
+                                                         raise_for_status=lambda: None)))
+
+    assert search_the_web("anything") == "No results."
+
+
+def test_a_repository_cannot_configure_search():
+    assert REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION["web_search"] == frozenset()


### PR DESCRIPTION
> **Stacked on `feat/model-tool-calling`.** Review that first; this branch adds one tool to the
> registry it introduces.

Implements #3095.

## Description

A review often turns on something the diff does not contain: whether an API is deprecated, what a
CVE covers, how a library behaves in the version being pinned. `web_search` gives the model one
bounded way to ask.

### What changed

**A tool** (`pr_agent/tools/model_tools/web_search.py`) with two providers, Exa and Tavily. Both
take a POST with a JSON body and an API key, so the provider table is a few lines of data rather
than a new dependency — `requests` is already used throughout.

**A registration entry point** (`pr_agent/tools/model_tools/__init__.py`).
`register_builtin_tools()` is what a server or the CLI calls once at start-up; a tool that is not
configured is skipped, and a tool that fails to register is logged rather than fatal.

**Configuration**, inert by default:

```toml
[web_search]
provider = ""     # "exa" or "tavily"; empty means the tool is never registered
api_key = ""      # belongs in .secrets.toml
result_count = 3  # clamped to 1..10
timeout = 10
```

### Two gates, not one

Configuring `[web_search]` only makes the tool *known*. `[tools]` still decides whether it is
*offered*, so an operator who sets a key has not thereby exposed the model to it. `[web_search]` is
host-only in `REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION` for the same reason `[tools]` is: the key
reaches a third party, and a repository must not be able to set the endpoint or the key.

### Containment

- an empty query, an unconfigured host, a network failure and an unreadable payload each return a
  string **to the model**, never an exception to the command;
- `allow_redirects=False`, so a search provider cannot redirect the request elsewhere;
- the failure message carries only the exception *type* — a search error routinely echoes the
  request URL, which carries the key;
- snippets are cut at 500 characters and results at 10, so a search cannot blow the prompt budget.

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3746 passed, 1 skipped, 1 xfailed, 91 warnings in 54.80s
```

New file `tests/unittest/test_web_search_tool.py` (21 tests), written first — before the module
existed the file could not even import. Covers registration with and without configuration, an
unsupported provider, both providers' request shapes and auth headers, result-count clamping over
six values, snippet truncation, the four containment paths, the assertion that the key never
appears in the returned message, and the two configuration gates.

**Verified end to end, not only against mocks.** The unit tests replace `requests.post`, so the
tool was additionally driven over a real socket: a local HTTP server stood in for Exa, and
`search_the_web` reached it through the real `requests` path. The server received the expected
body — `{"query": ..., "numResults": 2, "contents": {"text": true}}` — and the `x-api-key` header,
and the response was parsed into the titles, URLs and snippets the model sees.

The whole stack was then exercised with a live model: asked whether urllib3 2.0 removed
`Retry.DEFAULT_METHOD_WHITELIST`, `nvidia/nemotron-3.5-lightning` called `web_search`, the tool
made the HTTP round trip, and the model answered from the retrieved text rather than from memory.

Also checked: `ruff check` clean.

## Risk / compatibility

Nothing is registered, offered or called unless an operator configures a provider **and** enables
`[tools]`. No new dependency.

Exa and Tavily themselves are still only exercised through their request shape: no live call was
made to either service, because that needs a paid key.

