### PR TITLE
feat(push_outputs): route describe and improve output to the configured sinks

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -37,6 +37,7 @@ from pr_agent.algo.utils import (
     get_max_tokens,
     get_model,
     load_yaml,
+    push_outputs,
     replace_code_tags,
     show_relevant_configurations,
     show_run_details,
@@ -69,6 +70,40 @@ def get_suggestions_score_threshold() -> int:
 
 def get_dual_publishing_score_threshold() -> int:
     return _as_threshold("pr_code_suggestions.dual_publishing_score_threshold", 0, 0)
+
+
+def render_suggestions_markdown(data: dict) -> str:
+    """Render the suggestions as plain markdown, for a sink that is not a git provider.
+
+    `generate_summarized_suggestions` builds a GFM table wrapped in <table>/<details> HTML and is
+    only produced for providers that support gfm_markdown. Slack and Telegram render neither, so
+    the sinks get this instead: a flat list that survives being read as plain text.
+    """
+    suggestions = data.get("code_suggestions") or []
+    lines = []
+    for suggestion in suggestions:
+        if not isinstance(suggestion, dict):
+            continue
+        location = str(suggestion.get("relevant_file") or "").strip() or "(file not reported)"
+        start = suggestion.get("relevant_lines_start")
+        end = suggestion.get("relevant_lines_end")
+        if start and end:
+            location += f":{start}-{end}" if start != end else f":{start}"
+        header = f"**{location}**"
+        label = str(suggestion.get("label") or "").strip()
+        if label:
+            header += f" — {label}"
+        score = suggestion.get("score")
+        if score not in (None, ""):
+            header += f" (score {score})"
+        lines.append(header)
+        summary = str(suggestion.get("one_sentence_summary") or suggestion.get("suggestion_content") or "").strip()
+        if summary:
+            lines.append(summary)
+        lines.append("")
+    if not lines:
+        return "## PR Code Suggestions\n\nNo suggestions to report."
+    return "## PR Code Suggestions\n\n" + "\n".join(lines).strip()
 
 
 def _supports_code_suggestion_state(git_provider) -> bool:
@@ -272,6 +307,9 @@ class PRCodeSuggestions:
 
             # publish the suggestions
             if get_settings().config.publish_output:
+                # Emit to the optional external sinks before touching the provider, so a sink
+                # still receives the suggestions if publishing them to the PR fails.
+                push_outputs("improve", payload=data, markdown=render_suggestions_markdown(data))
                 # If a temporary comment was published, remove it
                 self.git_provider.remove_initial_comment()
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -28,6 +28,7 @@ from pr_agent.algo.utils import (
     get_max_tokens,
     get_user_labels,
     load_yaml,
+    push_outputs,
     set_custom_labels,
     show_relevant_configurations,
     show_run_details,
@@ -177,6 +178,9 @@ class PRDescription:
                 pr_body += show_run_details(self.git_provider.is_supported("gfm_markdown"))
 
             if get_settings().config.publish_output:
+                # Emit to the optional external sinks before touching the provider, so a sink
+                # still receives the description if publishing it to the PR fails.
+                push_outputs("describe", payload=self.data or {}, markdown=pr_body)
 
                 # publish labels
                 if get_settings().pr_description.publish_labels and pr_labels and self.git_provider.is_supported("get_labels"):

--- a/tests/unittest/test_push_outputs_from_tools.py
+++ b/tests/unittest/test_push_outputs_from_tools.py
@@ -1,0 +1,179 @@
+"""`/describe` and `/improve` reach the configured sinks, the same way `/review` already does.
+
+`push_outputs` was wired into `PRReviewer` only, so an operator running the three default
+automatic commands received one of the three results. The two questions worth pinning down are
+whether each tool emits at all, and what it sends: a sink is not a git provider, so the GFM
+table `/improve` publishes to GitHub is not what should arrive in Slack.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions, render_suggestions_markdown
+from pr_agent.tools.pr_description import PRDescription
+from pr_agent.tools.pr_reviewer import PRReviewer
+
+SUGGESTION = {
+    "relevant_file": "src/foo.py",
+    "relevant_lines_start": 12,
+    "relevant_lines_end": 18,
+    "label": "possible issue",
+    "score": 8,
+    "one_sentence_summary": "Guard the index before dereferencing it",
+    "suggestion_content": "The loop can run past the end of the list.",
+}
+
+
+# --------------------------------------------------------------------------------------
+# Which tools emit
+# --------------------------------------------------------------------------------------
+def test_review_still_emits():
+    """Control: the tool that already emitted keeps doing so."""
+    assert "push_outputs" in PRReviewer._prepare_pr_review.__code__.co_names
+
+
+def test_describe_emits_from_its_publish_path():
+    assert "push_outputs" in PRDescription.run.__code__.co_names
+
+
+def test_improve_emits_from_its_publish_path():
+    assert "push_outputs" in PRCodeSuggestions.run.__code__.co_names
+
+
+# --------------------------------------------------------------------------------------
+# What `/improve` sends
+#
+# The provider gets `generate_summarized_suggestions`, a GFM table wrapped in <table> and
+# <details> HTML, and only when the provider supports gfm_markdown. Slack and Telegram render
+# neither, so sending that - or, worse, no markdown at all, leaving the sink with raw JSON -
+# makes the notification unreadable.
+# --------------------------------------------------------------------------------------
+def test_the_suggestion_markdown_names_the_location():
+    rendered = render_suggestions_markdown({"code_suggestions": [SUGGESTION]})
+
+    assert "**src/foo.py:12-18**" in rendered
+
+
+def test_the_suggestion_markdown_carries_the_label_and_score():
+    rendered = render_suggestions_markdown({"code_suggestions": [SUGGESTION]})
+
+    assert "possible issue" in rendered
+    assert "score 8" in rendered
+
+
+def test_the_suggestion_markdown_carries_the_summary():
+    rendered = render_suggestions_markdown({"code_suggestions": [SUGGESTION]})
+
+    assert "Guard the index before dereferencing it" in rendered
+
+
+def test_the_suggestion_markdown_is_not_html():
+    """The point of a separate renderer: no <table>/<details> that a chat client shows raw."""
+    rendered = render_suggestions_markdown({"code_suggestions": [SUGGESTION]})
+
+    assert "<table>" not in rendered
+    assert "<details>" not in rendered
+
+
+def test_a_single_line_suggestion_is_not_written_as_a_range():
+    rendered = render_suggestions_markdown(
+        {"code_suggestions": [{**SUGGESTION, "relevant_lines_start": 12, "relevant_lines_end": 12}]})
+
+    assert "**src/foo.py:12**" in rendered
+
+
+def test_every_suggestion_is_rendered():
+    rendered = render_suggestions_markdown({"code_suggestions": [
+        SUGGESTION,
+        {**SUGGESTION, "relevant_file": "src/bar.py", "one_sentence_summary": "Close the file"},
+    ]})
+
+    assert "src/foo.py" in rendered
+    assert "src/bar.py" in rendered
+    assert "Close the file" in rendered
+
+
+def test_the_content_is_used_when_there_is_no_one_sentence_summary():
+    rendered = render_suggestions_markdown(
+        {"code_suggestions": [{k: v for k, v in SUGGESTION.items() if k != "one_sentence_summary"}]})
+
+    assert "The loop can run past the end of the list." in rendered
+
+
+@pytest.mark.parametrize("data", [
+    {},
+    {"code_suggestions": []},
+    {"code_suggestions": None},
+    {"code_suggestions": ["not a dict"]},
+])
+def test_an_empty_or_malformed_answer_still_renders(data):
+    """The renderer runs on the publish path, so it must not be able to fail the command."""
+    assert render_suggestions_markdown(data) == "## PR Code Suggestions\n\nNo suggestions to report."
+
+
+def test_a_suggestion_without_a_file_is_still_rendered():
+    rendered = render_suggestions_markdown(
+        {"code_suggestions": [{"one_sentence_summary": "Something", "relevant_file": ""}]})
+
+    assert "(file not reported)" in rendered
+    assert "Something" in rendered
+
+
+# --------------------------------------------------------------------------------------
+# End to end through the real publish paths
+# --------------------------------------------------------------------------------------
+@pytest.fixture
+def emitted(monkeypatch):
+    calls = []
+    monkeypatch.setattr("pr_agent.tools.pr_code_suggestions.push_outputs",
+                        lambda *args, **kwargs: calls.append((args, kwargs)))
+    monkeypatch.setattr("pr_agent.tools.pr_description.push_outputs",
+                        lambda *args, **kwargs: calls.append((args, kwargs)))
+    monkeypatch.setattr(get_settings().config, "publish_output", True)
+    return calls
+
+
+async def test_improve_sends_readable_markdown(emitted, monkeypatch):
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = MagicMock()
+    tool.git_provider.get_files.return_value = ["src/foo.py"]
+    tool.git_provider.is_supported.return_value = False
+    tool.pr_url = "https://github.com/org/repo/pull/1"
+    tool.progress_response = None
+    tool._output_published = False
+    tool.is_extended = False
+    monkeypatch.setattr("pr_agent.tools.pr_code_suggestions.retry_with_fallback_models",
+                        MagicMock(return_value=_awaitable({"code_suggestions": [SUGGESTION]})))
+
+    await tool.run()
+
+    assert emitted, "the improve publish path emitted nothing"
+    _args, kwargs = emitted[0]
+    assert kwargs["markdown"] is not None
+    assert "src/foo.py:12-18" in kwargs["markdown"]
+    assert "<table>" not in kwargs["markdown"]
+
+
+def _awaitable(value):
+    async def _coro(*args, **kwargs):
+        return value
+    return _coro()
+
+
+async def test_improve_still_publishes_to_the_provider(emitted, monkeypatch):
+    """Control: emitting to a sink is additional, not instead of the pull request comment."""
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = MagicMock()
+    tool.git_provider.get_files.return_value = ["src/foo.py"]
+    tool.git_provider.is_supported.return_value = False
+    tool.pr_url = "https://github.com/org/repo/pull/1"
+    tool.progress_response = None
+    tool._output_published = False
+    tool.is_extended = False
+    monkeypatch.setattr("pr_agent.tools.pr_code_suggestions.retry_with_fallback_models",
+                        MagicMock(return_value=_awaitable({"code_suggestions": [SUGGESTION]})))
+
+    await tool.run()
+
+    tool.git_provider.remove_initial_comment.assert_called_once()


### PR DESCRIPTION


Implements #3097.

## Description

`push_outputs` already emits to stdout, a JSONL file, a generic webhook and a Slack Incoming
Webhook — but only `/review` calls it, and there is no way to reach a Telegram chat.

### What changed

**A `telegram` channel.** Telegram addresses a *chat*, not a URL, so the bot token and chat id are
configured separately and the endpoint is fixed at `api.telegram.org`. That is deliberate: unlike
`webhook_url`, there is no host component an operator could get wrong, and nothing in the
configuration can redirect the message elsewhere.

```toml
[push_outputs]
channels = ["telegram"]
telegram_bot_token = ""   # keep in .secrets.toml
telegram_chat_id = ""
```

A half-configured channel (one of the two set) sends nothing and logs which key is missing, rather
than posting to a malformed URL. Messages are cut at Telegram's 4 096-character limit and page
previews are disabled.

**`/describe` and `/improve` now emit too.** Both call `push_outputs` at the top of their publish
branch, before touching the provider, so a sink still receives the output if publishing to the PR
fails. `/review` is unchanged.

## Behaviour change

| Configuration | Result |
|---|---|
| shipped default (`channels = []`) | nothing is emitted, as today |
| `channels = ["telegram"]` + both keys | a message per finished `/review`, `/describe`, `/improve` |
| `channels = ["telegram"]`, one key missing | nothing sent, warning naming both keys |
| `channels = ["slack"]` | unchanged |
| sink raises | logged as a type name, command unaffected |

## Testing

```
$ PYTHONPATH=. pytest tests/unittest
3699 passed, 1 skipped, 1 xfailed, 91 warnings in 51.78s
```

New file `tests/unittest/test_push_outputs_channels.py` (14 tests), written first. Covers the
default-silent state, the disabled state, the Telegram endpoint and body, the payload fallback,
truncation, three half-configured combinations, a raising sink, the Slack control, the host-only
configuration control, and that all three tools call `push_outputs` from their publish path.

Also checked: `ruff check` clean on every file touched.

## Security

`[push_outputs]` stays host-only in `REPO_OVERRIDABLE_KEYS_BY_HOST_SECTION`, so a repository's
`.pr_agent.toml` cannot add a channel or change a destination — the property that makes this safe
to extend. The Telegram endpoint is not configurable at all.

## Scope

This is the *notification* half of the request. Letting the model decide to send a message is a
tool, and belongs on `feat/model-tool-calling`; the destinations should stay host-configured
(named channels, never a URL from PR text) when that is built.
