### PR TITLE
feat(models): add Claude Fable 5.1 support

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -674,7 +674,7 @@ built-in defaults.
 !!! note "Only models that accept a thinking budget are supported"
     PR-Agent enables extended thinking through the manual
     `thinking={"type": "enabled", "budget_tokens": ...}` request. Adaptive-only Claude models
-    (e.g. Opus 4.7/4.8, Opus 5, Sonnet 5, Fable 5) reject `budget_tokens`, so they are
+    (e.g. Opus 4.7/4.8, Opus 5, Sonnet 5, Fable 5, Fable 5.1) reject `budget_tokens`, so they are
     intentionally excluded from the built-in defaults. If you add one to
     `claude_extended_thinking_models_override` anyway, PR-Agent skips the extended-thinking payload
     for it and logs a warning rather than sending a request the provider would reject — use

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -105,6 +105,17 @@ _CLAUDE_MODEL_FAMILIES = [
             "claude-3-7-sonnet-20250219",
         ],
     },
+    # claude-fable-5-1 is a 1M-context model with the same registry shape
+    # as Opus 5 / Sonnet 5 above; placed here next to its predecessor.
+    {
+        "model_id": "claude-fable-5-1",
+        "max_tokens": 1000000,
+        # Fable 5.1 exposes the global and US geo inference IDs on Bedrock;
+        # EU/AU/JP geo inference IDs are not available.
+        # Ref: https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock#regions
+        "bedrock_regions": ("global", "us"),
+        "no_temperature": True,
+    },
     # ── No-temperature only (not in MAX_TOKENS) ──────────────────────────
     {
         "model_id": "claude-fable-5",
@@ -584,7 +595,7 @@ GROK_REASONING_EFFORT_LEVELS = {
 # thinking={"type": "enabled", "budget_tokens": ...} request built by
 # LiteLLMAIHandler._configure_claude_extended_thinking(). Only models that
 # accept budget_tokens belong here. Adaptive-only models (Claude Opus 4.7/4.8,
-# Opus 5, Sonnet 5, Fable 5) reject budget_tokens with an HTTP 400 and must not be added
+# Opus 5, Sonnet 5, Fable 5, Fable 5.1) reject budget_tokens with an HTTP 400 and must not be added
 # without also adding an adaptive-thinking code path. This list is the built-in
 # default; it can be replaced via the `claude_extended_thinking_models_override`
 # configuration option.

--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -376,6 +376,29 @@ class TestGetMaxTokens:
     @pytest.mark.parametrize(
         "model",
         [
+            "anthropic/claude-fable-5-1",
+            "claude-fable-5-1",
+            "vertex_ai/claude-fable-5-1",
+            "bedrock/anthropic.claude-fable-5-1",
+            "bedrock/global.anthropic.claude-fable-5-1",
+            "bedrock/us.anthropic.claude-fable-5-1",
+        ],
+    )
+    def test_claude_fable_5_1_model_max_tokens(self, monkeypatch, model):
+        fake_settings = type("", (), {
+            "config": type("", (), {
+                "custom_model_max_tokens": 0,
+                "max_model_tokens": 0,
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        assert get_max_tokens(model) == 1000000
+
+    @pytest.mark.parametrize(
+        "model",
+        [
             "anthropic/claude-sonnet-4-6",
             "claude-sonnet-4-6",
             "vertex_ai/claude-sonnet-4-6",

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -213,6 +213,30 @@ async def test_chat_completion_strips_temperature_for_claude_sonnet_5(monkeypatc
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-fable-5-1",
+        "claude-fable-5-1",
+        "vertex_ai/claude-fable-5-1",
+        "bedrock/anthropic.claude-fable-5-1",
+        "bedrock/global.anthropic.claude-fable-5-1",
+        "bedrock/us.anthropic.claude-fable-5-1",
+    ],
+)
+async def test_chat_completion_strips_temperature_for_claude_fable_5_1(monkeypatch, model):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model=model, system="sys", user="usr", temperature=0.2)
+
+    assert "temperature" not in mock_call.call_args.kwargs
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_does_not_use_extended_thinking_for_claude_opus_4_8(monkeypatch):
     monkeypatch.setattr(
         litellm_handler,
@@ -277,6 +301,36 @@ async def test_chat_completion_does_not_use_extended_thinking_for_claude_sonnet_
         handler = litellm_handler.LiteLLMAIHandler()
 
         await handler.chat_completion(model="claude-sonnet-5", system="sys", user="usr", temperature=0.2)
+
+    assert "thinking" not in mock_call.call_args.kwargs
+    assert "max_tokens" not in mock_call.call_args.kwargs
+    assert "temperature" not in mock_call.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-fable-5-1",
+        "claude-fable-5-1",
+        "vertex_ai/claude-fable-5-1",
+        "bedrock/anthropic.claude-fable-5-1",
+        "bedrock/global.anthropic.claude-fable-5-1",
+        "bedrock/us.anthropic.claude-fable-5-1",
+    ],
+)
+async def test_chat_completion_does_not_use_extended_thinking_for_claude_fable_5_1(monkeypatch, model):
+    monkeypatch.setattr(
+        litellm_handler,
+        "get_settings",
+        lambda: FakeSettings(config_values={"enable_claude_extended_thinking": True}),
+    )
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(model=model, system="sys", user="usr", temperature=0.2)
 
     assert "thinking" not in mock_call.call_args.kwargs
     assert "max_tokens" not in mock_call.call_args.kwargs

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -99,6 +99,8 @@ async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled
         ("anthropic/claude-opus-5", True),
         ("bedrock/us.anthropic.claude-opus-5", True),
         ("anthropic/claude-fable-5", True),
+        ("anthropic/claude-fable-5-1", True),
+        ("bedrock/us.anthropic.claude-fable-5-1", True),
         ("anthropic/claude-opus-4-6", False),
         ("anthropic/claude-sonnet-50", False),
         ("anthropic/claude-opus-50", False),


### PR DESCRIPTION
Register the 1M-context aliases across Anthropic, Vertex AI, and supported Bedrock routes (global, us). Omit non-default sampling parameters and keep Claude Fable 5.1 outside manual extended thinking because the model uses adaptive thinking.

Bedrock regional endpoints for Fable 5.1 are currently us-east-1 only (plus the global endpoint), unlike Opus/Sonnet 5.

References:
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1
- https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock
- https://www.anthropic.com/claude-fable-and-mythos-5-1