### PR TITLE
chore: up uv 0.9.7 to 0.12.10 in dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12.14-slim AS base
-COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.10 /uv /uvx /bin/
 
 RUN apt update && apt install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.lambda
+++ b/docker/Dockerfile.lambda
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.12 AS base
-COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.10 /uv /uvx /bin/
 
 RUN dnf update -y && \
     dnf install -y gcc python3-devel git && \


### PR DESCRIPTION
Hello

In pr up uv from 0.9.7 to 0.12.10 (latest)

Since the release of the version, there have been many changes — including support for newer versions of Python. 
More details in https://github.com/astral-sh/uv/compare/0.9.7...0.12.10 