### PR TITLE
fix(diff): compare bad file extensions case-insensitively

### DIFF
--- a/pr_agent/algo/language_handler.py
+++ b/pr_agent/algo/language_handler.py
@@ -32,7 +32,11 @@ def is_valid_file(filename:str, bad_extensions=None) -> bool:
     if filename.endswith(auto_generated_suffixes):
         return False
 
-    return filename.split('.')[-1] not in bad_extensions
+    # Compare case-insensitively: bad_extensions lists binary and asset types (png, zip, svg),
+    # and 'logo.SVG' is the same kind of file as 'logo.svg'. The list is spelled in lower case,
+    # so a file named with an uppercase extension would otherwise slip into the diff.
+    bad_extensions_lower = {str(extension).lower() for extension in bad_extensions}
+    return filename.split('.')[-1].lower() not in bad_extensions_lower
 
 
 def build_language_file_matcher(language_extension_map: Dict) -> Callable[[str], str | None]:

--- a/tests/unittest/test_bad_extension_case.py
+++ b/tests/unittest/test_bad_extension_case.py
@@ -1,0 +1,40 @@
+"""Match bad extensions case-insensitively, so 'logo.SVG' is dropped like 'logo.svg'."""
+import pytest
+
+from pr_agent.algo.language_handler import filter_bad_extensions, is_valid_file
+
+
+class _File:
+    def __init__(self, filename):
+        self.filename = filename
+
+
+@pytest.mark.parametrize("filename", ["logo.SVG", "logo.Svg", "report.CSV", "photo.JPG", "bundle.ZIP"])
+def test_uppercase_bad_extension_is_dropped(filename):
+    """An asset named with an uppercase extension is the same asset."""
+    assert is_valid_file(filename) is False
+
+
+@pytest.mark.parametrize("filename", ["logo.svg", "report.csv", "photo.jpg", "bundle.zip"])
+def test_lowercase_bad_extension_is_still_dropped(filename):
+    """Keep the existing behaviour for the canonical spelling."""
+    assert is_valid_file(filename) is False
+
+
+@pytest.mark.parametrize("filename", ["main.py", "Makefile", "app.SVGZ"])
+def test_reviewable_files_are_kept(filename):
+    """Do not widen the filter: only the extension itself is compared."""
+    assert is_valid_file(filename) is True
+
+
+@pytest.mark.parametrize("filename,configured", [("archive.TAR", ["tar"]), ("archive.tar", ["TAR"])])
+def test_configured_extension_matches_either_case(filename, configured):
+    """A user-supplied bad_extensions entry matches regardless of how it is spelled."""
+    assert is_valid_file(filename, bad_extensions=configured) is False
+
+
+def test_filter_bad_extensions_drops_uppercase_assets():
+    """The filter used by sort_files_by_main_languages drops them too."""
+    files = [_File("logo.SVG"), _File("main.py")]
+
+    assert [f.filename for f in filter_bad_extensions(files)] == ["main.py"]


### PR DESCRIPTION
## What

`pr_agent/algo/language_handler.py`: lower-case both sides of the extension comparison in `is_valid_file()`, so `bad_extensions` matches whatever casing a repository actually uses.

`tests/unittest/test_bad_extension_case.py`: 15 new tests covering uppercase and mixed-case extensions, the unchanged lower-case behaviour, files that must still be reviewed, a user-supplied `bad_extensions` entry in either casing, and `filter_bad_extensions()`.

## Why

`is_valid_file()` ended with `return filename.split('.')[-1] not in bad_extensions` (`pr_agent/algo/language_handler.py:35`), and every entry of `bad_extensions.default` in `pr_agent/settings/language_extensions.toml` is spelled in lower case. The comparison only ever matched a lower-case extension, so the same file was filtered or not depending on how its name happens to be capitalised.

On `main`:

```
>>> from pr_agent.algo.language_handler import is_valid_file
>>> is_valid_file("logo.svg"), is_valid_file("logo.SVG")
(False, True)
>>> is_valid_file("report.csv"), is_valid_file("report.CSV")
(False, True)
```

That is not only a cosmetic mismatch, because several of the filtered types are text rather than binary. GitHub and GitLab return a real patch for `.SVG` and `.CSV`, so an uppercase-named one survives the filter, reaches `sort_files_by_main_languages()`, and lands in the diff sent to the model, taking token budget away from the source files the review is about. `.JPG` and `.ZIP` files stay in the file list for the same reason. Every provider filters through this one function, so this is not provider-specific: `github_provider.py:318`, `gitlab_provider.py:831`, `bitbucket_provider.py:323`, `bitbucket_server_provider.py:283`, `gitea_provider.py:194` and `:590`, `azuredevops_provider.py:555` and `:807`, `codecommit_provider.py:139`.

Only the extension comparison changed. The auto-generated lockfile names and the `.min.js` style suffixes just above it are untouched, and no uppercase extension in `language_extension_map_org` (`.C`, `.H`, `.E`, `.ML`, `.tmTheme` and friends) collides with a `bad_extensions` entry once lower-cased, so no language loses files to this.

## Testing

`PYTHONPATH=. uv run pytest tests/unittest/test_bad_extension_case.py -q` on this branch: 15 passed. With only the `language_handler.py` change reverted: 8 failed, 7 passed, the 7 passing ones being the cases that pin the existing behaviour.

`PYTHONPATH=. uv run pytest tests/unittest -q`: 3738 passed, 1 skipped, 1 xfailed in 164s.

`uv run ruff check pr_agent/algo/language_handler.py tests/unittest/test_bad_extension_case.py`: All checks passed.

`uv run pre-commit run --files pr_agent/algo/language_handler.py tests/unittest/test_bad_extension_case.py`: every applicable hook passed.
