### PR TITLE
feat(models): route small pull requests to a cheaper primary model

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -11,6 +11,7 @@ fallback_models = ["..."]
 ```
 
 To see which of these models actually handled a given PR, enable `config.output_run_details` (see [Additional configurations](./additional_configurations.md#showing-the-agent-run-details)).
+To send small pull requests to a cheaper model, see [Routing small pull requests to a cheaper model](#routing-small-pull-requests-to-a-cheaper-model).
 
 For models and environments not from OpenAI, you might need to provide additional keys and other parameters.
 You can give parameters via a configuration file, or from environment variables.
@@ -711,3 +712,36 @@ When Claude extended thinking is enabled, `extended_thinking_max_output_tokens` 
 For models with small context windows, keep in mind that prompt and completion tokens share the
 model's context window: size `config.max_model_tokens` so the packed prompt leaves room for the
 configured output limit.
+
+## Routing small pull requests to a cheaper model
+
+`config.model` handles every pull request, however small. With model routing enabled, a pull request under a
+configured size goes to a cheaper model instead, and `config.fallback_models` still apply after it:
+
+```toml
+[model_routing]
+enable = true
+
+[[model_routing.rules]]
+max_hunks = 3
+model = "gpt-5.6-luna"
+
+[[model_routing.rules]]
+max_hunks = 15
+max_files = 6
+model = "gpt-5.6-terra"
+```
+
+Rules are checked in order, and the first one whose limits the pull request fits selects the primary model for
+the call. A pull request that fits no rule uses `config.model`. Size is measured by the number of diff hunks
+(`max_hunks`) and changed files (`max_files`) left after the `[ignore]` rules. Every git provider reports both,
+and neither depends on a model's tokenizer, so a threshold means the same thing whichever model it selects.
+
+Routing applies only to calls that ask for the regular model: `/review`, `/improve`, `/generate_labels` and
+`/add_docs`. Tools that already use `config.model_weak` (`/describe`, `/ask`, `/update_changelog`) are left
+alone, and a dedicated `config.model_reasoning` is still used for self-reflection. With `config.output_run_details`
+enabled, the run details show which model a routed pull request ended up on.
+
+!!! note "Azure deployments"
+    An Azure deployment is tied to one model, so when `openai.deployment_id` is set each rule also needs its own
+    `deployment_id`. A rule without one is skipped with a warning and the configured primary model is used.

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -744,4 +744,4 @@ enabled, the run details show which model a routed pull request ended up on.
 
 !!! note "Azure deployments"
     An Azure deployment is tied to one model, so when `openai.deployment_id` is set each rule also needs its own
-    `deployment_id`. A rule without one is skipped with a warning and the configured primary model is used.
+    `deployment_id`. A rule without one is skipped with a warning and the next rule is tried.

--- a/pr_agent/algo/model_routing.py
+++ b/pr_agent/algo/model_routing.py
@@ -1,0 +1,80 @@
+"""Route a small pull request to a cheaper primary model.
+
+The [model_routing] settings hold an ordered list of rules, each naming a model and the largest
+pull request it takes, measured in diff hunks and changed files. Both counts come from the
+provider's diff, so they do not depend on which model's tokenizer would count the tokens.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.utils import ModelType
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+
+
+def count_hunks(diff_files: List[FilePatchInfo]) -> int:
+    """Count the diff hunks across the files. A patch without hunk headers still counts as one."""
+    total = 0
+    for diff_file in diff_files:
+        patch = getattr(diff_file, "patch", "") or ""
+        if not patch.strip():
+            continue
+        total += sum(1 for line in patch.splitlines() if line.startswith("@@")) or 1
+    return total
+
+
+def _limit(rule, key: str) -> Optional[int]:
+    value = rule.get(key)
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def route_primary_model(model_type: ModelType, git_provider) -> Optional[Tuple[str, Optional[str]]]:
+    """Return the (model, deployment_id) a routing rule picks for this pull request.
+
+    None keeps the configured primary. Only a call for the regular model is routed: a tool that
+    asked for the weak or the reasoning tier made that choice deliberately. Rules are checked in
+    order and the first one whose limits the pull request fits wins.
+    """
+    if model_type != ModelType.REGULAR or git_provider is None:
+        return None
+    settings = get_settings()
+    if not settings.get("model_routing.enable", False):
+        return None
+    rules = settings.get("model_routing.rules", None) or []
+    if not rules:
+        return None
+
+    diff_files = git_provider.get_diff_files()
+    num_files = len(diff_files)
+    num_hunks = count_hunks(diff_files)
+    size = f"{num_hunks} hunks in {num_files} files"
+    global_deployment_id = settings.get("openai.deployment_id", None)
+
+    for rule in rules:
+        try:
+            model = rule.get("model")
+            max_hunks = _limit(rule, "max_hunks")
+            max_files = _limit(rule, "max_files")
+        except (AttributeError, TypeError, ValueError):
+            model = max_hunks = max_files = None
+        if not model or (max_hunks is None and max_files is None):
+            get_logger().warning(f"Ignoring model routing rule without a model or a limit: {rule}")
+            continue
+        if max_hunks is not None and num_hunks > max_hunks:
+            continue
+        if max_files is not None and num_files > max_files:
+            continue
+        deployment_id = rule.get("deployment_id") or None
+        if global_deployment_id and not deployment_id:
+            get_logger().warning(f"Model routing rule for '{model}' has no deployment_id while "
+                                 f"openai.deployment_id is set, keeping the configured primary model")
+            return None
+        get_logger().info(f"Model routing: {size}, using '{model}' as the primary model")
+        return model, deployment_id
+
+    get_logger().info(f"Model routing: {size} fit no rule, keeping the configured primary model")
+    return None

--- a/pr_agent/algo/model_routing.py
+++ b/pr_agent/algo/model_routing.py
@@ -71,8 +71,8 @@ def route_primary_model(model_type: ModelType, git_provider) -> Optional[Tuple[s
         deployment_id = rule.get("deployment_id") or None
         if global_deployment_id and not deployment_id:
             get_logger().warning(f"Model routing rule for '{model}' has no deployment_id while "
-                                 f"openai.deployment_id is set, keeping the configured primary model")
-            return None
+                                 f"openai.deployment_id is set, skipping it")
+            continue
         get_logger().info(f"Model routing: {size}, using '{model}' as the primary model")
         return model, deployment_id
 

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -11,6 +11,7 @@ from pr_agent.algo.git_patch_processing import (
     handle_patch_deletions,
 )
 from pr_agent.algo.language_handler import sort_files_by_main_languages
+from pr_agent.algo.model_routing import route_primary_model
 from pr_agent.algo.run_details import record_model_used
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.types import EDIT_TYPE
@@ -331,9 +332,14 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
     return total_tokens, patches, remaining_files_list_new, files_in_patch_list
 
 
-async def retry_with_fallback_models(f: Callable, model_type: ModelType = ModelType.REGULAR):
+async def retry_with_fallback_models(f: Callable, model_type: ModelType = ModelType.REGULAR,
+                                     git_provider: GitProvider | None = None):
     all_models = _get_all_models(model_type)
     all_deployments = _get_all_deployments(all_models)
+    routed = route_primary_model(model_type, git_provider)
+    if routed:
+        # A cheaper primary for a small pull request; config.fallback_models still follow it.
+        all_models[0], all_deployments[0] = routed
     original_deployment_id = get_settings().get("openai.deployment_id", None)
     try:
         # try each (model, deployment_id) pair until one is successful, otherwise raise exception

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -449,6 +449,16 @@ reasoning_effort = ""
 reasoning_max_tokens = 0
 max_tokens = 0 # hard cap on completion tokens for the request; 0 = unset
 
+[model_routing] # send a small pull request to a cheaper primary model (disabled by default)
+# Rules are checked in order; the first one whose limits the pull request fits selects the primary model for the
+# call, and config.fallback_models still apply after it. A pull request that fits no rule uses config.model.
+# Size is measured after the [ignore] rules by diff hunks (max_hunks) and changed files (max_files), which every
+# git provider reports and which do not depend on any model's tokenizer. Only calls that ask for the regular model
+# are routed (/review, /improve, /generate_labels, /add_docs); tools that use model_weak are left alone.
+# With Azure (openai.deployment_id set) a rule also needs its own deployment_id, or it is skipped.
+enable = false
+rules = [] # e.g. [{ max_hunks = 3, model = "gpt-5.6-luna" }, { max_hunks = 15, max_files = 6, model = "gpt-5.6-terra" }]
+
 [otel]
 # Keys map to settings.get("OTEL.*") via section-key dot notation.
 is_enabled = false # disabled by default; set to true to enable telemetry

--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -59,7 +59,7 @@ class PRAddDocs:
                 self.git_provider.publish_comment("Generating Documentation...", is_temporary=True)
 
             get_logger().info('Preparing PR documentation...')
-            await retry_with_fallback_models(self._prepare_prediction)
+            await retry_with_fallback_models(self._prepare_prediction, git_provider=self.git_provider)
             data = self._prepare_pr_code_docs()
             if (not data) or ("Code Documentation" not in data):
                 get_logger().info('No code documentation found for PR.')

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -295,7 +295,8 @@ class PRCodeSuggestions:
             # if not self.is_extended:
             #     data = await retry_with_fallback_models(self._prepare_prediction, model_type=ModelType.REGULAR)
             # else:
-            data = await retry_with_fallback_models(self.prepare_prediction_main, model_type=ModelType.REGULAR)
+            data = await retry_with_fallback_models(self.prepare_prediction_main, model_type=ModelType.REGULAR,
+                                                    git_provider=self.git_provider)
             if not data:
                 data = {"code_suggestions": []}
             self.data = data
@@ -855,10 +856,14 @@ class PRCodeSuggestions:
             return ""
 
         models = _get_all_models(ModelType.REASONING)
-        if get_model('model_reasoning') == get_settings().config.model and model in models:
-            # No dedicated reasoning model, so this is the regular chain and the outer fallback
-            # loop has already burned everything before the model it settled on.
-            models = models[models.index(model):]
+        if get_model('model_reasoning') == get_settings().config.model:
+            # No dedicated reasoning model, so this is the regular chain.
+            if model in models:
+                # The outer fallback loop has already burned everything before the model it settled on.
+                models = models[models.index(model):]
+            else:
+                # A routed primary ([model_routing]) stood in for config.model, ahead of the same fallbacks.
+                models = [model] + models[1:]
         if get_settings().get("openai.fallback_deployments", []):
             # Each model is pinned to its own deployment, and openai.deployment_id is global to a
             # run whose chunk calls are already in flight concurrently. Retrying another model here

--- a/pr_agent/tools/pr_generate_labels.py
+++ b/pr_agent/tools/pr_generate_labels.py
@@ -87,7 +87,7 @@ class PRGenerateLabels:
             if get_settings().config.publish_output:
                 self.git_provider.publish_comment("Preparing PR labels...", is_temporary=True)
 
-            await retry_with_fallback_models(self._prepare_prediction)
+            await retry_with_fallback_models(self._prepare_prediction, git_provider=self.git_provider)
 
             get_logger().info(f"Preparing answer {self.pr_id}")
             if self.prediction:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -302,7 +302,8 @@ class PRReviewer:
             if get_settings().config.publish_output and not get_settings().config.get('is_auto_command', False):
                 progress_response = self.git_provider.publish_comment("Preparing review...", is_temporary=True)
 
-            await retry_with_fallback_models(self._prepare_prediction, model_type=ModelType.REGULAR)
+            await retry_with_fallback_models(self._prepare_prediction, model_type=ModelType.REGULAR,
+                                             git_provider=self.git_provider)
             if not self.prediction:
                 return None
 

--- a/tests/unittest/test_model_routing.py
+++ b/tests/unittest/test_model_routing.py
@@ -1,0 +1,184 @@
+"""
+Tests for [model_routing]: a small pull request gets a cheaper primary model, the configured
+fallbacks still follow it, and every other call keeps the model it asked for.
+"""
+import asyncio
+
+import pytest
+
+from pr_agent.algo.model_routing import count_hunks, route_primary_model
+from pr_agent.algo.pr_processing import retry_with_fallback_models
+from pr_agent.algo.run_details import get_run_details, init_run_details
+from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.utils import ModelType
+from pr_agent.config_loader import get_settings
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+_TRACKED_KEYS = (
+    "config.model",
+    "config.model_weak",
+    "config.fallback_models",
+    "openai.deployment_id",
+    "openai.fallback_deployments",
+    "model_routing.enable",
+    "model_routing.rules",
+)
+
+
+def _patch(hunks: int) -> str:
+    return "".join(f"@@ -{i},1 +{i},2 @@\n line\n+added\n" for i in range(1, hunks + 1))
+
+
+def _file(name: str, hunks: int, patch: str = None) -> FilePatchInfo:
+    return FilePatchInfo(base_file="", head_file="", patch=_patch(hunks) if patch is None else patch, filename=name)
+
+
+class _Provider:
+    def __init__(self, files):
+        self.files = files
+        self.calls = 0
+
+    def get_diff_files(self):
+        self.calls += 1
+        return self.files
+
+
+def _pr(num_files: int, hunks_per_file: int) -> _Provider:
+    return _Provider([_file(f"f{i}.py", hunks_per_file) for i in range(num_files)])
+
+
+@pytest.fixture
+def settings():
+    snapshot = snapshot_settings(_TRACKED_KEYS)
+    s = get_settings()
+    s.set("config.model", "primary-model")
+    s.set("config.model_weak", "weak-model")
+    s.set("config.fallback_models", ["fallback-1"])
+    s.set("openai.deployment_id", None)
+    s.set("openai.fallback_deployments", [])
+    s.set("model_routing.enable", True)
+    s.set("model_routing.rules", [
+        {"max_hunks": 3, "model": "tiny-model"},
+        {"max_hunks": 10, "max_files": 4, "model": "small-model"},
+    ])
+    yield s
+    restore_settings(snapshot)
+
+
+def _models_tried(git_provider, model_type=ModelType.REGULAR, fail=()):
+    calls = []
+
+    async def fake_f(model):
+        calls.append(model)
+        if model in fail:
+            raise RuntimeError(f"{model} failed")
+        return model
+
+    asyncio.run(retry_with_fallback_models(fake_f, model_type=model_type, git_provider=git_provider))
+    return calls
+
+
+class TestCountHunks:
+    def test_counts_hunk_headers_across_files(self):
+        assert count_hunks([_file("a.py", 2), _file("b.py", 3)]) == 5
+
+    def test_patch_without_headers_counts_as_one_hunk(self):
+        assert count_hunks([_file("a.py", 0, patch="+whole file\n"), _file("b.py", 0, patch="")]) == 1
+
+    def test_no_files(self):
+        assert count_hunks([]) == 0
+
+
+class TestRouting:
+    def test_small_pr_routes_to_the_first_matching_rule(self, settings):
+        assert _models_tried(_pr(num_files=1, hunks_per_file=2)) == ["tiny-model"]
+
+    def test_medium_pr_skips_to_the_next_rule(self, settings):
+        assert _models_tried(_pr(num_files=2, hunks_per_file=3)) == ["small-model"]
+
+    def test_files_limit_is_checked_too(self, settings):
+        # 5 hunks fit the second rule, 5 files do not
+        assert _models_tried(_pr(num_files=5, hunks_per_file=1)) == ["primary-model"]
+
+    def test_large_pr_keeps_the_configured_primary(self, settings):
+        assert _models_tried(_pr(num_files=3, hunks_per_file=10)) == ["primary-model"]
+
+    def test_configured_fallbacks_follow_the_routed_primary(self, settings):
+        calls = _models_tried(_pr(num_files=1, hunks_per_file=1), fail=("tiny-model",))
+        assert calls == ["tiny-model", "fallback-1"]
+
+    def test_weak_tier_is_not_routed(self, settings):
+        provider = _pr(num_files=1, hunks_per_file=1)
+        assert _models_tried(provider, model_type=ModelType.WEAK) == ["weak-model"]
+        assert provider.calls == 0
+
+    def test_disabled_routing_does_not_touch_the_provider(self, settings):
+        settings.set("model_routing.enable", False)
+        provider = _pr(num_files=1, hunks_per_file=1)
+        assert _models_tried(provider) == ["primary-model"]
+        assert provider.calls == 0
+
+    def test_no_rules_does_not_touch_the_provider(self, settings):
+        settings.set("model_routing.rules", [])
+        provider = _pr(num_files=1, hunks_per_file=1)
+        assert _models_tried(provider) == ["primary-model"]
+        assert provider.calls == 0
+
+    def test_call_without_a_git_provider_keeps_the_primary(self, settings):
+        assert _models_tried(None) == ["primary-model"]
+
+    def test_rule_without_a_model_or_a_limit_is_ignored(self, settings):
+        settings.set("model_routing.rules", [
+            {"max_hunks": 3},
+            {"model": "catch-all-model"},
+            "not-a-rule",
+            {"max_hunks": 3, "model": "tiny-model"},
+        ])
+        assert _models_tried(_pr(num_files=1, hunks_per_file=1)) == ["tiny-model"]
+
+    def test_routed_primary_is_recorded_as_the_model_used(self, settings):
+        init_run_details()
+        _models_tried(_pr(num_files=1, hunks_per_file=1))
+        details = get_run_details()
+        assert details.model_used == "tiny-model"
+        assert details.fallback_used is False
+
+
+class TestAzureDeployments:
+    def test_rule_without_a_deployment_is_skipped_when_a_deployment_is_configured(self, settings):
+        settings.set("openai.deployment_id", "primary-deployment")
+        assert route_primary_model(ModelType.REGULAR, _pr(num_files=1, hunks_per_file=1)) is None
+
+    def test_rule_deployment_is_used_for_the_call_and_restored_after(self, settings):
+        settings.set("openai.deployment_id", "primary-deployment")
+        settings.set("model_routing.rules", [
+            {"max_hunks": 3, "model": "tiny-model", "deployment_id": "tiny-deployment"},
+        ])
+        observed = []
+
+        async def fake_f(model):
+            observed.append((model, get_settings().get("openai.deployment_id")))
+            return model
+
+        asyncio.run(retry_with_fallback_models(fake_f, git_provider=_pr(num_files=1, hunks_per_file=1)))
+
+        assert observed == [("tiny-model", "tiny-deployment")]
+        assert get_settings().get("openai.deployment_id") == "primary-deployment"
+
+    def test_fallback_deployments_stay_paired_with_their_models(self, settings):
+        settings.set("openai.deployment_id", "primary-deployment")
+        settings.set("openai.fallback_deployments", ["fallback-deployment"])
+        settings.set("model_routing.rules", [
+            {"max_hunks": 3, "model": "tiny-model", "deployment_id": "tiny-deployment"},
+        ])
+        observed = []
+
+        async def fake_f(model):
+            observed.append((model, get_settings().get("openai.deployment_id")))
+            if model == "tiny-model":
+                raise RuntimeError("tiny failed")
+            return model
+
+        asyncio.run(retry_with_fallback_models(fake_f, git_provider=_pr(num_files=1, hunks_per_file=1)))
+
+        assert observed == [("tiny-model", "tiny-deployment"), ("fallback-1", "fallback-deployment")]

--- a/tests/unittest/test_model_routing.py
+++ b/tests/unittest/test_model_routing.py
@@ -147,7 +147,12 @@ class TestRouting:
 class TestAzureDeployments:
     def test_rule_without_a_deployment_is_skipped_when_a_deployment_is_configured(self, settings):
         settings.set("openai.deployment_id", "primary-deployment")
-        assert route_primary_model(ModelType.REGULAR, _pr(num_files=1, hunks_per_file=1)) is None
+        settings.set("model_routing.rules", [
+            {"max_hunks": 3, "model": "tiny-model"},
+            {"max_hunks": 3, "model": "small-model", "deployment_id": "small-deployment"},
+        ])
+        routed = route_primary_model(ModelType.REGULAR, _pr(num_files=1, hunks_per_file=1))
+        assert routed == ("small-model", "small-deployment")
 
     def test_rule_deployment_is_used_for_the_call_and_restored_after(self, settings):
         settings.set("openai.deployment_id", "primary-deployment")

--- a/tests/unittest/test_pr_reviewer_core.py
+++ b/tests/unittest/test_pr_reviewer_core.py
@@ -588,7 +588,7 @@ async def test_run_removes_its_progress_comment_when_quiet_output_suppresses_rev
     reviewer.prediction = None
     reviewer._prepare_pr_review = lambda: "No major issues detected"
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
@@ -755,7 +755,7 @@ async def test_run_does_not_publish_an_empty_review(
     reviewer.prediction = None
     reviewer.prediction_data = None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = prediction
 
     monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", AsyncMock())
@@ -1196,7 +1196,7 @@ async def test_run_threads_only_the_final_review_comment(monkeypatch, persistent
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", fake_extract_tickets)
@@ -1271,7 +1271,7 @@ async def test_nonpersistent_review_adds_identity_for_incremental_capable_provid
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr(pr_reviewer_module, "extract_and_cache_pr_tickets", fake_extract_tickets)

--- a/tests/unittest/test_pr_reviewer_finding_state.py
+++ b/tests/unittest/test_pr_reviewer_finding_state.py
@@ -732,7 +732,7 @@ async def test_run_publishes_state_transition_even_when_review_has_no_suggestion
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
@@ -768,7 +768,7 @@ async def test_invalid_history_updates_persistent_comment_without_fallback(monke
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
@@ -803,7 +803,7 @@ async def test_non_marker_state_block_publishes_without_overwriting_state(monkey
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", fake_extract_tickets)
@@ -1019,7 +1019,7 @@ async def test_review_publish_uses_shared_full_signature_for_authorship(monkeypa
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr(
@@ -1229,7 +1229,7 @@ def _patch_run_dependencies(monkeypatch, reviewer):
     async def fake_extract_tickets(git_provider, vars):
         return None
 
-    async def fake_retry(prepare_fn, model_type=None):
+    async def fake_retry(prepare_fn, model_type=None, git_provider=None):
         reviewer.prediction = "prediction"
 
     monkeypatch.setattr(

--- a/tests/unittest/test_review_persistent_comment_authorship.py
+++ b/tests/unittest/test_review_persistent_comment_authorship.py
@@ -170,7 +170,7 @@ def _wire_reviewer(monkeypatch, provider):
     async def no_tickets(git_provider, vars):
         return None
 
-    async def direct_model(f, model_type=None):
+    async def direct_model(f, model_type=None, git_provider=None):
         return await f("gpt-4o")
 
     monkeypatch.setattr("pr_agent.tools.pr_reviewer.extract_and_cache_pr_tickets", no_tickets)

--- a/tests/unittest/test_self_reflect_fallback.py
+++ b/tests/unittest/test_self_reflect_fallback.py
@@ -131,6 +131,22 @@ class TestSelfReflectFallback:
         assert reflect.call_args.kwargs["model"] == "fallback-model"
 
     @pytest.mark.asyncio
+    async def test_routed_primary_reflects_on_itself_before_the_fallbacks(
+            self, settings_no_reasoning_model):
+        # [model_routing] can put a model from outside the configured chain in front of the same
+        # fallbacks. Reflection then starts on that model, not on the config.model it replaced.
+        tool = _tool()
+        with patch.object(PRCodeSuggestions, "self_reflect_on_suggestions",
+                          new_callable=AsyncMock) as reflect:
+            reflect.side_effect = ["", "reflection"]
+            result = await tool._self_reflect_with_fallback([{"suggestion": "a"}], "diff",
+                                                            "routed-model")
+
+        assert result == "reflection"
+        assert [call.kwargs["model"] for call in reflect.call_args_list] == [
+            "routed-model", "fallback-model"]
+
+    @pytest.mark.asyncio
     async def test_pinned_deployments_do_not_retry_other_models(self, settings_pinned_deployments):
         # With fallback_deployments configured each model lives on its own deployment, and
         # openai.deployment_id is global. Retrying the next model here would send it to the


### PR DESCRIPTION
`config.model` handles every pull request, however small, and the only way to send trivial
changes to a cheaper model was a LiteLLM proxy in front of PR-Agent. With
`model_routing.enable = true` an ordered list of rules picks the primary model for a call from
the size of the pull request; `config.fallback_models` still follow it, and a pull request that
fits no rule keeps `config.model`. The flag defaults to `false`, so nothing changes for an
existing install.

```toml
[model_routing]
enable = true

[[model_routing.rules]]
max_hunks = 3
model = "gpt-5.6-luna"

[[model_routing.rules]]
max_hunks = 15
max_files = 6
model = "gpt-5.6-terra"
```

Design, following the thread on the issue:

- **Size is hunks and files, not tokens.** Both come from the provider's diff after the
  `[ignore]` rules, every provider reports them, and neither depends on which model's
  tokenizer would have counted the tokens, so a threshold means the same thing whichever
  model it selects. `num_plus_lines` is set by only four providers, so it is not used.
- **Routing only moves a call down from the tier it asked for.** The primary is picked before
  the fallback chain is built, so a call for the regular model (`/review`, `/improve`,
  `/generate_labels`, `/add_docs`) can be routed, while a tool that asked for `model_weak`
  or `model_reasoning` made that choice on purpose and is left alone. `model_type` keeps its
  meaning.
- **Deployments stay paired.** Deployments are zipped to models positionally, so a routed
  primary needs a `deployment_id` of its own when `openai.deployment_id` is set; a rule
  without one is skipped with a warning rather than mispaired.
- **`/improve` reflection follows the route.** `_self_reflect_with_fallback` sliced the
  regular chain from the model the outer loop settled on, which a routed model is not in, so
  a cheap route would still have paid for a reflection call on `config.model`. It now reflects
  on the routed model first and walks the same fallbacks after it.
- `record_model_used` is unchanged: `model_used` shows the routed model and `fallback_used`
  still means the primary of the call failed.

`retry_with_fallback_models` gains an optional `git_provider` argument; the four regular-tier
call sites pass it, every other caller is untouched. Repo-level `.pr_agent.toml` can set
`[model_routing]` on the same footing as it can already set `config.model`.

Tests cover hunk counting, rule order, the files limit, fallbacks after a routed primary,
the weak tier and disabled routing not touching the provider, malformed rules, run details,
the Azure pairing, and the reflection chain. Docs: a new section in `changing_a_model.md`.

Closes #2434
