### PR TITLE
feat(artifacts): read the CI artifact context from the CLI as well

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -442,6 +442,8 @@ max_artifact_size = 50000                                   # characters; longer
 !!! note
     A path that resolves outside `GITHUB_WORKSPACE` is rejected, and a missing or unreadable file is skipped with a warning — in both cases the tools still run, just without the artifact context.
 
+The same settings apply when PR-Agent runs as a CLI from another CI system, with `ARTIFACT_PATH` set in the job's environment; see the [GitLab pipeline example](./gitlab.md#ci-artifact-context).
+
 #### Using Configuration Files
 
 Instead of setting all options via environment variables, you can use a `.pr_agent.toml` file in your repository root:

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -34,6 +34,26 @@ pr_agent_job:
 This script runs PR-Agent when a merge request pipeline is created, including when a merge request is opened and when new commits are pushed to its source branch. You can modify the `rules` section to run PR-Agent on different events.
 You can also modify the `script` section to run different PR-Agent commands, or with different parameters by exporting different environment variables.
 
+### CI artifact context
+
+A file produced by an earlier job — a test report, a coverage summary, a linter or SAST output — can be handed to `/review`, `/describe` and `/improve` as extra context, so the model reviews the merge request with your pipeline's own findings in hand. Save the file as a job artifact, make the PR-Agent job depend on that job with `needs:`, and point PR-Agent at it with `ARTIFACT_PATH`. The job above runs from `/app`, so give the path in full:
+
+```yaml
+pr_agent_job:
+  stage: pr_agent
+  needs: ["test_job"]
+  image:
+    name: pragent/pr-agent:latest
+    entrypoint: [""]
+  script:
+    - cd /app
+    - export ARTIFACT_PATH="$CI_PROJECT_DIR/reports/pytest.xml"
+    - export ARTIFACT_INSTRUCTIONS="These are the failing tests from this MR's pipeline. Call out any suggestion that would not fix them."
+    - python -m pr_agent.cli --pr_url="$MR_URL" review
+```
+
+Setting `ARTIFACT_PATH` turns the feature on by itself. The remaining knobs — which tools receive the context, the label, the size limit — are the `[artifacts]` settings described under [CI artifact context](./github.md#ci-artifact-context) for the GitHub Action, and they apply to the CLI in the same way.
+
 ### Ignore bot-created merge requests
 
 Dependency update bots usually use predictable source branch prefixes. Add a higher-priority `when: never` rule before the general merge request rule to skip those branches:

--- a/pr_agent/algo/artifacts.py
+++ b/pr_agent/algo/artifacts.py
@@ -109,3 +109,54 @@ def load_artifact() -> str:
     label = artifacts_settings.get("artifact_label", "") or artifact_path.name
     instructions = artifacts_settings.get("artifact_instructions", "")
     return format_artifact_content(content, label, instructions)
+
+
+def inject_artifact_context() -> None:
+    """Append the CI artifact (see [artifacts]) to the extra_instructions of the target tools.
+
+    ARTIFACT_PATH in the environment turns the feature on by itself. Called once before a
+    command runs, by the GitHub Action runner and by the CLI.
+    """
+    artifact_path_env = (
+        os.environ.get("ARTIFACT_PATH") or os.environ.get("PR_AGENT_ARTIFACT_PATH") or ""
+    ).strip()
+    artifact_instructions_env = (
+        os.environ.get("ARTIFACT_INSTRUCTIONS") or os.environ.get("PR_AGENT_ARTIFACT_INSTRUCTIONS") or ""
+    ).strip()
+    if artifact_path_env:
+        get_settings().set("ARTIFACTS.ENABLE", True)
+        get_settings().set("ARTIFACTS.ARTIFACT_PATH", artifact_path_env)
+        if artifact_instructions_env:
+            get_settings().set("ARTIFACTS.ARTIFACT_INSTRUCTIONS", artifact_instructions_env)
+
+    artifacts_enabled = get_settings().get("ARTIFACTS.ENABLE", False)
+    if isinstance(artifacts_enabled, str):
+        artifacts_enabled = artifacts_enabled.lower() == "true"
+    if not artifacts_enabled:
+        return
+
+    try:
+        artifact_text = load_artifact()
+        if not artifact_text:
+            return
+        target_tools = get_settings().get(
+            "ARTIFACTS.TARGET_TOOLS",
+            ["pr_reviewer", "pr_description", "pr_code_suggestions"]
+        )
+        if isinstance(target_tools, str):
+            target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
+        target_tools = {str(t).lower() for t in target_tools}
+        separator = "\n======\n\n"
+        for key in get_settings():
+            setting = get_settings().get(key)
+            if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+                if key.lower() in target_tools and hasattr(setting, 'extra_instructions'):
+                    extra_instructions = str(setting.extra_instructions or "")
+                    if artifact_text not in extra_instructions:
+                        setting.extra_instructions = (
+                            extra_instructions + separator + artifact_text
+                            if extra_instructions else artifact_text
+                        )
+        get_logger().info(f"Injected artifact context into tools: {target_tools}")
+    except (OSError, ValueError, TypeError) as e:
+        get_logger().warning(f"Failed to process artifacts: {e}", exc_info=True)

--- a/pr_agent/algo/artifacts.py
+++ b/pr_agent/algo/artifacts.py
@@ -132,7 +132,7 @@ def inject_artifact_context() -> None:
     artifacts_enabled = get_settings().get("ARTIFACTS.ENABLE", False)
     if isinstance(artifacts_enabled, str):
         artifacts_enabled = artifacts_enabled.lower() == "true"
-    if not artifacts_enabled:
+    if artifacts_enabled is not True:
         return
 
     try:

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -9,6 +9,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     drain_litellm_callbacks,
     litellm_callbacks_registered,
 )
+from pr_agent.algo.artifacts import inject_artifact_context
 from pr_agent.algo.utils import get_version
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger, setup_logger
@@ -140,6 +141,9 @@ def run(inargs=None, args=None):
     # previously-set value from an earlier run() call in the same process can't
     # leak into a later one (get_settings() is a process-wide singleton).
     get_settings().set("CONFIG.EXTRA_CONFIG_URL", getattr(args, "extra_config_url", None))
+    # A CI artifact (see [artifacts]) reaches the prompts from the environment or the settings files,
+    # the same way it does under the GitHub Action, so any pipeline that runs the CLI can supply one.
+    inject_artifact_context()
 
     async def inner():
         if args.issue_url:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -9,6 +9,7 @@ from pr_agent.algo.ai_handlers.litellm_helpers import (
     drain_litellm_callbacks,
     litellm_callbacks_registered,
 )
+from pr_agent.algo.artifacts import inject_artifact_context as _inject_artifact_context
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.utils import apply_repo_settings
@@ -52,53 +53,6 @@ def get_list_setting_or_env(key, fallback=None):
     if isinstance(value, (list, tuple, set)):
         return list(value)
     return [value]
-
-
-def _inject_artifact_context():
-    """Inject CI artifact content into extra_instructions for configured tools."""
-    artifact_path_env = (
-        os.environ.get("ARTIFACT_PATH") or os.environ.get("PR_AGENT_ARTIFACT_PATH") or ""
-    ).strip()
-    artifact_instructions_env = (
-        os.environ.get("ARTIFACT_INSTRUCTIONS") or os.environ.get("PR_AGENT_ARTIFACT_INSTRUCTIONS") or ""
-    ).strip()
-    if artifact_path_env:
-        get_settings().set("ARTIFACTS.ENABLE", True)
-        get_settings().set("ARTIFACTS.ARTIFACT_PATH", artifact_path_env)
-        if artifact_instructions_env:
-            get_settings().set("ARTIFACTS.ARTIFACT_INSTRUCTIONS", artifact_instructions_env)
-
-    artifacts_enabled = get_settings().get("ARTIFACTS.ENABLE", False)
-    if not is_true(artifacts_enabled):
-        return
-
-    try:
-        from pr_agent.algo.artifacts import load_artifact
-
-        artifact_text = load_artifact()
-        if not artifact_text:
-            return
-        target_tools = get_settings().get(
-            "ARTIFACTS.TARGET_TOOLS",
-            ["pr_reviewer", "pr_description", "pr_code_suggestions"]
-        )
-        if isinstance(target_tools, str):
-            target_tools = [t.strip() for t in target_tools.split(",") if t.strip()]
-        target_tools = {str(t).lower() for t in target_tools}
-        separator = "\n======\n\n"
-        for key in get_settings():
-            setting = get_settings().get(key)
-            if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
-                if key.lower() in target_tools and hasattr(setting, 'extra_instructions'):
-                    extra_instructions = str(setting.extra_instructions or "")
-                    if artifact_text not in extra_instructions:
-                        setting.extra_instructions = (
-                            extra_instructions + separator + artifact_text
-                            if extra_instructions else artifact_text
-                        )
-        get_logger().info(f"Injected artifact context into tools: {target_tools}")
-    except (OSError, ValueError, TypeError) as e:
-        get_logger().warning(f"github action: failed to process artifacts: {e}", exc_info=True)
 
 
 async def _run_review_commands(event_payload):

--- a/tests/unittest/test_artifacts.py
+++ b/tests/unittest/test_artifacts.py
@@ -1,13 +1,18 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from pr_agent.algo.artifacts import (
     DEFAULT_ARTIFACT_INSTRUCTIONS,
     _read_and_truncate,
     format_artifact_content,
+    inject_artifact_context,
     load_artifact,
     resolve_artifact_path,
 )
+from pr_agent.config_loader import get_settings
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
 
 
 class TestResolveArtifactPathRobustness:
@@ -245,3 +250,82 @@ class TestLoadArtifact:
             assert "CI Artifact: Test Results" in result
             assert "FAILED: test_login" in result
             assert "Flag any test failures." in result
+
+
+class TestInjectArtifactContext:
+    """The injection step shared by the GitHub Action runner and the CLI."""
+
+    _KEYS = (
+        "artifacts.enable",
+        "artifacts.artifact_path",
+        "artifacts.artifact_instructions",
+        "artifacts.target_tools",
+        "pr_reviewer.extra_instructions",
+        "pr_description.extra_instructions",
+        "pr_code_suggestions.extra_instructions",
+    )
+
+    @pytest.fixture
+    def settings(self):
+        snapshot = snapshot_settings(self._KEYS)
+        s = get_settings()
+        s.set("artifacts.enable", False)
+        s.set("artifacts.artifact_path", "")
+        s.set("artifacts.artifact_instructions", "")
+        s.set("artifacts.target_tools", ["pr_reviewer", "pr_description", "pr_code_suggestions"])
+        for tool in ("pr_reviewer", "pr_description", "pr_code_suggestions"):
+            s.set(f"{tool}.extra_instructions", "")
+        yield s
+        restore_settings(snapshot)
+
+    @pytest.fixture
+    def report(self, tmp_path):
+        f = tmp_path / "report.xml"
+        f.write_text("FAILED: test_login")
+        return f
+
+    def test_disabled_leaves_extra_instructions_alone(self, settings, report):
+        with patch.dict(os.environ, {"GITHUB_WORKSPACE": str(report.parent)}):
+            os.environ.pop("ARTIFACT_PATH", None)
+            os.environ.pop("PR_AGENT_ARTIFACT_PATH", None)
+            inject_artifact_context()
+        assert settings.get("pr_reviewer.extra_instructions") == ""
+
+    def test_env_path_enables_and_appends_to_every_target_tool(self, settings, report):
+        env = {"GITHUB_WORKSPACE": str(report.parent), "ARTIFACT_PATH": str(report),
+               "ARTIFACT_INSTRUCTIONS": "Flag any test failures."}
+        with patch.dict(os.environ, env):
+            inject_artifact_context()
+
+        assert settings.get("artifacts.enable") is True
+        for tool in ("pr_reviewer", "pr_description", "pr_code_suggestions"):
+            extra = settings.get(f"{tool}.extra_instructions")
+            assert "CI Artifact: report.xml" in extra
+            assert "FAILED: test_login" in extra
+            assert "Flag any test failures." in extra
+
+    def test_settings_alone_are_enough_without_the_env_var(self, settings, report):
+        settings.set("artifacts.enable", True)
+        settings.set("artifacts.artifact_path", str(report))
+        with patch.dict(os.environ, {"GITHUB_WORKSPACE": str(report.parent)}):
+            os.environ.pop("ARTIFACT_PATH", None)
+            os.environ.pop("PR_AGENT_ARTIFACT_PATH", None)
+            inject_artifact_context()
+        assert "FAILED: test_login" in settings.get("pr_reviewer.extra_instructions")
+
+    def test_only_target_tools_get_it_and_existing_instructions_are_kept(self, settings, report):
+        settings.set("artifacts.target_tools", ["pr_reviewer"])
+        settings.set("pr_reviewer.extra_instructions", "Be terse.")
+        with patch.dict(os.environ, {"GITHUB_WORKSPACE": str(report.parent), "ARTIFACT_PATH": str(report)}):
+            inject_artifact_context()
+
+        extra = settings.get("pr_reviewer.extra_instructions")
+        assert extra.startswith("Be terse.\n======\n\n")
+        assert "FAILED: test_login" in extra
+        assert settings.get("pr_description.extra_instructions") == ""
+
+    def test_running_twice_does_not_duplicate_the_artifact(self, settings, report):
+        with patch.dict(os.environ, {"GITHUB_WORKSPACE": str(report.parent), "ARTIFACT_PATH": str(report)}):
+            inject_artifact_context()
+            inject_artifact_context()
+        assert settings.get("pr_reviewer.extra_instructions").count("FAILED: test_login") == 1

--- a/tests/unittest/test_artifacts.py
+++ b/tests/unittest/test_artifacts.py
@@ -291,6 +291,16 @@ class TestInjectArtifactContext:
             inject_artifact_context()
         assert settings.get("pr_reviewer.extra_instructions") == ""
 
+    def test_a_value_that_is_neither_bool_nor_string_stays_disabled(self, settings, report):
+        """ARTIFACTS__ENABLE=1 from the environment is off, as it was in the GitHub Action runner."""
+        settings.set("artifacts.enable", 1)
+        settings.set("artifacts.artifact_path", str(report))
+        with patch.dict(os.environ, {"GITHUB_WORKSPACE": str(report.parent)}):
+            os.environ.pop("ARTIFACT_PATH", None)
+            os.environ.pop("PR_AGENT_ARTIFACT_PATH", None)
+            inject_artifact_context()
+        assert settings.get("pr_reviewer.extra_instructions") == ""
+
     def test_env_path_enables_and_appends_to_every_target_tool(self, settings, report):
         env = {"GITHUB_WORKSPACE": str(report.parent), "ARTIFACT_PATH": str(report),
                "ARTIFACT_INSTRUCTIONS": "Flag any test failures."}

--- a/tests/unittest/test_cli_artifact_context.py
+++ b/tests/unittest/test_cli_artifact_context.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pr_agent import cli
+
+
+def test_run_injects_the_artifact_context_before_handling_the_request():
+    """A pipeline that runs the CLI gets the same [artifacts] injection as the GitHub Action."""
+    order = []
+    fake_settings = SimpleNamespace(litellm={}, set=MagicMock())
+
+    async def fake_handle_request(*_args, **_kwargs):
+        order.append("handle_request")
+        return True
+
+    with patch("pr_agent.cli.get_settings", return_value=fake_settings), \
+         patch("pr_agent.cli.inject_artifact_context", side_effect=lambda: order.append("inject")), \
+         patch("pr_agent.cli.PRAgent", return_value=SimpleNamespace(handle_request=fake_handle_request)):
+        cli.run(inargs=["--pr_url=https://github.com/a/b/pull/1", "review"])
+
+    assert order == ["inject", "handle_request"]

--- a/uv.lock
+++ b/uv.lock
@@ -153,9 +153,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -609,8 +609,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "aiologic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -882,14 +882,14 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.13'" },
-    { name = "decorator", marker = "python_full_version < '3.13'" },
-    { name = "fsspec", version = "2025.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "google-auth", marker = "python_full_version < '3.13'" },
-    { name = "google-auth-oauthlib", marker = "python_full_version < '3.13'" },
-    { name = "google-cloud-storage", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "google-cloud-storage-control", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "aiohttp" },
+    { name = "decorator" },
+    { name = "fsspec", version = "2025.12.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-storage", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-cloud-storage-control" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/3e/453b42bbcda2177daba97ebc5202faf5c57cc0c2bb4aac7081c12b0471da/gcsfs-2025.12.0.tar.gz", hash = "sha256:9a9c1c32b7899a3967ba30a7e9422cdfda596266f03476cdf5545402b8af4cd5", size = 95148, upload-time = "2025-12-03T15:44:59.703Z" }
 wheels = [
@@ -909,14 +909,14 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.13'" },
-    { name = "decorator", marker = "python_full_version >= '3.13'" },
-    { name = "fsspec", version = "2026.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "google-auth", marker = "python_full_version >= '3.13'" },
-    { name = "google-auth-oauthlib", marker = "python_full_version >= '3.13'" },
-    { name = "google-cloud-storage", version = "3.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "google-cloud-storage-control", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
+    { name = "aiohttp" },
+    { name = "decorator" },
+    { name = "fsspec", version = "2026.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-storage", version = "3.12.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-cloud-storage-control" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/33/58e23c6f492e091c2f01ae1bffe331aa97e18a0b3d24ff90ef648335ddc8/gcsfs-2026.7.0.tar.gz", hash = "sha256:2df36ce1e9010e76dc4295774030495a97496838483c619e9f63bc0ab7bdc770", size = 1265874, upload-time = "2026-07-06T15:02:30.683Z" }
 wheels = [
@@ -1097,11 +1097,11 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "google-api-core", marker = "python_full_version < '3.13'" },
-    { name = "google-auth", marker = "python_full_version < '3.13'" },
-    { name = "google-cloud-core", marker = "python_full_version < '3.13'" },
-    { name = "google-resumable-media", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/20/51e9676cc112ec7344c0a8690361175dc1f41ed6edf618eae8af87d92a49/google-cloud-storage-2.10.0.tar.gz", hash = "sha256:934b31ead5f3994e5360f9ff5750982c5b6b11604dc072bc452c25965e076dc7", size = 5504936, upload-time = "2023-06-26T20:34:54.303Z" }
 wheels = [
@@ -1121,12 +1121,12 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "google-api-core", marker = "python_full_version >= '3.13'" },
-    { name = "google-auth", marker = "python_full_version >= '3.13'" },
-    { name = "google-cloud-core", marker = "python_full_version >= '3.13'" },
-    { name = "google-crc32c", marker = "python_full_version >= '3.13'" },
-    { name = "google-resumable-media", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
 wheels = [
@@ -1875,9 +1875,9 @@ sdist = { url = "https://files.pythonhosted.org/packages/6c/1a/76b5f28ba9e07fa0c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/ef/4ef1afe95d3a7c52d63b5f2bb32ec5264a4cea198a7dddb8ceff9633f2da/litellm-1.99.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a43e8716da8beed04480e91b4233ff2f1ab1fedd84cad332dbc526b54a9229ca", size = 23350560, upload-time = "2026-09-01T00:42:41.449Z" },
     { url = "https://files.pythonhosted.org/packages/03/8d/f329cf74fc1f929a93210b16523bbcebd679694090df741bb8bee726a473/litellm-1.99.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e2b383070656fdbec4bc44602edaaed2a21e99ceee4ea0a4650c8cb381e67b59", size = 22999186, upload-time = "2026-09-01T00:42:44.978Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4f/0e73fc3f0740249b676d0714bd58c4141f1fc733b88a85b6001f9f2e5e62/litellm-1.99.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e461b7ce53af990e5287cf7ae30d82c956b56dcce886f63ef39a76e678f82a3b", size = 23145753, upload-time = "2026-09-01T00:42:48.190Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/0e73fc3f0740249b676d0714bd58c4141f1fc733b88a85b6001f9f2e5e62/litellm-1.99.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e461b7ce53af990e5287cf7ae30d82c956b56dcce886f63ef39a76e678f82a3b", size = 23145753, upload-time = "2026-09-01T00:42:48.19Z" },
     { url = "https://files.pythonhosted.org/packages/db/c4/8e92a6277e28096784616cfda16b2cd839c7bdaabce692ae950e2f0cf72e/litellm-1.99.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1c45097e426fed2ae7fbd38b5404c3addeb203d0e1148c0a59848aabd5fe83c6", size = 23518654, upload-time = "2026-09-01T00:42:51.582Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/aa/11c9bd6297e4a9001426ff825bc8bb119d3a9a3de4e5ee9fed22997e6e28/litellm-1.99.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e42f94731665b68e263481efd79f7629e9b97eed7e10c57dc37a890eca058227", size = 23218889, upload-time = "2026-09-01T00:42:54.990Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/aa/11c9bd6297e4a9001426ff825bc8bb119d3a9a3de4e5ee9fed22997e6e28/litellm-1.99.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e42f94731665b68e263481efd79f7629e9b97eed7e10c57dc37a890eca058227", size = 23218889, upload-time = "2026-09-01T00:42:54.99Z" },
     { url = "https://files.pythonhosted.org/packages/3f/a9/1fc21c6fb21897867d9c753d651b24903e63955dadffeb2a73517f35003a/litellm-1.99.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71109c323164b4b6776ff259876523e6e883a465aa1413dd51a1bda8e92efc5f", size = 23617457, upload-time = "2026-09-01T00:42:59.173Z" },
     { url = "https://files.pythonhosted.org/packages/7c/4f/df449e0cfa1f40025e91f3a47b03109e16de44d43149e97fbcbd1ae8c5e2/litellm-1.99.0-cp310-abi3-win_amd64.whl", hash = "sha256:5617804e838499bce8fecb41ad9bc984b7977361e557666fed0fef0c4623ce62", size = 23432066, upload-time = "2026-09-01T00:43:03.177Z" },
 ]
@@ -2525,7 +2525,7 @@ wheels = [
 
 [[package]]
 name = "pr-agent"
-version = "0.43.0"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
The `[artifacts]` section hands a file from an earlier CI step to `/review`, `/describe` and
`/improve`, but the step that reads it lived in `github_action_runner.py`, so a GitLab,
Bitbucket or Jenkins pipeline running the CLI had no way to use it. This is the first of the
two catches noted on #2640: the feature exists, it just could not be reached outside the
GitHub Action.

The injection now lives next to the loader in `pr_agent/algo/artifacts.py` and runs before
the CLI hands the command over, the same way the Action does it: `ARTIFACT_PATH` in the
job's environment turns it on, and the remaining knobs are the same `[artifacts]` settings.

```yaml
pr_agent_job:
  needs: ["test_job"]
  script:
    - cd /app
    - export ARTIFACT_PATH="$CI_PROJECT_DIR/reports/pytest.xml"
    - python -m pr_agent.cli --pr_url="$MR_URL" review
```

- The runner keeps calling the same function under its old name, so its behaviour and tests
  are unchanged.
- Nothing runs on the webhook servers: a repository's `.pr_agent.toml` still cannot point a
  server at a local file. The CLI reads the artifact before `apply_repo_settings`, as the
  Action does.
- Docs: a `CI artifact context` subsection under the GitLab pipeline page, and a pointer
  from the GitHub Action section.

Deliberately not in here: the deduplication across jobs and the "is this failure related to
the diff" signal discussed on the issue. That is the second catch and needs the maintainer
read on appetite that is still open there.

Refs #2640
