### PR TITLE
fix(ask): bound image URL liveness probes

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -35,6 +35,7 @@ from pr_agent.log import get_logger
 
 MODEL_RETRIES = 2
 DUMMY_LITELLM_API_KEY = "dummy_key"  # placeholder set when no OpenAI key is configured
+_IMAGE_HEAD_TIMEOUT_SECONDS = 5
 
 
 def _as_bool(value, default: bool) -> bool:
@@ -794,7 +795,12 @@ class LiteLLMAIHandler(BaseAiHandler):
                 if img_path:
                     try:
                         # check if the image link is alive
-                        r = requests.head(img_path, allow_redirects=True)
+                        r = await asyncio.to_thread(
+                            requests.head,
+                            img_path,
+                            allow_redirects=True,
+                            timeout=_IMAGE_HEAD_TIMEOUT_SECONDS,
+                        )
                         if r.status_code == 404:
                             error_msg = "The image link is not [alive](img_path).\nPlease repost the original image as a comment, and send the question again with 'quote reply' (see [instructions](https://pr-agent-docs.codium.ai/tools/ask/#ask-on-images-using-the-pr-code-as-context))."
                             get_logger().error(error_msg)

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -1,3 +1,5 @@
+import threading
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -60,6 +62,38 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
         await handler.chat_completion(model="gpt-4o", system="sys", user="usr", temperature=0)
 
     assert mock_call.call_args.kwargs["seed"] == 123
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_probes_images_off_loop_with_timeout(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+    loop_thread = threading.get_ident()
+    observed = {}
+
+    def fake_head(url, **kwargs):
+        observed.update(url=url, kwargs=kwargs, thread=threading.get_ident())
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(litellm_handler.requests, "head", fake_head)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(
+            model="gpt-4o",
+            system="sys",
+            user="usr",
+            img_path="https://example.test/image.png",
+        )
+
+    assert observed["url"] == "https://example.test/image.png"
+    assert observed["kwargs"] == {"allow_redirects": True, "timeout": 5}
+    assert observed["thread"] != loop_thread
+    assert mock_call.call_args.kwargs["messages"][1]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.test/image.png"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/test_pr_description_lifecycle.py
+++ b/tests/unittest/test_pr_description_lifecycle.py
@@ -24,6 +24,7 @@ def _make_description(provider):
     description.git_provider = provider
     description.vars = {}
     description.prediction = None
+    description.data = None
     description.file_label_dict = None
     return description
 


### PR DESCRIPTION
## Summary

- bound the `/ask` image liveness HEAD request to five seconds
- offload the synchronous `requests.head` call from the async LiteLLM handler
- preserve existing 404/error handling and the image message payload

## Root cause

`PRQuestions._get_prediction()` forwards image URLs to `LiteLLMAIHandler.chat_completion()`. The image branch called `requests.head()` inline from `async def chat_completion()` without a `timeout`, so a slow or unreachable image host could block the process event loop.

## Fix

Run the liveness probe with `asyncio.to_thread()` and `timeout=5`. The probe still treats HTTP 404 and request exceptions as the existing error result, and successful probes still add the same `image_url` message content.

## Validation

- Baseline red: the provider-free fake regression `tests/unittest/test_litellm_chat_completion_core.py::test_chat_completion_probes_images_off_loop_with_timeout` failed on `origin/main` because `requests.head` received only `allow_redirects=True`.
- Fixed focused regression: `1 passed`.
- Full focused file: `52 passed`.
- Full unit suite: `3840 passed, 1 skipped, 1 xfailed, 91 warnings`.
- Ruff on changed files: `All checks passed!`.
- All enabled pre-commit hooks: passed.
- `git diff --check`: passed.

## Collision and evidence boundary

An exact current open/closed Issue and PR search for `requests.head`, `image timeout`, and the image-probe symbols found no matching report or patch. #2367 and the open #3064 are adjacent timeout/blocking-HTTP work at different call sites, not this LiteLLM image branch.

The regression uses a fake `requests.head` and mocked LiteLLM completion. No live image URL, external provider, network, CI, review, merge, deployment, or production behavior was exercised. The event-loop starvation impact is inferred from the synchronous call inside the async handler; no production latency measurement is claimed.
