### PR TITLE
Fix: use logger instead of print() in file_filter exception handler

### DIFF
--- a/pr_agent/algo/file_filter.py
+++ b/pr_agent/algo/file_filter.py
@@ -85,7 +85,7 @@ def filter_ignored(files, platform = 'github'):
 
 
     except Exception as e:
-        print(f"Could not filter file list: {e}")
+        get_logger().error(f"Could not filter file list: {e}")
 
     return files
 


### PR DESCRIPTION
Fixes #3112

Replaces the bare `print()` call in `filter_ignored`'s exception handler with `get_logger().error()`, matching the logging pattern already used elsewhere in this function. This ensures the error is captured by the configured logging sink (with level/timestamp/context) instead of appearing as a raw stdout line.