### PR TITLE
fix(mosaico): parse supplied diff paths containing " b/"

### DIFF
--- a/pr_agent/mosaico/diff_provider.py
+++ b/pr_agent/mosaico/diff_provider.py
@@ -27,13 +27,23 @@ class _PullRequestMimic:
 _DIFF_GIT_RE = re.compile(r'^diff --git a/(?P<a>.+?) b/(?P<b>.+?)\s*$')
 
 
+def _normalize_file_header_path(path: str) -> str:
+    if path == "/dev/null":
+        return ""
+    if path.startswith(("a/", "b/")):
+        return path[2:]
+    return path
+
+
 def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
     """Parse a supplied unified diff (git format) into a list of FilePatchInfo.
 
     Splits on ``diff --git a/<f> b/<f>`` headers; per file: filename = the b/ path,
     patch = that file's hunk body, edit_type inferred from new/deleted/rename file
     modes, and head/base file content reconstructed best-effort from +/-/context
-    lines. Degrades gracefully: a blob with no ``diff --git`` header yields []."""
+    lines. File paths are taken from the ``---``/``+++`` headers when present, since
+    those headers do not ambiguously split paths containing `` b/``. Degrades
+    gracefully: a blob with no ``diff --git`` header yields []."""
     if not diff_text or not isinstance(diff_text, str):
         return []
 
@@ -47,7 +57,7 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
     files: List[FilePatchInfo] = []
     for idx in range(len(starts) - 1):
         section = lines[starts[idx]:starts[idx + 1]]
-        header = section[0].rstrip("\n")
+        header = section[0].rstrip("\r\n")
         m = _DIFF_GIT_RE.match(header)
         a_path = m.group("a") if m else ""
         b_path = m.group("b") if m else ""
@@ -55,7 +65,13 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
         edit_type = EDIT_TYPE.MODIFIED
         old_filename = None
         for ln in section[1:]:
-            s = ln.rstrip("\n")
+            s = ln.rstrip("\r\n")
+            if s.startswith("@@"):
+                break
+            if s.startswith("--- "):
+                a_path = _normalize_file_header_path(s[4:])
+            elif s.startswith("+++ "):
+                b_path = _normalize_file_header_path(s[4:])
             if s.startswith("new file mode"):
                 edit_type = EDIT_TYPE.ADDED
             elif s.startswith("deleted file mode"):
@@ -65,7 +81,12 @@ def parse_unified_diff(diff_text: str) -> List[FilePatchInfo]:
                 old_filename = s[len("rename from "):].strip()
             elif s.startswith("rename to "):
                 edit_type = EDIT_TYPE.RENAMED
-        if a_path != b_path and old_filename is None and a_path:
+        if (
+            edit_type not in (EDIT_TYPE.ADDED, EDIT_TYPE.DELETED)
+            and a_path != b_path
+            and old_filename is None
+            and a_path
+        ):
             old_filename = a_path
 
         # Best-effort reconstruct head/base file content from hunk lines.

--- a/tests/unittest/test_mosaico_provider.py
+++ b/tests/unittest/test_mosaico_provider.py
@@ -89,6 +89,25 @@ class TestParseUnifiedDiff:
         assert files[0].old_filename == "old.py"
         assert files[0].patch == ""
 
+    def test_paths_with_spaces_are_read_from_file_headers(self):
+        diff = (
+            "diff --git a/src/a b/file.py b/src/a b/file.py\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/src/a b/file.py\n"
+            "+++ b/src/a b/file.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+
+        files = parse_unified_diff(diff)
+
+        assert len(files) == 1
+        assert files[0].filename == "src/a b/file.py"
+        assert files[0].old_filename is None
+        assert "-old" in files[0].patch
+        assert "+new" in files[0].patch
+
 
 class TestProviderRegistration:
     def test_registry_has_mosaico_diff_and_originals_intact(self):


### PR DESCRIPTION
## Summary

- Fix MOSAICO supplied-diff parsing for valid paths containing the substring ` b/`.
- Read paths from the `---`/`+++` file headers when present, while preserving the existing `diff --git` fallback for metadata-only sections.
- Add a regression test that asserts the filename metadata and hunk content.

## Root cause

`pr_agent/mosaico/diff_provider.py::parse_unified_diff()` split the `diff --git` header with the non-greedy separator `(?P<a>.+?) b/`. When a path itself contained ` b/`, the first matching substring was treated as the boundary between the old and new paths. The resulting `FilePatchInfo.filename` and `old_filename` were incorrect.

## Fix

The parser now treats the `---` and `+++` file headers as authoritative path sources when they exist. `/dev/null` is normalized for added/deleted files, and metadata-only sections retain the prior header-based fallback. Path and edit-type parsing stop before the first hunk so source lines cannot be mistaken for file metadata.

## Testing

- Baseline red test on `origin/main`:

  ```bash
  docker run --rm -v /Users/jacob.z/open-source/pr-agent-semantic-audit-fresh-20260907:/workspace -w /workspace pragent/pr-agent:test-feature-20260904 python -m pytest tests/unittest/test_mosaico_provider.py::TestParseUnifiedDiff::test_paths_with_spaces_are_read_from_file_headers -q
  ```

  Result: `1 failed` with the corrupted baseline filename `file.py b/src/a b/file.py`.

- Focused MOSAICO and diff-provider suite:

  ```bash
  docker run --rm pr-agent-semantic-audit-20260907 pytest tests/unittest/test_mosaico_provider.py tests/unittest/test_mosaico_router.py tests/unittest/test_plain_diff_provider.py tests/unittest/test_diff_parsing.py -q
  ```

  Result: `124 passed, 1 warning`.

- Ruff: passed on both changed files.
- Pre-commit: passed on both changed files, including AST/file checks, actionlint, and Ruff.
- Docker test target: built successfully with `docker build -f docker/Dockerfile --target test -t pr-agent-semantic-audit-20260907 .`.
- Full repository CI test command: `3982 passed, 1 skipped, 1 xfailed, 2 failed`; the two failures are existing `PRDescription` lifecycle failures reproduced on a clean `origin/main` worktree and are unrelated to this change.

## Scope and evidence boundary

This change is limited to the supplied unified-diff parser. It does not change remote-provider fetching, model/provider behavior, prompt construction, deployment, or production behavior. No live provider, network, CI, deployment, or production result is claimed here.
