### PR TITLE
fix(bitbucket): align publish_inline_comment signature with GitProvider base

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -491,15 +491,15 @@ class BitbucketProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None) -> bool:
-        comment = self.limit_output_characters(comment, self.max_comment_length)
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None) -> bool:
+        body = self.limit_output_characters(body, self.max_comment_length)
         payload = json.dumps({
             "content": {
-                "raw": comment,
+                "raw": body,
             },
             "inline": {
-                "to": from_line,
-                "path": file
+                "to": relevant_line_in_file,
+                "path": relevant_file
             },
         })
         try:
@@ -509,7 +509,7 @@ class BitbucketProvider(GitProvider):
             response.raise_for_status()
         except Exception as e:
             get_logger().error(
-                f"Failed to publish inline comment to '{file}' at line {from_line}, error: {e}")
+                f"Failed to publish inline comment to '{relevant_file}' at line {relevant_line_in_file}, error: {e}")
             return False
         return True
 
@@ -556,7 +556,7 @@ class BitbucketProvider(GitProvider):
                 continue
 
             publishable_count += 1
-            if self.publish_inline_comment(comment['body'], from_line, comment['path']):
+            if self.publish_inline_comment(comment['body'], comment['path'], from_line):
                 published_count += 1
 
         # A partial failure must not report failure: the caller republishes the whole

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -430,15 +430,15 @@ class BitbucketServerProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, comment: str, from_line: int, file: str, original_suggestion=None) -> bool:
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None) -> bool:
         payload = {
-            "text": comment,
+            "text": body,
             "severity": "NORMAL",
             "anchor": {
                 "diffType": "EFFECTIVE",
-                "path": file,
+                "path": relevant_file,
                 "lineType": "ADDED",
-                "line": from_line,
+                "line": relevant_line_in_file,
                 "fileType": "TO"
             }
         }
@@ -446,7 +446,7 @@ class BitbucketServerProvider(GitProvider):
         try:
             self.bitbucket_client.post(self._get_pr_comments_path(), data=payload)
         except Exception as e:
-            get_logger().error(f"Failed to publish inline comment to '{file}' at line {from_line}, error: {e}")
+            get_logger().error(f"Failed to publish inline comment to '{relevant_file}' at line {relevant_line_in_file}, error: {e}")
             return False
         return True
 
@@ -504,7 +504,7 @@ class BitbucketServerProvider(GitProvider):
                 continue
 
             publishable_count += 1
-            if self.publish_inline_comment(comment['body'], from_line, comment['path']):
+            if self.publish_inline_comment(comment['body'], comment['path'], from_line):
                 published_count += 1
 
         # A partial failure must not report failure: the caller republishes the whole

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -485,6 +485,21 @@ not a valid hunk
         existing.put.assert_called_once()
         provider.publish_comment.assert_not_called()
 
+    def test_publish_inline_comment_maps_payload_correctly(self):
+        provider = self._provider_for_code_suggestions()
+        response = self._inline_comment_response(201)
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response) as request:
+            result = provider.publish_inline_comment("looks good", "src/example.py", 42)
+
+        assert result is True
+        request.assert_called_once_with(
+            "POST",
+            provider.bitbucket_comment_api_url,
+            data='{"content": {"raw": "looks good"}, "inline": {"to": 42, "path": "src/example.py"}}',
+            headers=provider.headers,
+        )
+
     def test_publish_code_suggestions_reports_success(self):
         provider = self._provider_for_code_suggestions()
         responses = [self._inline_comment_response(201), self._inline_comment_response(201)]
@@ -829,6 +844,28 @@ class TestBitbucketServerProvider:
         assert PRCodeSuggestionsIdentity.SUMMARY.value in updated_body
         assert "new suggestions" in updated_body
         assert "Previous suggestions" in updated_body
+
+    def test_publish_inline_comment_maps_payload_correctly(self):
+        provider = self._provider_for_code_suggestions()
+
+        result = provider.publish_inline_comment("looks good", "src/example.py", 42)
+
+
+        assert result is True
+        provider.bitbucket_client.post.assert_called_once_with(
+            "rest/api/latest/projects/AAA/repos/my-repo/pull-requests/1/comments",
+            data={
+                "text": "looks good",
+                "severity": "NORMAL",
+                "anchor": {
+                    "diffType": "EFFECTIVE",
+                    "path": "src/example.py",
+                    "lineType": "ADDED",
+                    "line": 42,
+                    "fileType": "TO",
+                },
+            },
+        )
 
     def test_publish_code_suggestions_reports_success(self):
         provider = self._provider_for_code_suggestions()

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -50,6 +50,7 @@ class MethodContract:
     check_supported: Callable[[object], None]
     tiers: dict[str, Tier]
     check_return_annotation: bool = True
+    check_execution: bool = True
 
 
 def _github(monkeypatch) -> GithubProvider:
@@ -207,11 +208,24 @@ METHOD_CONTRACTS = (
         check_supported=_is_success,
         tiers=REACTION_TIERS,
     ),
+    MethodContract(
+        name="publish_inline_comment",
+        args=(),
+        noop_value=None,
+        check_supported=lambda _: None,
+        tiers=_tiers(),
+        # Signature-only contract: catches signature drift against GitProvider without
+        # requiring live backends or mock state for every provider.
+        check_return_annotation=False,
+        check_execution=False,
+    ),
 )
 
 
-def _rows(tier: Tier | None = None):
+def _rows(tier: Tier | None = None, check_execution_only: bool = False):
     for contract in METHOD_CONTRACTS:
+        if check_execution_only and not contract.check_execution:
+            continue
         for provider_name, provider_tier in contract.tiers.items():
             if tier is None or provider_tier is tier:
                 yield pytest.param(provider_name, contract, id=f"{provider_name}-{contract.name}")
@@ -252,7 +266,7 @@ def test_implementation_declares_the_base_return_type(provider_name: str, contra
     assert implementation_hints.get("return") == base_hints["return"]
 
 
-@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.SUPPORTED)))
+@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.SUPPORTED, check_execution_only=True)))
 def test_supported_tier_returns_the_contract_value(provider_name: str, contract: MethodContract, monkeypatch):
     _, factory = PROVIDERS[provider_name]
     provider = factory(monkeypatch)
@@ -260,7 +274,7 @@ def test_supported_tier_returns_the_contract_value(provider_name: str, contract:
     contract.check_supported(getattr(provider, contract.name)(*contract.args))
 
 
-@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.NOOP)))
+@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.NOOP, check_execution_only=True)))
 def test_noop_tier_returns_the_empty_value_without_a_backend(provider_name: str, contract: MethodContract):
     provider_type, _ = PROVIDERS[provider_name]
     provider = provider_type.__new__(provider_type)
@@ -271,7 +285,7 @@ def test_noop_tier_returns_the_empty_value_without_a_backend(provider_name: str,
     assert result == contract.noop_value
 
 
-@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.NOT_IMPLEMENTED)))
+@pytest.mark.parametrize("provider_name,contract", tuple(_rows(Tier.NOT_IMPLEMENTED, check_execution_only=True)))
 def test_not_implemented_tier_raises(provider_name: str, contract: MethodContract):
     provider_type, _ = PROVIDERS[provider_name]
     provider = provider_type.__new__(provider_type)


### PR DESCRIPTION
Fixes #3113

### What

Aligns `publish_inline_comment` on both `BitbucketProvider` (Cloud) and `BitbucketServerProvider` to match the base `GitProvider` signature:

```python
def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None) -> bool:
```

Positions 2 and 3 previously had swapped semantics (`comment, from_line, file, ...`), which violated the base interface contract.

### Changes

1. **`BitbucketProvider` & `BitbucketServerProvider`**:
   - Signature parameter order updated to `(body, relevant_file, relevant_line_in_file, original_suggestion=None)`.
   - Outbound API payloads updated to map `relevant_file` -> `path` and `relevant_line_in_file` -> `to` / `line`.
   - Internal callers in `publish_inline_comments` updated to pass `(comment['body'], comment['path'], from_line)`.

2. **Contract & Unit Tests**:
   - Added `publish_inline_comment` row to `METHOD_CONTRACTS` in `tests/unittest/test_git_provider_method_contract.py` to prevent future signature drift.
   - Added unit tests in `tests/unittest/test_bitbucket_provider.py` (`TestBitbucketProvider` and `TestBitbucketServerProvider`) verifying that `publish_inline_comment` maps parameters accurately to outbound API payloads.

### Verification

- `PYTHONPATH=. uv run pytest tests/unittest/test_git_provider_method_contract.py tests/unittest/test_bitbucket_provider.py -v`: 220 passed.
- `uv run ruff check` on touched files: all clean.
- Pre-commit hooks: all passed.
