### PR TITLE
fix(github): avoid shared mutable default on GithubProvider.get_incremental_commits

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -111,7 +111,9 @@ class GithubProvider(GitProvider):
             get_logger().exception(f"Failed to get an issue object for issue: {issue_url}, belonging to owner/repo: {repo_name}")
             return None
 
-    def get_incremental_commits(self, incremental=IncrementalPR(False)):
+    def get_incremental_commits(self, incremental: IncrementalPR | None = None):
+        if incremental is None:
+            incremental = IncrementalPR(False)
         self.incremental = incremental
         if self.incremental.is_incremental:
             self.unreviewed_files_map = dict()

--- a/tests/unittest/test_github_provider_urls_and_diffs.py
+++ b/tests/unittest/test_github_provider_urls_and_diffs.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
+from pr_agent.git_providers.git_provider import IncrementalPR
 from pr_agent.git_providers.github_provider import GithubProvider
 
 
@@ -371,3 +372,39 @@ class TestGetDiffFilesRename:
         original_content_call = spy.call_args_list[-1]
         assert original_content_call.args[1] == "prev-sha"
         assert original_content_call.kwargs.get("path") == "old_dir/module.py"
+
+
+# ---------------------------------------------------------------------------
+# get_incremental_commits
+# ---------------------------------------------------------------------------
+class TestGetIncrementalCommits:
+    def test_default_incremental_is_fresh_instance_per_call(self):
+        p1 = _bare_provider()
+        p1.get_incremental_commits()
+
+        p2 = _bare_provider()
+        p2.get_incremental_commits()
+
+        assert isinstance(p1.incremental, IncrementalPR)
+        assert isinstance(p2.incremental, IncrementalPR)
+        assert p1.incremental is not p2.incremental
+        assert not p1.incremental.is_incremental
+        assert not p2.incremental.is_incremental
+
+    def test_explicit_incremental_passed_through(self):
+        p = _bare_provider()
+        custom_inc = IncrementalPR(False)
+        p.get_incremental_commits(custom_inc)
+        assert p.incremental is custom_inc
+
+    def test_mutating_one_incremental_does_not_leak_to_subsequent_default(self):
+        p1 = _bare_provider()
+        p1.get_incremental_commits()
+        p1.incremental.is_incremental = True
+        p1.incremental.commits_range = ["commit-1", "commit-2"]
+
+        p2 = _bare_provider()
+        p2.get_incremental_commits()
+        assert not p2.incremental.is_incremental
+        assert p2.incremental.commits_range is None
+


### PR DESCRIPTION
### Description
Fixes #3114.

In `GithubProvider.get_incremental_commits`, `incremental` defaulted to `IncrementalPR(False)`, which was constructed once at module import time and shared across all instances calling without arguments. When `self.incremental` was mutated during incremental review paths (such as `_get_incremental_commits` or `get_commit_range`), that state leaked across provider instances.

This PR changes the parameter default to `None` and constructs `IncrementalPR(False)` inside the body (consistent with `GitLabProvider.get_incremental_commits` and `AzureDevopsProvider.get_incremental_commits`).

### Testing
- Added unit tests in `TestGetIncrementalCommits` (`tests/unittest/test_github_provider_urls_and_diffs.py`) verifying:
  - Default `incremental` creates a fresh `IncrementalPR` instance on each call.
  - Explicit `incremental` instance is preserved.
  - Mutating one provider's incremental state does not leak to subsequent calls with default arguments.
- Ran all 224 unit tests in `tests/unittest/test_github*.py` — all passed.
- Ran `ruff check` on the changed files — all passed.