### PR TITLE
fix(describe): give PRDescription the data attribute run() now reads (main is red)

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -108,6 +108,12 @@ class PRDescription:
         self.patches_diff = None
         self.prediction = None
         self.file_label_dict = None
+        # The parsed prediction, set by `_prepare_data()`. Initialised here because
+        # `run()` reads it on the publish path (#3098) and every path that reaches
+        # that read does not necessarily assign it first: a run whose prediction
+        # step is skipped or short-circuited would raise AttributeError from inside
+        # the `try`, and be reported as a failed description rather than published.
+        self.data = {}
 
     async def run(self):
         init_run_details()

--- a/tests/unittest/test_pr_description_lifecycle.py
+++ b/tests/unittest/test_pr_description_lifecycle.py
@@ -33,6 +33,10 @@ def _make_description(provider):
     description.vars = {}
     description.prediction = None
     description.file_label_dict = None
+    # `run()` reads `self.data` on the publish path (#3098). This fixture builds the
+    # instance with `__new__`, so it does not inherit `__init__`'s attributes and has
+    # to name every one `run()` touches.
+    description.data = {}
     return description
 
 


### PR DESCRIPTION
**`main` is red, and so is every open pull request's CI.** This fixes it.

#3098 (`52fa7270`, merged today) added to the publish path:

```python
push_outputs("describe", payload=self.data or {}, markdown=pr_body)
```

`self.data` is assigned in `_prepare_data()`, not in `__init__`, so:

```
tests/unittest/test_pr_description_lifecycle.py
  test_run_reports_description_publication_failure[True]
    AttributeError: 'PRDescription' object has no attribute 'data'
  test_run_reports_description_publication_failure[False]
    AssertionError: Expected 'publish_description' to have been called once. Called 0 times.
```

The two failures are one bug. The `AttributeError` is raised **inside `run()`'s `try`**, so it is swallowed and reported as a failed description at `pr_description.py:240` — `publish_description` is then never called at all, which is what the `[False]` case is reporting.

Bisected: green at `52fa7270~1`, red at `52fa7270`. The last CI run on `main` itself was 2026-09-04, before it landed.

### Two changes, one per half of the gap

- **`__init__` initialises `self.data = {}`.** A real instance then always carries the attribute the publish path reads, whatever happens to the prediction step before it. The `or {}` already at the call site says an empty payload is the intended fallback, so this only makes that reachable.
- **`_make_description` names `data`.** That fixture builds its instance with `PRDescription.__new__(PRDescription)`, so it inherits nothing from `__init__` and has to list every attribute `run()` touches. It is also *why* this reaches CI as a test failure rather than as a production crash report, and worth knowing about: the fixture rots silently every time `run()` grows a new attribute dependency.

I kept `getattr(self, "data", None)` out of it deliberately. It would make the two tests pass without saying which of the two places was actually wrong, and it hides the next instance of the same gap.

### Checks

`PYTHONPATH=. uv run pytest tests/unittest`: **3983 pass, 0 fail** (on `main`: 3981 pass, 2 fail). `uv run ruff check` and `uv run pre-commit run --files` clean on both files.

My other three open PRs (#3120, #3121, #3123) show the same two failures in CI and are unrelated to them; this one unblocks all of them.
