### PR TITLE
fix(gitlab): report suggestion publication failures

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -2,6 +2,7 @@ import difflib
 import re
 import urllib.parse
 from datetime import datetime, timezone
+from enum import Enum, auto
 from types import SimpleNamespace
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -45,6 +46,14 @@ from .git_provider import (
 class DiffNotFoundError(Exception):
     """Raised when the diff for a merge request cannot be found."""
     pass
+
+
+class _InlineCommentResult(Enum):
+    FAILED = auto()
+    DUPLICATE = auto()
+    PUBLIC_DUPLICATE = auto()
+    LIVE = auto()
+    DRAFT = auto()
 
 
 def _parse_gitlab_iso_datetime(value) -> Optional[datetime]:
@@ -1044,6 +1053,8 @@ class GitLabProvider(GitProvider):
             return
         resolved = 0
         released_fps = set()
+        # Old public markers cannot prove that a replacement draft was published.
+        released_note_ids = getattr(self, "_superseded_inline_note_ids", set())
         for discussion in discussions:
             discussion_id = getattr(discussion, 'id', None)
             try:
@@ -1055,8 +1066,11 @@ class GitLabProvider(GitProvider):
                 for note in discussion.attributes.get('notes') or []:
                     if isinstance(note, dict):
                         released_fps |= marker_fingerprints(note.get('body'))
+                        if note.get('id') is not None:
+                            released_note_ids.add(note['id'])
             except Exception as e:
                 get_logger().warning(f"Failed to resolve outdated inline thread {discussion_id}: {e}")
+        self._superseded_inline_note_ids = released_note_ids
         if released_fps:
             get_inline_comment_store(self).release(released_fps)
         if resolved:
@@ -1096,9 +1110,16 @@ class GitLabProvider(GitProvider):
                             source_line_no: int, target_file: str, target_line_no: int,
                             original_suggestion=None, as_draft: bool = False) -> bool:
         """Returns True iff a comment (live or draft, primary or fallback) was created."""
+        result = self._send_inline_comment(body, edit_type, found, relevant_file, relevant_line_in_file,
+                                           source_line_no, target_file, target_line_no, original_suggestion, as_draft)
+        return result in (_InlineCommentResult.LIVE, _InlineCommentResult.DRAFT)
+
+    def _send_inline_comment(self, body: str, edit_type: str, found: bool, relevant_file: str,
+                             relevant_line_in_file: str, source_line_no: int, target_file: str, target_line_no: int,
+                             original_suggestion=None, as_draft: bool = False) -> _InlineCommentResult:
         if not found:
             get_logger().info(f"Could not find position for {relevant_file} {relevant_line_in_file}")
-            return False
+            return _InlineCommentResult.FAILED
         else:
             store = None
             body_fp = code_fp = None
@@ -1114,7 +1135,10 @@ class GitLabProvider(GitProvider):
                     get_logger().info(
                         f"Persistent inline comments: skipping duplicate inline "
                         f"comment on {relevant_file}:{anchor_line}")
-                    return False
+                    if self._is_inline_comment_public(body_fp, code_fp):
+                        return _InlineCommentResult.PUBLIC_DUPLICATE
+                    self._record_pending_inline_comment({body_fp, code_fp} - {None})
+                    return _InlineCommentResult.DUPLICATE
                 body = body_with_markers(
                     body, body_fp, code_fp, getattr(self, "max_comment_chars", None))
             # in order to have exact sha's we have to find correct diff for this change
@@ -1146,7 +1170,44 @@ class GitLabProvider(GitProvider):
                     f"live comment instead of a draft")
                 created = self._create_suggestion_note(False, body, pos_obj, diff, target_file, relevant_file,
                                                         original_suggestion, store, body_fp, code_fp)
-            return created
+                as_draft = False
+            if not created:
+                return _InlineCommentResult.FAILED
+            if as_draft:
+                self._record_pending_inline_comment({body_fp, code_fp} - {None})
+            return _InlineCommentResult.DRAFT if as_draft else _InlineCommentResult.LIVE
+
+    def _record_pending_inline_comment(self, fingerprints: set):
+        self._code_suggestion_drafts_pending = True
+        pending = getattr(self, "_pending_code_suggestion_fingerprints", [])
+        if fingerprints not in pending:
+            pending.append(fingerprints)
+        self._pending_code_suggestion_fingerprints = pending
+
+    def _is_inline_comment_public(self, body_fp: str, code_fp: Optional[str]) -> bool:
+        # The dedup store includes drafts. Verify public markers separately so an
+        # unavailable draft endpoint cannot turn an already-public duplicate into a failure.
+        fingerprints = {body_fp, code_fp} - {None}
+        superseded = getattr(self, "_superseded_inline_note_ids", set())
+        try:
+            for note in self.mr.notes.list(get_all=True):
+                if getattr(note, "id", None) in superseded:
+                    continue
+                if fingerprints & marker_fingerprints(getattr(note, "body", "") or ""):
+                    return True
+        except Exception as e:
+            get_logger().warning(f"Could not verify public notes for MR {self.id_mr}: {e}")
+        try:
+            for discussion in self.mr.discussions.list(get_all=True):
+                attrs = getattr(discussion, "attributes", None) or {}
+                for note in attrs.get("notes", []) or []:
+                    if isinstance(note, dict) and note.get("id") in superseded:
+                        continue
+                    if isinstance(note, dict) and fingerprints & marker_fingerprints(note.get("body", "") or ""):
+                        return True
+        except Exception as e:
+            get_logger().warning(f"Could not verify public inline comment for MR {self.id_mr}: {e}")
+        return False
 
     def _create_suggestion_note(self, as_draft: bool, body: str, pos_obj: dict, diff, target_file,
                                 relevant_file: str, original_suggestion, store, body_fp, code_fp) -> bool:
@@ -1247,6 +1308,38 @@ class GitLabProvider(GitProvider):
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         # Runs first so the fingerprints it frees are in the store before any dedup lookup.
         self.resolve_outdated_inline_threads()
+        if not code_suggestions:
+            return True
+        published = False
+        retry_results = getattr(self, "_code_suggestion_retry_results", {})
+        needs_draft_publication = getattr(self, "_code_suggestion_drafts_pending", False)
+        results = {}
+
+        def finish(success):
+            # Remember each initial attempt for one individual retry. Consuming even
+            # failed retries avoids suppressing later runs when persistence is disabled.
+            if not success:
+                for key, attempted_results in results.items():
+                    retry_results[key] = attempted_results + retry_results.get(key, [])
+            self._code_suggestion_retry_results = retry_results
+            return success
+
+        def drafts_published():
+            self._code_suggestion_drafts_pending = False
+            self._pending_code_suggestion_fingerprints = []
+            for key, pending_results in retry_results.items():
+                retry_results[key] = [_InlineCommentResult.PUBLIC_DUPLICATE
+                                      if result in (_InlineCommentResult.DRAFT, _InlineCommentResult.DUPLICATE)
+                                      else result for result in pending_results]
+
+        def verify_pending_publication():
+            fingerprints = getattr(self, "_pending_code_suggestion_fingerprints", [])
+            if fingerprints and all(keys and any(self._is_inline_comment_public(key, None) for key in keys)
+                                    for keys in fingerprints):
+                drafts_published()
+                return True
+            return False
+
         # When true, suggestions are queued as GitLab draft notes and published together in a single
         # batch at the end, instead of each one going out as its own live discussion (and its own
         # notification/email) as soon as it's created.
@@ -1261,6 +1354,18 @@ class GitLabProvider(GitProvider):
                 relevant_file = suggestion['relevant_file']
                 relevant_lines_start = suggestion['relevant_lines_start']
                 relevant_lines_end = suggestion['relevant_lines_end']
+
+                key = (relevant_file, relevant_lines_start, relevant_lines_end, body)
+                is_retry = key in retry_results
+                result = None
+                if is_retry:
+                    result = retry_results[key].pop(0)
+                    if not retry_results[key]:
+                        del retry_results[key]
+                else:
+                    # Record the occurrence before any diff/API call can raise or skip it.
+                    results.setdefault(key, []).append(_InlineCommentResult.FAILED)
+                    result_index = len(results[key]) - 1
 
                 diff_files = self.get_diff_files()
                 target_file = None
@@ -1290,30 +1395,46 @@ class GitLabProvider(GitProvider):
                 found = True
                 edit_type = 'addition'
 
-                self.send_inline_comment(body, edit_type, found, relevant_file, relevant_line_in_file,
-                                         source_line_no, target_file, target_line_no, original_suggestion,
-                                         as_draft=as_review)
+                if result in (None, _InlineCommentResult.FAILED, _InlineCommentResult.DUPLICATE):
+                    result = self._send_inline_comment(body, edit_type, found, relevant_file, relevant_line_in_file,
+                                                       source_line_no, target_file, target_line_no, original_suggestion,
+                                                       as_draft=as_review)
+                if not is_retry:
+                    results[key][result_index] = result
+                if result in (_InlineCommentResult.LIVE, _InlineCommentResult.PUBLIC_DUPLICATE):
+                    published = True
+                # Dedup also scans pending drafts, so a duplicate is not necessarily public yet.
+                if result in (_InlineCommentResult.DRAFT, _InlineCommentResult.DUPLICATE):
+                    needs_draft_publication = True
+                if result == _InlineCommentResult.DRAFT:
+                    self._code_suggestion_drafts_pending = True
             except Exception as e:
                 get_logger().exception(f"Could not publish code suggestion:\nsuggestion: {suggestion}\nerror: {e}")
 
         if as_review:
             try:
-                # Check the MR's actual pending drafts rather than tracking creations from this call
-                # alone: this correctly skips bulk-publish when nothing is pending (e.g. an empty or
-                # all-failed suggestion list, which would otherwise publish unrelated drafts already on
-                # the MR from a previous run or a manual draft review in progress), while still
-                # retrying to publish drafts left over from an earlier run whose bulk_publish failed -
-                # even if every suggestion in this run was skipped as a dedup-detected duplicate of one
-                # of those still-pending drafts.
+                # Include drafts left by an earlier failed batch even when this call dedupes every suggestion.
                 try:
                     pending = self.mr.draft_notes.list(get_all=True)
+                    self._code_suggestion_drafts_pending = bool(pending)
+                    self._pending_code_suggestion_fingerprints = [
+                        marker_fingerprints(getattr(draft, "note", "") or "") for draft in pending]
                 except Exception as e:
-                    # Draft notes are unusable on this instance/token; send_inline_comment has
-                    # already degraded every suggestion to a live comment, so nothing is pending.
                     get_logger().warning(f"Could not list draft notes for MR {self.id_mr}: {e}")
-                    pending = []
+                    # A bulk request can time out after publishing server-side. Only
+                    # recover when every last-known draft has a verifiable public marker.
+                    if verify_pending_publication():
+                        return finish(True)
+                    # A live fallback can succeed on instances without a draft endpoint, but a
+                    # queued/deduped draft must not be reported as public without verification.
+                    return finish(published and not needs_draft_publication)
                 if pending:
                     self.mr.draft_notes.bulk_publish()
+                    published = True
+                elif needs_draft_publication:
+                    # No pending drafts remain (possibly published concurrently).
+                    published = True
+                drafts_published()
             except Exception as e:
                 # Draft notes are only visible to the posting user until published, so a failure here
                 # leaves the suggestions invisible to everyone else. They aren't lost: GitLab keeps
@@ -1324,9 +1445,21 @@ class GitLabProvider(GitProvider):
                     f"Failed to bulk-publish draft code-suggestion notes for MR {self.id_mr}; they remain "
                     f"as pending drafts, visible only to the posting user, until published manually from "
                     f"the GitLab UI or by a subsequent successful run: {e}")
+                return finish(False)
 
         # note that we publish suggestions one-by-one. so, if one fails, the rest will still be published
-        return True
+        if not as_review and needs_draft_publication:
+            try:
+                pending = self.mr.draft_notes.list(get_all=True)
+                if pending:
+                    return finish(False)
+                drafts_published()
+                return finish(True)
+            except Exception as e:
+                get_logger().warning(f"Could not refresh pending draft notes for MR {self.id_mr}: {e}")
+                if verify_pending_publication():
+                    return finish(True)
+        return finish(published and (as_review or not needs_draft_publication))
 
     def publish_file_comments(self, file_comments: list) -> bool:
         pass

--- a/tests/unittest/test_gitlab_batch_publish_suggestions.py
+++ b/tests/unittest/test_gitlab_batch_publish_suggestions.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from pr_agent.algo import inline_comment_dedup as dedup
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
 
@@ -47,6 +49,17 @@ def _gl_provider():
     p.get_line_link = MagicMock(return_value="http://link")
 
     pending_drafts = []
+    published_notes = []
+
+    def _publish(payload):
+        note = MagicMock()
+        note.body = payload['body']
+        published_notes.append(note)
+        return note
+
+    p.mr.notes.list.side_effect = lambda get_all=True: list(published_notes)
+    p.mr.notes.create.side_effect = _publish
+    p.mr.discussions.create.side_effect = _publish
 
     def _create(payload):
         note = MagicMock()
@@ -58,6 +71,8 @@ def _gl_provider():
         return list(pending_drafts)
 
     def _bulk_publish():
+        for draft in pending_drafts:
+            _publish({'body': draft.note})
         pending_drafts.clear()
 
     p.mr.draft_notes.create.side_effect = _create
@@ -159,8 +174,8 @@ def test_bulk_publish_failure_is_caught_and_does_not_propagate():
     p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("network error")
     gs = _settings(as_review=True)
     try:
-        # must not raise, and must still report success for the individually-queued suggestions
-        assert p.publish_code_suggestions([_suggestion()]) is True
+        # Queued drafts are still invisible to the reviewer; the caller must retry.
+        assert p.publish_code_suggestions([_suggestion()]) is False
     finally:
         gs.stop()
 
@@ -168,9 +183,10 @@ def test_bulk_publish_failure_is_caught_and_does_not_propagate():
 
 
 def test_empty_suggestions_does_not_bulk_publish_unrelated_pending_drafts():
-    # Regression: bulk_publish() must not fire when nothing is pending, since it would
-    # otherwise publish any unrelated drafts already on the MR for this user.
+    # An empty input is a no-op even when the user has an unrelated draft review.
     p = _gl_provider()
+    p.mr.draft_notes.create({'note': 'unrelated manual draft'})
+    p.mr.draft_notes.create.reset_mock()
     gs = _settings(as_review=True)
     try:
         assert p.publish_code_suggestions([]) is True
@@ -187,7 +203,7 @@ def test_all_suggestions_failing_to_queue_does_not_bulk_publish():
     p.get_diff_files = MagicMock(return_value=[])
     gs = _settings(as_review=True)
     try:
-        assert p.publish_code_suggestions([_suggestion()]) is True
+        assert p.publish_code_suggestions([_suggestion()]) is False
     finally:
         gs.stop()
 
@@ -220,3 +236,551 @@ def test_bulk_publish_still_fires_for_stuck_drafts_even_if_this_run_dedupes_ever
 
     p.mr.draft_notes.create.assert_not_called()  # skipped as a duplicate of the stuck draft
     p.mr.draft_notes.bulk_publish.assert_called_once()  # but still retried
+
+
+@pytest.fixture
+def publication_settings(monkeypatch):
+    def configure(as_review=False, persistent=False):
+        monkeypatch.setattr("pr_agent.git_providers.gitlab_provider.get_settings", lambda: {
+            "gitlab.publish_code_suggestions_as_review": as_review,
+            "config.persistent_inline_comments": persistent,
+        })
+    return configure
+
+
+@pytest.mark.parametrize("as_review", [False, True])
+def test_total_creation_failure_reports_failure(publication_settings, as_review):
+    publication_settings(as_review=as_review)
+    p = _gl_provider()
+    p.mr.draft_notes.create.side_effect = RuntimeError("draft endpoint unavailable")
+    p.mr.discussions.create.side_effect = RuntimeError("discussion rejected")
+    p.mr.notes.create.side_effect = RuntimeError("fallback rejected")
+
+    assert p.publish_code_suggestions([_suggestion(), _suggestion()]) is False
+    assert p.mr.discussions.create.call_count == 2
+    assert p.mr.notes.create.call_count == 2
+    p.mr.draft_notes.bulk_publish.assert_not_called()
+
+
+@pytest.mark.parametrize("failure_first", [False, True])
+def test_partial_live_publication_keeps_processing_the_batch(publication_settings, failure_first):
+    publication_settings()
+    p = _gl_provider()
+    p.mr.discussions.create.side_effect = (
+        [RuntimeError("rejected"), MagicMock()] if failure_first else [MagicMock(), RuntimeError("rejected")])
+    p.mr.notes.create.side_effect = RuntimeError("fallback rejected")
+
+    assert p.publish_code_suggestions([_suggestion(), _suggestion()]) is True
+    assert p.mr.discussions.create.call_count == 2
+    p.mr.notes.create.assert_called_once()
+
+
+def test_live_general_note_fallback_counts_as_published(publication_settings):
+    publication_settings()
+    p = _gl_provider()
+    p.mr.discussions.create.side_effect = RuntimeError("position rejected")
+
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert len(p.mr.notes.list()) == 1
+
+
+@pytest.mark.parametrize("suggestion", [{}, _suggestion(relevant_file="missing.py")])
+def test_invalid_suggestions_do_not_report_success(publication_settings, suggestion):
+    publication_settings()
+    p = _gl_provider()
+
+    assert p.publish_code_suggestions([suggestion]) is False
+    p.mr.discussions.create.assert_not_called()
+
+
+@pytest.mark.parametrize("as_review", [False, True])
+def test_published_duplicate_is_a_successful_noop_across_runs(publication_settings, as_review):
+    publication_settings(as_review=as_review, persistent=True)
+    p = _gl_provider()
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    # A new provider must rediscover the public marker, not rely on its in-memory store.
+    next_run = _gl_provider()
+    next_run.mr = p.mr
+    creates = p.mr.discussions.create.call_count + p.mr.draft_notes.create.call_count
+    publishes = p.mr.draft_notes.bulk_publish.call_count
+
+    assert next_run.publish_code_suggestions([_suggestion()]) is True
+    assert p.mr.discussions.create.call_count + p.mr.draft_notes.create.call_count == creates
+    assert p.mr.draft_notes.bulk_publish.call_count == publishes
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_mixed_live_and_pending_draft_reports_failure_then_retries_without_duplicates(publication_settings, persistent):
+    publication_settings(as_review=True, persistent=persistent)
+    p = _gl_provider()
+    create_draft = p.mr.draft_notes.create.side_effect
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+
+    def selectively_create(payload):
+        if 'live fallback' in payload['note']:
+            raise RuntimeError("draft rejected")
+        return create_draft(payload)
+
+    p.mr.draft_notes.create.side_effect = selectively_create
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("publish unavailable")
+    live = _suggestion(body="live fallback", improved_code="live fallback")
+    draft = _suggestion()
+
+    assert p.publish_code_suggestions([live, draft]) is False
+    assert len(p.mr.notes.list()) == 1
+    assert len(p.mr.draft_notes.list()) == 1
+
+    # Mirror the caller's individual retries: even the already-live suggestion cannot
+    # hide a failed publish of the draft left over from the batch.
+    assert p.publish_code_suggestions([live]) is False
+    p.mr.draft_notes.bulk_publish.side_effect = publish_drafts
+    assert p.publish_code_suggestions([draft]) is True
+    assert len(p.mr.notes.list()) == 2
+    assert p.mr.draft_notes.list() == []
+    p.mr.discussions.create.assert_called_once()
+    assert p.mr.draft_notes.create.call_count == 3  # two rejected fallbacks + one draft
+    assert p.publish_code_suggestions([live, draft]) is True
+    assert len(p.mr.notes.list()) == (2 if persistent else 4)
+
+
+@pytest.mark.parametrize("notes_available", [True, False])
+@pytest.mark.parametrize("human_resolved", [True, False])
+def test_publication_verification_distinguishes_superseded_and_human_resolved_notes(
+    monkeypatch, notes_available, human_resolved
+):
+    settings = {
+        "GITLAB.RESOLVE_OUTDATED_INLINE_THREADS": True,
+        "gitlab.publish_code_suggestions_as_review": True,
+        "config.persistent_inline_comments": True,
+    }
+    monkeypatch.setattr("pr_agent.git_providers.gitlab_provider.get_settings", lambda: settings)
+    p = _gl_provider()
+    body = _suggestion()['body'].replace("```suggestion", "```suggestion:-0+0")
+    old_body = dedup.body_with_markers(
+        body, dedup.body_fingerprint("a.py", 3, body), dedup.code_fingerprint("a.py", 3, body))
+    old_public = p.mr.notes.create({'body': old_body})
+    old_public.id = 10
+    old_note = {
+        'id': 10, 'body': old_body, 'author': {'id': 7}, 'resolved': human_resolved, 'resolvable': True,
+        'position': {'position_type': 'text', 'head_sha': 'old-head', 'new_line': 2},
+    }
+    thread = MagicMock()
+    thread.id = "old-thread"
+    thread.attributes = {'notes': [old_note]}
+    thread.save.side_effect = lambda: old_note.update(resolved=True)
+    p.mr.discussions.list.return_value = [thread]
+    p.mr.diff_refs = {'head_sha': 'head'}
+    p._get_own_user_id = lambda: 7
+    public_notes = p.mr.notes.list.side_effect
+    pending = p.mr.draft_notes.list.side_effect
+    publish = p.mr.draft_notes.bulk_publish.side_effect
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    if not notes_available:
+        p.mr.notes.list.side_effect = RuntimeError("cannot list public notes")
+
+    assert p.publish_code_suggestions([_suggestion()]) is human_resolved
+    if human_resolved:
+        # Human-resolved comments intentionally remain suppressive, including on an older head.
+        thread.save.assert_not_called()
+        p.mr.draft_notes.create.assert_not_called()
+        return
+
+    thread.save.assert_called_once()
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list drafts")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    assert len(pending()) == 1
+
+    publish()
+    replacement = public_notes()[-1]
+    replacement.id = 11
+    new_thread = MagicMock()
+    new_thread.attributes = {'notes': [{'id': 11, 'body': replacement.body}]}
+    p.mr.discussions.list.return_value.append(new_thread)
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    p.mr.draft_notes.create.assert_called_once()
+    assert len(pending()) == 0
+
+
+def test_draft_listing_failure_does_not_claim_queued_drafts_are_public(publication_settings):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    p.mr.draft_notes.bulk_publish.assert_not_called()
+
+
+def test_unavailable_draft_endpoint_preserves_successful_live_fallback(publication_settings):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    p.mr.draft_notes.create.side_effect = RuntimeError("unsupported")
+    p.mr.draft_notes.list.side_effect = RuntimeError("unsupported")
+
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert len(p.mr.notes.list()) == 1
+
+
+def test_listing_failure_on_duplicate_pending_draft_still_reports_failure(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    p.mr.draft_notes.create.assert_called_once()
+
+
+def test_missing_diff_reports_failure_and_continues(publication_settings):
+    publication_settings()
+    p = _gl_provider()
+    p.get_relevant_diff.side_effect = [None, _FakeDiff()]
+
+    assert p.publish_code_suggestions([_suggestion(), _suggestion()]) is True
+    p.mr.discussions.create.assert_called_once()
+    assert p.get_relevant_diff.call_count == 2
+
+
+def test_wrapped_original_suggestion_preserves_general_note_fallback(publication_settings):
+    publication_settings()
+    p = _gl_provider()
+    p.mr.discussions.create.side_effect = RuntimeError("position rejected")
+
+    assert p.publish_code_suggestions([_suggestion(original_suggestion=_suggestion())]) is True
+    assert 'fix it' in p.mr.notes.list()[0].body
+
+
+@pytest.mark.parametrize("as_draft", [False, True])
+@pytest.mark.parametrize("edit_type", ["addition", "deletion", "context"])
+def test_send_inline_comment_keeps_boolean_creation_contract(publication_settings, as_draft, edit_type):
+    publication_settings(persistent=True)
+    p = _gl_provider()
+    args = ("body", edit_type, True, "a.py", "line2", 3, _FakeTargetFile(), 3, _suggestion())
+
+    assert p.send_inline_comment(*args, as_draft=as_draft) is True
+    assert p.send_inline_comment(*args, as_draft=as_draft) is False  # duplicate, not a new creation
+
+
+def test_send_inline_comment_without_position_keeps_false_result(publication_settings):
+    publication_settings()
+    p = _gl_provider()
+
+    assert p.send_inline_comment("body", "addition", False, "a.py", "line2", -1, _FakeTargetFile(), 3) is False
+    p.get_relevant_diff.assert_not_called()
+    p.mr.discussions.create.assert_not_called()
+
+
+@pytest.mark.parametrize("fresh_provider", [False, True])
+def test_public_duplicate_succeeds_when_draft_endpoint_is_unavailable(publication_settings, fresh_provider):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    p.mr.draft_notes.create.side_effect = RuntimeError("unsupported")
+    p.mr.draft_notes.list.side_effect = RuntimeError("unsupported")
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    retry = _gl_provider() if fresh_provider else p
+    retry.mr = p.mr
+
+    assert retry.publish_code_suggestions([_suggestion()]) is True
+    assert len(p.mr.notes.list()) == 1
+    p.mr.discussions.create.assert_called_once()
+    p.mr.draft_notes.bulk_publish.assert_not_called()
+
+
+@pytest.mark.parametrize("notes_error", [False, True])
+@pytest.mark.parametrize("as_review", [False, True])
+def test_public_duplicate_in_discussion_preserves_success_on_draft_endpoint_error(
+        publication_settings, notes_error, as_review):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    discussion = MagicMock()
+    discussion.attributes = {"notes": [None, {}, {"body": p.mr.notes.list()[0].body}]}
+    unrelated = MagicMock()
+    unrelated.attributes = {"notes": [{"body": "unrelated comment"}]}
+    p.mr.notes.list.side_effect = RuntimeError("cannot list notes") if notes_error else lambda get_all=True: []
+    p.mr.discussions.list.return_value = [unrelated, discussion]
+    p.mr.draft_notes.list.side_effect = RuntimeError("unsupported")
+    publication_settings(as_review=as_review, persistent=True)
+
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    p.mr.draft_notes.create.assert_called_once()
+
+
+@pytest.mark.parametrize("as_review", [False, True])
+def test_unverifiable_duplicate_does_not_claim_publication(publication_settings, as_review):
+    publication_settings(as_review=as_review, persistent=True)
+    p = _gl_provider()
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    list_notes = p.mr.notes.list.side_effect
+    p.mr.notes.list.side_effect = RuntimeError("cannot verify")
+    p.mr.discussions.list.side_effect = RuntimeError("cannot verify discussions")
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    assert p.mr.draft_notes.create.call_count == int(as_review)
+    p.mr.notes.list.side_effect = list_notes
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert p.mr.draft_notes.create.call_count == int(as_review)
+    if not as_review:
+        assert p.publish_code_suggestions([_suggestion(body="independent")]) is True
+        assert len(p.mr.notes.list()) == 2
+
+
+def test_pending_duplicate_is_not_successful_after_disabling_review_mode(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    publication_settings(persistent=True)
+
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    assert len(p.mr.draft_notes.list()) == 1
+    p.mr.draft_notes.create.assert_called_once()
+    p.mr.discussions.create.assert_not_called()
+
+
+def test_concurrently_published_drafts_do_not_report_failure(publication_settings):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+
+    def list_after_concurrent_publication(get_all=True):
+        publish_drafts()
+        return []
+
+    p.mr.draft_notes.list.side_effect = list_after_concurrent_publication
+
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert len(p.mr.notes.list()) == 1
+    p.mr.draft_notes.bulk_publish.assert_not_called()
+
+
+@pytest.mark.parametrize("repeated_key", [False, True])
+@pytest.mark.parametrize("first_retry_fails", [False, True])
+def test_failed_batch_retries_without_duplicates_when_persistence_is_disabled(
+        publication_settings, repeated_key, first_retry_fails):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("temporary publication failure")
+    suggestions = [_suggestion(), _suggestion() if repeated_key else _suggestion(body="second", improved_code="second")]
+
+    assert p.publish_code_suggestions(suggestions) is False
+    for index, suggestion in enumerate(suggestions):
+        if not first_retry_fails or index:
+            p.mr.draft_notes.bulk_publish.side_effect = publish_drafts
+        assert p.publish_code_suggestions([suggestion]) is (not first_retry_fails or bool(index))
+    assert len(p.mr.notes.list()) == 2
+    assert p.mr.draft_notes.create.call_count == 2
+
+    # The retry identities are consumed: persistence remains opt-in for later runs.
+    assert p.publish_code_suggestions(suggestions) is True
+    assert len(p.mr.notes.list()) == 4
+
+
+def test_pending_batch_is_not_hidden_by_live_retry_when_draft_listing_fails(publication_settings):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    create_draft = p.mr.draft_notes.create.side_effect
+
+    def selectively_create(payload):
+        if "live" in payload['note']:
+            raise RuntimeError("draft rejected")
+        return create_draft(payload)
+
+    live = _suggestion(body="live", improved_code="live", suggestion_content="live")
+    p.mr.draft_notes.create.side_effect = selectively_create
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([live, _suggestion()]) is False
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list pending drafts")
+
+    assert p.publish_code_suggestions([live]) is False
+    assert len(p.mr.notes.list()) == 1
+
+
+def test_public_duplicate_is_found_among_unrelated_notes(publication_settings):
+    publication_settings(persistent=True)
+    p = _gl_provider()
+    p.mr.notes.create({'body': 'unrelated comment'})
+
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert len(p.mr.notes.list()) == 2
+    p.mr.discussions.create.assert_called_once()
+
+
+@pytest.mark.parametrize("listing_fails_after_dedup", [False, True])
+def test_rediscovered_pending_draft_blocks_live_retry_when_listing_becomes_unavailable(
+        publication_settings, listing_fails_after_dedup):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    draft = _suggestion()
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([draft]) is False
+    retry = _gl_provider()
+    retry.mr = p.mr
+    create_draft = retry.mr.draft_notes.create.side_effect
+
+    def selectively_create(payload):
+        if "live" in payload['note']:
+            raise RuntimeError("draft rejected")
+        return create_draft(payload)
+
+    live = _suggestion(body="live", improved_code="live", suggestion_content="live")
+    retry.mr.draft_notes.create.side_effect = selectively_create
+    pending = retry.mr.draft_notes.list.side_effect
+    if listing_fails_after_dedup:
+        calls = 0
+
+        def list_once(get_all=True):
+            nonlocal calls
+            calls += 1
+            if calls > 1:
+                raise RuntimeError("cannot list")
+            return pending()
+
+        retry.mr.draft_notes.list.side_effect = list_once
+    assert retry.publish_code_suggestions([live, draft]) is False
+    retry.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    assert retry.publish_code_suggestions([live]) is False
+    assert retry.publish_code_suggestions([draft]) is False
+    assert len(pending()) == 1
+    assert len(retry.mr.notes.list()) == 1
+
+
+def test_lost_bulk_publish_response_is_verified_through_public_markers(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+    suggestions = [_suggestion(), _suggestion(body="second", improved_code="second")]
+
+    def publish_then_timeout():
+        publish_drafts()
+        raise RuntimeError("response timed out after publication")
+
+    p.mr.draft_notes.bulk_publish.side_effect = publish_then_timeout
+    assert p.publish_code_suggestions(suggestions) is False
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    for suggestion in suggestions:
+        assert p.publish_code_suggestions([suggestion]) is True
+    assert len(p.mr.notes.list()) == 2
+    assert p.mr.draft_notes.create.call_count == 2
+
+
+def test_verifying_one_public_draft_does_not_hide_another_pending_draft(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    suggestions = [_suggestion(), _suggestion(body="second", improved_code="second")]
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions(suggestions) is False
+    pending = p.mr.draft_notes.list.side_effect
+    # One draft becomes public, but the other remains private and retryable.
+    p.mr.notes.create({'body': pending()[0].note})
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    for suggestion in suggestions:
+        assert p.publish_code_suggestions([suggestion]) is False
+    assert len(p.mr.notes.list()) == 1
+    assert p.mr.draft_notes.create.call_count == 2
+
+
+def test_new_draft_is_not_hidden_by_an_older_public_snapshot(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    first = _suggestion(body="first", improved_code="first", suggestion_content="first")
+    second = _suggestion(body="second", improved_code="second", suggestion_content="second")
+    create_draft = p.mr.draft_notes.create.side_effect
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+    pending = p.mr.draft_notes.list.side_effect
+
+    def reject_first(payload):
+        if "first" in payload['note']:
+            raise RuntimeError("first rejected")
+        return create_draft(payload)
+
+    def publish_then_timeout():
+        publish_drafts()
+        raise RuntimeError("lost response")
+
+    p.mr.draft_notes.create.side_effect = reject_first
+    p.mr.discussions.create.side_effect = RuntimeError("live rejected")
+    p.mr.notes.create.side_effect = RuntimeError("fallback rejected")
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([first, second]) is False
+    p.mr.draft_notes.bulk_publish.side_effect = publish_then_timeout
+    assert p.publish_code_suggestions([second]) is False
+    assert len(p.mr.notes.list()) == 1
+    p.mr.draft_notes.create.side_effect = create_draft
+    p.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+
+    assert p.publish_code_suggestions([first]) is False
+    assert len(pending()) == 1
+    assert len(p.mr.notes.list()) == 1
+
+
+def test_code_duplicate_with_new_wording_can_verify_publication_after_listing_failure(publication_settings):
+    publication_settings(as_review=True, persistent=True)
+    p = _gl_provider()
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    retry = _gl_provider()
+    retry.mr = p.mr
+    # Load the old pending marker, then lose the draft endpoint for subsequent calls.
+    dedup.get_inline_comment_store(retry).load()
+    retry.mr.draft_notes.list.side_effect = RuntimeError("cannot list")
+    reworded = _suggestion(body=_suggestion()['body'].replace("fix it", "another explanation"))
+    assert retry.publish_code_suggestions([reworded]) is False
+    publish_drafts()
+
+    assert retry.publish_code_suggestions([reworded]) is True
+    assert len(retry.mr.notes.list()) == 1
+    retry.mr.draft_notes.create.assert_called_once()
+
+
+@pytest.mark.parametrize("failed_method", ["get_diff_files", "get_relevant_diff"])
+def test_initial_exception_does_not_leave_a_retry_identity_for_later_runs(publication_settings, failed_method):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    method = getattr(p, failed_method)
+    method.side_effect = RuntimeError("transient diff API failure")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    method.side_effect = None
+    publish_drafts = p.mr.draft_notes.bulk_publish.side_effect
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    assert len(p.mr.draft_notes.list()) == 1
+    p.mr.draft_notes.bulk_publish.side_effect = publish_drafts
+
+    # The caller's retry was consumed despite its failure; a later run may repost.
+    assert p.publish_code_suggestions([_suggestion()]) is True
+    assert p.mr.draft_notes.create.call_count == 2
+    assert len(p.mr.notes.list()) == 2
+
+
+@pytest.mark.parametrize("still_pending", [True, False])
+def test_live_mode_refreshes_markerless_drafts_without_hiding_pending_work(publication_settings, still_pending):
+    publication_settings(as_review=True)
+    p = _gl_provider()
+    publish = p.mr.draft_notes.bulk_publish.side_effect
+    pending = p.mr.draft_notes.list.side_effect
+    p.mr.draft_notes.bulk_publish.side_effect = RuntimeError("cannot publish")
+    assert p.publish_code_suggestions([_suggestion()]) is False
+    if not still_pending:
+        publish()
+    publication_settings(as_review=False)
+
+    assert p.publish_code_suggestions([_suggestion()]) is (not still_pending)
+    p.mr.draft_notes.create.assert_called_once()
+    p.mr.discussions.create.assert_not_called()
+    assert len(pending()) == int(still_pending)
+    if still_pending:
+        publish()
+        p.mr.draft_notes.list.side_effect = RuntimeError("cannot refresh yet")
+        assert p.publish_code_suggestions([_suggestion(body="new live suggestion")]) is False
+        p.mr.draft_notes.list.side_effect = pending
+
+    assert p.publish_code_suggestions([_suggestion(body="independent live suggestion")]) is True
+    assert p._code_suggestion_drafts_pending is False

--- a/tests/unittest/test_gitlab_publish_guard.py
+++ b/tests/unittest/test_gitlab_publish_guard.py
@@ -1,4 +1,5 @@
 """Skip suggestions that point past blanked head content instead of indexing the file."""
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,8 +20,10 @@ def _provider(monkeypatch, head=HEAD):
     provider.resolve_outdated_inline_threads = lambda: None
     provider.get_diff_files = lambda: [FilePatchInfo(base_file="", head_file=head, patch="",
                                                      filename="a.py", edit_type=EDIT_TYPE.MODIFIED)]
-    provider.sent = []
-    provider.send_inline_comment = lambda *args, **kwargs: provider.sent.append(args)
+    provider.mr = MagicMock()
+    provider.id_mr = 1
+    provider.get_relevant_diff = MagicMock(return_value=SimpleNamespace(
+        base_commit_sha="base", start_commit_sha="start", head_commit_sha="head"))
     return provider, logger
 
 
@@ -34,8 +37,8 @@ def test_unpublishable_suggestion_is_skipped_with_warning(monkeypatch, head, sta
     """Blank head, out-of-range, or zero line numbers must not raise IndexError."""
     provider, logger = _provider(monkeypatch, head)
 
-    assert provider.publish_code_suggestions([_suggestion(start=start, end=start)]) is True
-    assert provider.sent == []
+    assert provider.publish_code_suggestions([_suggestion(start=start, end=start)]) is False
+    provider.mr.discussions.create.assert_not_called()
     warned = [c[0][0] for c in logger.warning.call_args_list]
     assert any("Skipping suggestion" in w for w in warned)
 
@@ -45,5 +48,5 @@ def test_populated_head_file_still_publishes(monkeypatch):
     provider, _ = _provider(monkeypatch)
 
     assert provider.publish_code_suggestions([_suggestion()]) is True
-    assert len(provider.sent) == 1
-    assert provider.sent[0][4] == "line2"
+    provider.mr.discussions.create.assert_called_once()
+    provider.get_relevant_diff.assert_called_once_with("a.py", "line2")


### PR DESCRIPTION
Fixes #3109. Implements the [confirmed publication contract](https://github.com/The-PR-Agent/pr-agent/issues/3109#issuecomment-5566061661).

## Changes

- Distinguish failed creation, live publication, queued drafts and public duplicates without changing the caller's retry policy or `send_inline_comment`'s boolean interface.
- Return failure while known drafts remain unpublished, including mixed live/draft batches and draft-list errors. Verify all known draft markers when a bulk response is lost after server-side publication.
- Remember failed-batch attempts for their individual retries, preventing duplicate posts even with persistence disabled, without suppressing later independent runs.
- Exclude notes superseded by automatic outdated-thread cleanup from publication evidence, while preserving human-resolved duplicates and recognizing newly published replacements.
- Keep the change within the GitLab provider and its tests; no dependency, lockfile or workflow changes.

## Validation

- 273 focused tests passed across the GitLab provider, batching, position guards and persistent dedup suites, with branch coverage enabled.
- Modified executable lines: 117/117 covered, no uncovered branches originating from changed lines. Publication-result helpers have 100% statement and branch coverage. Touched-file Ruff and pre-commit checks passed; `git diff --check` passed.
- Replayed the public-duplicate failure through the unchanged caller: both runs succeeded with one public post.
- Replayed the obsolete-thread/pending-draft failure: the retry stays false until the replacement is actually public; no duplicate draft is created.
- After merging upstream `dd4088f9`, independent full-diff/integration review found no actionable regressions; reviewer ran 508 targeted tests and eight caller/provider retry scenarios successfully. Focused coverage and touched-file checks above were rerun and remain passing.
- The first Linux CI run failed only the two `test_run_reports_description_publication_failure` cases. Upstream #3107 already fixed their fixture; merged current main without changing this PR's three-file diff. Both exact cases now pass locally.
- Latest full Windows unit suite: **4250 passed, 26 failed, 1 skipped, 1 xfailed** (387.91 seconds). All 26 failure IDs were previously reproduced on the clean baseline: 25 in its full run and the callback-cleanup timeout in a separate baseline replay. They concern CRLF assertions, Bash workflow tests, callback timing and Windows home expansion. The two description fixture failures are gone.
- Baseline evidence at `9b7bb8cd`: 3956 passed, 27 failed, 1 skipped, 1 xfailed; original PR head: 4008 passed, 28 failed, 1 skipped, 1 xfailed. These are historical Windows results, not green full-suite claims.

No live GitLab/LLM e2e or local Docker smoke run. Keeping this Draft pending the new upstream Linux CI result; the old head's CodeQL passed, but that does not validate the new head. Local full-suite failures are not presented as passing.

Implementation and regression tests assisted by Codex, with independent Codex diff reviews.
