### PR TITLE
fix(improve): preserve quoted file headings

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -1618,12 +1618,13 @@ class PRCodeSuggestions:
                     patches = patch_prompt.strip().split(f"\n{file_prefix}")
                     patches_new = copy.deepcopy(patches)
                     for i in range(len(patches_new)):
+                        patch_body = patches_new[i].rstrip("\n")
                         if i == 0:
-                            prefix = patches_new[i].split("\n@@")[0].strip()
+                            prefix = patch_body.split("\n@@")[0].strip()
                         else:
-                            prefix = file_prefix + patches_new[i].split("\n@@")[0][1:]
+                            prefix = file_prefix + patch_body.split("\n@@")[0]
                             prefix = prefix.strip()
-                        patches_new[i] = prefix + '\n\n' + decouple_and_convert_to_hunks_with_lines_numbers(patches_new[i],
+                        patches_new[i] = prefix + '\n\n' + decouple_and_convert_to_hunks_with_lines_numbers(patch_body,
                                                                                                           file=None).strip()
                         patches_new[i] = patches_new[i].strip()
                     patch_final = "\n\n\n".join(patches_new)

--- a/tests/unittest/test_pr_code_suggestions_core.py
+++ b/tests/unittest/test_pr_code_suggestions_core.py
@@ -94,10 +94,66 @@ async def test_convert_to_decoupled_uses_normalized_diff_and_keeps_ai_summary():
     result = await tool.convert_to_decoupled_with_line_numbers(patches, "gpt-4o-mini")
 
     assert len(result) == 1
+    assert result[0].startswith("## File: 'app.py'")
     assert "### AI-generated changes summary:" in result[0]
     assert "Keep the existing summary." in result[0]
     assert not any(line.startswith(("---", "+++")) for line in result[0].splitlines())
     assert "1 +new" in result[0]
+
+
+@pytest.mark.asyncio
+async def test_convert_to_decoupled_preserves_quoted_file_headings_across_files():
+    token_handler = MagicMock(prompt_tokens=0)
+    token_handler.count_tokens.return_value = 1
+    first_base = "keep first\nold first\n"
+    first_head = "keep first\nnew first\n"
+    second_base = "".join(f"line {i}\n" for i in range(1, 10)) + "keep second\nold second\n"
+    second_head = "".join(f"line {i}\n" for i in range(1, 10)) + "keep second\nnew second\n"
+    files = (
+        FilePatchInfo(
+            base_file=first_base,
+            head_file=first_head,
+            patch=load_large_diff("first.py", first_head, first_base),
+            filename="first.py",
+        ),
+        FilePatchInfo(
+            base_file=second_base,
+            head_file=second_head,
+            patch=load_large_diff("second.py", second_head, second_base),
+            filename="second.py",
+        ),
+    )
+    patches, _, _ = pr_generate_extended_diff(
+        [{"language": "Python", "files": files}],
+        token_handler,
+        add_line_numbers_to_hunks=False,
+    )
+    tool = _make_tool()
+    tool.token_handler = token_handler
+
+    result = await tool.convert_to_decoupled_with_line_numbers(["\n".join(patches)], "gpt-4o-mini")
+
+    assert len(result) == 1
+    converted = result[0]
+    assert converted.count("## File: 'first.py'") == 1
+    assert converted.count("## File: 'second.py'") == 1
+    assert "## File: second.py'" not in converted
+    first_index = converted.index("## File: 'first.py'")
+    second_index = converted.index("## File: 'second.py'")
+    assert first_index < second_index
+
+    first_section = converted[first_index:second_index]
+    second_section = converted[second_index:]
+    assert "1  keep first" in first_section
+    assert "2 +new first" in first_section
+    assert "10  keep second" not in first_section
+    assert "11 +new second" not in first_section
+    first_new_hunk = first_section.split("__new hunk__\n", 1)[1].split("__old hunk__", 1)[0]
+    assert first_new_hunk.splitlines() == ["1  keep first", "2 +new first"]
+    assert "10  keep second" in second_section
+    assert "11 +new second" in second_section
+    assert "1  keep first" not in second_section
+    assert "2 +new first" not in second_section
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3133.

Follow-up to #3069.

## Summary

- Preserve quoted `## File: '<path>'` headings when the default `/improve` path converts multi-file non-decoupled chunks to numbered hunks.
- Trim generated section padding before hunk conversion so separator blank lines are not numbered as file content.
- Add provider-neutral regression coverage using generated multi-file input.

## Testing

- `PYTHONPATH=. python -m pytest tests/unittest/test_pr_code_suggestions_core.py::test_convert_to_decoupled_uses_normalized_diff_and_keeps_ai_summary tests/unittest/test_pr_code_suggestions_core.py::test_convert_to_decoupled_preserves_quoted_file_headings_across_files -q`
- `PYTHONPATH=. python -m pytest tests/unittest/test_pr_code_suggestions_core.py -q`
- `PYTHONPATH=. python -m pytest tests/unittest/test_prompt_fragments.py tests/unittest/test_diff_pipeline_core.py tests/unittest/test_pr_processing_core.py -q`
- `PYTHONPATH=. python -m pytest tests/unittest -q --tb=short --maxfail=20`
- `PYTHONPATH=. python -m ruff check --fix pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_core.py`
- `python -m pre_commit run --files pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_core.py`
- `git diff --check upstream/main...HEAD`
