### PR TITLE
fix(bitbucket): resolve line text in publish_inline_comment like the other providers

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -491,8 +491,17 @@ class BitbucketProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None) -> bool:
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str | int,
+                               original_suggestion=None) -> bool:
         body = self.limit_output_characters(body, self.max_comment_length)
+        # The base contract passes the line's text; publish_inline_comments passes an already resolved line number.
+        if not isinstance(relevant_line_in_file, int):
+            comment = self.create_inline_comment(body, relevant_file, relevant_line_in_file)
+            if not comment:
+                get_logger().error(f"Could not find line '{relevant_line_in_file}' in '{relevant_file}' "
+                                   "to publish an inline comment")
+                return False
+            relevant_file, relevant_line_in_file = comment["path"], comment["position"]
         payload = json.dumps({
             "content": {
                 "raw": body,

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -430,7 +430,16 @@ class BitbucketServerProvider(GitProvider):
         path = relevant_file.strip()
         return dict(body=body, path=path, position=absolute_position) if subject_type == "LINE" else {}
 
-    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None) -> bool:
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str | int,
+                               original_suggestion=None) -> bool:
+        # The base contract passes the line's text; publish_inline_comments passes an already resolved line number.
+        if not isinstance(relevant_line_in_file, int):
+            comment = self.create_inline_comment(body, relevant_file, relevant_line_in_file)
+            if not comment:
+                get_logger().error(f"Could not find line '{relevant_line_in_file}' in '{relevant_file}' "
+                                   "to publish an inline comment")
+                return False
+            relevant_file, relevant_line_in_file = comment["path"], comment["position"]
         payload = {
             "text": body,
             "severity": "NORMAL",

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -17,6 +17,12 @@ from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 
 
+def _added_file(filename="src/example.py", lines=("a = 1", "b = 2", "c = 3")):
+    patch = f"@@ -0,0 +1,{len(lines)} @@\n" + "\n".join("+" + line for line in lines)
+    return FilePatchInfo(base_file="", head_file="\n".join(lines), patch=patch, filename=filename,
+                         edit_type=EDIT_TYPE.ADDED)
+
+
 class TestBitbucketProvider:
     @staticmethod
     def _code_suggestion(line: int):
@@ -500,6 +506,33 @@ not a valid hunk
             headers=provider.headers,
         )
 
+    def test_publish_inline_comment_resolves_line_text_to_line_number(self):
+        # The GitProvider contract passes the line's text, as the other providers already accept.
+        provider = self._provider_for_code_suggestions()
+        provider.get_diff_files = MagicMock(return_value=[_added_file()])
+        response = self._inline_comment_response(201)
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request", return_value=response) as request:
+            result = provider.publish_inline_comment("looks good", "src/example.py", "b = 2")
+
+        assert result is True
+        request.assert_called_once_with(
+            "POST",
+            provider.bitbucket_comment_api_url,
+            data='{"content": {"raw": "looks good"}, "inline": {"to": 2, "path": "src/example.py"}}',
+            headers=provider.headers,
+        )
+
+    def test_publish_inline_comment_does_not_post_when_line_text_is_not_in_the_diff(self):
+        provider = self._provider_for_code_suggestions()
+        provider.get_diff_files = MagicMock(return_value=[_added_file()])
+
+        with patch("pr_agent.git_providers.bitbucket_provider.requests.request") as request:
+            result = provider.publish_inline_comment("looks good", "src/example.py", "no such line")
+
+        assert result is False
+        request.assert_not_called()
+
     def test_publish_code_suggestions_reports_success(self):
         provider = self._provider_for_code_suggestions()
         responses = [self._inline_comment_response(201), self._inline_comment_response(201)]
@@ -866,6 +899,27 @@ class TestBitbucketServerProvider:
                 },
             },
         )
+
+    def test_publish_inline_comment_resolves_line_text_to_line_number(self):
+        # The GitProvider contract passes the line's text, as the other providers already accept.
+        provider = self._provider_for_code_suggestions()
+        provider.get_diff_files = MagicMock(return_value=[_added_file()])
+
+        result = provider.publish_inline_comment("looks good", "src/example.py", "b = 2")
+
+        assert result is True
+        anchor = provider.bitbucket_client.post.call_args.kwargs["data"]["anchor"]
+        assert anchor["path"] == "src/example.py"
+        assert anchor["line"] == 2
+
+    def test_publish_inline_comment_does_not_post_when_line_text_is_not_in_the_diff(self):
+        provider = self._provider_for_code_suggestions()
+        provider.get_diff_files = MagicMock(return_value=[_added_file()])
+
+        result = provider.publish_inline_comment("looks good", "src/example.py", "no such line")
+
+        assert result is False
+        provider.bitbucket_client.post.assert_not_called()
 
     def test_publish_code_suggestions_reports_success(self):
         provider = self._provider_for_code_suggestions()


### PR DESCRIPTION
Fixes #3130

`GitProvider.publish_inline_comment` takes the relevant line's text, and GitHub, GitLab, Azure DevOps and Gitea resolve it to a line number before posting. Both Bitbucket providers posted the argument as-is (`inline.to` on cloud, `anchor.line` on server), so a caller following the base signature got an API 400 after #3126 fixed the parameter order.

Both providers now route a non-integer `relevant_line_in_file` through the existing `create_inline_comment` (`find_line_number_of_relevant_line_in_file`) and post the resolved path/line, returning `False` without posting when the text is not in the diff. The integer path that `publish_inline_comments` uses is unchanged, so the existing `"to": 42` / `"line": 42` payload tests still pass alongside the new ones.

Tests: `PYTHONPATH=. uv run pytest tests/unittest -q` (full unit suite green); the four new payload tests fail on `main` (server posts `'b = 2'` as the line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
