### PR TITLE
refactor: remove dead shared rate-limit handlers

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import traceback
 from typing import Callable, List, Tuple
 
-from github import RateLimitExceededException
-
 from pr_agent.algo.git_patch_processing import (
     decouple_and_convert_to_hunks_with_lines_numbers,
     extend_patch,
@@ -59,11 +57,7 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
         PATCH_EXTRA_LINES_BEFORE = cap_and_log_extra_lines(PATCH_EXTRA_LINES_BEFORE, "before")
         PATCH_EXTRA_LINES_AFTER = cap_and_log_extra_lines(PATCH_EXTRA_LINES_AFTER, "after")
 
-    try:
-        diff_files = git_provider.get_diff_files()
-    except RateLimitExceededException as e:
-        get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
-        raise
+    diff_files = git_provider.get_diff_files()
 
     # get pr languages
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)
@@ -153,11 +147,7 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
 
 def get_pr_diff_multiple_patchs(git_provider: GitProvider, token_handler: TokenHandler, model: str,
                 add_line_numbers_to_hunks: bool = False, disable_extra_lines: bool = False):
-    try:
-        diff_files = git_provider.get_diff_files()
-    except RateLimitExceededException as e:
-        get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
-        raise
+    diff_files = git_provider.get_diff_files()
 
     # get pr languages
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)
@@ -419,14 +409,8 @@ def get_pr_multi_diffs(git_provider: GitProvider,
         List[str]: A list of final diff strings, split into multiple groups based on the maximum number of tokens allowed for the given model.
         With `return_remaining_files`, a tuple of that list and the list of omitted file names.
 
-    Raises:
-        RateLimitExceededException: If the rate limit for the Git provider API is exceeded.
     """
-    try:
-        diff_files = git_provider.get_diff_files()
-    except RateLimitExceededException as e:
-        get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
-        raise
+    diff_files = git_provider.get_diff_files()
 
     # Sort files by main language
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -53,7 +53,7 @@ def test_shared_diff_processing_does_not_import_pygithub_rate_limit_exception():
         isinstance(node, ast.ImportFrom)
         and node.module == "github"
         and any(alias.name == "RateLimitExceededException" for alias in node.names)
-        for node in tree.body
+        for node in ast.walk(tree)
     )
 
 

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -1,9 +1,13 @@
+import ast
+from pathlib import Path
+
 import pytest
 
 import pr_agent.algo.pr_processing as pr_processing
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.algo.utils import ModelType
 from pr_agent.config_loader import get_settings
+from pr_agent.servers.utils import RateLimitExceeded
 
 
 class FakeTokenHandler:
@@ -23,6 +27,34 @@ class FakeProvider:
 
     def get_languages(self):
         return {"Python": 100}
+
+
+@pytest.mark.parametrize(
+    "call_diff",
+    [
+        lambda provider, token_handler: pr_processing.get_pr_diff(provider, token_handler, "model"),
+        lambda provider, token_handler: pr_processing.get_pr_diff_multiple_patchs(provider, token_handler, "model"),
+        lambda provider, token_handler: pr_processing.get_pr_multi_diffs(provider, token_handler, "model"),
+    ],
+)
+def test_shared_diff_paths_propagate_project_rate_limit(call_diff):
+    class RateLimitedProvider(FakeProvider):
+        def get_diff_files(self):
+            raise RateLimitExceeded("rate limit exceeded")
+
+    with pytest.raises(RateLimitExceeded, match="rate limit exceeded"):
+        call_diff(RateLimitedProvider([]), FakeTokenHandler())
+
+
+def test_shared_diff_processing_does_not_import_pygithub_rate_limit_exception():
+    tree = ast.parse(Path(pr_processing.__file__).read_text())
+
+    assert not any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "github"
+        and any(alias.name == "RateLimitExceededException" for alias in node.names)
+        for node in tree.body
+    )
 
 
 def test_generate_full_patch_keeps_remaining_files_when_patch_exceeds_soft_budget():


### PR DESCRIPTION
## Summary

- Remove the unused module-level PyGithub `RateLimitExceededException` import from the shared diff-processing path.
- Remove the three handlers that could never match after providers translate rate-limit failures to the project-level `RateLimitExceeded` exception.
- Keep GitHub retry and exception translation unchanged in `GithubProvider`.
- Add regression coverage for propagation through all three shared diff entry points and for the provider-agnostic import boundary.

Closes #3139

## Why this does not change runtime behavior

`GithubProvider._get_diff_files()` already converts the PyGithub exception to the project-level `RateLimitExceeded` exception, and `GithubProvider.get_diff_files()` retries that project exception before it returns. The shared handlers only logged and re-raised `RateLimitExceededException`, so they were unreachable for GitHub and for every other provider. Removing them leaves the actual retry and conversion behavior in the provider where it already occurs; other exceptions still propagate normally from the shared path.

## Verification

- `PYTHONPATH=. uv run pytest tests/unittest -q` — 4232 passed, 1 skipped, 1 xfailed.
- `uv run ruff check pr_agent/algo/pr_processing.py tests/unittest/test_pr_processing_core.py` — passed.
- `uv run pre-commit run --files pr_agent/algo/pr_processing.py tests/unittest/test_pr_processing_core.py` — passed.
- `git diff --check` — passed.

## 中文说明

本 PR 删除共享 diff 路径中永远匹配不到的 PyGithub 限流异常导入、三个 handler 和过时的 Raises 文档。GitHub provider 原有的重试与项目级 `RateLimitExceeded` 转换保持不变，因此不改变运行时行为；新增测试覆盖三个共享入口的项目级异常传播及 provider-agnostic 导入边界。
