### PR TITLE
fix: enable Azure DevOps thread resolution

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -477,6 +477,9 @@ class AzureDevopsProvider(GitProvider):
     def supports_line_question_history(self) -> bool:
         return True
 
+    def supports_thread_resolution(self) -> bool:
+        return True
+
     def set_pr(self, pr_url: str):
         self.diff_files = None
         self._diff_path_map = None
@@ -1504,6 +1507,9 @@ class AzureDevopsProvider(GitProvider):
         except Exception as e:
             get_logger().exception(f"Failed to set thread status, error: {e}")
             return False
+
+    def resolve_comment_thread(self, comment_id: int) -> bool:
+        return self.set_thread_status(comment_id, "closed")
 
     def reply_to_thread(self, thread_id: int, body: str, is_temporary: bool = False) -> Comment:
         try:

--- a/pr_agent/tools/pr_line_questions.py
+++ b/pr_agent/tools/pr_line_questions.py
@@ -27,8 +27,8 @@ class PR_LineQuestions:
         self.ai_handler = ai_handler()
         self.ai_handler.main_pr_language = self.main_pr_language
 
-        # only GitHub can resolve threads today; elsewhere the marker would be
-        # requested from the model and every answer would log a failed resolve
+        # Request the marker only for providers that can resolve threads;
+        # otherwise every resolved answer would log a failed resolve.
         self.resolve_threads = (get_settings().pr_questions.get("resolve_threads", False)
                                 and self.git_provider.supports_thread_resolution())
         self.vars = {

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -27,6 +27,20 @@ def test_publish_description_propagates_update_failure():
         provider.publish_description("AI title", "Updated description")
 
 
+def test_azure_supports_thread_resolution():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+
+    assert provider.supports_thread_resolution() is True
+
+
+def test_azure_resolve_comment_thread_closes_thread():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.set_thread_status = MagicMock(return_value=True)
+
+    assert provider.resolve_comment_thread(42) is True
+    provider.set_thread_status.assert_called_once_with(42, "closed")
+
+
 class TestAzureDevopsProviderRepoContext:
     def test_get_repo_file_content_reads_from_target_commit(self):
         # Repo-context files must be read from the PR target (base) commit, matching


### PR DESCRIPTION
## Summary

- advertise Azure DevOps' existing thread-resolution capability to `/ask_line`
- map the generic resolve operation to `set_thread_status(thread_id, "closed")`
- keep the provider-gated prompt comment accurate and add focused regression tests

Fixes #3144

## Validation

- `uv run --python 3.12 --frozen pytest tests/unittest/test_azure_devops_provider.py tests/unittest/test_pr_questions_helpers.py -q` — 192 passed
- `uv run --python 3.12 --frozen ruff check pr_agent/git_providers/azuredevops_provider.py pr_agent/tools/pr_line_questions.py tests/unittest/test_azure_devops_provider.py` — passed