### PR TITLE
fix(repo-context): key cache by target revision

### DIFF
--- a/pr_agent/algo/repo_context.py
+++ b/pr_agent/algo/repo_context.py
@@ -60,17 +60,17 @@ def _get_markdown_fence(content: str) -> str:
 
 
 def _get_repo_context_cache_key(
-    context_files: list, max_lines: int, from_default_branch: bool
-) -> tuple[tuple[tuple[str, str], ...], int, bool]:
+    context_files: list, max_lines: int, repo_context_ref: str | None
+) -> tuple[tuple[tuple[str, str], ...], int, str | None]:
     return (
         tuple((type(file_path).__name__, str(file_path)) for file_path in context_files),
         max_lines,
-        from_default_branch,
+        repo_context_ref,
     )
 
 
 def _get_repo_context_process_cache_key(
-    git_provider, context_files: list, max_lines: int, from_default_branch: bool
+    git_provider, context_files: list, max_lines: int, repo_context_ref: str | None
 ) -> tuple | None:
     try:
         pr_url = git_provider.get_pr_url()
@@ -81,7 +81,7 @@ def _get_repo_context_process_cache_key(
         return None
 
     return type(git_provider).__name__, pr_url, _get_repo_context_cache_key(
-        context_files, max_lines, from_default_branch
+        context_files, max_lines, repo_context_ref
     )
 
 
@@ -136,17 +136,17 @@ def _get_provider_repo_context_cache(git_provider) -> _RepoContextCache:
 
 
 def _get_cached_repo_context(
-    git_provider, context_files: list, max_lines: int, from_default_branch: bool
+    git_provider, context_files: list, max_lines: int, repo_context_ref: str | None
 ):
     process_cache_key = _get_repo_context_process_cache_key(
-        git_provider, context_files, max_lines, from_default_branch
+        git_provider, context_files, max_lines, repo_context_ref
     )
     if process_cache_key is not None:
         cached_repo_context = _repo_context_process_cache.get(process_cache_key, _REPO_CONTEXT_CACHE_MISS)
         if cached_repo_context is not _REPO_CONTEXT_CACHE_MISS:
             return cached_repo_context
 
-    cache_key = _get_repo_context_cache_key(context_files, max_lines, from_default_branch)
+    cache_key = _get_repo_context_cache_key(context_files, max_lines, repo_context_ref)
     cached_repo_context = _get_provider_repo_context_cache(git_provider).get(
         cache_key, _REPO_CONTEXT_CACHE_MISS
     )
@@ -157,13 +157,13 @@ def _get_cached_repo_context(
 
 
 def _store_repo_context(
-    git_provider, context_files: list, max_lines: int, from_default_branch: bool, repo_context: str
+    git_provider, context_files: list, max_lines: int, repo_context_ref: str | None, repo_context: str
 ) -> None:
-    cache_key = _get_repo_context_cache_key(context_files, max_lines, from_default_branch)
+    cache_key = _get_repo_context_cache_key(context_files, max_lines, repo_context_ref)
     _get_provider_repo_context_cache(git_provider)[cache_key] = repo_context
 
     process_cache_key = _get_repo_context_process_cache_key(
-        git_provider, context_files, max_lines, from_default_branch
+        git_provider, context_files, max_lines, repo_context_ref
     )
     if process_cache_key:
         _repo_context_process_cache[process_cache_key] = repo_context
@@ -290,8 +290,9 @@ def build_repo_context(git_provider) -> str:
         return ""
 
     from_default_branch = _read_bool_setting("repo_context_from_default_branch", default=True)
+    repo_context_ref = git_provider.get_repo_context_ref(from_default_branch)
     cached_repo_context = _get_cached_repo_context(
-        git_provider, context_files, max_lines, from_default_branch
+        git_provider, context_files, max_lines, repo_context_ref
     )
     if cached_repo_context is not _REPO_CONTEXT_CACHE_MISS:
         return cached_repo_context
@@ -303,5 +304,5 @@ def build_repo_context(git_provider) -> str:
     # Only cache when every file was fetched successfully. A transient/unexpected fetch error must
     # not be cached as a real result, so it is retried instead of being served until the TTL expires.
     if not had_fetch_error:
-        _store_repo_context(git_provider, context_files, max_lines, from_default_branch, repo_context)
+        _store_repo_context(git_provider, context_files, max_lines, repo_context_ref, repo_context)
     return repo_context

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -660,6 +660,11 @@ class AzureDevopsProvider(GitProvider):
                 get_logger().error(f"Failed to get repo settings, error: {e}")
             return ""
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        if from_default_branch:
+            return getattr(self._get_repo(), "default_branch", None)
+        return self.pr.last_merge_target_commit.commit_id
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
             # Read from the PR target (base) commit, matching the other providers. When
@@ -668,7 +673,7 @@ class AzureDevopsProvider(GitProvider):
                 version = None
             else:
                 version = GitVersionDescriptor(
-                    version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
+                    version=self.get_repo_context_ref(), version_type="commit"
                 )
             item = self.azure_devops_client.get_item(
                 repository_id=self.repo_slug,

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -124,10 +124,13 @@ class BitbucketProvider(GitProvider):
         file_resp.raise_for_status()
         return file_resp.text.encode('utf-8')
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        return self.get_repo_default_branch() if from_default_branch else self.pr.destination_branch
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         # Read from the PR destination (target) branch, matching the other providers,
         # or from the repository default branch when from_default_branch is requested.
-        branch = self.get_repo_default_branch() if from_default_branch else self.pr.destination_branch
+        branch = self.get_repo_context_ref(from_default_branch)
         return self.get_pr_file_content(file_path, branch, propagate_errors=True)
 
     def get_git_repo_url(self, pr_url: str=None) -> str: #bitbucket does not support issue url, so ignore param

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -118,14 +118,16 @@ class BitbucketServerProvider(GitProvider):
             get_logger().info(f"Failed to load .pr_agent.toml file, error: {e}")
             return ""
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        if from_default_branch:
+            default_branch = self.bitbucket_client.get_default_branch(self.workspace_slug, self.repo_slug)
+            return default_branch.get('displayId') or self.pr.toRef['latestCommit']
+        return self.pr.toRef['latestCommit']
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         # Read from the PR target ref (the branch being merged into), matching the other providers,
         # or from the repository default branch when from_default_branch is requested.
-        if from_default_branch:
-            default_branch_dict = self.bitbucket_client.get_default_branch(self.workspace_slug, self.repo_slug)
-            ref = default_branch_dict.get('displayId') or self.pr.toRef['latestCommit']
-        else:
-            ref = self.pr.toRef['latestCommit']
+        ref = self.get_repo_context_ref(from_default_branch)
         return self.get_file(file_path, ref)
 
     def get_pr_id(self):

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -419,6 +419,9 @@ class GitProvider(ABC):
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         return ""
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        return None
+
     def get_workspace_name(self):
         return ""
 

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -883,6 +883,11 @@ class GiteaProvider(GitProvider):
         clone_url += f"{gitea_token}@{base_url}{repo_full_name}"
         return clone_url
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        if from_default_branch:
+            return self.repo_api.repo_get(self.owner, self.repo).default_branch
+        return self.base_sha or self.base_ref
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False) -> str:
         """Get content of a file from the PR target (base) branch.
 
@@ -896,11 +901,8 @@ class GiteaProvider(GitProvider):
                 self.logger.warning("Cannot get repo file content: owner or repo not set")
                 return ""
 
-            if from_default_branch:
-                ref = self.repo_api.repo_get(self.owner, self.repo).default_branch
-            else:
-                # Only trust the PR target (base) ref — never fall back to the PR head (self.sha).
-                ref = self.base_sha or self.base_ref
+            # Only trust the PR target (base) ref — never fall back to the PR head (self.sha).
+            ref = self.get_repo_context_ref(from_default_branch)
             if not ref:
                 self.logger.warning("Cannot get repo file content: no target/base ref available")
                 return ""

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -1253,16 +1253,18 @@ class GithubProvider(GitProvider):
             # Transient/unexpected errors propagate so the caller does not cache the failure.
             raise
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        if from_default_branch:
+            return None
+        base = getattr(getattr(self, "pr", None), "base", None)
+        return getattr(base, "sha", None) or getattr(base, "ref", None)
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
             # Prefer the PR target (base) ref so repo-context instruction files match the branch
             # the PR is merging into. Fall back to the repo default branch when no PR base is
             # available, or always when from_default_branch is requested.
-            if from_default_branch:
-                ref = None
-            else:
-                base = getattr(getattr(self, "pr", None), "base", None)
-                ref = getattr(base, "sha", None) or getattr(base, "ref", None)
+            ref = self.get_repo_context_ref(from_default_branch)
             if ref:
                 contents = self.repo_obj.get_contents(file_path, ref=ref).decoded_content
             else:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1477,16 +1477,20 @@ class GitLabProvider(GitProvider):
             return ""
         # Transient/unexpected errors propagate so the caller does not cache the failure.
 
+    def get_repo_context_ref(self, from_default_branch: bool = False) -> Optional[str]:
+        if not from_default_branch:
+            target_branch = getattr(self.mr, "target_branch", None)
+            if target_branch:
+                return target_branch
+        return self.gl.projects.get(self.id_project).default_branch
+
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         try:
             project = self.gl.projects.get(self.id_project)
             # Read from the MR target branch (the branch being merged into), matching the other
             # providers; fall back to the project default branch outside of an MR context, or
             # always when from_default_branch is requested.
-            if from_default_branch:
-                ref = project.default_branch
-            else:
-                ref = getattr(self.mr, "target_branch", None) or project.default_branch
+            ref = self.get_repo_context_ref(from_default_branch)
             contents = project.files.get(file_path=file_path, ref=ref).decode()
             return decode_if_bytes(contents)
         except GitlabGetError as e:

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -219,6 +219,17 @@ METHOD_CONTRACTS = (
         check_return_annotation=False,
         check_execution=False,
     ),
+    MethodContract(
+        name="get_repo_context_ref",
+        args=(),
+        noop_value=None,
+        check_supported=lambda value: isinstance(value, str),
+        tiers=_tiers(
+            supported=("github", "gitlab", "gitea", "azure-devops", "bitbucket", "bitbucket-server")
+        ),
+        # Signature and return-type contract; provider behavior is covered by repo-context tests.
+        check_execution=False,
+    ),
 )
 
 

--- a/tests/unittest/test_repo_context.py
+++ b/tests/unittest/test_repo_context.py
@@ -18,11 +18,17 @@ from pr_agent.git_providers.github_provider import GithubProvider
 
 
 class FakeProvider:
-    def __init__(self, files, pr_url=None):
+    def __init__(self, files, pr_url=None, repo_context_ref=None):
         self.files = files
         self.pr_url = pr_url
+        self.repo_context_ref = repo_context_ref
         self.requested_paths = []
         self.from_default_branch_calls = []
+
+    def get_repo_context_ref(self, from_default_branch: bool = False):
+        if self.repo_context_ref is not None:
+            return self.repo_context_ref
+        return "default" if from_default_branch else "target"
 
     def get_repo_file_content(self, file_path: str, from_default_branch: bool = False):
         self.requested_paths.append(file_path)
@@ -183,6 +189,25 @@ def test_build_repo_context_reuses_process_cache_for_same_pr_url(repo_context_se
     assert "Changed repo purpose" not in second_context
     assert first_provider.requested_paths == ["AGENTS.md"]
     assert second_provider.requested_paths == []
+
+
+def test_build_repo_context_invalidates_cache_when_revision_changes(repo_context_settings):
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_FILES", ["AGENTS.md"])
+    repo_context_settings.set("CONFIG.REPO_CONTEXT_MAX_LINES", 500)
+    provider = FakeProvider(
+        {"AGENTS.md": "Rules at base A"},
+        pr_url="https://example.com/org/repo/pull/1",
+        repo_context_ref="base-a",
+    )
+
+    first_context = build_repo_context(provider)
+    provider.files["AGENTS.md"] = "Rules at base B"
+    provider.repo_context_ref = "base-b"
+    second_context = build_repo_context(provider)
+
+    assert "Rules at base A" in first_context
+    assert "Rules at base B" in second_context
+    assert provider.requested_paths == ["AGENTS.md", "AGENTS.md"]
 
 
 def test_build_repo_context_process_cache_separates_default_and_target_branch(repo_context_settings):


### PR DESCRIPTION
## Summary
- add a provider contract for the repository-context ref used to fetch files
- key both provider-local and process-wide caches by that ref instead of only the default/target boolean
- reuse the provider ref in GitHub, GitLab, Gitea, Azure DevOps, Bitbucket Cloud, and Bitbucket Server file reads
- cover revision changes with a cache invalidation regression test and add the method to the provider contract matrix

## Why
The previous key could serve repository context from a stale base commit for up to the 15-minute TTL after the target revision moved.

## Validation
- 229 passed: tests/unittest/test_repo_context.py and tests/unittest/test_git_provider_method_contract.py
- ruff check on all changed files
- git diff --check

Closes #3119