### PR TITLE
fix(servers): share push-trigger deduplication across five providers

### DIFF
--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -26,7 +26,7 @@ from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
-from pr_agent.servers.utils import get_pr_commands
+from pr_agent.servers.utils import get_pr_commands, push_trigger_slot
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -202,6 +202,16 @@ async def _perform_commands_bitbucket(commands_conf: str, agent: PRAgent, api_ur
         if not is_valid_push:
             get_logger().info("Bitbucket skipping 'pullrequest:updated' for push commands")
             return
+        # Validate the event before waiting: a backlog delegate processes the latest
+        # commits, which may be newer than this webhook's updated_on timestamp.
+        async with push_trigger_slot(api_url, allow_backlog=True, ttl=300) as proceed:
+            if proceed:
+                await _run_commands_bitbucket(commands, agent, api_url, log_context)
+    else:
+        await _run_commands_bitbucket(commands, agent, api_url, log_context)
+
+
+async def _run_commands_bitbucket(commands, agent: PRAgent, api_url: str, log_context: dict):
     for command in commands:
         try:
             new_command = prepare_command(command)

--- a/pr_agent/servers/bitbucket_server_webhook.py
+++ b/pr_agent/servers/bitbucket_server_webhook.py
@@ -21,7 +21,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import get_pr_commands, verify_signature
+from pr_agent.servers.utils import get_pr_commands, push_trigger_slot, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -159,6 +159,7 @@ async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
     log_context["event"] = "pull_request"
 
     commands_to_run = []
+    is_push_event = False
 
     # push event; -1 for push unassigned to a PR: Check auto commands for creation/updating
     if (data["eventKey"] == "pr:opened"
@@ -187,6 +188,7 @@ async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
 
             get_settings().set("config.is_new_pr", False)
             commands_to_run.extend(_get_commands_list_from_settings('BITBUCKET_SERVER.PUSH_COMMANDS'))
+            is_push_event = True
     elif data["eventKey"] == "pr:comment:added":
         commands_to_run.append(data["comment"]["text"])
     else:
@@ -197,7 +199,12 @@ async def handle_webhook(background_tasks: BackgroundTasks, request: Request):
 
     async def inner():
         try:
-            await _run_commands_sequentially(commands_to_run, pr_url, log_context)
+            if is_push_event:
+                async with push_trigger_slot(pr_url, allow_backlog=True, ttl=300) as proceed:
+                    if proceed:
+                        await _run_commands_sequentially(commands_to_run, pr_url, log_context)
+            else:
+                await _run_commands_sequentially(commands_to_run, pr_url, log_context)
         except Exception as e:
             get_logger().error(f"Failed to handle webhook: {e}")
 

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -13,7 +13,7 @@ from pr_agent.agent.pr_agent import PRAgent, prepare_command
 from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import get_pr_commands, verify_signature
+from pr_agent.servers.utils import get_pr_commands, push_trigger_slot, verify_signature
 
 # Setup logging and router
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
@@ -106,7 +106,9 @@ async def handle_pr_event(body: Dict[str, Any], event: str, action: str, agent: 
             get_logger().info("Push event, but no push commands found or push trigger is disabled")
             return
         get_logger().debug(f'A push event has been received: {api_url}')
-        await _perform_commands_gitea("push_commands", agent, body, api_url)
+        async with push_trigger_slot(api_url, allow_backlog=True, ttl=300) as proceed:
+            if proceed:
+                await _perform_commands_gitea("push_commands", agent, body, api_url)
         # for command in commands_on_push:
         #     await agent.handle_request(api_url, command)
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -1,4 +1,3 @@
-import asyncio.locks
 import copy
 import os
 import re
@@ -19,7 +18,7 @@ from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
-from pr_agent.servers.utils import DefaultDictWithTimeout, get_pr_commands, verify_signature
+from pr_agent.servers.utils import get_pr_commands, push_trigger_slot, verify_signature
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -91,9 +90,6 @@ async def get_body(request):
     verify_signature(body_bytes, webhook_secret, signature_header)
     return body
 
-
-_duplicate_push_triggers = DefaultDictWithTimeout(int, ttl=get_settings().github_app.push_trigger_pending_tasks_ttl)
-_pending_task_duplicate_push_conditions = DefaultDictWithTimeout(asyncio.locks.Condition, ttl=get_settings().github_app.push_trigger_pending_tasks_ttl)
 
 async def handle_comments_on_pr(body: Dict[str, Any],
                                 event: str,
@@ -261,44 +257,16 @@ async def handle_push_trigger_for_new_commits(body: Dict[str, Any],
     if get_settings().github_app.push_trigger_ignore_merge_commits and after_sha == merge_commit_sha:
         return {}
 
-    # Prevent triggering multiple times for subsequent push triggers when one is enough:
-    # The first push will trigger the processing, and if there's a second push in the meanwhile it will wait.
-    # Any more events will be discarded, because they will all trigger the exact same processing on the PR.
-    # We let the second event wait instead of discarding it because while the first event was being processed,
-    # more commits may have been pushed that led to the subsequent events,
-    # so we keep just one waiting as a delegate to trigger the processing for the new commits when done waiting.
-    current_active_tasks = _duplicate_push_triggers.setdefault(api_url, 0)
-    max_active_tasks = 2 if get_settings().github_app.push_trigger_pending_tasks_backlog else 1
-    if current_active_tasks < max_active_tasks:
-        # first task can enter, and second tasks too if backlog is enabled
-        get_logger().info(
-            f"Continue processing push trigger for {api_url=} because there are {current_active_tasks} active tasks"
-        )
-        _duplicate_push_triggers[api_url] += 1
-    else:
-        get_logger().info(
-            f"Skipping push trigger for {api_url=} because another event already triggered the same processing"
-        )
-        return {}
-    try:
-        async with _pending_task_duplicate_push_conditions[api_url]:
-            if current_active_tasks == 1:
-                # second task waits
-                get_logger().info(
-                    f"Waiting to process push trigger for {api_url=} because the first task is still in progress"
-                )
-                await _pending_task_duplicate_push_conditions[api_url].wait()
-                get_logger().info(f"Finished waiting to process push trigger for {api_url=} - continue with flow")
-
+    async with push_trigger_slot(
+        api_url,
+        allow_backlog=get_settings().github_app.push_trigger_pending_tasks_backlog,
+        ttl=get_settings().github_app.push_trigger_pending_tasks_ttl,
+    ) as proceed:
+        if not proceed:
+            return {}
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
             get_logger().info(f"Performing incremental review for {api_url=} because of {event=} and {action=}")
             await _perform_auto_commands_github("push_commands", agent, body, api_url, log_context)
-
-    finally:
-        # release the waiting task block
-        async with _pending_task_duplicate_push_conditions[api_url]:
-            _pending_task_duplicate_push_conditions[api_url].notify(1)
-            _duplicate_push_triggers[api_url] = max(0, _duplicate_push_triggers[api_url] - 1)
 
 
 def handle_closed_pr(body, event, action, log_context):

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -22,7 +22,7 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
-from pr_agent.servers.utils import get_pr_commands
+from pr_agent.servers.utils import get_pr_commands, push_trigger_slot
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -376,7 +376,9 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                     return
 
                 get_logger().debug(f'A push event has been received: {url}')
-                await _perform_commands_gitlab("push_commands", PRAgent(), url, log_context, data)
+                async with push_trigger_slot(url, allow_backlog=True, ttl=300) as proceed:
+                    if proceed:
+                        await _perform_commands_gitlab("push_commands", PRAgent(), url, log_context, data)
 
             # for draft to ready triggered merge requests
             elif object_attributes.get('action') == 'update' and is_draft_ready(data):

--- a/pr_agent/servers/utils.py
+++ b/pr_agent/servers/utils.py
@@ -1,13 +1,17 @@
+import asyncio
 import hashlib
 import hmac
 import secrets
 import time
 from collections import defaultdict
-from typing import Any, Callable, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, Sequence
 
 from fastapi import HTTPException
 
 from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
 
 # custom_merge_loader bypasses Dynaconf token expansion, so TOML references such as
 # @get would remain strings. Keep the shared profiles immutable and copy only defaults.
@@ -146,3 +150,66 @@ class DefaultDictWithTimeout(defaultdict):
             return super().__getitem__(__key)
         self[__key] = __default
         return __default
+
+
+@dataclass
+class _PushTriggerState:
+    condition: asyncio.Condition = field(default_factory=asyncio.Condition)
+    active_tasks: int = 0
+    running: bool = False
+
+
+_push_trigger_states_by_ttl = {}
+_active_push_trigger_states = {}
+
+
+def _get_push_trigger_state(key: str, ttl: int | None) -> _PushTriggerState:
+    # TTL changes and cache eviction must never split an active PR's queue.
+    if key in _active_push_trigger_states:
+        return _active_push_trigger_states[key]
+    if ttl not in _push_trigger_states_by_ttl:
+        _push_trigger_states_by_ttl[ttl] = DefaultDictWithTimeout(_PushTriggerState, ttl=ttl)
+    states = _push_trigger_states_by_ttl[ttl]
+    # setdefault expires idle entries before refreshing their access time.
+    state = states.setdefault(key)
+    if state is None:
+        state = states[key] = _PushTriggerState()
+    return state
+
+
+@asynccontextmanager
+async def push_trigger_slot(key: str, *, allow_backlog: bool, ttl: int | None) -> AsyncIterator[bool]:
+    """Run one push per PR, optionally keeping one delegate for subsequent pushes.
+
+    State is process-local. TTL bounds idle cache retention; active runs and
+    waiters retain their state until all reserved slots have been released.
+    """
+    state = _get_push_trigger_state(key, ttl)
+    max_active_tasks = 2 if allow_backlog else 1
+    if state.active_tasks >= max_active_tasks:
+        get_logger().info(
+            f"Skipping push trigger for {key=} because another event already triggered the same processing"
+        )
+        yield False
+        return
+
+    get_logger().info(
+        f"Continue processing push trigger for {key=} because there are {state.active_tasks} active tasks"
+    )
+    _active_push_trigger_states[key] = state
+    state.active_tasks += 1
+    acquired = False
+    try:
+        async with state.condition:
+            await state.condition.wait_for(lambda: not state.running)
+            state.running = True
+            acquired = True
+        yield True
+    finally:
+        async with state.condition:
+            if acquired:
+                state.running = False
+            state.active_tasks -= 1
+            state.condition.notify(1)
+            if state.active_tasks == 0:
+                del _active_push_trigger_states[key]

--- a/tests/unittest/test_bitbucket_push_dedupe.py
+++ b/tests/unittest/test_bitbucket_push_dedupe.py
@@ -1,0 +1,118 @@
+import asyncio
+import copy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette_context import request_cycle_context
+
+from pr_agent.config_loader import global_settings
+from pr_agent.servers import bitbucket_app
+from pr_agent.servers import utils as servers_utils
+
+
+@pytest.fixture
+def push_env(monkeypatch):
+    settings = copy.deepcopy(global_settings)
+    settings.set("BITBUCKET_APP.HANDLE_PUSH_TRIGGER", True)
+    settings.set("BITBUCKET_APP.PUSH_COMMANDS", ["/review"])
+    monkeypatch.setattr(bitbucket_app, "get_settings", lambda: settings)
+    monkeypatch.setattr(bitbucket_app, "apply_repo_settings", lambda _url: None)
+    monkeypatch.setattr(servers_utils, "_push_trigger_states_by_ttl", {})
+    monkeypatch.setattr(servers_utils, "_active_push_trigger_states", {})
+    return settings
+
+
+def push_payload(second):
+    return {
+        "event": "pullrequest:updated",
+        "data": {
+            "actor": {"display_name": "alice"},
+            "pullrequest": {
+                "updated_on": f"2026-09-07T00:00:{second:02d}+00:00",
+                "links": {"commits": {"href": "https://example.test/commits"}},
+            },
+        },
+    }
+
+
+async def test_bitbucket_backlog_reviews_latest_push_without_revalidating_old_event(push_env, monkeypatch):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    queued = asyncio.Event()
+    latest = {"second": 0}
+    reviewed = []
+    validated = []
+    original_validate = bitbucket_app._validate_time_from_last_commit_to_pr_update
+
+    async def validate(data):
+        result = await original_validate(data)
+        validated.append((data["data"]["pullrequest"]["updated_on"], result))
+        if len(validated) == 2:
+            queued.set()
+        return result
+
+    def fetch_commits(*args, **kwargs):
+        second = latest["second"]
+        return SimpleNamespace(status_code=200, json=lambda: {
+            "values": [{
+                "date": f"2026-09-07T00:00:{second:02d}+00:00",
+                "author": {"user": {"display_name": "alice"}},
+            }]
+        })
+
+    class Agent:
+        async def handle_request(self, _url, _command):
+            reviewed.append(latest["second"])
+            if len(reviewed) == 1:
+                entered.set()
+                await release.wait()
+
+    async def push(second):
+        await bitbucket_app._perform_commands_bitbucket(
+            "push_commands", Agent(), "https://example.test/pr/1", {}, push_payload(second)
+        )
+
+    monkeypatch.setattr(bitbucket_app.requests, "get", fetch_commits)
+    monkeypatch.setattr(bitbucket_app, "_validate_time_from_last_commit_to_pr_update", validate)
+    with request_cycle_context({"bitbucket_bearer_token": "test"}):
+        first = asyncio.create_task(push(1))
+        second = None
+        try:
+            await asyncio.wait_for(entered.wait(), 2)
+            latest["second"] = 10
+            second = asyncio.create_task(push(11))
+            await asyncio.wait_for(queued.wait(), 2)
+            latest["second"] = 20
+            await asyncio.wait_for(push(21), 2)
+            assert reviewed == [0]
+            release.set()
+            await asyncio.wait_for(asyncio.gather(first, second), 2)
+        finally:
+            release.set()
+            for task in (first, second):
+                if task is not None and not task.done():
+                    task.cancel()
+            await asyncio.gather(*(task for task in (first, second) if task is not None), return_exceptions=True)
+    assert reviewed == [0, 20]
+    assert len(validated) == 3
+    assert all(result for _, result in validated)
+    assert not servers_utils._active_push_trigger_states
+
+
+@pytest.mark.parametrize("enabled,valid", [(False, True), (True, False)])
+async def test_bitbucket_disabled_or_invalid_push_does_not_reserve_slot(push_env, monkeypatch, enabled, valid):
+    push_env.set("BITBUCKET_APP.HANDLE_PUSH_TRIGGER", enabled)
+    validate = AsyncMock(return_value=valid)
+    monkeypatch.setattr(bitbucket_app, "_validate_time_from_last_commit_to_pr_update", validate)
+    agent = SimpleNamespace(handle_request=AsyncMock())
+
+    def unexpected_slot(*args, **kwargs):
+        pytest.fail("Rejected pushes must not consume the backlog slot")
+
+    monkeypatch.setattr(bitbucket_app, "push_trigger_slot", unexpected_slot)
+    await bitbucket_app._perform_commands_bitbucket(
+        "push_commands", agent, "https://example.test/pr/1", {}, push_payload(1)
+    )
+    agent.handle_request.assert_not_awaited()
+    assert validate.await_count == int(enabled)

--- a/tests/unittest/test_github_app_timeout_core.py
+++ b/tests/unittest/test_github_app_timeout_core.py
@@ -416,26 +416,15 @@ def _run(coro):
 @pytest.fixture
 def push_trigger_env(monkeypatch):
     """Set up minimal mocks so handle_push_trigger_for_new_commits can run."""
-    # Swap module-level dedupe state with fresh test-local instances so we
-    # don't leak entries into other tests and don't depend on prior state.
-    fresh_duplicate_push_triggers = DefaultDictWithTimeout(ttl=None)
-    fresh_pending_conditions = DefaultDictWithTimeout(
-        asyncio.locks.Condition, ttl=None
-    )
-    monkeypatch.setattr(
-        github_app, "_duplicate_push_triggers", fresh_duplicate_push_triggers
-    )
-    monkeypatch.setattr(
-        github_app,
-        "_pending_task_duplicate_push_conditions",
-        fresh_pending_conditions,
-    )
+    monkeypatch.setattr(servers_utils, "_push_trigger_states_by_ttl", {})
+    monkeypatch.setattr(servers_utils, "_active_push_trigger_states", {})
 
     settings = SimpleNamespace(
         github_app=SimpleNamespace(
             handle_push_trigger=True,
             push_trigger_ignore_merge_commits=False,
             push_trigger_pending_tasks_backlog=False,
+            push_trigger_pending_tasks_ttl=300,
         )
     )
     monkeypatch.setattr(github_app, "get_settings", lambda: settings)
@@ -483,7 +472,8 @@ class TestPushTriggerDedupe:
 
         assert push_trigger_env["count"] == 1
         # Counter incremented then decremented back to 0.
-        assert github_app._duplicate_push_triggers[api_url] == 0
+        state = servers_utils._get_push_trigger_state(api_url, 300)
+        assert state.active_tasks == 0
 
     def test_skips_when_before_equals_after(self, push_trigger_env):
         body = _push_body()
@@ -526,7 +516,8 @@ class TestPushTriggerDedupe:
         body = _push_body()
         api_url = body["pull_request"]["url"]
         # Simulate an already-running task with backlog disabled (max=1).
-        github_app._duplicate_push_triggers[api_url] = 1
+        state = servers_utils._get_push_trigger_state(api_url, 300)
+        state.active_tasks = 1
 
         asyncio.run(
             github_app.handle_push_trigger_for_new_commits(
@@ -536,7 +527,7 @@ class TestPushTriggerDedupe:
 
         # Third path: counter is left untouched, perform never runs.
         assert push_trigger_env["count"] == 0
-        assert github_app._duplicate_push_triggers[api_url] == 1
+        assert state.active_tasks == 1
 
     def test_cancelled_backlog_waiter_releases_dedupe_slot(self, push_trigger_env, monkeypatch):
         settings = github_app.get_settings()
@@ -567,11 +558,12 @@ class TestPushTriggerDedupe:
                     body, "push", "alice", "1", "synchronize", {}, agent=None
                 )
             )
+            state = servers_utils._get_push_trigger_state(api_url, 300)
             for _ in range(10):
-                if github_app._duplicate_push_triggers[api_url] == 2:
+                if state.active_tasks == 2:
                     break
                 await asyncio.sleep(0)
-            assert github_app._duplicate_push_triggers[api_url] == 2
+            assert state.active_tasks == 2
 
             second.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -579,12 +571,12 @@ class TestPushTriggerDedupe:
 
             try:
                 # Cancelling the waiting task must return its reserved slot.
-                assert github_app._duplicate_push_triggers[api_url] == 1
+                assert state.active_tasks == 1
             finally:
                 release_first.set()
                 await first
 
-            assert github_app._duplicate_push_triggers[api_url] == 0
+            assert state.active_tasks == 0
             await asyncio.wait_for(
                 github_app.handle_push_trigger_for_new_commits(
                     body, "push", "alice", "1", "synchronize", {}, agent=None

--- a/tests/unittest/test_pr_command_profiles.py
+++ b/tests/unittest/test_pr_command_profiles.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import tomllib
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -279,3 +280,70 @@ async def test_bitbucket_app_default_profile_passes_the_early_gate(monkeypatch):
     assert result == "OK"
     assert len(calls) == 1
     assert calls[0][0] == "pr_commands"
+
+
+@pytest.mark.parametrize("proceed", [True, False])
+async def test_bitbucket_app_push_uses_shared_dedupe_slot(monkeypatch, proceed):
+    calls = []
+    slots = []
+    pr_url = "https://example.test/pr/1"
+    payload = {
+        "event": "pullrequest:updated",
+        "data": {
+            "actor": {"type": "user", "account_id": "account"},
+            "pullrequest": {"links": {"html": {"href": pr_url}}},
+        },
+    }
+    secret_provider = type(
+        "SecretProvider",
+        (),
+        {"get_secret": lambda self, _key: json.dumps({"shared_secret": "secret"})},
+    )()
+
+    async def get_bearer_token(_shared_secret, _client_key):
+        return "bearer"
+
+    async def run_commands(*args):
+        calls.append(args)
+
+    @asynccontextmanager
+    async def record_slot(key, **kwargs):
+        slots.append((key, kwargs))
+        yield proceed
+
+    monkeypatch.setattr(bitbucket_app, "is_bot_user", lambda _data: False)
+    monkeypatch.setattr(bitbucket_app, "get_fork_safe_secret_provider", lambda: secret_provider)
+    monkeypatch.setattr(bitbucket_app, "get_bearer_token", get_bearer_token)
+    monkeypatch.setattr(bitbucket_app.jwt, "decode", lambda *args, **kwargs: {})
+    monkeypatch.setattr(bitbucket_app, "get_identity_provider", _IdentityProvider)
+    monkeypatch.setattr(bitbucket_app, "_run_commands_bitbucket", run_commands)
+    monkeypatch.setattr(bitbucket_app, "apply_repo_settings", lambda _url: None)
+
+    async def valid_push(_data):
+        return True
+
+    monkeypatch.setattr(bitbucket_app, "_validate_time_from_last_commit_to_pr_update", valid_push)
+    monkeypatch.setattr(bitbucket_app, "push_trigger_slot", record_slot)
+    endpoint = next(route.endpoint for route in bitbucket_app.router.routes if route.path == "/webhook")
+    background_tasks = BackgroundTasks()
+    original_push_commands = global_settings.get("BITBUCKET_APP.PUSH_COMMANDS", None)
+    original_handle_push = global_settings.get("BITBUCKET_APP.HANDLE_PUSH_TRIGGER", None)
+    global_settings.set("BITBUCKET_APP.HANDLE_PUSH_TRIGGER", True)
+    original_base_url = global_settings.get("BITBUCKET.BASE_URL", None)
+    global_settings.set("BITBUCKET_APP.PUSH_COMMANDS", ["/review"])
+    global_settings.set("BITBUCKET.BASE_URL", "https://example.test/app")
+
+    try:
+        with request_cycle_context({}):
+            result = await endpoint(background_tasks, _Request(payload))
+            await background_tasks()
+    finally:
+        global_settings.set("BITBUCKET_APP.PUSH_COMMANDS", original_push_commands)
+        global_settings.set("BITBUCKET_APP.HANDLE_PUSH_TRIGGER", original_handle_push)
+        global_settings.set("BITBUCKET.BASE_URL", original_base_url)
+
+    assert result == "OK"
+    assert slots == [(pr_url, {"allow_backlog": True, "ttl": 300})]
+    assert len(calls) == int(proceed)
+    if proceed:
+        assert calls[0][0] == ["/review"]

--- a/tests/unittest/test_push_trigger_slot.py
+++ b/tests/unittest/test_push_trigger_slot.py
@@ -1,0 +1,187 @@
+import asyncio
+
+import pytest
+
+from pr_agent.servers import utils as servers_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_push_trigger_state(monkeypatch):
+    monkeypatch.setattr(servers_utils, "_push_trigger_states_by_ttl", {})
+    monkeypatch.setattr(servers_utils, "_active_push_trigger_states", {})
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_discards_duplicates_without_backlog():
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first_run():
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300) as proceed:
+            assert proceed is True
+            first_entered.set()
+            await release_first.wait()
+
+    first = asyncio.create_task(first_run())
+    await first_entered.wait()
+
+    async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300) as proceed:
+        assert proceed is False
+
+    release_first.set()
+    await first
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_keeps_one_backlog_delegate():
+    order = []
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def run(name):
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=True, ttl=300) as proceed:
+            if not proceed:
+                order.append(f"{name}-skipped")
+                return
+            order.append(name)
+            if name == "first":
+                first_entered.set()
+                await release_first.wait()
+
+    first = asyncio.create_task(run("first"))
+    await first_entered.wait()
+    second = asyncio.create_task(run("second"))
+    await asyncio.sleep(0)
+    await run("third")
+    assert order == ["first", "third-skipped"]
+
+    release_first.set()
+    await asyncio.gather(first, second)
+    assert order == ["first", "third-skipped", "second"]
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_releases_cancelled_waiter():
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def run():
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=True, ttl=300) as proceed:
+            assert proceed is True
+            if not first_entered.is_set():
+                first_entered.set()
+                await release_first.wait()
+
+    first = asyncio.create_task(run())
+    await first_entered.wait()
+    waiter = asyncio.create_task(run())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    state = servers_utils._get_push_trigger_state("pr", 300)
+    assert state.active_tasks == 1
+    release_first.set()
+    await first
+    assert state.active_tasks == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_push_trigger_slot_releases_failed_or_cancelled_runner(cancel):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    followed_up = asyncio.Event()
+
+    async def first_run():
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=True, ttl=300) as proceed:
+            assert proceed
+            entered.set()
+            await release.wait()
+            raise RuntimeError("command failed")
+
+    async def follow_up():
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=True, ttl=300) as proceed:
+            assert proceed
+            followed_up.set()
+
+    first = asyncio.create_task(first_run())
+    await asyncio.wait_for(entered.wait(), 1)
+    second = asyncio.create_task(follow_up())
+    await asyncio.sleep(0)
+    if cancel:
+        first.cancel()
+    else:
+        release.set()
+    with pytest.raises(asyncio.CancelledError if cancel else RuntimeError):
+        await first
+    await asyncio.wait_for(second, 1)
+    assert followed_up.is_set()
+    assert not servers_utils._active_push_trigger_states
+    async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300) as proceed:
+        assert proceed
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_does_not_block_other_prs():
+    async with servers_utils.push_trigger_slot("first-pr", allow_backlog=False, ttl=300) as first:
+        async with servers_utils.push_trigger_slot("second-pr", allow_backlog=False, ttl=300) as second:
+            assert first and second
+    assert not servers_utils._active_push_trigger_states
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_keeps_active_queue_after_ttl_expiry(monkeypatch):
+    now = [0]
+    monkeypatch.setattr(servers_utils.DefaultDictWithTimeout,
+                        "_DefaultDictWithTimeout__time", staticmethod(lambda: now[0]))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    order = []
+
+    async def run(name):
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=True, ttl=300) as proceed:
+            if not proceed:
+                order.append(f"{name}-skipped")
+                return
+            order.append(name)
+            if name == "first":
+                entered.set()
+                await release.wait()
+
+    first = asyncio.create_task(run("first"))
+    await asyncio.wait_for(entered.wait(), 1)
+    second = asyncio.create_task(run("second"))
+    await asyncio.sleep(0)
+    now[0] = 301
+    # Another PR sweeps expired cache entries while the original PR is running.
+    async with servers_utils.push_trigger_slot("other", allow_backlog=True, ttl=300) as proceed:
+        assert proceed
+    await run("third")
+    assert order == ["first", "third-skipped"]
+    release.set()
+    await asyncio.wait_for(asyncio.gather(first, second), 1)
+    assert order == ["first", "third-skipped", "second"]
+    assert not servers_utils._active_push_trigger_states
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_keeps_same_queue_when_ttl_changes():
+    async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300) as first:
+        assert first
+        async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=600) as duplicate:
+            assert not duplicate
+
+
+@pytest.mark.asyncio
+async def test_push_trigger_slot_expires_idle_state(monkeypatch):
+    now = [0]
+    monkeypatch.setattr(servers_utils.DefaultDictWithTimeout, "_DefaultDictWithTimeout__time",
+                        staticmethod(lambda: now[0]))
+    async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300):
+        previous = servers_utils._active_push_trigger_states["pr"]
+    now[0] = 301
+    async with servers_utils.push_trigger_slot("pr", allow_backlog=False, ttl=300) as proceed:
+        assert proceed
+        assert servers_utils._active_push_trigger_states["pr"] is not previous

--- a/tests/unittest/test_webhook_logic_core.py
+++ b/tests/unittest/test_webhook_logic_core.py
@@ -1,6 +1,7 @@
 import copy
 import importlib
 import json
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import httpx
@@ -67,14 +68,17 @@ class _StubRequest:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("event_key", ["pr:from_ref_updated", "repo:refs_changed"])
-async def test_bitbucket_server_handle_webhook_accepts_push_trigger_event_keys(event_key, monkeypatch):
+@pytest.mark.parametrize("proceed", [True, False])
+async def test_bitbucket_server_handle_webhook_accepts_push_trigger_event_keys(event_key, proceed, monkeypatch):
     # Regression test: "pr:from_ref_updated" used to be excluded from this branch and
     # fell through to the "Unsupported event" 400 response instead of running push commands.
     settings = get_settings()
     original_webhook_secret = settings.get("BITBUCKET_SERVER.WEBHOOK_SECRET", None)
     original_handle_push_trigger = settings.get("BITBUCKET_SERVER.HANDLE_PUSH_TRIGGER", None)
+    original_url = settings.get("BITBUCKET_SERVER.URL", None)
     settings.set("BITBUCKET_SERVER.WEBHOOK_SECRET", None)
     settings.set("BITBUCKET_SERVER.HANDLE_PUSH_TRIGGER", True)
+    settings.set("BITBUCKET_SERVER.URL", "https://bitbucket.example.com")
 
     monkeypatch.setattr(bitbucket_server_webhook, "apply_repo_settings", lambda url: None)
     monkeypatch.setattr(bitbucket_server_webhook, "should_process_pr_logic", lambda data: True)
@@ -83,6 +87,19 @@ async def test_bitbucket_server_handle_webhook_accepts_push_trigger_event_keys(e
         "_get_commands_list_from_settings",
         lambda key: ["/review"] if key == "BITBUCKET_SERVER.PUSH_COMMANDS" else [],
     )
+    slots = []
+    commands = []
+
+    @asynccontextmanager
+    async def record_slot(key, **kwargs):
+        slots.append((key, kwargs))
+        yield proceed
+
+    async def record_commands(commands_to_run, url, _log_context):
+        commands.append((commands_to_run, url))
+
+    monkeypatch.setattr(bitbucket_server_webhook, "push_trigger_slot", record_slot)
+    monkeypatch.setattr(bitbucket_server_webhook, "_run_commands_sequentially", record_commands)
 
     payload = _bitbucket_server_payload()
     payload["eventKey"] = event_key
@@ -92,13 +109,18 @@ async def test_bitbucket_server_handle_webhook_accepts_push_trigger_event_keys(e
     try:
         with request_cycle_context({}):
             response = await bitbucket_server_webhook.handle_webhook(background_tasks, request)
+            await background_tasks()
     finally:
         settings.set("BITBUCKET_SERVER.WEBHOOK_SECRET", original_webhook_secret)
         settings.set("BITBUCKET_SERVER.HANDLE_PUSH_TRIGGER", original_handle_push_trigger)
+        settings.set("BITBUCKET_SERVER.URL", original_url)
 
     assert response.status_code == 200
     assert json.loads(response.body)["message"] == "success"
     assert len(background_tasks.tasks) == 1
+    expected_url = "https://bitbucket.example.com/projects/PROJ/repos/repo/pull-requests/7"
+    assert slots == [(expected_url, {"allow_backlog": True, "ttl": 300})]
+    assert commands == ([(["/review"], expected_url)] if proceed else [])
 
 
 def _gitlab_payload(**object_attributes):
@@ -637,6 +659,57 @@ async def _run_gitlab_pr_commands(module, monkeypatch, draft, repo_setting, even
 
     assert response.status_code == 200
     return agent.commands, repo_settings_calls
+
+
+@pytest.mark.asyncio
+async def test_gitlab_push_uses_shared_dedupe_slot(gitlab_webhook_module, monkeypatch):
+    slots = []
+
+    @asynccontextmanager
+    async def reject_duplicate(key, **kwargs):
+        slots.append((key, kwargs))
+        yield False
+
+    monkeypatch.setattr(gitlab_webhook_module, "push_trigger_slot", reject_duplicate)
+    commands, _ = await _run_gitlab_pr_commands(
+        gitlab_webhook_module, monkeypatch, draft=False, repo_setting=False, event="update"
+    )
+
+    assert commands == []
+    assert slots == [
+        ("https://gitlab.com/org/repo/-/merge_requests/1", {"allow_backlog": True, "ttl": 300})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gitea_push_uses_shared_dedupe_slot(monkeypatch):
+    settings = get_settings()
+    original_gitea = copy.deepcopy(settings.get("GITEA"))
+    settings.set("GITEA.HANDLE_PUSH_TRIGGER", True)
+    settings.set("GITEA.PUSH_COMMANDS", ["/review"])
+    slots = []
+    performed = []
+
+    @asynccontextmanager
+    async def reject_duplicate(key, **kwargs):
+        slots.append((key, kwargs))
+        yield False
+
+    async def perform_commands(*args):
+        performed.append(args)
+
+    monkeypatch.setattr(gitea_app, "push_trigger_slot", reject_duplicate)
+    monkeypatch.setattr(gitea_app, "_perform_commands_gitea", perform_commands)
+    api_url = "https://gitea.example.com/org/repo/pulls/1"
+    try:
+        await gitea_app.handle_pr_event(
+            {"pull_request": {"url": api_url}}, "pull_request", "synchronized", RecordingAgent()
+        )
+    finally:
+        settings.set("GITEA", original_gitea)
+
+    assert performed == []
+    assert slots == [(api_url, {"allow_backlog": True, "ttl": 300})]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Previously, only the GitHub app deduplicated push-triggered runs. GitLab, Gitea, Bitbucket Cloud, and Bitbucket Server started a separate run for every push.

This PR extracts `push_trigger_slot()` into `servers/utils.py` and integrates all five providers. It allows one running task per PR and, when backlog is enabled, one pending task to process subsequent pushes.

## Changes

- Retain GitHub's existing configuration. Use `allow_backlog=True` and `ttl=300` for the other four providers without adding configuration.
- Validate Bitbucket Cloud push events before queueing, preventing a pending run from being rejected when newer commits arrive.
- Release slots on exceptions and cancellation.
- Harden the existing TTL behavior: active queues survive cache expiry and TTL changes; TTL applies to idle cached state.
- Add regression tests for provider integration, backlog collapsing, cancellation, exceptions, PR isolation, TTL behavior, and consecutive Bitbucket pushes.

Provider-specific event filtering remains in the corresponding servers. Deduplication remains process-local. Azure DevOps and Gerrit are unchanged.

## Validation

Validated in an isolated Python 3.12 environment using `uv 0.12.10` and `uv sync --locked`.

- Full unit suite: **4,254 passed, 1 skipped, 1 expected failure**.
- All applicable pre-commit checks passed, including the Ruff hook.
- `git diff --check` passed.

The expected failure is an existing Markdown backtick-stripping test unrelated to this change.

Fixes #3118