### PR TITLE
chore: pin uv 0.12.10 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,11 @@ dev = [
   "ruff==0.16.5",
 ]
 
+[tool.uv]
+# Keep this exact pin in sync with docker/Dockerfile and docker/Dockerfile.lambda
+# so local, CI, release, and container builds use the same uv version.
+required-version = "==0.12.10"
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
Refs:
- PR #3102
- commit 6a34276604a3fc005d382d742c78d11c5af77068