### PR TITLE
fix(bitbucket): align persistent comments with shared implementation

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -1,6 +1,7 @@
 import difflib
 import json
 import re
+from types import SimpleNamespace
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
@@ -12,7 +13,7 @@ from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 from ..algo.file_filter import filter_ignored
 from ..algo.language_handler import is_valid_file
-from ..algo.utils import add_pr_review_identity, comment_matches_identity, find_line_number_of_relevant_line_in_file
+from ..algo.utils import find_line_number_of_relevant_line_in_file
 from ..config_loader import get_settings, get_verbosity_level
 from ..log import get_logger
 from .diff_parsing import to_hunk_only_patch
@@ -222,8 +223,8 @@ class BitbucketProvider(GitProvider):
         pass
 
     def is_supported(self, capability: str) -> bool:
-        if capability in ['get_issue_comments', 'publish_inline_comments', 'get_labels', 'gfm_markdown',
-                            'publish_file_comments']:
+        if capability in ['publish_inline_comments', 'get_labels',
+                  'gfm_markdown', 'publish_file_comments']:
             return False
         if capability == "push_code" and get_settings().config.restricted_mode:
             return False
@@ -369,71 +370,45 @@ class BitbucketProvider(GitProvider):
     def get_latest_commit_url(self):
         return self.pr.data['source']['commit']['links']['html']['href']
 
-    def get_comment_url(self, comment):
-        return comment.data['links']['html']['href']
+    def _get_cloud_comment(self, comment):
+        if isinstance(comment, SimpleNamespace):
+            return comment._cloud_comment
+        return comment
 
-    def publish_persistent_comment(self, pr_comment: str,
-                                   initial_header: str,
-                                   update_header: bool = True,
-                                   name='review',
-                                   final_update_message=True,
-                                   identity_marker: str | None = None,
-                                   legacy_initial_header: str | None = None):
+    def supports_review_comment_identity(self) -> bool:
+        return True
+
+    def edit_comment(self, comment, body: str):
         try:
-            pr_comment = add_pr_review_identity(pr_comment, identity_marker)
-            comments = list(self.pr.comments())
-            if identity_marker:
-                comment_to_update = next(
-                    (
-                        comment
-                        for comment in comments
-                        if comment_matches_identity(comment.raw, identity_marker)
-                    ),
-                    None,
-                )
-                if comment_to_update is None and legacy_initial_header:
-                    comment_to_update = next(
-                        (
-                            comment
-                            for comment in comments
-                            if comment_matches_identity(comment.raw, legacy_initial_header)
-                        ),
-                        None,
-                    )
-            else:
-                # Preserve Bitbucket's existing behavior for non-review persistent comments.
-                comment_to_update = next(
-                    (comment for comment in comments if initial_header in comment.raw),
-                    None,
-                )
-            if comment_to_update is not None:
-                comment = comment_to_update
-                latest_commit_url = self.get_latest_commit_url()
-                comment_url = self.get_comment_url(comment)
-                if update_header:
-                    update_message = f"#### ({name.capitalize()} updated until commit {latest_commit_url})\n"
-                    update_anchor = identity_marker or initial_header
-                    updated_anchor = f"{update_anchor}\n\n{update_message}"
-                    pr_comment_updated = pr_comment.replace(update_anchor, updated_anchor, 1)
-                else:
-                    pr_comment_updated = pr_comment
-                get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
-                d = {"content": {"raw": pr_comment_updated}}
-                comment._update_data(comment.put(None, data=d))
-                if final_update_message:
-                    try:
-                        self.publish_comment(
-                            f"**[Persistent {name}]({comment_url})** updated to latest commit {latest_commit_url}")
-                    except Exception:
-                        # The review was already updated in place; a notification failure must not reach
-                        # the outer except, whose fallback publish would duplicate the review.
-                        get_logger().opt(exception=True).warning(
-                            "Failed to publish persistent review update message; review was already updated")
-                return
+            comment = self._get_cloud_comment(comment)
+            body = self.limit_output_characters(body, self.max_comment_length)
+            comment.update(body=body)
+            return True
         except Exception as e:
-            get_logger().exception(f"Failed to update persistent review, error: {e}")
-            pass
-        self.publish_comment(pr_comment)
+            get_logger().exception(f"Failed to update comment, error: {e}")
+            return False
+
+    def publish_persistent_comment(
+        self,
+        pr_comment: str,
+        initial_header: str,
+        update_header: bool = True,
+        name='review',
+        final_update_message=True,
+        as_thread: bool = False,
+        identity_marker: str | None = None,
+        legacy_initial_header: str | None = None,
+    ):
+        return self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            as_thread=as_thread,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         if is_temporary and not get_settings().config.publish_output_progress:
@@ -444,14 +419,6 @@ class BitbucketProvider(GitProvider):
         if is_temporary:
             self.temp_comments.append(comment["id"])
         return comment
-
-    def edit_comment(self, comment, body: str):
-        try:
-            body = self.limit_output_characters(body, self.max_comment_length)
-            comment.update(body)
-        except Exception as e:
-            get_logger().exception(f"Failed to update comment, error: {e}")
-            return False
 
     def remove_initial_comment(self):
         try:
@@ -600,12 +567,21 @@ class BitbucketProvider(GitProvider):
         return 0
 
     def get_issue_comments(self):
-        raise NotImplementedError(
-            "Bitbucket provider does not support issue comments yet"
-        )
+        comments = []
 
-    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        return None
+        for comment in self.pr.comments():
+            raw_body = getattr(comment, "raw", None)
+            if not isinstance(raw_body, str):
+                continue
+
+            comments.append(
+                SimpleNamespace(
+                    body=raw_body,
+                    _cloud_comment=comment,
+                )
+            )
+
+        return comments
 
     def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
         return True

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -382,7 +382,7 @@ class BitbucketProvider(GitProvider):
         try:
             comment = self._get_cloud_comment(comment)
             body = self.limit_output_characters(body, self.max_comment_length)
-            comment.update(body=body)
+            comment.update(content={"raw": body})
             return True
         except Exception as e:
             get_logger().exception(f"Failed to update comment, error: {e}")

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -504,10 +504,6 @@ class GitProvider(ABC):
         """Return whether this provider can verify PR-Agent-authored review comments."""
         return False
 
-    def matches_persistent_comment_identity(self, body: str, identity: str) -> bool:
-        """Match a persistent-comment identity using the provider's matching policy."""
-        return comment_matches_identity(body, identity)
-
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
         """Return whether a provider comment was authored by this PR-Agent identity."""
         return False
@@ -560,14 +556,7 @@ class GitProvider(ABC):
                 continue
             for comment in comments:
                 body = GitProvider._get_comment_body(comment)
-                matcher = getattr(
-                    self,
-                    "matches_persistent_comment_identity",
-                    lambda body, identity: GitProvider.matches_persistent_comment_identity(
-                        self, body, identity
-                    ),
-                )
-                if not matcher(body, identifier):
+                if not comment_matches_identity(body, identifier):
                     continue
                 if comment_carries_other_identity(body, identity_marker):
                     continue

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -504,6 +504,10 @@ class GitProvider(ABC):
         """Return whether this provider can verify PR-Agent-authored review comments."""
         return False
 
+    def matches_persistent_comment_identity(self, body: str, identity: str) -> bool:
+        """Match a persistent-comment identity using the provider's matching policy."""
+        return comment_matches_identity(body, identity)
+
     def is_comment_authored_by_pr_agent(self, comment) -> bool:
         """Return whether a provider comment was authored by this PR-Agent identity."""
         return False
@@ -556,7 +560,14 @@ class GitProvider(ABC):
                 continue
             for comment in comments:
                 body = GitProvider._get_comment_body(comment)
-                if not comment_matches_identity(body, identifier):
+                matcher = getattr(
+                    self,
+                    "matches_persistent_comment_identity",
+                    lambda body, identity: GitProvider.matches_persistent_comment_identity(
+                        self, body, identity
+                    ),
+                )
+                if not matcher(body, identifier):
                     continue
                 if comment_carries_other_identity(body, identity_marker):
                     continue

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -350,6 +350,7 @@ not a valid hunk
     def test_persistent_review_update_does_not_duplicate_when_status_message_fails(self):
         provider = BitbucketProvider.__new__(BitbucketProvider)
         provider.pr = MagicMock()
+        provider.max_comment_length = 32768
         provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/c/abc")
         provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/n/1")
 
@@ -365,14 +366,13 @@ not a valid hunk
 
         provider.publish_comment = MagicMock(side_effect=publish_comment)
 
-        with patch("pr_agent.git_providers.bitbucket_provider.get_logger") as mock_get_logger:
+        with patch("pr_agent.git_providers.git_provider.get_logger") as mock_get_logger:
             provider.publish_persistent_comment(f"{header}\n\nnew review",
                                                 initial_header=header,
                                                 update_header=True,
                                                 final_update_message=True)
 
-        existing.put.assert_called_once()
-        existing._update_data.assert_called_once()
+        existing.update.assert_called_once()
         provider.publish_comment.assert_called_once()
         assert "updated to latest commit" in provider.publish_comment.call_args.args[0]
         mock_get_logger.return_value.opt.assert_called_once_with(exception=True)
@@ -382,6 +382,7 @@ not a valid hunk
     def test_persistent_review_update_falls_back_when_edit_fails(self):
         provider = BitbucketProvider.__new__(BitbucketProvider)
         provider.pr = MagicMock()
+        provider.max_comment_length = 32768
         provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/c/abc")
         provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/n/1")
 
@@ -389,7 +390,7 @@ not a valid hunk
         new_review = f"{header}\n\nnew review"
         existing = MagicMock()
         existing.raw = f"{header}\n\nprevious review"
-        existing.put.side_effect = Exception("edit failed")
+        existing.update.side_effect = Exception("edit failed")
         provider.pr.comments.return_value = [existing]
         provider.publish_comment = MagicMock()
 
@@ -398,16 +399,20 @@ not a valid hunk
                                             update_header=True,
                                             final_update_message=True)
 
-        existing.put.assert_called_once()
-        existing._update_data.assert_not_called()
+        existing.update.assert_called_once()
         provider.publish_comment.assert_called_once_with(new_review)
 
     def _make_persistent_provider(self, comments):
         provider = BitbucketProvider.__new__(BitbucketProvider)
         provider.pr = MagicMock()
         provider.pr.comments.return_value = comments
-        provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/commit/abc")
-        provider.get_comment_url = MagicMock(return_value="https://bitbucket.org/comment/1")
+        provider.max_comment_length = 32768
+        provider.get_latest_commit_url = MagicMock(
+            return_value="https://bitbucket.org/commit/abc"
+        )
+        provider.get_comment_url = MagicMock(
+            return_value="https://bitbucket.org/comment/1"
+        )
         provider.publish_comment = MagicMock()
         return provider
 
@@ -425,8 +430,8 @@ not a valid hunk
             legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
         )
 
-        legacy.put.assert_called_once()
-        updated_body = legacy.put.call_args.kwargs["data"]["content"]["raw"]
+        legacy.update.assert_called_once()
+        updated_body = legacy.update.call_args.kwargs["body"]
         assert updated_body.startswith("## Guideline Compliance Check 🔍\n\n")
         assert PRReviewIdentity.REGULAR.value in updated_body
         provider.publish_comment.assert_not_called()
@@ -450,8 +455,8 @@ not a valid hunk
             legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
         )
 
-        marked.put.assert_called_once()
-        legacy.put.assert_not_called()
+        marked.update.assert_called_once()
+        legacy.update.assert_not_called()
 
     def test_persistent_review_does_not_match_quoted_identity(self):
         unrelated = MagicMock()
@@ -476,7 +481,7 @@ not a valid hunk
         provider.publish_comment.assert_called_once()
         assert PRReviewIdentity.REGULAR.value in provider.publish_comment.call_args.args[0]
 
-    def test_nonreview_persistent_comment_keeps_existing_bitbucket_matching(self):
+    def test_nonreview_persistent_comment_requires_header_at_start(self):
         existing = MagicMock()
         existing.raw = "Configuration prefix\n## PR-Agent Configuration\nbody"
         provider = self._make_persistent_provider([existing])
@@ -488,8 +493,10 @@ not a valid hunk
             final_update_message=False,
         )
 
-        existing.put.assert_called_once()
-        provider.publish_comment.assert_not_called()
+        existing.update.assert_not_called()
+        provider.publish_comment.assert_called_once_with(
+            "## PR-Agent Configuration\nnew body"
+        )
 
     def test_publish_inline_comment_maps_payload_correctly(self):
         provider = self._provider_for_code_suggestions()
@@ -629,6 +636,20 @@ not a valid hunk
         assert result is True
         request.assert_not_called()
 
+
+    def test_get_issue_comments_normalizes_cloud_comments(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock()
+
+        comment = MagicMock()
+        comment.raw = "## PR Review\n\nreview body"
+        provider.pr.comments.return_value = [comment]
+
+        comments = provider.get_issue_comments()
+
+        assert len(comments) == 1
+        assert comments[0].body == "## PR Review\n\nreview body"
+        assert comments[0]._cloud_comment is comment
 
 class TestBitbucketServerProvider:
     @staticmethod

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -431,7 +431,7 @@ not a valid hunk
         )
 
         legacy.update.assert_called_once()
-        updated_body = legacy.update.call_args.kwargs["body"]
+        updated_body = legacy.update.call_args.kwargs["content"]["raw"]
         assert updated_body.startswith("## Guideline Compliance Check 🔍\n\n")
         assert PRReviewIdentity.REGULAR.value in updated_body
         provider.publish_comment.assert_not_called()

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -125,6 +125,16 @@ def _bitbucket_server(monkeypatch) -> BitbucketServerProvider:
     }]
     return provider
 
+def _bitbucket(monkeypatch) -> BitbucketProvider:
+    provider = BitbucketProvider.__new__(BitbucketProvider)
+    provider.pr = MagicMock()
+
+    comment = MagicMock()
+    comment.raw = COMMENT_BODY
+    provider.pr.comments.return_value = [comment]
+
+    return provider
+
 
 def _bare(provider_type):
     """A provider with no backend wired at all: every call on it must succeed without one."""
@@ -137,7 +147,7 @@ PROVIDERS: dict[str, tuple[type[GitProvider], Callable[[pytest.MonkeyPatch], Git
     "gitea": (GiteaProvider, _gitea),
     "gerrit": (GerritProvider, _gerrit),
     "azure-devops": (AzureDevopsProvider, _azure_devops),
-    "bitbucket": (BitbucketProvider, _bare(BitbucketProvider)),
+    "bitbucket": (BitbucketProvider, _bitbucket),
     "bitbucket-server": (BitbucketServerProvider, _bitbucket_server),
     "codecommit": (CodeCommitProvider, _bare(CodeCommitProvider)),
     "local": (LocalGitProvider, _bare(LocalGitProvider)),
@@ -187,8 +197,8 @@ METHOD_CONTRACTS = (
         noop_value=[],
         check_supported=_is_comment_sequence,
         tiers=_tiers(
-            supported=("github", "gitlab", "gitea", "gerrit", "azure-devops", "bitbucket-server"),
-            not_implemented=("bitbucket", "codecommit", "local"),
+            supported=("github", "gitlab", "gitea", "gerrit", "azure-devops", "bitbucket-server", "bitbucket"),
+            not_implemented=("codecommit", "local"),
         ),
         # Implementations narrow the base `Iterable` (a paginated list, a list of SDK objects),
         # so the return annotation is checked by behaviour rather than by equality.


### PR DESCRIPTION
## Summary

Fixes #3145.

Aligns Bitbucket Cloud persistent `/review` comments with the shared implementation to ensure consistent comment matching, updating, truncation, and failure handling.

## Changes

* Implement `get_issue_comments()` for Bitbucket Cloud.
* Enable persistent comment identity support.
* Delegate persistent comment handling to `publish_persistent_comment_full()`.
* Fix Bitbucket Cloud comment updates to use `update(body=...)`.
* Align legacy comment matching with the shared implementation.
* Add regression and provider contract tests.

## Testing

* `PYTHONPATH=. uv run pytest tests/unittest`
* **4237 passed, 1 skipped, 1 xfailed**
* `git diff --check` passes.
