### PR TITLE
fix(codecommit): update persistent review comments

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -845,6 +845,7 @@ Example IAM permissions to that user to allow access to CodeCommit:
                 "codecommit:List*",
                 "codecommit:PostComment*",
                 "codecommit:PutCommentReaction",
+                "codecommit:UpdateComment",
                 "codecommit:UpdatePullRequestDescription",
                 "codecommit:UpdatePullRequestTitle"
             ],

--- a/pr_agent/git_providers/codecommit_client.py
+++ b/pr_agent/git_providers/codecommit_client.py
@@ -54,6 +54,7 @@ class CodeCommitClient:
 
     def __init__(self):
         self.boto_client = None
+        self.comments_page_size = 100
 
     def is_supported(self, capability: str) -> bool:
         if capability in ["gfm_markdown"]:
@@ -235,7 +236,7 @@ class CodeCommitClient:
         It does not support the ending line number to highlight a range of lines.
 
         Returns:
-        - None
+        - The boto3 post_comment_for_pull_request response
 
         Boto3 Documentation:
         - aws codecommit post_comment_for_pull_request
@@ -248,7 +249,7 @@ class CodeCommitClient:
             # If the comment has code annotations,
             # then set the file path and line number in the location dictionary
             if annotation_file and annotation_line:
-                self.boto_client.post_comment_for_pull_request(
+                return self.boto_client.post_comment_for_pull_request(
                     pullRequestId=str(pr_number),
                     repositoryName=repo_name,
                     beforeCommitId=destination_commit,
@@ -262,7 +263,7 @@ class CodeCommitClient:
                 )
             else:
                 # The comment does not have code annotations
-                self.boto_client.post_comment_for_pull_request(
+                return self.boto_client.post_comment_for_pull_request(
                     pullRequestId=str(pr_number),
                     repositoryName=repo_name,
                     beforeCommitId=destination_commit,
@@ -277,3 +278,66 @@ class CodeCommitClient:
             raise ValueError("Boto3 client error calling post_comment_for_pull_request") from e
         except Exception as e:
             raise ValueError("Error calling post_comment_for_pull_request") from e
+
+    def get_comments_for_pull_request(self, pr_number: int):
+        """
+        Retrieve all comments for a pull request.
+
+        Args:
+        - pr_number: The AWS CodeCommit pull request number
+
+        Returns:
+        - The flattened commentsForPullRequestData entries from all result pages
+
+        Boto3 Documentation:
+        - aws codecommit get_comments_for_pull_request
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/get_comments_for_pull_request.html
+        """
+        if self.boto_client is None:
+            self._connect_boto_client()
+
+        comments_for_pull_request = []
+        try:
+            paginator = self.boto_client.get_paginator("get_comments_for_pull_request")
+            for page in paginator.paginate(
+                pullRequestId=str(pr_number),
+                PaginationConfig={"PageSize": self.comments_page_size},
+            ):
+                comments_for_pull_request.extend(page.get("commentsForPullRequestData", []))
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == 'PullRequestDoesNotExistException':
+                raise ValueError(f"PR number does not exist: {pr_number}") from e
+            raise ValueError("Boto3 client error calling get_comments_for_pull_request") from e
+        except Exception as e:
+            raise ValueError("Error calling get_comments_for_pull_request") from e
+
+        return comments_for_pull_request
+
+    def update_comment(self, comment_id: str, comment: str):
+        """
+        Update an existing pull request comment.
+
+        Args:
+        - comment_id: The system-generated CodeCommit comment identifier
+        - comment: The replacement comment body
+
+        Returns:
+        - The boto3 update_comment response
+
+        Boto3 Documentation:
+        - aws codecommit update_comment
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/update_comment.html
+        """
+        if self.boto_client is None:
+            self._connect_boto_client()
+
+        try:
+            return self.boto_client.update_comment(commentId=str(comment_id), content=comment)
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == 'CommentDoesNotExistException':
+                raise ValueError(f"CodeCommit comment does not exist: {comment_id}") from e
+            if e.response["Error"]["Code"] == 'CommentDeletedException':
+                raise ValueError(f"CodeCommit comment has been deleted: {comment_id}") from e
+            raise ValueError("Boto3 client error calling update_comment") from e
+        except Exception as e:
+            raise ValueError("Error calling update_comment") from e

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -1,6 +1,8 @@
 import os
 import re
 from collections import Counter
+from datetime import datetime
+from types import SimpleNamespace
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -8,7 +10,12 @@ from pr_agent.algo.language_handler import is_valid_file
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.git_providers.codecommit_client import CodeCommitClient
 
-from ..algo.utils import load_large_diff
+from ..algo.utils import (
+    add_pr_review_identity,
+    comment_carries_other_identity,
+    comment_matches_identity,
+    load_large_diff,
+)
 from ..config_loader import get_settings
 from ..log import get_logger
 from .git_provider import GitProvider
@@ -79,7 +86,6 @@ class CodeCommitProvider(GitProvider):
 
     def is_supported(self, capability: str) -> bool:
         if capability in [
-            "get_issue_comments",
             "create_inline_comment",
             "publish_inline_comments",
             "get_labels",
@@ -195,22 +201,90 @@ class CodeCommitProvider(GitProvider):
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         if is_temporary:
             get_logger().info(pr_comment)
-            return
-
-        pr_comment = CodeCommitProvider._remove_markdown_html(pr_comment)
-        pr_comment = CodeCommitProvider._add_additional_newlines(pr_comment)
+            return None
 
         try:
-            for target in self._get_target_contexts():
-                self.codecommit_client.publish_comment(
-                    repo_name=target["repository_name"],
-                    pr_number=self.pr_num,
-                    destination_commit=target["destination_commit"],
-                    source_commit=target["source_commit"],
-                    comment=pr_comment,
-                )
+            published_comments = [
+                self._publish_comment_to_target(pr_comment, target)
+                for target in self._get_target_contexts()
+            ]
+            if len(published_comments) == 1:
+                return published_comments[0]
+            return published_comments
         except Exception as e:
             raise ValueError(f"CodeCommit Cannot publish comment for PR: {self.pr_num}") from e
+
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_header: str,
+                                   update_header: bool = True,
+                                   name='review',
+                                   final_update_message=True,
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        if as_thread:
+            get_logger().debug("CodeCommit does not support threaded persistent comments; publishing as a PR comment")
+
+        if not identity_marker:
+            get_logger().debug(
+                "CodeCommit persistent comment updates require a stable identity marker; publishing a new comment"
+            )
+            return self.publish_comment(pr_comment)
+
+        persistent_comment = add_pr_review_identity(pr_comment, identity_marker)
+        try:
+            comments = self.get_issue_comments_newest_first()
+        except Exception as e:
+            get_logger().warning(
+                f"CodeCommit could not read existing comments; publishing a new persistent comment: {e}"
+            )
+            return self.publish_comment(persistent_comment)
+
+        identifiers = [identity_marker, legacy_initial_header]
+        used_comment_ids = set()
+        published_comments = []
+        target_contexts = self._get_target_contexts()
+        destination_counts = Counter(
+            (target["repository_name"], target["destination_commit"])
+            for target in target_contexts
+        )
+        allow_repository_fallback = len(target_contexts) == 1
+
+        for target in target_contexts:
+            comment_to_update = self._find_persistent_comment_for_target(
+                comments,
+                target,
+                identifiers,
+                identity_marker,
+                used_comment_ids,
+                destination_counts[(target["repository_name"], target["destination_commit"])] == 1,
+                allow_repository_fallback,
+            )
+            if comment_to_update is None:
+                published_comments.append(self._publish_comment_to_target(persistent_comment, target))
+                continue
+
+            used_comment_ids.add(comment_to_update.id)
+            comment_body = self._persistent_body_for_target(
+                persistent_comment,
+                update_header,
+                name,
+                identity_marker,
+                target,
+            )
+            comment_url = self.get_comment_url(comment_to_update)
+            get_logger().info(f"Persistent mode - updating comment {comment_url} to latest {name} message")
+            if self.edit_comment(comment_to_update, comment_body) is not False:
+                published_comments.append(comment_to_update)
+                continue
+
+            published_comments.append(self._publish_comment_to_target(persistent_comment, target))
+
+        if final_update_message:
+            get_logger().debug("CodeCommit does not publish separate persistent update status comments")
+        if len(published_comments) == 1:
+            return published_comments[0]
+        return published_comments
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         counter = 1
@@ -260,6 +334,26 @@ class CodeCommitProvider(GitProvider):
 
     def remove_comment(self, comment):
         return ""  # not implemented yet
+
+    def edit_comment(self, comment, body: str):
+        comment_id = comment.get("id") if isinstance(comment, dict) else getattr(comment, "id", None)
+        if not isinstance(comment_id, str) or not comment_id:
+            get_logger().warning(f"CodeCommit cannot update comment without a valid comment id: {comment_id!r}")
+            return False
+
+        body = self._prepare_comment_body(body)
+        try:
+            response = self.codecommit_client.update_comment(comment_id, body)
+        except Exception as e:
+            get_logger().warning(f"CodeCommit failed to update comment {comment_id}: {e}")
+            return False
+
+        updated_comment = response.get("comment") if isinstance(response, dict) else None
+        if not isinstance(updated_comment, dict):
+            return False
+        if updated_comment.get("deleted") is True:
+            return False
+        return updated_comment.get("commentId") == comment_id and updated_comment.get("content") == body
 
     def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/post_comment_for_compared_commit.html
@@ -326,7 +420,19 @@ class CodeCommitProvider(GitProvider):
         return -1  # not implemented yet
 
     def get_issue_comments(self):
-        raise NotImplementedError("CodeCommit provider does not support issue comments yet")
+        comments = []
+        for comment_data in self.codecommit_client.get_comments_for_pull_request(self.pr_num):
+            comments.extend(self._extract_issue_comments(comment_data))
+        return sorted(comments, key=self._comment_sort_key)
+
+    def get_issue_comments_newest_first(self):
+        return sorted(self.get_issue_comments(), key=self._comment_sort_key, reverse=True)
+
+    def supports_review_comment_identity(self) -> bool:
+        return True
+
+    def get_comment_url(self, comment) -> str:
+        return self.get_pr_url()
 
     def get_repo_settings(self):
         # a local ".pr_agent.toml" settings file is optional
@@ -466,6 +572,168 @@ class CodeCommitProvider(GitProvider):
 
     def get_commit_messages(self) -> str:
         return ""  # not implemented yet
+
+    def _publish_comment_to_target(self, pr_comment: str, target: dict):
+        pr_comment = self._prepare_comment_body(pr_comment)
+        response = self.codecommit_client.publish_comment(
+            repo_name=target["repository_name"],
+            pr_number=self.pr_num,
+            destination_commit=target["destination_commit"],
+            source_commit=target["source_commit"],
+            comment=pr_comment,
+        )
+        if isinstance(response, dict):
+            return self._comment_from_api_comment(
+                response.get("comment"),
+                {
+                    "repositoryName": target["repository_name"],
+                    "beforeCommitId": target["destination_commit"],
+                    "afterCommitId": target["source_commit"],
+                },
+            )
+        return response
+
+    def _find_persistent_comment_for_target(
+        self,
+        comments: list,
+        target: dict,
+        identifiers: list,
+        identity_marker: str,
+        used_comment_ids: set,
+        allow_destination_fallback: bool,
+        allow_repository_fallback: bool,
+    ):
+        matchers = [self._comment_matches_target_exact]
+        if allow_destination_fallback:
+            matchers.append(self._comment_matches_target_destination)
+        if allow_repository_fallback:
+            matchers.append(self._comment_matches_target_repository)
+
+        for matcher in matchers:
+            comment = self._find_persistent_comment(
+                comments,
+                identifiers,
+                identity_marker,
+                used_comment_ids,
+                lambda candidate: matcher(candidate, target),
+            )
+            if comment is not None:
+                return comment
+        return None
+
+    @staticmethod
+    def _find_persistent_comment(
+        comments: list,
+        identifiers: list,
+        identity_marker: str,
+        used_comment_ids: set,
+        target_matcher,
+    ):
+        for identifier in identifiers:
+            if not identifier:
+                continue
+            for comment in comments:
+                if comment.id in used_comment_ids or not target_matcher(comment):
+                    continue
+                body = GitProvider._get_comment_body(comment)
+                if not comment_matches_identity(body, identifier):
+                    continue
+                if comment_carries_other_identity(body, identity_marker):
+                    continue
+                return comment
+        return None
+
+    @staticmethod
+    def _comment_matches_target_exact(comment, target: dict) -> bool:
+        return (
+            CodeCommitProvider._comment_matches_target_destination(comment, target)
+            and getattr(comment, "after_commit_id", None) == target["source_commit"]
+        )
+
+    @staticmethod
+    def _comment_matches_target_destination(comment, target: dict) -> bool:
+        return (
+            CodeCommitProvider._comment_matches_target_repository(comment, target)
+            and getattr(comment, "before_commit_id", None) == target["destination_commit"]
+        )
+
+    @staticmethod
+    def _comment_matches_target_repository(comment, target: dict) -> bool:
+        repository_name = getattr(comment, "repository_name", None)
+        return repository_name == target["repository_name"]
+
+    @staticmethod
+    def _persistent_body_for_target(
+        pr_comment: str,
+        update_header: bool,
+        name: str,
+        identity_marker: str,
+        target: dict,
+    ) -> str:
+        if not update_header:
+            return pr_comment
+
+        update_message = f"#### ({name.capitalize()} updated until commit {target['source_commit']})\n"
+        updated_anchor = f"{identity_marker}\n\n{update_message}"
+        return pr_comment.replace(identity_marker, updated_anchor, 1)
+
+    @staticmethod
+    def _prepare_comment_body(pr_comment: str) -> str:
+        pr_comment = CodeCommitProvider._remove_markdown_html(pr_comment)
+        return CodeCommitProvider._add_additional_newlines(pr_comment)
+
+    @staticmethod
+    def _extract_issue_comments(comment_data: dict):
+        if not isinstance(comment_data, dict) or comment_data.get("location"):
+            return []
+
+        comments = []
+        for comment in comment_data.get("comments", []):
+            issue_comment = CodeCommitProvider._comment_from_api_comment(comment, comment_data)
+            if issue_comment is not None:
+                comments.append(issue_comment)
+        return comments
+
+    @staticmethod
+    def _comment_from_api_comment(comment: dict, comment_data: dict):
+        if not isinstance(comment, dict):
+            return None
+        if comment.get("deleted") is True or comment.get("inReplyTo"):
+            return None
+
+        body = comment.get("content")
+        comment_id = comment.get("commentId")
+        created_at = CodeCommitProvider._comment_timestamp(comment.get("creationDate"))
+        if not isinstance(body, str) or not body:
+            return None
+        if not isinstance(comment_id, str) or not comment_id:
+            return None
+        if created_at is None:
+            return None
+
+        author_arn = comment.get("authorArn") if isinstance(comment.get("authorArn"), str) else ""
+        return SimpleNamespace(
+            body=body,
+            id=comment_id,
+            created_at=created_at,
+            last_modified_at=CodeCommitProvider._comment_timestamp(comment.get("lastModifiedDate")),
+            repository_name=comment_data.get("repositoryName"),
+            before_commit_id=comment_data.get("beforeCommitId"),
+            after_commit_id=comment_data.get("afterCommitId"),
+            user=SimpleNamespace(login=author_arn),
+        )
+
+    @staticmethod
+    def _comment_timestamp(value):
+        if isinstance(value, datetime):
+            return value.timestamp()
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    @staticmethod
+    def _comment_sort_key(comment):
+        return (comment.created_at, comment.id)
 
     @staticmethod
     def _add_additional_newlines(body: str) -> str:

--- a/tests/unittest/test_codecommit_client.py
+++ b/tests/unittest/test_codecommit_client.py
@@ -164,3 +164,63 @@ class TestCodeCommitProvider:
             ("repo-one", "source-one", "destination-one"),
             ("repo-two", "source-two", "destination-two"),
         ]
+
+    def test_get_comments_for_pull_request_uses_safe_page_size_and_all_pages(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+        paginator = api.boto_client.get_paginator.return_value
+        paginator.paginate.return_value = [
+            {"commentsForPullRequestData": [{"comments": [{"commentId": "comment-1"}]}]},
+            {"commentsForPullRequestData": [{"comments": [{"commentId": "comment-2"}]}]},
+        ]
+
+        comments = api.get_comments_for_pull_request(321)
+
+        assert comments == [
+            {"comments": [{"commentId": "comment-1"}]},
+            {"comments": [{"commentId": "comment-2"}]},
+        ]
+        api.boto_client.get_paginator.assert_called_once_with("get_comments_for_pull_request")
+        paginator.paginate.assert_called_once_with(
+            pullRequestId="321",
+            PaginationConfig={"PageSize": 100},
+        )
+
+    def test_publish_comment_returns_boto_response(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+        api.boto_client.post_comment_for_pull_request.return_value = {
+            "comment": {"commentId": "comment-1", "content": "Review"}
+        }
+
+        response = api.publish_comment(
+            repo_name="my_test_repo",
+            pr_number=321,
+            destination_commit="destination-commit",
+            source_commit="source-commit",
+            comment="Review",
+        )
+
+        assert response == {"comment": {"commentId": "comment-1", "content": "Review"}}
+        api.boto_client.post_comment_for_pull_request.assert_called_once_with(
+            pullRequestId="321",
+            repositoryName="my_test_repo",
+            beforeCommitId="destination-commit",
+            afterCommitId="source-commit",
+            content="Review",
+        )
+
+    def test_update_comment_returns_boto_response(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+        api.boto_client.update_comment.return_value = {
+            "comment": {"commentId": "comment-1", "content": "Updated review"}
+        }
+
+        response = api.update_comment("comment-1", "Updated review")
+
+        assert response == {"comment": {"commentId": "comment-1", "content": "Updated review"}}
+        api.boto_client.update_comment.assert_called_once_with(
+            commentId="comment-1",
+            content="Updated review",
+        )

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -1,9 +1,13 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from pr_agent.algo.types import EDIT_TYPE
+from pr_agent.algo.utils import PRReviewHeader, PRReviewIdentity
 from pr_agent.git_providers.codecommit_provider import CodeCommitFile, CodeCommitProvider, PullRequestCCMimic
+from pr_agent.tools.pr_reviewer import PRReviewer
 
 
 class TestCodeCommitFile:
@@ -38,6 +42,74 @@ class TestCodeCommitProvider:
         provider.git_files = git_files
         provider.codecommit_client = MagicMock()
         return provider
+
+    @staticmethod
+    def _make_persistent_provider(targets=None):
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "source-repository"
+        provider.pr_num = 321
+        provider.pr_url = (
+            "https://us-east-1.console.aws.amazon.com/codesuite/codecommit/"
+            "repositories/source-repository/pull-requests/321"
+        )
+        provider.diff_files = None
+        provider.git_files = []
+        provider.codecommit_client = MagicMock()
+        targets = targets or [
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-1",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-1",
+                destination_branch="refs/heads/main",
+            )
+        ]
+        provider.pr = PullRequestCCMimic("Persistent PR", [], targets=targets)
+        provider.pr.source_commit = targets[0].source_commit
+        provider.pr.source_branch = targets[0].source_branch
+        provider.pr.destination_commit = targets[0].destination_commit
+        provider.pr.destination_branch = targets[0].destination_branch
+        return provider
+
+    @staticmethod
+    def _comment(
+        body,
+        comment_id="comment-1",
+        created_at=None,
+        last_modified_at=None,
+        **overrides,
+    ):
+        comment = {
+            "commentId": comment_id,
+            "content": body,
+            "creationDate": created_at or datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "lastModifiedDate": last_modified_at or created_at or datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "authorArn": "arn:aws:iam::123456789012:user/pr-agent",
+        }
+        comment.update(overrides)
+        return comment
+
+    @staticmethod
+    def _comment_group(
+        *comments,
+        repository_name="source-repository",
+        before_commit_id="old-destination-commit",
+        after_commit_id="old-source-commit",
+        location=None,
+    ):
+        group = {
+            "repositoryName": repository_name,
+            "beforeCommitId": before_commit_id,
+            "afterCommitId": after_commit_id,
+            "comments": list(comments),
+        }
+        if location is not None:
+            group["location"] = location
+        return group
+
+    @staticmethod
+    def _successful_update_response(comment_id, body):
+        return {"comment": {"commentId": comment_id, "content": body, "deleted": False}}
 
     def test_get_diff_files_includes_deleted_file(self):
         provider = object.__new__(CodeCommitProvider)
@@ -240,6 +312,477 @@ class TestCodeCommitProvider:
                 comment="Review\n\ncomment",
             ),
         ]
+
+    def test_persistent_review_creates_then_updates_each_pull_request_target(self):
+        targets = [
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-1",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-1",
+                destination_branch="refs/heads/main",
+            ),
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-2",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-2",
+                destination_branch="refs/heads/release",
+            ),
+        ]
+        provider = self._make_persistent_provider(targets=targets)
+        provider.codecommit_client.get_comments_for_pull_request.return_value = []
+
+        def publish_comment(**kwargs):
+            return {
+                "comment": self._comment(
+                    kwargs["comment"],
+                    comment_id=f"comment-{kwargs['source_commit']}",
+                )
+            }
+
+        provider.codecommit_client.publish_comment.side_effect = publish_comment
+        provider.codecommit_client.update_comment.side_effect = self._successful_update_response
+        header = "## Team Review"
+
+        created = provider.publish_persistent_comment(
+            f"{header}\n\nfirst review",
+            initial_header=header,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+        first_bodies = {
+            call.kwargs["source_commit"]: call.kwargs["comment"]
+            for call in provider.codecommit_client.publish_comment.call_args_list
+        }
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                self._comment(first_bodies["source-commit-1"], comment_id="comment-source-commit-1"),
+                before_commit_id="destination-commit-1",
+                after_commit_id="source-commit-1",
+            ),
+            self._comment_group(
+                self._comment(first_bodies["source-commit-2"], comment_id="comment-source-commit-2"),
+                before_commit_id="destination-commit-2",
+                after_commit_id="source-commit-2",
+            ),
+        ]
+        provider.codecommit_client.publish_comment.reset_mock()
+
+        updated = provider.publish_persistent_comment(
+            f"{header}\n\nsecond review",
+            initial_header=header,
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert [comment.id for comment in created] == ["comment-source-commit-1", "comment-source-commit-2"]
+        assert [comment.id for comment in updated] == ["comment-source-commit-1", "comment-source-commit-2"]
+        provider.codecommit_client.publish_comment.assert_not_called()
+        assert provider.codecommit_client.update_comment.call_count == 2
+        update_bodies = {
+            call.args[0]: call.args[1]
+            for call in provider.codecommit_client.update_comment.call_args_list
+        }
+        assert set(update_bodies) == {"comment-source-commit-1", "comment-source-commit-2"}
+        assert PRReviewIdentity.REGULAR.value in first_bodies["source-commit-1"]
+        assert PRReviewIdentity.REGULAR.value in update_bodies["comment-source-commit-1"]
+        assert PRReviewIdentity.REGULAR.value in update_bodies["comment-source-commit-2"]
+        assert "second review" in update_bodies["comment-source-commit-1"]
+        assert "Review updated until commit source-commit-1" in update_bodies["comment-source-commit-1"]
+        assert "Review updated until commit source-commit-2" in update_bodies["comment-source-commit-2"]
+
+    def test_persistent_review_updates_comment_from_older_commit_pair_for_single_target(self):
+        provider = self._make_persistent_provider()
+        existing_body = f"## Team Review\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                self._comment(existing_body, comment_id="older-commit-comment"),
+                before_commit_id="older-destination-commit",
+                after_commit_id="older-source-commit",
+            )
+        ]
+        provider.codecommit_client.update_comment.side_effect = self._successful_update_response
+
+        result = provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert result.id == "older-commit-comment"
+        provider.codecommit_client.publish_comment.assert_not_called()
+        comment_id, updated_body = provider.codecommit_client.update_comment.call_args.args
+        assert comment_id == "older-commit-comment"
+        assert "Review updated until commit source-commit-1" in updated_body
+
+    def test_persistent_review_falls_back_to_new_comment_when_comment_listing_fails(self):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.get_comments_for_pull_request.side_effect = ValueError("AccessDenied")
+        provider.codecommit_client.publish_comment.return_value = {
+            "comment": self._comment("created body", comment_id="fallback-comment")
+        }
+
+        result = provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert result.id == "fallback-comment"
+        provider.codecommit_client.update_comment.assert_not_called()
+        provider.codecommit_client.publish_comment.assert_called_once()
+        assert PRReviewIdentity.REGULAR.value in provider.codecommit_client.publish_comment.call_args.kwargs["comment"]
+
+    def test_persistent_review_does_not_use_repository_only_match_for_multiple_targets(self):
+        targets = [
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-1",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-1",
+                destination_branch="refs/heads/main",
+            ),
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-2",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-2",
+                destination_branch="refs/heads/release",
+            ),
+        ]
+        provider = self._make_persistent_provider(targets=targets)
+        existing_body = f"## Team Review\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                self._comment(existing_body, comment_id="unmatched-comment"),
+                before_commit_id="older-destination-commit",
+                after_commit_id="older-source-commit",
+            )
+        ]
+
+        provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        provider.codecommit_client.update_comment.assert_not_called()
+        assert provider.codecommit_client.publish_comment.call_args_list == [
+            call(
+                repo_name="source-repository",
+                pr_number=321,
+                destination_commit="destination-commit-1",
+                source_commit="source-commit-1",
+                comment=provider.codecommit_client.publish_comment.call_args_list[0].kwargs["comment"],
+            ),
+            call(
+                repo_name="source-repository",
+                pr_number=321,
+                destination_commit="destination-commit-2",
+                source_commit="source-commit-2",
+                comment=provider.codecommit_client.publish_comment.call_args_list[1].kwargs["comment"],
+            ),
+        ]
+
+    def test_persistent_review_does_not_use_ambiguous_destination_match_for_multiple_targets(self):
+        targets = [
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-a-new",
+                source_branch="refs/heads/feature-a",
+                destination_commit="shared-destination-commit",
+                destination_branch="refs/heads/main",
+            ),
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-b-new",
+                source_branch="refs/heads/feature-b",
+                destination_commit="shared-destination-commit",
+                destination_branch="refs/heads/main",
+            ),
+        ]
+        provider = self._make_persistent_provider(targets=targets)
+        existing_body = f"## Team Review\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                self._comment(
+                    existing_body,
+                    comment_id="target-b-old",
+                    created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                ),
+                before_commit_id="shared-destination-commit",
+                after_commit_id="source-commit-b-old",
+            ),
+            self._comment_group(
+                self._comment(
+                    existing_body,
+                    comment_id="target-a-old",
+                    created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                ),
+                before_commit_id="shared-destination-commit",
+                after_commit_id="source-commit-a-old",
+            ),
+        ]
+
+        provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        provider.codecommit_client.update_comment.assert_not_called()
+        assert [
+            call.kwargs["source_commit"]
+            for call in provider.codecommit_client.publish_comment.call_args_list
+        ] == ["source-commit-a-new", "source-commit-b-new"]
+
+    @pytest.mark.parametrize("raw_order", [("old", "new"), ("new", "old")])
+    def test_get_issue_comments_uses_oldest_first_creation_order_for_answer(self, raw_order):
+        provider = self._make_persistent_provider()
+        comments_by_name = {
+            "old": self._comment(
+                "older answer",
+                comment_id="old-comment",
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                last_modified_at=datetime(2024, 1, 10, tzinfo=timezone.utc),
+            ),
+            "new": self._comment(
+                "newer answer",
+                comment_id="new-comment",
+                created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            ),
+        }
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(*(comments_by_name[name] for name in raw_order))
+        ]
+
+        comments = provider.get_issue_comments()
+
+        assert provider.is_supported("get_issue_comments") is True
+        assert provider.supports_review_comment_identity() is True
+        assert [comment.id for comment in comments] == ["old-comment", "new-comment"]
+        assert comments[0].user.login == "arn:aws:iam::123456789012:user/pr-agent"
+        provider.codecommit_client.get_comments_for_pull_request.assert_called_once_with(321)
+
+    @pytest.mark.parametrize("raw_order", [("q-old", "a-old", "q-new", "a-new"), ("a-new", "q-new", "a-old", "q-old")])
+    def test_answer_mode_uses_newest_question_and_answer_after_oldest_first_sort(self, raw_order):
+        provider = self._make_persistent_provider()
+        bodies_by_name = {
+            "q-old": "Questions to better understand the PR:\n\nold question",
+            "a-old": "/answer old answer",
+            "q-new": "Questions to better understand the PR:\n\nnew question",
+            "a-new": "/answer new answer",
+        }
+        dates_by_name = {
+            "q-old": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "a-old": datetime(2024, 1, 2, tzinfo=timezone.utc),
+            "q-new": datetime(2024, 1, 3, tzinfo=timezone.utc),
+            "a-new": datetime(2024, 1, 4, tzinfo=timezone.utc),
+        }
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                *(
+                    self._comment(
+                        bodies_by_name[name],
+                        comment_id=name,
+                        created_at=dates_by_name[name],
+                    )
+                    for name in raw_order
+                )
+            )
+        ]
+        reviewer = PRReviewer.__new__(PRReviewer)
+        reviewer.is_answer = True
+        reviewer.git_provider = provider
+
+        question, answer = reviewer._get_user_answers()
+
+        assert question == bodies_by_name["q-new"]
+        assert answer == bodies_by_name["a-new"]
+
+    @pytest.mark.parametrize("raw_order", [("old", "new"), ("new", "old")])
+    def test_persistent_review_updates_newest_duplicate_under_both_api_feed_orders(self, raw_order):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.update_comment.side_effect = self._successful_update_response
+        body = f"## Team Review\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        comments_by_name = {
+            "old": self._comment(
+                body,
+                comment_id="old-comment",
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                last_modified_at=datetime(2024, 1, 10, tzinfo=timezone.utc),
+            ),
+            "new": self._comment(
+                body,
+                comment_id="new-comment",
+                created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            ),
+        }
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(*(comments_by_name[name] for name in raw_order))
+        ]
+
+        provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        provider.codecommit_client.update_comment.assert_called_once()
+        assert provider.codecommit_client.update_comment.call_args.args[0] == "new-comment"
+        provider.codecommit_client.publish_comment.assert_not_called()
+
+    def test_get_issue_comments_filters_deleted_replies_inline_and_malformed_comments(self):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            "not a group",
+            self._comment_group(self._comment("valid old", comment_id="valid-old")),
+            self._comment_group(
+                self._comment("reply", comment_id="reply", inReplyTo="valid-old"),
+                self._comment("deleted", comment_id="deleted", deleted=True),
+                self._comment("missing id", commentId=None),
+                self._comment("", comment_id="empty-body"),
+                self._comment("bad timestamp", comment_id="bad-timestamp", creationDate="yesterday"),
+            ),
+            self._comment_group(
+                self._comment("inline", comment_id="inline"),
+                location={"filePath": "src/app.py", "filePosition": 7},
+            ),
+            self._comment_group(
+                self._comment(
+                    "valid new",
+                    comment_id="valid-new",
+                    created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                )
+            ),
+        ]
+
+        comments = provider.get_issue_comments()
+
+        assert [(comment.id, comment.body) for comment in comments] == [
+            ("valid-old", "valid old"),
+            ("valid-new", "valid new"),
+        ]
+
+    def test_persistent_review_migrates_legacy_heading_to_stable_identity(self):
+        provider = self._make_persistent_provider()
+        legacy_body = f"{PRReviewHeader.REGULAR.value} 🔍\n\nprevious review"
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(self._comment(legacy_body, comment_id="legacy-comment"))
+        ]
+        provider.codecommit_client.update_comment.side_effect = self._successful_update_response
+
+        provider.publish_persistent_comment(
+            "## Custom Review\n\nnew review",
+            initial_header="## Custom Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        provider.codecommit_client.publish_comment.assert_not_called()
+        comment_id, updated_body = provider.codecommit_client.update_comment.call_args.args
+        assert comment_id == "legacy-comment"
+        assert updated_body.startswith("## Custom Review\n\n")
+        assert PRReviewIdentity.REGULAR.value in updated_body
+
+    def test_persistent_review_falls_back_to_new_comment_only_for_failed_target_update(self):
+        targets = [
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-1",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-1",
+                destination_branch="refs/heads/main",
+            ),
+            SimpleNamespace(
+                repository_name="source-repository",
+                source_commit="source-commit-2",
+                source_branch="refs/heads/feature",
+                destination_commit="destination-commit-2",
+                destination_branch="refs/heads/release",
+            ),
+        ]
+        provider = self._make_persistent_provider(targets=targets)
+        existing_body = f"## Team Review\n\n{PRReviewIdentity.REGULAR.value}\n\nprevious review"
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(
+                self._comment(existing_body, comment_id="comment-target-1"),
+                before_commit_id="destination-commit-1",
+                after_commit_id="source-commit-1",
+            ),
+            self._comment_group(
+                self._comment(existing_body, comment_id="comment-target-2"),
+                before_commit_id="destination-commit-2",
+                after_commit_id="source-commit-2",
+            ),
+        ]
+
+        def update_comment(comment_id, body):
+            if comment_id == "comment-target-2":
+                return {"comment": {"commentId": comment_id, "content": "unexpected body", "deleted": False}}
+            return self._successful_update_response(comment_id, body)
+
+        provider.codecommit_client.update_comment.side_effect = update_comment
+        provider.codecommit_client.publish_comment.return_value = {
+            "comment": self._comment("fallback body", comment_id="fallback-comment")
+        }
+
+        result = provider.publish_persistent_comment(
+            "## Team Review\n\nnew review",
+            initial_header="## Team Review",
+            final_update_message=False,
+            identity_marker=PRReviewIdentity.REGULAR.value,
+            legacy_initial_header=f"{PRReviewHeader.REGULAR.value} 🔍",
+        )
+
+        assert [comment.id for comment in result] == ["comment-target-1", "fallback-comment"]
+        assert provider.codecommit_client.update_comment.call_count == 2
+        provider.codecommit_client.publish_comment.assert_called_once()
+        assert provider.codecommit_client.publish_comment.call_args.kwargs["repo_name"] == "source-repository"
+        assert provider.codecommit_client.publish_comment.call_args.kwargs["destination_commit"] == "destination-commit-2"
+        assert provider.codecommit_client.publish_comment.call_args.kwargs["source_commit"] == "source-commit-2"
+
+    def test_unmarked_persistent_comment_remains_create_only(self):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            self._comment_group(self._comment("## Title\n\nold description", comment_id="describe-comment"))
+        ]
+        provider.codecommit_client.publish_comment.return_value = {
+            "comment": self._comment("## Title\n\nnew description", comment_id="new-describe-comment")
+        }
+
+        result = provider.publish_persistent_comment(
+            "## Title\n\nnew description",
+            initial_header="## Title",
+            update_header=True,
+            name="describe",
+            final_update_message=False,
+        )
+
+        assert result.id == "new-describe-comment"
+        provider.codecommit_client.get_comments_for_pull_request.assert_not_called()
+        provider.codecommit_client.update_comment.assert_not_called()
+        provider.codecommit_client.publish_comment.assert_called_once()
+
+    def test_get_issue_comments_support_does_not_enable_gfm_improve_history(self):
+        provider = self._make_persistent_provider()
+
+        assert provider.is_supported("get_issue_comments") is True
+        assert provider.is_supported("gfm_markdown") is False
 
     def test_publish_code_suggestion_uses_target_that_contains_file(self):
         provider = object.__new__(CodeCommitProvider)

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -8,6 +8,7 @@ differ: a backend either supports the operation, has nothing to do, or declares 
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from types import SimpleNamespace
 from typing import get_type_hints
@@ -137,6 +138,7 @@ def _bitbucket_server(monkeypatch) -> BitbucketServerProvider:
     }]
     return provider
 
+
 def _bitbucket(monkeypatch) -> BitbucketProvider:
     provider = BitbucketProvider.__new__(BitbucketProvider)
     provider.pr = MagicMock()
@@ -145,6 +147,38 @@ def _bitbucket(monkeypatch) -> BitbucketProvider:
     comment.raw = COMMENT_BODY
     provider.pr.comments.return_value = [comment]
 
+    return provider
+
+
+def _codecommit(monkeypatch) -> CodeCommitProvider:
+    provider = CodeCommitProvider.__new__(CodeCommitProvider)
+    provider.repo_name = "repo"
+    provider.pr_num = 7
+    provider.pr_url = "https://us-east-1.console.aws.amazon.com/codesuite/codecommit/repositories/repo/pull-requests/7"
+    provider.pr = SimpleNamespace(
+        source_commit="source",
+        destination_commit="destination",
+        targets=[
+            SimpleNamespace(
+                repository_name="repo",
+                source_commit="source",
+                destination_commit="destination",
+            )
+        ],
+    )
+    provider.codecommit_client = MagicMock()
+    provider.codecommit_client.get_comments_for_pull_request.return_value = [
+        {
+            "repositoryName": "repo",
+            "beforeCommitId": "destination",
+            "afterCommitId": "source",
+            "comments": [{
+                "commentId": "comment-1",
+                "content": COMMENT_BODY,
+                "creationDate": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            }],
+        }
+    ]
     return provider
 
 
@@ -161,7 +195,7 @@ PROVIDERS: dict[str, tuple[type[GitProvider], Callable[[pytest.MonkeyPatch], Git
     "azure-devops": (AzureDevopsProvider, _azure_devops),
     "bitbucket": (BitbucketProvider, _bitbucket),
     "bitbucket-server": (BitbucketServerProvider, _bitbucket_server),
-    "codecommit": (CodeCommitProvider, _bare(CodeCommitProvider)),
+    "codecommit": (CodeCommitProvider, _codecommit),
     "local": (LocalGitProvider, _bare(LocalGitProvider)),
     "plain-diff": (PlainDiffGitProvider, _bare(PlainDiffGitProvider)),
     "mosaico-diff": (DiffInputProvider, _bare(DiffInputProvider)),
@@ -233,8 +267,17 @@ METHOD_CONTRACTS = (
         noop_value=[],
         check_supported=_is_comment_sequence,
         tiers=_tiers(
-            supported=("github", "gitlab", "gitea", "gerrit", "azure-devops", "bitbucket-server", "bitbucket"),
-            not_implemented=("codecommit", "local"),
+            supported=(
+                "github",
+                "gitlab",
+                "gitea",
+                "gerrit",
+                "azure-devops",
+                "bitbucket-server",
+                "bitbucket",
+                "codecommit",
+            ),
+            not_implemented=("local",),
         ),
         # Implementations narrow the base `Iterable` (a paginated list, a list of SDK objects),
         # so the return annotation is checked by behaviour rather than by equality.


### PR DESCRIPTION
Fixes #3157

## Summary
- add CodeCommit PR comment listing and update-by-id support
- update persistent `/review` reruns in place while preserving CodeCommit target commit context
- keep unmarked persistent comments create-only and leave review finding state out of CodeCommit
- keep this PR scoped to CodeCommit; #3181 tracks the shared provider-level cleanup

## Verified result
```text
pre-fix baseline (29709d42): creates=2 updates=0 get_comments=0
this branch (5b58c81c): creates=1 updates=1 get_comments=2
updated_id=comment-1
updated_contains_marker=True
updated_contains_latest_review=True
```

## Tests
- GitHub Actions on `5b58c81c`: `Analyze (python)`, `CodeQL`, `build-and-test`, `pre-commit`, `update_release_draft`
- `PYTHONPATH=. uv run pytest tests/unittest/test_codecommit_client.py tests/unittest/test_codecommit_provider.py tests/unittest/test_git_provider_method_contract.py -q` (`234 passed`)
- `PYTHONPATH=. uv run pytest -q` (`4474 passed, 1 skipped, 1 xfailed`)
- `uv run ruff check pr_agent/git_providers/codecommit_provider.py` (passed)
- `git diff --check` (passed)
