### PR TITLE
fix(diff): count compressed file wrappers before admission

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -290,7 +290,6 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
             continue
 
         patch = data['patch']
-        new_patch_tokens = data['tokens']
         edit_type = data['edit_type']
 
         # Hard Stop, no more tokens
@@ -298,6 +297,16 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
             get_logger().warning(f"File was fully skipped, no more tokens: {filename}.")
             remaining_files_list_new.append(filename)
             continue
+
+        if patch:
+            if not convert_hunks_to_line_numbers:
+                patch_final = f"\n\n## File: '{filename.strip()}'\n\n{patch.strip()}\n"
+            else:
+                patch_final = "\n\n" + patch.strip()
+            new_patch_tokens = token_handler.count_tokens(patch_final)
+        else:
+            patch_final = ""
+            new_patch_tokens = 0
 
         # If the patch is too large, just show the file name
         if total_tokens + new_patch_tokens > max_tokens_model - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD:
@@ -310,12 +319,8 @@ def generate_full_patch(convert_hunks_to_line_numbers, file_dict, max_tokens_mod
             continue
 
         if patch:
-            if not convert_hunks_to_line_numbers:
-                patch_final = f"\n\n## File: '{filename.strip()}'\n\n{patch.strip()}\n"
-            else:
-                patch_final = "\n\n" + patch.strip()
             patches.append(patch_final)
-            total_tokens += token_handler.count_tokens(patch_final)
+            total_tokens += new_patch_tokens
             files_in_patch_list.append(filename)
             if get_verbosity_level() >= 2:
                 get_logger().info(f"Tokens: {total_tokens}, last filename: {filename}")

--- a/tests/unittest/test_diff_pipeline_core.py
+++ b/tests/unittest/test_diff_pipeline_core.py
@@ -12,7 +12,6 @@ rather than on full golden strings, so they remain robust to minor
 formatting tweaks.
 """
 
-from unittest.mock import patch
 
 import pytest
 
@@ -36,6 +35,13 @@ class FakeTokenHandler:
 
     def count_tokens(self, patch: str) -> int:
         return len(patch.split())
+
+
+class Utf8TokenHandler(FakeTokenHandler):
+    """Deterministic token handler that makes filename length visible."""
+
+    def count_tokens(self, patch: str) -> int:
+        return len(patch.encode())
 
 
 MULTI_HUNK_PATCH = (
@@ -281,10 +287,9 @@ class TestGenerateFullPatch:
 
     def test_oversized_patch_is_deferred_to_remaining_list(self):
         token_handler = FakeTokenHandler(prompt_tokens=10)
-        big_tokens = 5000  # exceeds (max_tokens - SOFT=1500) when added on top of prompt
         file_dict = {
             "small.py": {"patch": "+ small", "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
-            "huge.py":  {"patch": "+ huge",  "tokens": big_tokens, "edit_type": EDIT_TYPE.MODIFIED},
+            "huge.py": {"patch": "+ " + "huge " * 5_000, "tokens": 5_000, "edit_type": EDIT_TYPE.MODIFIED},
         }
         total, patches, remaining, files_in = pr_processing.generate_full_patch(
             convert_hunks_to_line_numbers=False,
@@ -296,6 +301,49 @@ class TestGenerateFullPatch:
         assert "small.py" in files_in
         assert "huge.py" not in files_in
         assert remaining == ["huge.py"]
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "src/app.py",
+            "src/" + "long-segment/" * 12 + "app.py",
+            "src/quoted-'module'.py",
+            "src/非常に長い名前.py",
+        ],
+    )
+    def test_file_wrapper_is_counted_before_soft_budget_admission(self, filename):
+        token_handler = Utf8TokenHandler(prompt_tokens=100)
+        patch = "+ value"
+        patch_final = f"\n\n## File: '{filename}'\n\n{patch}\n"
+        max_tokens_model = (
+            pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+            + token_handler.prompt_tokens
+            + token_handler.count_tokens(patch_final)
+            - 1
+        )
+        file_dict = {
+            filename: {
+                "patch": patch,
+                "tokens": token_handler.count_tokens(patch),
+                "edit_type": EDIT_TYPE.MODIFIED,
+            }
+        }
+
+        total, patches, remaining, files_in = pr_processing.generate_full_patch(
+            convert_hunks_to_line_numbers=False,
+            file_dict=file_dict,
+            max_tokens_model=max_tokens_model,
+            remaining_files_list_prev=[filename],
+            token_handler=token_handler,
+        )
+
+        assert token_handler.prompt_tokens + file_dict[filename]["tokens"] <= (
+            max_tokens_model - pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+        )
+        assert total == token_handler.prompt_tokens
+        assert patches == []
+        assert remaining == [filename]
+        assert files_in == []
 
     def test_remaining_files_list_prev_filters_input(self):
         token_handler = FakeTokenHandler(prompt_tokens=10)
@@ -319,7 +367,7 @@ class TestGenerateFullPatch:
         file_dict = {
             "a.py": {"patch": prebuilt, "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
         }
-        _, patches, _, _ = pr_processing.generate_full_patch(
+        total, patches, _, _ = pr_processing.generate_full_patch(
             convert_hunks_to_line_numbers=True,
             file_dict=file_dict,
             max_tokens_model=10_000,
@@ -328,6 +376,7 @@ class TestGenerateFullPatch:
         )
         # In line-numbered mode, the function does not wrap with another header.
         assert patches[0].count("## File: 'a.py'") == 1
+        assert total == token_handler.prompt_tokens + token_handler.count_tokens(patches[0])
 
 
 # ---------------------------------------------------------------------------
@@ -383,7 +432,7 @@ class TestPrGenerateCompressedDiff:
         prompt_tokens = 100
         token_handler = FakeTokenHandler(prompt_tokens=prompt_tokens)
         patch_str = "@@ -1,1 +1,1 @@\n+" + " ".join(["tok"] * 100) + "\n"
-        patch_tokens = token_handler.count_tokens(patch_str)
+        patch_tokens = token_handler.count_tokens(f"\n\n## File: 'f0.py'\n\n{patch_str.strip()}\n")
         soft_threshold = pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
         # Budget allows exactly one patch per iteration (prompt + patch fits,
         # but prompt + 2*patch does not):
@@ -424,69 +473,55 @@ class TestPrGenerateCompressedDiff:
         finally:
             settings.pr_description.max_ai_calls = original_max_ai_calls
 
-    def test_large_pr_handling_retries_file_after_hard_stop(self, monkeypatch):
-        """A hard-stopped file remains eligible for the next large-PR iteration."""
-
+    def test_large_pr_handling_retries_file_when_wrapper_crosses_soft_budget(self, monkeypatch):
         prompt_tokens = 100
-        max_tokens = 3_000
+        token_handler = Utf8TokenHandler(prompt_tokens=prompt_tokens)
+        patch_str = "@@ -1 +1 @@\n+" + "value " * 100
+        filenames = [
+            "src/quoted-'one'/非常に長い名前_" + "segment_" * 10 + "a.py",
+            "src/quoted-'two'/非常に長い名前_" + "segment_" * 10 + "b.py",
+        ]
+        bare_patch_tokens = token_handler.count_tokens(patch_str)
+        rendered_patch_tokens = token_handler.count_tokens(
+            f"\n\n## File: '{filenames[0]}'\n\n{patch_str.strip()}\n"
+        )
+        max_tokens = (
+            pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+            + prompt_tokens
+            + rendered_patch_tokens
+            + bare_patch_tokens
+        )
         monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: max_tokens)
-
-        class HardStopAcrossIterationsTokenHandler(FakeTokenHandler):
-            def __init__(self):
-                super().__init__(prompt_tokens=prompt_tokens)
-                self.first_marker_calls = 0
-
-            def count_tokens(self, patch):
-                if "FIRST_MARKER" in patch:
-                    self.first_marker_calls += 1
-                    # The compressed file entry fits, and its final rendered
-                    # patch count crosses the hard-stop threshold after the
-                    # first file is included.
-                    return {1: 100, 2: 2_500}[self.first_marker_calls]
-                return super().count_tokens(patch)
-
-        token_handler = HardStopAcrossIterationsTokenHandler()
         settings = self._settings()
         original_max_ai_calls = settings.pr_description.max_ai_calls
         settings.pr_description.max_ai_calls = 3
 
         try:
             files = [
-                _make_file(
-                    filename="first.py",
-                    patch="@@ -1 +1 @@\n+FIRST_MARKER\n",
-                    tokens=10,
-                ),
-                _make_file(
-                    filename="hard_stop.py",
-                    patch="@@ -1 +1 @@\n+SECOND_MARKER\n",
-                    tokens=5,
-                ),
+                _make_file(filename=filename, patch=patch_str, tokens=10)
+                for filename in filenames
             ]
 
-            with patch.object(pr_processing, "get_logger") as logger:
-                (patches_list, _, deleted_files_list, remaining_files_list,
-                 file_dict, files_in_patches_list) = \
-                    pr_processing.pr_generate_compressed_diff(
-                        top_langs=[{"files": files}],
-                        token_handler=token_handler,
-                        model="some-model",
-                        convert_hunks_to_line_numbers=False,
-                        large_pr_handling=True,
-                    )
-
-            assert token_handler.first_marker_calls == 2
-            assert prompt_tokens + 2_500 > max_tokens - pr_processing.OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD
-            logger.return_value.warning.assert_any_call(
-                "File was fully skipped, no more tokens: hard_stop.py."
+            (patches_list, total_tokens_list, deleted_files_list, remaining_files_list,
+             file_dict, files_in_patches_list) = pr_processing.pr_generate_compressed_diff(
+                top_langs=[{"files": files}],
+                token_handler=token_handler,
+                model="some-model",
+                convert_hunks_to_line_numbers=False,
+                large_pr_handling=True,
             )
-            assert file_dict["first.py"]["tokens"] == 100
+
+            assert file_dict[filenames[0]]["tokens"] == bare_patch_tokens
             assert len(patches_list) == 2
-            assert files_in_patches_list == [["first.py"], ["hard_stop.py"]]
+            assert files_in_patches_list == [[filenames[0]], [filenames[1]]]
+            assert all(
+                total <= max_tokens - pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD
+                for total in total_tokens_list
+            )
             assert remaining_files_list == []
             assert deleted_files_list == []
             processed_files = [filename for batch in files_in_patches_list for filename in batch]
-            assert processed_files == ["first.py", "hard_stop.py"]
+            assert processed_files == filenames
             assert len(processed_files) == len(set(processed_files))
         finally:
             settings.pr_description.max_ai_calls = original_max_ai_calls

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -67,12 +67,19 @@ def test_generate_full_patch_keeps_remaining_files_when_patch_exceeds_soft_budge
         "large.py": {"patch": "+ " + "large " * 80, "tokens": 250, "edit_type": EDIT_TYPE.MODIFIED},
         "second_small.py": {"patch": "+ second change", "tokens": 10, "edit_type": EDIT_TYPE.MODIFIED},
     }
+    included_tokens = sum(
+        token_handler.count_tokens(f"\n\n## File: '{filename}'\n\n{file_dict[filename]['patch'].strip()}\n")
+        for filename in ("small.py", "second_small.py")
+    )
+    max_tokens_model = (
+        pr_processing.OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD + token_handler.prompt_tokens + included_tokens
+    )
 
     try:
         total_tokens, patches, remaining_files, files_in_patch = pr_processing.generate_full_patch(
             convert_hunks_to_line_numbers=False,
             file_dict=file_dict,
-            max_tokens_model=1800,
+            max_tokens_model=max_tokens_model,
             remaining_files_list_prev=list(file_dict),
             token_handler=token_handler,
         )
@@ -89,11 +96,9 @@ def test_generate_full_patch_keeps_remaining_files_when_patch_exceeds_soft_budge
 def test_generate_full_patch_records_files_after_hard_token_stop():
     class HardStopTokenHandler(FakeTokenHandler):
         def count_tokens(self, patch):
-            if "first.py" in patch:
-                return 2_000
-            return super().count_tokens(patch)
+            raise AssertionError("hard-stopped patches must not be counted")
 
-    token_handler = HardStopTokenHandler(prompt_tokens=100)
+    token_handler = HardStopTokenHandler(prompt_tokens=2_001)
     file_dict = {
         "first.py": {"patch": "+ first change", "tokens": 1, "edit_type": EDIT_TYPE.MODIFIED},
         "hard_stop.py": {"patch": "+ hard stop change", "tokens": 1, "edit_type": EDIT_TYPE.MODIFIED},
@@ -109,16 +114,16 @@ def test_generate_full_patch_records_files_after_hard_token_stop():
     )
 
     assert total_tokens > 3_000 - pr_processing.OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD
-    assert files_in_patch == ["first.py"]
-    assert remaining_files == ["hard_stop.py", "after_stop.py"]
-    assert len(patches) == 1
+    assert files_in_patch == []
+    assert remaining_files == list(file_dict)
+    assert patches == []
 
 
 def test_generate_full_patch_records_too_large_patch_files():
     token_handler = FakeTokenHandler(prompt_tokens=100)
     file_dict = {
         "included.py": {"patch": "+ included change", "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
-        "too_large.py": {"patch": "+ too large change", "tokens": 5_000, "edit_type": EDIT_TYPE.MODIFIED},
+        "too_large.py": {"patch": "+ " + "large " * 5_000, "tokens": 5_000, "edit_type": EDIT_TYPE.MODIFIED},
         "after_large.py": {"patch": "+ after large change", "tokens": 5, "edit_type": EDIT_TYPE.MODIFIED},
     }
 


### PR DESCRIPTION
Fixes #3161

## Summary

- include each compressed file block's header in the token-budget check
- defer a file when its complete emitted block does not fit, while preserving the existing soft and hard reserves
- cover filename-wrapper boundaries and repeated large-PR packing iterations

## Result

For the ordinary filename and patch from #3161, the final head returns:

```text
prompt_tokens=100
bare_patch_tokens=13
emitted_patch_tokens=25
soft_admission_limit=113
included_files=[]
remaining_files=['src/services/user_profile.py']
returned_total_tokens=100
```

The complete file block is deferred instead of crossing the reserved budget.

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_processing_core.py tests/unittest/test_diff_pipeline_core.py tests/unittest/test_compressed_diff_token_sort.py -q` (`52 passed`)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (`4341 passed, 1 skipped, 1 xfailed`)
- `uv run pre-commit run --files pr_agent/algo/pr_processing.py tests/unittest/test_diff_pipeline_core.py tests/unittest/test_pr_processing_core.py` (passed)
