### PR TITLE
fix(describe): retain successful chunks after partial failure

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -375,7 +375,7 @@ class PRDescription:
                     required_fields.append('changes_summary')
                 valid_file_descriptions = (
                     isinstance(file_descriptions, list) and file_descriptions and
-                    all(isinstance(file_description, dict) and
+                    any(isinstance(file_description, dict) and
                         all(isinstance(file_description.get(field), str) and file_description[field].strip()
                             for field in required_fields)
                         for file_description in file_descriptions)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -43,6 +43,8 @@ from pr_agent.tools.ticket_pr_compliance_check import (
     fit_related_tickets_to_prompt_budget,
 )
 
+MAX_DESCRIPTION_COVERAGE_FILES = 50
+
 
 class PRDescription:
     def __init__(self, pr_url: str, args: list = None,
@@ -149,6 +151,7 @@ class PRDescription:
                 if not self.git_provider.is_supported(
                         "publish_file_comments") or not get_settings().pr_description.inline_file_summary:
                     pr_body += "\n\n" + changes_walkthrough + "___\n\n"
+            pr_body += self._get_description_coverage_footer()
             get_logger().debug("PR output", artifact={"title": pr_title, "body": pr_body})
 
             # Add help text if gfm_markdown is supported
@@ -259,6 +262,9 @@ class PRDescription:
         return ""
 
     async def _prepare_prediction(self, model: str) -> None:
+        self.description_total_chunk_count = 0
+        self.description_failed_chunk_count = 0
+        self.description_failed_files = []
         if get_settings().pr_description.use_description_markers and 'pr_agent:' not in self.user_description:
             get_logger().info("Markers were enabled, but user description does not contain markers. Skipping AI prediction")
             return None
@@ -309,33 +315,87 @@ class PRDescription:
                 self.git_provider, token_handler_only_files_prompt, model)
 
             # get the files prediction for each patch
+            chunk_pairs = list(zip(patches_compressed_list, files_in_patches_list, strict=True))
+            self.description_total_chunk_count = len(chunk_pairs)
+            results = [None] * len(chunk_pairs)
             if not get_settings().pr_description.get("async_ai_calls", True):
-                results = []
-                for i, patches in enumerate(patches_compressed_list):  # sync calls
+                for i, (patches, _files_in_patch) in enumerate(chunk_pairs):  # sync calls
+                    if not patches:
+                        continue
                     patches_diff = "\n".join(patches)
                     get_logger().debug(f"PR diff number {i + 1} for describe files")
-                    prediction_files = await self._get_prediction(model, patches_diff,
-                                                                  prompt="pr_description_only_files_prompts")
-                    results.append(prediction_files)
+                    try:
+                        results[i] = await self._get_prediction(
+                            model, patches_diff, prompt="pr_description_only_files_prompts")
+                    except Exception as e:
+                        results[i] = e
             else:  # async calls
                 tasks = []
-                for i, patches in enumerate(patches_compressed_list):
+                task_indices = []
+                for i, (patches, _files_in_patch) in enumerate(chunk_pairs):
                     if patches:
                         patches_diff = "\n".join(patches)
                         get_logger().debug(f"PR diff number {i + 1} for describe files")
                         task = asyncio.create_task(
                             self._get_prediction(model, patches_diff, prompt="pr_description_only_files_prompts"))
                         tasks.append(task)
+                        task_indices.append(i)
                 # Wait for all tasks to complete
-                results = await asyncio.gather(*tasks)
+                task_results = await asyncio.gather(*tasks, return_exceptions=True)
+                for chunk_index, result in zip(task_indices, task_results, strict=True):
+                    results[chunk_index] = result
             file_description_str_list = []
-            for i, result in enumerate(results):
+            chunk_errors = []
+            failed_files = []
+            for i, (result, (_patches, files_in_patch)) in enumerate(zip(results, chunk_pairs, strict=True)):
+                if isinstance(result, Exception):
+                    chunk_errors.append(result)
+                    failed_files.extend(files_in_patch)
+                    get_logger().warning(
+                        f"Failed to generate description for chunk {i + 1}; retaining successful chunks",
+                        artifact={"error": result, "files": files_in_patch},
+                    )
+                    continue
+                if isinstance(result, BaseException):
+                    raise result
+                if not isinstance(result, str):
+                    chunk_errors.append(ValueError(f"Description chunk {i + 1} returned no prediction"))
+                    failed_files.extend(files_in_patch)
+                    get_logger().warning(
+                        f"Description chunk {i + 1} returned no prediction; retaining successful chunks",
+                        artifact={"files": files_in_patch},
+                    )
+                    continue
                 prediction_files = result.strip().removeprefix('```yaml').strip('`').strip()
-                if load_yaml(prediction_files, keys_fix_yaml=self.keys_fix) and prediction_files.startswith('pr_files'):
+                prediction_files_data = load_yaml(prediction_files, keys_fix_yaml=self.keys_fix)
+                file_descriptions = (prediction_files_data.get('pr_files')
+                                     if isinstance(prediction_files_data, dict) else None)
+                required_fields = ['filename', 'changes_title', 'label']
+                if self.vars.get('include_file_summary_changes', True):
+                    required_fields.append('changes_summary')
+                valid_file_descriptions = (
+                    isinstance(file_descriptions, list) and file_descriptions and
+                    all(isinstance(file_description, dict) and
+                        all(isinstance(file_description.get(field), str) and file_description[field].strip()
+                            for field in required_fields)
+                        for file_description in file_descriptions)
+                )
+                if (prediction_files.startswith('pr_files') and isinstance(prediction_files_data, dict) and
+                        valid_file_descriptions):
                     prediction_files = prediction_files.removeprefix('pr_files:').strip()
                     file_description_str_list.append(prediction_files)
                 else:
-                    get_logger().debug(f"failed to generate predictions in iteration {i + 1} for describe files")
+                    chunk_errors.append(ValueError(f"Description chunk {i + 1} returned invalid YAML"))
+                    failed_files.extend(files_in_patch)
+                    get_logger().warning(
+                        f"Failed to parse description chunk {i + 1}; retaining successful chunks",
+                        artifact={"files": files_in_patch},
+                    )
+
+            self.description_failed_chunk_count = len(chunk_pairs) - len(file_description_str_list)
+            self.description_failed_files = list(dict.fromkeys(failed_files))
+            if not file_description_str_list:
+                raise chunk_errors[0] if chunk_errors else ValueError("No description chunks were generated")
 
             # generate files_walkthrough string, with proper token handling
             self.vars, token_handler_only_description_prompt = fit_related_tickets_to_prompt_budget(
@@ -389,6 +449,27 @@ class PRDescription:
                 if load_yaml(prediction_headers, keys_fix_yaml=self.keys_fix):
                     get_logger().debug(f"Using only headers for describe {self.pr_id}")
                     self.prediction = prediction_headers
+
+    def _get_description_coverage_footer(self) -> str:
+        failed_chunk_count = getattr(self, "description_failed_chunk_count", 0)
+        if not failed_chunk_count:
+            return ""
+
+        total_chunk_count = getattr(self, "description_total_chunk_count", failed_chunk_count)
+        footer = (
+            f"\n\n⚠️ **Description coverage:** {failed_chunk_count} of {total_chunk_count} "
+            "file-description chunks failed; the description above is based on the successful chunks only."
+        )
+        failed_files = getattr(self, "description_failed_files", [])
+        if failed_files:
+            displayed_files = failed_files[:MAX_DESCRIPTION_COVERAGE_FILES]
+            footer += "\n\nFiles from failed chunks may not be covered:\n" + "\n".join(
+                f"- `{filename}`" for filename in displayed_files
+            )
+            remaining_count = len(failed_files) - len(displayed_files)
+            if remaining_count:
+                footer += f"\n... and {remaining_count} more"
+        return footer
 
     async def extend_uncovered_files(self, original_prediction: str) -> str:
         try:

--- a/tests/unittest/test_linked_ticket_token_budget.py
+++ b/tests/unittest/test_linked_ticket_token_budget.py
@@ -258,7 +258,8 @@ async def test_description_large_pr_fits_each_prompt_from_raw_tickets(monkeypatc
     async def get_prediction(_model, patches_diff=None, prompt=None):
         prediction_calls.append((prompt, patches_diff, tool.vars))
         if prompt == "pr_description_only_files_prompts":
-            return "pr_files:\n- filename: src/app.py"
+            return ("pr_files:\n- filename: src/app.py\n  changes_title: Update app\n"
+                    "  changes_summary: Updates app behavior.\n  label: enhancement")
         return "title: Test\ndescription: Test"
 
     monkeypatch.setattr(module, "fit_related_tickets_to_prompt_budget", fit_payload)

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -671,6 +671,45 @@ description: |
         assert obj.description_failed_files == ["src/file2.py"]
 
     @pytest.mark.asyncio
+    async def test_large_pr_keeps_complete_records_from_mixed_chunk(self, monkeypatch):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            if prompt == "pr_description_only_description_prompts":
+                return _header_prediction()
+            return """pr_files:
+- filename: src/file1.py
+  changes_title: Describe src/file1.py
+  changes_summary: File summary
+  label: enhancement
+- filename: src/file2.py
+  changes_title: Missing summary
+  label: enhancement"""
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=(
+                [["diff --git a/src/file1.py b/src/file1.py\n... file1 ...",
+                  "diff --git a/src/file2.py b/src/file2.py\n... file2 ..."]],
+                [20],
+                [],
+                [],
+                {},
+                [["src/file1.py", "src/file2.py"]],
+            ),
+        ):
+            await obj._prepare_prediction("gpt-4o")
+
+        parsed = load_yaml(obj.prediction, keys_fix_yaml=obj.keys_fix)
+        assert [file["filename"].strip() for file in parsed["pr_files"]] == ["src/file1.py", "src/file2.py"]
+        obj._prepare_data()
+        assert obj._prepare_file_labels() == {
+            "enhancement": [("src/file1.py", "Describe src/file1.py", "File summary")]
+        }
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("async_calls", [True, False])
     async def test_large_pr_all_failed_chunks_raise_for_model_fallback(self, monkeypatch, async_calls):
         obj = _make_large_pr_instance()

--- a/tests/unittest/test_pr_description.py
+++ b/tests/unittest/test_pr_description.py
@@ -1,11 +1,13 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import yaml
 from jinja2 import Environment, StrictUndefined
 
+from pr_agent.algo.pr_processing import retry_with_fallback_models
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.algo.utils import load_yaml
+from pr_agent.algo.utils import ModelType, load_yaml
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_description import (
     PRDescription,
@@ -66,6 +68,29 @@ def _make_large_pr_instance(diff_files=None):
         "enable_pr_description": True,
     }
     return obj
+
+
+def _large_pr_chunks():
+    chunks = [
+        ["diff --git a/src/file1.py b/src/file1.py\n... file1 ..."],
+        ["diff --git a/src/file2.py b/src/file2.py\n... file2 ..."],
+    ]
+    return chunks, [10, 10], [], [], {}, [["src/file1.py"], ["src/file2.py"]]
+
+
+def _file_prediction(filename: str) -> str:
+    return f"""pr_files:
+- filename: {filename}
+  changes_title: Describe {filename}
+  changes_summary: File summary
+  label: enhancement"""
+
+
+def _header_prediction() -> str:
+    return """type:
+- Enhancement
+title: Partial description
+description: Summarizes the successfully described files."""
 
 
 def _mock_settings(pr_diagram_direction: str = 'adaptive', pr_diagram_direction_threshold: int = 5):
@@ -584,6 +609,196 @@ description: |
         assert [f["filename"].strip() for f in obj.data["pr_files"]] == ["src/file1.py", "src/file2.py"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("async_calls", [True, False])
+    async def test_large_pr_retains_valid_chunk_when_sibling_raises(self, monkeypatch, async_calls):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", async_calls)
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            if prompt == "pr_description_only_description_prompts":
+                return _header_prediction()
+            if "file1" in patches_diff:
+                return _file_prediction("src/file1.py")
+            raise RuntimeError("file2 transport failed")
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ):
+            await obj._prepare_prediction("gpt-4o")
+
+        parsed = load_yaml(obj.prediction, keys_fix_yaml=obj.keys_fix)
+        assert [file["filename"].strip() for file in parsed["pr_files"]] == ["src/file1.py", "src/file2.py"]
+        assert parsed["pr_files"][1]["label"].strip() == "additional files"
+        assert obj.description_failed_chunk_count == 1
+        assert obj.description_total_chunk_count == 2
+        assert obj.description_failed_files == ["src/file2.py"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("malformed_prediction", [
+        "pr_files: []",
+        "pr_files:\n- not-a-file-record",
+        "pr_files:\n- {}",
+        """pr_files:
+- filename: src/file2.py
+  changes_title: Missing label
+  changes_summary: File summary
+  label:""",
+    ])
+    async def test_large_pr_retains_valid_chunk_when_sibling_is_malformed(
+            self, monkeypatch, malformed_prediction):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            if prompt == "pr_description_only_description_prompts":
+                return _header_prediction()
+            if "file1" in patches_diff:
+                return _file_prediction("src/file1.py")
+            return malformed_prediction
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ):
+            await obj._prepare_prediction("gpt-4o")
+
+        parsed = load_yaml(obj.prediction, keys_fix_yaml=obj.keys_fix)
+        assert [file["filename"].strip() for file in parsed["pr_files"]] == ["src/file1.py", "src/file2.py"]
+        assert obj.description_failed_chunk_count == 1
+        assert obj.description_failed_files == ["src/file2.py"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("async_calls", [True, False])
+    async def test_large_pr_all_failed_chunks_raise_for_model_fallback(self, monkeypatch, async_calls):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", async_calls)
+        chunk_calls = []
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            chunk_calls.append(patches_diff)
+            raise RuntimeError(f"{patches_diff.splitlines()[0]} failed")
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ), pytest.raises(RuntimeError, match="file1.py"):
+            await obj._prepare_prediction("gpt-4o")
+
+        assert len(chunk_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_large_pr_all_malformed_chunks_raise_for_model_fallback(self, monkeypatch):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+
+        obj._get_prediction = AsyncMock(return_value="pr_files:\n- not-a-file-record")
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ), pytest.raises(ValueError, match="invalid YAML"):
+            await obj._prepare_prediction("gpt-4o")
+
+        assert all(
+            call.kwargs["prompt"] == "pr_description_only_files_prompts"
+            for call in obj._get_prediction.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_large_pr_empty_chunk_keeps_result_associated_with_its_files(self, monkeypatch):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+        chunks = [[], ["diff --git a/src/file2.py b/src/file2.py\n... file2 ..."]]
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            if prompt == "pr_description_only_description_prompts":
+                return _header_prediction()
+            return _file_prediction("src/file2.py")
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=(chunks, [0, 10], [], [], {}, [["src/file1.py"], ["src/file2.py"]]),
+        ):
+            await obj._prepare_prediction("gpt-4o")
+
+        assert obj.description_failed_files == ["src/file1.py"]
+        assert obj.description_failed_chunk_count == 1
+        assert len(obj._get_prediction.await_args_list) == 2  # one non-empty chunk and the header pass
+
+    @pytest.mark.asyncio
+    async def test_large_pr_chunk_cancellation_propagates(self, monkeypatch):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            if "file2" in patches_diff:
+                raise asyncio.CancelledError()
+            return _file_prediction("src/file1.py")
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ), pytest.raises(asyncio.CancelledError):
+            await obj._prepare_prediction("gpt-4o")
+
+    @pytest.mark.asyncio
+    async def test_large_pr_all_fail_then_fallback_model_keeps_partial_result(self, monkeypatch):
+        obj = _make_large_pr_instance()
+        monkeypatch.setattr(get_settings().pr_description, "async_ai_calls", True)
+        calls = []
+
+        async def mock_get_prediction(model, patches_diff, prompt="pr_description_prompt"):
+            calls.append((model, prompt, patches_diff))
+            if model == "gpt-4o":
+                raise RuntimeError("primary chunk failed")
+            if prompt == "pr_description_only_description_prompts":
+                return _header_prediction()
+            if "file1" in patches_diff:
+                return _file_prediction("src/file1.py")
+            raise RuntimeError("fallback file2 failed")
+
+        obj._get_prediction = AsyncMock(side_effect=mock_get_prediction)
+        with patch("pr_agent.tools.pr_description.get_pr_diff", return_value=""), patch(
+            "pr_agent.tools.pr_description.get_pr_diff_multiple_patchs",
+            return_value=_large_pr_chunks(),
+        ), patch(
+            "pr_agent.algo.pr_processing._get_all_models", return_value=["gpt-4o", "gpt-4o-mini"]
+        ), patch(
+            "pr_agent.algo.pr_processing._get_all_deployments", return_value=[None, None]
+        ), patch(
+            "pr_agent.algo.pr_processing.route_primary_model", return_value=None
+        ):
+            await retry_with_fallback_models(obj._prepare_prediction, ModelType.WEAK)
+
+        assert [(model, prompt) for model, prompt, _ in calls] == [
+            ("gpt-4o", "pr_description_only_files_prompts"),
+            ("gpt-4o", "pr_description_only_files_prompts"),
+            ("gpt-4o-mini", "pr_description_only_files_prompts"),
+            ("gpt-4o-mini", "pr_description_only_files_prompts"),
+            ("gpt-4o-mini", "pr_description_only_description_prompts"),
+        ]
+        assert obj.description_failed_chunk_count == 1
+        assert obj.description_failed_files == ["src/file2.py"]
+
+    def test_description_coverage_footer_names_failed_chunks_and_files(self):
+        obj = _make_large_pr_instance()
+        obj.description_failed_chunk_count = 1
+        obj.description_total_chunk_count = 2
+        obj.description_failed_files = ["src/file2.py"]
+
+        footer = obj._get_description_coverage_footer()
+
+        assert "1 of 2 file-description chunks failed" in footer
+        assert "based on the successful chunks only" in footer
+        assert "`src/file2.py`" in footer
+        assert "<hr>" not in footer
+
+    @pytest.mark.asyncio
     async def test_prepare_prediction_normal_diff_uses_single_prompt(self):
         """Verify normal diff under token limit does NOT fall into the large-PR multi-patch path."""
         obj = _make_large_pr_instance()
@@ -632,6 +847,7 @@ pr_files:
                 return """pr_files:
 - filename: src/file1.py
   changes_title: Add diagram support
+  changes_summary: Adds diagram support.
   label: enhancement"""
             elif prompt == "pr_description_only_description_prompts":
                 return """type:

--- a/tests/unittest/test_pr_description_lifecycle.py
+++ b/tests/unittest/test_pr_description_lifecycle.py
@@ -149,6 +149,40 @@ async def test_run_neutralizes_progress_comment_before_delete(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_appends_partial_description_coverage_to_output(monkeypatch):
+    settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.is_supported.return_value = False
+        description = _make_description(provider)
+        description.prediction = "generated"
+        description.description_failed_chunk_count = 1
+        description.description_total_chunk_count = 2
+        description.description_failed_files = ["src/file2.py"]
+        description._prepare_data = MagicMock()
+        description._prepare_pr_answer = MagicMock(return_value=("AI title", "Description", "", []))
+
+        monkeypatch.setattr(pr_description_module, "extract_and_cache_pr_tickets", AsyncMock())
+        monkeypatch.setattr(pr_description_module, "retry_with_fallback_models", AsyncMock())
+        settings = get_settings()
+        settings.config.publish_output = False
+        settings.pr_description.enable_help_comment = False
+        settings.pr_description.enable_help_text = False
+        settings.pr_description.enable_semantic_files_types = False
+        settings.pr_description.publish_labels = False
+        settings.pr_description.use_description_markers = False
+
+        await description.run()
+
+        artifact = get_settings().data["artifact"]
+        assert "Description coverage" in artifact
+        assert "1 of 2 file-description chunks failed" in artifact
+        assert "`src/file2.py`" in artifact
+    finally:
+        restore_settings(settings_snapshot)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("propagate_tool_errors", [False, True])
 async def test_run_reports_description_publication_failure(monkeypatch, propagate_tool_errors):
     settings_snapshot = snapshot_settings(_TRACKED_SETTINGS)


### PR DESCRIPTION
Fixes #3160

## Summary

- retain valid file-description chunks when a sibling model call fails or returns malformed output in async and sync large-PR handling
- keep chunk/file association deterministic, propagate cancellation, and use fallback models only when no usable chunk remains
- disclose partial coverage by counting failed chunks and listing files from those chunks

## Result

With two chunks, one valid and one transport failure, `/describe` now keeps the valid file description and reports the incomplete coverage:

> ⚠️ **Description coverage:** 1 of 2 file-description chunks failed; the description above is based on the successful chunks only.
>
> Files from failed chunks may not be covered:
> - `src/file2.py`

## Testing

- `PYTHONPATH=. uv run --frozen pytest -q -p no:cacheprovider tests/unittest/test_pr_description.py tests/unittest/test_pr_description_lifecycle.py tests/unittest/test_linked_ticket_token_budget.py` (107 passed)
- `PYTHONPATH=. uv run --frozen pytest -q tests/unittest --cov=pr_agent --cov-report=term` (4351 passed, 1 skipped, 1 xfailed; 74% coverage)
- `uv run --frozen pre-commit run --files pr_agent/tools/pr_description.py tests/unittest/test_pr_description.py tests/unittest/test_pr_description_lifecycle.py tests/unittest/test_linked_ticket_token_budget.py` (passed)
