### PR TITLE
fix(bitbucket-server): preserve personal repository context path

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -614,9 +614,11 @@ class BitbucketServerProvider(GitProvider):
 
     @staticmethod
     def _parse_bitbucket_server(url: str) -> str:
-        # pr url format: f"{bitbucket_server}/projects/{project_name}/repos/{repository_name}/pull-requests/{pr_id}"
+        # PR URLs use either projects/{project} or users/{user} after the Bitbucket Server base URL.
         parsed_url = urlparse(url)
-        server_path = parsed_url.path.split("/projects/")
+        server_path = parsed_url.path.split("/projects/", maxsplit=1)
+        if len(server_path) == 1:
+            server_path = parsed_url.path.split("/users/", maxsplit=1)
         if len(server_path) > 1:
             server_path = server_path[0].strip("/")
             return f"{parsed_url.scheme}://{parsed_url.netloc}/{server_path}".strip("/")

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -689,6 +689,80 @@ class TestBitbucketServerProvider:
         assert repo_slug == "my-repo"
         assert pr_number == 1
 
+    @pytest.mark.parametrize(
+        ("pr_url", "server_url"),
+        [
+            (
+                "https://git.example.com/projects/PROJ/repos/repo/pull-requests/7",
+                "https://git.example.com",
+            ),
+            (
+                "https://git.example.com/users/alice/repos/repo/pull-requests/7",
+                "https://git.example.com",
+            ),
+            (
+                "https://git.example.com/bitbucket/projects/PROJ/repos/repo/pull-requests/7",
+                "https://git.example.com/bitbucket",
+            ),
+            (
+                "https://git.example.com/bitbucket/users/alice/repos/repo/pull-requests/7",
+                "https://git.example.com/bitbucket",
+            ),
+            (
+                "http://git.example.com:7990/apps/bitbucket/projects/PROJ/repos/repo/pull-requests/7",
+                "http://git.example.com:7990/apps/bitbucket",
+            ),
+            (
+                "http://git.example.com:7990/apps/bitbucket/users/alice/repos/repo/pull-requests/7/?tab=overview#comment-1",
+                "http://git.example.com:7990/apps/bitbucket",
+            ),
+        ],
+    )
+    def test_parse_bitbucket_server_url(self, pr_url, server_url):
+        assert BitbucketServerProvider._parse_bitbucket_server(pr_url) == server_url
+
+    @pytest.mark.parametrize(
+        ("pr_url", "server_url", "workspace_slug"),
+        [
+            (
+                "https://git.example.com/projects/PROJ/repos/repo/pull-requests/7",
+                "https://git.example.com",
+                "PROJ",
+            ),
+            (
+                "https://git.example.com/users/alice/repos/repo/pull-requests/7",
+                "https://git.example.com",
+                "~alice",
+            ),
+            (
+                "https://git.example.com/bitbucket/projects/PROJ/repos/repo/pull-requests/7",
+                "https://git.example.com/bitbucket",
+                "PROJ",
+            ),
+            (
+                "https://git.example.com/bitbucket/users/alice/repos/repo/pull-requests/7",
+                "https://git.example.com/bitbucket",
+                "~alice",
+            ),
+        ],
+    )
+    def test_constructor_uses_pr_context_path_for_api_client(self, pr_url, server_url, workspace_slug):
+        bitbucket_client = MagicMock(Bitbucket)
+        bitbucket_client.get.return_value = {"version": "8.16"}
+        bitbucket_client.get_pull_request.return_value = {}
+
+        with patch(
+            "pr_agent.git_providers.bitbucket_server_provider.Bitbucket",
+            return_value=bitbucket_client,
+        ) as bitbucket_class:
+            provider = BitbucketServerProvider(pr_url)
+
+        assert provider.bitbucket_server_url == server_url
+        assert provider.workspace_slug == workspace_slug
+        assert bitbucket_class.call_args.kwargs["url"] == server_url
+        bitbucket_client.get.assert_called_once_with("rest/api/1.0/application-properties")
+        bitbucket_client.get_pull_request.assert_called_once_with(workspace_slug, "repo", pull_request_id=7)
+
     def test_get_issue_comments_normalizes_top_level_comments_from_all_activities(self):
         provider = self._persistent_provider()
         provider.bitbucket_client.get_pull_requests_activities.return_value = iter([


### PR DESCRIPTION
Fixes #3159

## Summary

- Preserve the Bitbucket Server context path when a personal-repository PR URL uses `/users/{user}/...`.
- Keep existing project URL precedence and `~user` workspace handling, with regression coverage for root and context-path URLs.

## Result

For `https://git.example.com/bitbucket/users/alice/repos/repo/pull-requests/7`, the provider now uses:

```text
client base: https://git.example.com/bitbucket
first REST target: https://git.example.com/bitbucket/rest/api/1.0/application-properties
pull request target: https://git.example.com/bitbucket/rest/api/1.0/projects/~alice/repos/repo/pull-requests/7
```

Root-hosted project and personal URLs, and project URLs under a context path, retain their existing behavior.

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_bitbucket_provider.py` (90 passed)
- `PYTHONPATH=. uv run pytest -q tests/unittest` (4347 passed, 1 skipped, 1 xfailed)
- `uv run ruff check pr_agent/git_providers/bitbucket_server_provider.py tests/unittest/test_bitbucket_provider.py` (passed)
