### PR TITLE
fix(mosaico): support A2A task cancellation

### DIFF
--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -6,8 +6,10 @@ mutates only the per-request copy — load-bearing isolation under concurrency),
 the inbound text to a pr-agent command, and completes the Task with the rendered
 markdown.
 
-On success the review text is published as an artifact (RISK 2: the reference agent's
-pollTask reads task.artifacts, not the completion message), then complete().
+For a new request, a working Task is published before the long-running route starts so
+that A2A cancellation can resolve the task from the store. On success the review text
+is published as an artifact (RISK 2: the reference agent's pollTask reads
+task.artifacts, not the completion message), then complete().
 
 On any failure — including ok=False from the router (Fix C) — an artifact containing
 the error text is published first (required to initialise the task before sending a
@@ -21,7 +23,7 @@ import copy
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
-from a2a.types import Part
+from a2a.types import Part, Task, TaskState, TaskStatus
 from starlette_context import context as sctx
 
 from pr_agent.algo import normalize_litellm_model
@@ -45,6 +47,19 @@ class PRAgentExecutor(AgentExecutor):
             if not context.task_id or not context.context_id:
                 raise ValueError("A2A 1.0 RequestContext missing task_id/context_id")
             updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+
+            # A2A cancellation looks up the persisted Task before invoking this
+            # executor's cancel() callback. Establish the task before starting the
+            # long-running route, but do not replace an existing task on follow-up work.
+            if context.current_task is None:
+                await event_queue.enqueue_event(
+                    Task(
+                        id=context.task_id,
+                        context_id=context.context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+                        history=[context.message] if context.message else [],
+                    )
+                )
 
             # Request-scoped settings: the tool run mutates ONLY this deepcopy, never the
             # shared global. get_settings() resolves to sctx["settings"] when present.
@@ -84,9 +99,8 @@ class PRAgentExecutor(AgentExecutor):
         if not context.task_id or not context.context_id:
             raise ValueError("A2A 1.0 RequestContext missing task_id/context_id")
 
-        # DefaultRequestHandler invokes the executor before it cancels the running
-        # producer task. Publish the terminal state first so the handler can finish
-        # the cancellation handshake instead of returning a NotImplementedError.
+        # ActiveTask cancels the producer before invoking this callback. The initial
+        # Task event from execute() makes the task/context identifiers resolvable here.
         updater = TaskUpdater(event_queue, context.task_id, context.context_id)
         await updater.cancel()
 

--- a/pr_agent/mosaico/executor.py
+++ b/pr_agent/mosaico/executor.py
@@ -81,7 +81,14 @@ class PRAgentExecutor(AgentExecutor):
             await updater.failed(msg)
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
-        raise NotImplementedError("cancel is not supported by the PR-Agent solution agent")
+        if not context.task_id or not context.context_id:
+            raise ValueError("A2A 1.0 RequestContext missing task_id/context_id")
+
+        # DefaultRequestHandler invokes the executor before it cancels the running
+        # producer task. Publish the terminal state first so the handler can finish
+        # the cancellation handshake instead of returning a NotImplementedError.
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.cancel()
 
 
 async def health_check() -> str:

--- a/tests/unittest/test_mosaico_a2a_roundtrip.py
+++ b/tests/unittest/test_mosaico_a2a_roundtrip.py
@@ -20,17 +20,22 @@ bad-URL assertion to TASK_STATE_COMPLETED — making test_bad_url_roundtrip fail
 
 Note: import pr_agent.config_loader first to avoid the pr_agent.log <->
 custom_merge_loader circular import (mirrors server.py)."""
+import asyncio
 import os
+from contextlib import suppress
 
 import pr_agent.config_loader  # noqa: F401  (import-order load; see module docstring)
+import pr_agent.mosaico.executor as executor_mod
 
 # isort: split
 
 import httpx
 import pytest
-from a2a.types import Message, Part, Role, SendMessageRequest
+from a2a.types import CancelTaskRequest, GetTaskRequest, Message, Part, Role, SendMessageRequest
 from google.protobuf.json_format import MessageToDict
 from httpx import ASGITransport
+
+from pr_agent.mosaico.dispatch import RouteResult
 
 # A small, valid unified diff wrapped in a ```diff fence -> the supplied-diff (path b)
 # of the router: no PR URL, no network, parsed by the mosaico_diff provider.
@@ -73,7 +78,7 @@ review:
 _A2A_HEADERS = {"A2A-Version": "1.0"}
 
 
-def _message_send_body(text: str) -> dict:
+def _message_send_body(text: str, return_immediately: bool = False) -> dict:
     """Build a genuine A2A 1.0 JSON-RPC message/send body from the SDK's own types.
 
     Using MessageToDict(SendMessageRequest(...)) ensures the payload shape is identical
@@ -84,10 +89,32 @@ def _message_send_body(text: str) -> dict:
         parts=[Part(text=text)],
     )
     req = SendMessageRequest(message=msg)
+    if return_immediately:
+        req.configuration.return_immediately = True
     return {
         "id": "rt-1",
         "jsonrpc": "2.0",
         "method": "SendMessage",
+        "params": MessageToDict(req),
+    }
+
+
+def _cancel_task_body(task_id: str) -> dict:
+    req = CancelTaskRequest(id=task_id)
+    return {
+        "id": "rt-cancel-1",
+        "jsonrpc": "2.0",
+        "method": "CancelTask",
+        "params": MessageToDict(req),
+    }
+
+
+def _get_task_body(task_id: str) -> dict:
+    req = GetTaskRequest(id=task_id)
+    return {
+        "id": "rt-get-1",
+        "jsonrpc": "2.0",
+        "method": "GetTask",
         "params": MessageToDict(req),
     }
 
@@ -127,6 +154,66 @@ def _live_llm_creds_absent() -> bool:
 
 
 class TestA2ARoundTripStubbedLLM:
+    @pytest.mark.asyncio
+    async def test_cancel_running_task_roundtrip(self, monkeypatch):
+        """CancelTask must return and persist TASK_STATE_CANCELED for active work."""
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocking_route(_text):
+            started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            return RouteResult("released", True)
+
+        monkeypatch.setattr(executor_mod, "route_and_run_result", blocking_route)
+
+        from pr_agent.mosaico.server import build_app
+
+        app = build_app()
+        async with _build_client(app) as client:
+            send_task = asyncio.create_task(
+                client.post(
+                    "/",
+                    json=_message_send_body(
+                        "review this", return_immediately=True
+                    ),
+                )
+            )
+            try:
+                send_resp = await asyncio.wait_for(asyncio.shield(send_task), timeout=1)
+                assert send_resp.status_code == 200, send_resp.text
+                send_payload = send_resp.json()
+                assert "error" not in send_payload, send_payload
+                task = send_payload["result"]["task"]
+                task_id = task["id"]
+                assert task["status"]["state"] == "TASK_STATE_WORKING"
+
+                await asyncio.wait_for(started.wait(), timeout=1)
+
+                cancel_resp = await client.post("/", json=_cancel_task_body(task_id))
+                assert cancel_resp.status_code == 200, cancel_resp.text
+                cancel_payload = cancel_resp.json()
+                assert "error" not in cancel_payload, cancel_payload
+                assert _get_task_state(cancel_payload["result"]) == "TASK_STATE_CANCELED"
+
+                await asyncio.wait_for(cancelled.wait(), timeout=1)
+
+                get_resp = await client.post("/", json=_get_task_body(task_id))
+                assert get_resp.status_code == 200, get_resp.text
+                get_payload = get_resp.json()
+                assert "error" not in get_payload, get_payload
+                assert _get_task_state(get_payload["result"]) == "TASK_STATE_CANCELED"
+            finally:
+                release.set()
+                if not send_task.done():
+                    with suppress(asyncio.TimeoutError):
+                        await asyncio.wait_for(send_task, timeout=1)
+
     @pytest.mark.asyncio
     async def test_warmup_health_and_card(self, monkeypatch):
         """Warm-up: /health and the agent card respond over the same transport."""

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -61,6 +61,7 @@ class _SpyTaskUpdater:
         self.context_id = context_id
         self.artifacts = []       # list of Part lists passed to add_artifact
         self.completed = False
+        self.cancelled = False
         self.failed_with = None   # message text passed to failed()
         type(self).last = self
 
@@ -72,6 +73,9 @@ class _SpyTaskUpdater:
 
     async def failed(self, message=None):
         self.failed_with = _message_text(message)
+
+    async def cancel(self, message=None):
+        self.cancelled = True
 
     def new_agent_message(self, parts, metadata=None):
         return _FakeMessage(parts)
@@ -228,9 +232,13 @@ class TestExecute:
         assert spy_updater.last is None
 
     @pytest.mark.asyncio
-    async def test_cancel_raises_not_implemented(self):
-        with pytest.raises(NotImplementedError):
+    async def test_cancel_marks_task_canceled(self, spy_updater):
+        with request_cycle_context({}):
             await PRAgentExecutor().cancel(_FakeRequestContext("z"), _RecordingEventQueue())
+
+        spy = spy_updater.last
+        assert (spy.task_id, spy.context_id) == ("task-001", "ctx-001")
+        assert spy.cancelled is True
 
     @pytest.mark.asyncio
     async def test_settings_writes_are_request_scoped_under_concurrency(self, monkeypatch, spy_updater):

--- a/tests/unittest/test_mosaico_executor.py
+++ b/tests/unittest/test_mosaico_executor.py
@@ -45,6 +45,7 @@ class _FakeRequestContext:
         # A2A 1.0: task_id/context_id are set by DefaultRequestHandler before execute.
         self.task_id = "task-001"
         self.context_id = "ctx-001"
+        self.current_task = None
 
     def get_user_input(self, delimiter: str = "\n") -> str:
         return self._text
@@ -61,7 +62,6 @@ class _SpyTaskUpdater:
         self.context_id = context_id
         self.artifacts = []       # list of Part lists passed to add_artifact
         self.completed = False
-        self.cancelled = False
         self.failed_with = None   # message text passed to failed()
         type(self).last = self
 
@@ -73,9 +73,6 @@ class _SpyTaskUpdater:
 
     async def failed(self, message=None):
         self.failed_with = _message_text(message)
-
-    async def cancel(self, message=None):
-        self.cancelled = True
 
     def new_agent_message(self, parts, metadata=None):
         return _FakeMessage(parts)
@@ -230,15 +227,6 @@ class TestExecute:
         # TaskUpdater was never constructed (validation fires first), so no task
         # lifecycle events were emitted.
         assert spy_updater.last is None
-
-    @pytest.mark.asyncio
-    async def test_cancel_marks_task_canceled(self, spy_updater):
-        with request_cycle_context({}):
-            await PRAgentExecutor().cancel(_FakeRequestContext("z"), _RecordingEventQueue())
-
-        spy = spy_updater.last
-        assert (spy.task_id, spy.context_id) == ("task-001", "ctx-001")
-        assert spy.cancelled is True
 
     @pytest.mark.asyncio
     async def test_settings_writes_are_request_scoped_under_concurrency(self, monkeypatch, spy_updater):

--- a/tests/unittest/test_mosaico_isolation.py
+++ b/tests/unittest/test_mosaico_isolation.py
@@ -46,6 +46,7 @@ class _FakeRequestContext:
         self.message = _make_message(text)
         self.task_id = f"task-{text}"
         self.context_id = f"ctx-{text}"
+        self.current_task = None
 
     def get_user_input(self, delimiter: str = "\n") -> str:
         return self._text


### PR DESCRIPTION
Fixes #3165

## Summary

Make in-flight MOSAICO tasks addressable throughout the A2A lifecycle so `CancelTask` can return a persisted canceled task.

## Root cause

A2A SDK 1.0.3 uses the v2 `ActiveTask` lifecycle: it cancels the producer first and then invokes the executor's `cancel()` callback. On the baseline, `PRAgentExecutor.execute()` only causes a `Task` to be persisted after the long-running route produces its first artifact. During the in-flight window there is therefore no persisted task/context for `TaskUpdater.cancel()` to update.

The baseline `PRAgentExecutor.cancel()` is also unimplemented. Adding the canceled transition without establishing the initial Task still fails at the protocol boundary.

## Change

- Publish an initial `TASK_STATE_WORKING` Task, including the inbound message history, before entering a new task's long-running route.
- Keep existing tasks intact on follow-up execution instead of publishing a duplicate initial Task.
- Implement `PRAgentExecutor.cancel()` with `TaskUpdater.cancel()` so the supplied A2A event queue receives `TASK_STATE_CANCELED`.
- Add a real Starlette/A2A JSON-RPC round-trip regression covering `SendMessage(return_immediately=true)`, `CancelTask`, producer cancellation, and `GetTask`.
- Correct the cancellation lifecycle comment and remove the fake cancellation test that could not exercise the real server path.

## Validation

All commands ran against the isolated worktree and the repository's Python 3.12 Docker test image.

```text
Baseline regression:
docker run --rm -e PYTHONPATH=. -v "$PWD":/workspace -w /workspace pragent/semantic-audit-20260908-red /app/.venv/bin/pytest -q tests/unittest/test_mosaico_a2a_roundtrip.py::TestA2ARoundTripStubbedLLM::test_cancel_running_task_roundtrip
Result: 1 failed; baseline timed out before the initial working Task was available.

Focused executor and A2A round-trip tests:
docker run --rm -e PYTHONPATH=. -v "$PWD":/workspace -w /workspace pragent/semantic-audit-20260908-red /app/.venv/bin/pytest -q tests/unittest/test_mosaico_executor.py tests/unittest/test_mosaico_a2a_roundtrip.py
Result: 12 passed, 1 skipped, 38 warnings.

All MOSAICO tests:
docker run --rm -e PYTHONPATH=. -v "$PWD":/workspace -w /workspace pragent/semantic-audit-20260908-red /app/.venv/bin/pytest -q tests/unittest/test_mosaico*.py
Result: 171 passed, 1 skipped, 101 warnings.

Full unit suite:
docker run --rm -e PYTHONPATH=. -v "$PWD":/workspace -w /workspace pragent/semantic-audit-20260908-red /app/.venv/bin/pytest -q tests/unittest
Result: 4337 passed, 1 skipped, 1 xfailed, 105 warnings.

Ruff:
docker run --rm -e PYTHONPATH=. -v "$PWD":/workspace -w /workspace pragent/semantic-audit-20260908-red /app/.venv/bin/ruff check pr_agent/mosaico/executor.py tests/unittest/test_mosaico_a2a_roundtrip.py tests/unittest/test_mosaico_executor.py tests/unittest/test_mosaico_isolation.py
Result: All checks passed.

Changed-file pre-commit:
docker run --rm -e UV_PROJECT_ENVIRONMENT=/app/.venv -v /Users/jacob.z/open-source/pr-agent-semantic-audit-20260908:/Users/jacob.z/open-source/pr-agent-semantic-audit-20260908 -v /Users/jacob.z/open-source/pr-agent/.git:/Users/jacob.z/open-source/pr-agent/.git -w /Users/jacob.z/open-source/pr-agent-semantic-audit-20260908 pragent/semantic-audit-20260908-red /app/.venv/bin/pre-commit run --files pr_agent/mosaico/executor.py tests/unittest/test_mosaico_a2a_roundtrip.py tests/unittest/test_mosaico_executor.py tests/unittest/test_mosaico_isolation.py
Result: all hooks passed.

git diff --check
Result: passed.
```

`ruff format --check` still reports pre-existing formatting differences in touched files, so no format-check pass is claimed. No type-check, live provider, network, CI, deployment, or production result is claimed.

## Scope

This focused lifecycle fix changes only:

- `pr_agent/mosaico/executor.py`
- `tests/unittest/test_mosaico_a2a_roundtrip.py`
- `tests/unittest/test_mosaico_executor.py`
- `tests/unittest/test_mosaico_isolation.py`

## AI assistance

This patch was prepared with AI assistance. The contributor is responsible for the code, tests, and claims in this pull request.
