### PR TITLE
fix(gitlab): preserve context lines in suggestions

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -1281,13 +1281,21 @@ class GitLabProvider(GitProvider):
                     continue
                 relevant_line_in_file = lines[relevant_lines_start - 1]
 
-                # edit_type, found, source_line_no, target_file, target_line_no = self.find_in_file(target_file,
-                #                                                                            relevant_line_in_file)
-                # for code suggestions, we want to edit the new code
-                source_line_no = -1
-                target_line_no = relevant_lines_start + 1
-                found = True
-                edit_type = 'addition'
+                if relevant_line_in_file:
+                    edit_type, found, source_line_no, target_file, target_line_no = self.find_in_file(
+                        target_file, relevant_line_in_file
+                    )
+                else:
+                    found = False
+
+                if not found:
+                    # Keep the existing fallback path for anchors outside the diff. GitLab will
+                    # reject the optimistic addition position and _create_suggestion_note will
+                    # publish the general file note instead.
+                    source_line_no = -1
+                    target_line_no = relevant_lines_start + 1
+                    found = True
+                    edit_type = 'addition'
 
                 self.send_inline_comment(body, edit_type, found, relevant_file, relevant_line_in_file,
                                          source_line_no, target_file, target_line_no, original_suggestion,

--- a/tests/unittest/test_gitlab_batch_publish_suggestions.py
+++ b/tests/unittest/test_gitlab_batch_publish_suggestions.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import MagicMock, patch
 
 from pr_agent.algo import inline_comment_dedup as dedup
@@ -14,6 +15,7 @@ class _FakeTargetFile:
     filename = "a.py"
     old_filename = "a.py"
     head_file = "line1\nline2\nline3\n"
+    patch = "@@ -1,3 +1,3 @@\n line1\n line2\n line3\n"
 
 
 def _suggestion(**overrides):
@@ -38,6 +40,7 @@ def _gl_provider():
     clears them - so tests exercise the same create -> list -> bulk_publish flow the real code
     depends on, instead of asserting on call counts alone."""
     p = GitLabProvider.__new__(GitLabProvider)
+    p.RE_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
     p.id_mr = 1
     p.mr = MagicMock()
     p.mr.discussions.list.return_value = []
@@ -92,6 +95,19 @@ def test_flag_off_posts_live_discussions_and_skips_bulk_publish():
     assert p.mr.discussions.create.call_count == 1
     p.mr.draft_notes.create.assert_not_called()
     p.mr.draft_notes.bulk_publish.assert_not_called()
+
+
+def test_context_line_suggestion_sends_both_gitlab_line_numbers():
+    p = _gl_provider()
+    gs = _settings(as_review=False)
+    try:
+        assert p.publish_code_suggestions([_suggestion()]) is True
+    finally:
+        gs.stop()
+
+    position = p.mr.discussions.create.call_args.args[0]['position']
+    assert position['old_line'] == 2
+    assert position['new_line'] == 2
 
 
 def test_flag_on_queues_draft_notes_and_bulk_publishes_once():


### PR DESCRIPTION
## What changed
- Derive GitLab suggestion positions from hunk context instead of always marking them as additions.
- Send both old_line and new_line for context anchors while preserving the general-note fallback outside the diff.
- Add regression coverage for context-line suggestions.

## Why
GitLab requires both line numbers for a context-line position. Previously, /improve suggestions anchored to context lines were rejected and degraded to a general note.

## Validation
- PYTHONPATH=. python -m pytest tests/unittest/test_gitlab_provider.py tests/unittest/test_gitlab_batch_publish_suggestions.py tests/unittest/test_gitlab_publish_guard.py -q (180 passed)
- Ruff check on the two changed files (passed)

Closes #3131