### PR TITLE
fix(suggestions): allow required imports in improvements

### DIFF
--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts.toml
@@ -25,11 +25,12 @@ Specific guidelines for generating code suggestions:
 - Only give suggestions that address critical problems and bugs in the PR code. If no relevant suggestions are applicable, return an empty list.
 - DO NOT suggest the following:
     - change packages version
-    - add missing import statement
+    - suggest standalone or unrelated missing import statements
     - declare undefined variable, or remove unused variable
     - use more specific exception types
     - repeat changes already done in the PR code
 {%- endif %}
+- If the suggested `improved_code` introduces a dependency, include the import needed to make that suggestion valid. Do not suggest unrelated or standalone missing imports.
 - Be aware that your input consists only of partial code segments (PR diff code), not the complete codebase. Therefore, avoid making suggestions that might duplicate existing functionality, and refrain from questioning code elements (such as variable declarations or import statements) that may be defined elsewhere in the codebase.
 - When mentioning code elements (variables, names, or files) in your response, surround them with backticks (`). For example: "verify that `user_id` is..."
 

--- a/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
+++ b/pr_agent/settings/code_suggestions/pr_code_suggestions_prompts_not_decoupled.toml
@@ -54,10 +54,10 @@ Specific guidelines for generating code suggestions:
 - Only give suggestions that address critical problems and bugs in the PR code. If no relevant suggestions are applicable, return an empty list.
 - DO NOT suggest the following:
     - change packages version
-    - add missing import statement
-    - declare undefined variable, add missing imports, etc.
+    - suggest standalone or unrelated missing imports or declarations
     - use more specific exception types
 {%- endif %}
+- If the suggested `improved_code` introduces a dependency, include the import needed to make that suggestion valid. Do not suggest unrelated or standalone missing imports.
 - When mentioning code elements (variables, names, or files) in your response, surround them with markdown backticks (`). For example: "verify that `user_id` is..."
 - Note that you will only see partial code segments that were changed (diff hunks in a PR code), and not the entire codebase. Avoid suggestions that might duplicate existing functionality of the outer codebase. In addition, the absence of a definition, declaration, import, or initialization for any entity in the PR code is NEVER a basis for a suggestion.
 - Also note that if the code ends at an opening brace or statement that begins a new scope (like 'if', 'for', 'try'), don't treat it as incomplete. Instead, acknowledge the visible scope boundary and analyze only the code shown.

--- a/tests/unittest/test_prompt_fragments.py
+++ b/tests/unittest/test_prompt_fragments.py
@@ -106,6 +106,27 @@ def test_affected_templates_delegate_to_shared_fragment_once(prompt_name, legacy
     assert legacy_example not in system_prompt
 
 
+@pytest.mark.parametrize("prompt_name", [
+    "pr_code_suggestions_prompt",
+    "pr_code_suggestions_prompt_not_decoupled",
+])
+def test_suggestion_prompts_allow_dependencies_introduced_by_improved_code(prompt_name):
+    prompt = get_settings().get(prompt_name).system
+    variables = {
+        "focus_only_on_problems": True,
+        "num_code_suggestions": 3,
+        "diff_hunk_format": "diff",
+        "skills_context": "",
+        "extra_instructions": "",
+        "repo_context": "",
+    }
+
+    rendered = Environment().from_string(prompt).render(variables)
+
+    assert "If the suggested `improved_code` introduces a dependency" in rendered
+    assert "standalone or unrelated missing" in rendered
+
+
 def test_fragment_renderer_sandboxes_host_overrides(restore_prompt_settings):
     get_settings().set(
         "prompt_fragments.diff_hunk_format",


### PR DESCRIPTION
## What changed
- Refine both code-suggestion prompt variants so required imports introduced by a suggestion's own improved code are allowed.
- Continue rejecting standalone or unrelated missing imports and declarations.
- Add regression coverage for the focus-only prompt wording.

## Why
With the default focus_only_on_problems=true, the prompt explicitly prohibited missing imports. That made an otherwise valid suggestion unusable when its own replacement code introduced a dependency.

## Validation
- Targeted prompt-fragment tests: 7 passed
- Ruff check on the changed test and prompt files (passed)
- TOML parsing and git diff checks (passed)

Closes #3108