### PR TITLE
chore(deps): bump pytest to 9.1.1 and clear the parametrize deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,9 @@ similar-issue = [
   "qdrant-client==1.15.1",
 ]
 dev = [
-  "pytest==9.0.3",
-  "pytest-asyncio>=1.3.0",
-  "pytest-cov==7.0.0",
+  "pytest==9.1.1",
+  "pytest-asyncio>=1.4.0",
+  "pytest-cov==7.1.0",
   "httpx==0.28.1",
   "pre-commit>=4,<5",
   "ruff==0.16.5",

--- a/tests/unittest/test_apply_repo_settings.py
+++ b/tests/unittest/test_apply_repo_settings.py
@@ -119,4 +119,3 @@ foo = "X-FROM-REPO-A"
             git_utils.apply_repo_settings("https://git.example/projects/B/repos/b/pull-requests/1")
             assert get_settings().get("my_custom_repo_section.foo") is None, \
                 "repo A's [my_custom_repo_section] leaked into repo B"
-

--- a/tests/unittest/test_git_provider_line_link_contract.py
+++ b/tests/unittest/test_git_provider_line_link_contract.py
@@ -235,7 +235,7 @@ def test_contract_tier_matches_expected_anchor_shapes(contract: ProviderContract
 
 @pytest.mark.parametrize(
     "contract",
-    (contract for contract in PROVIDER_CONTRACTS if contract.tier is AnchorTier.FILE_ONLY),
+    list(contract for contract in PROVIDER_CONTRACTS if contract.tier is AnchorTier.FILE_ONLY),
     ids=lambda contract: contract.name,
 )
 def test_file_only_contract_ignores_all_line_arguments(contract: ProviderContract):
@@ -249,7 +249,7 @@ def test_file_only_contract_ignores_all_line_arguments(contract: ProviderContrac
 
 @pytest.mark.parametrize(
     "contract",
-    (contract for contract in PROVIDER_CONTRACTS if contract.tier is AnchorTier.SINGLE_LINE),
+    list(contract for contract in PROVIDER_CONTRACTS if contract.tier is AnchorTier.SINGLE_LINE),
     ids=lambda contract: contract.name,
 )
 def test_single_line_contract_ignores_end_argument(contract: ProviderContract):

--- a/uv.lock
+++ b/uv.lock
@@ -2656,9 +2656,9 @@ provides-extras = ["lambda", "otel-grpc", "langchain"]
 dev = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "pre-commit", specifier = ">=4,<5" },
-    { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.16.5" },
 ]
 similar-issue = [
@@ -3080,7 +3080,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -3089,9 +3089,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -3109,16 +3109,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hello

In PR:
1) up pytest libs
2) fix PytestRemovedIn10Warning warnings
`  /Users/vyuroshchin/github_my/pr-agent/.venv/lib/python3.12/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/unittest/test_git_provider_line_link_contract.py::test_file_only_contract_ignores_all_line_arguments, argvalues type: generator
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

.venv/lib/python3.12/site-packages/_pytest/python.py:124
  /Users/vyuroshchin/github_my/pr-agent/.venv/lib/python3.12/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/unittest/test_git_provider_line_link_contract.py::test_single_line_contract_ignores_end_argument, argvalues type: generator
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)`