### PR TITLE
docs: fix automations note to reflect self-hosted deployments

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -93,8 +93,7 @@ When this parameter is set to `true`, PR-Agent will not run any automatic tools 
 ### GitHub App
 
 !!! note "Configurations for PR-Agent"
-    PR-Agent for GitHub is an App, hosted by Codium. So all the instructions below are relevant for PR-Agent users.
-    Same goes for [GitLab webhook](#gitlab-webhook) and [BitBucket App](#bitbucket-app) sections.
+    These settings apply to self-hosted GitHub App, GitLab webhook, and Bitbucket App deployments.
 
 #### GitHub app automatic tools when a new PR is opened
 


### PR DESCRIPTION
## Description

The "Configurations for PR-Agent" note in `automations_and_usage.md` states that the GitHub App is "hosted by Codium". There is no Codium-hosted app for this project; every deployment is self-hosted, which the rest of the page goes on to explain.

This updates the note to state that these settings apply to self-hosted GitHub App, GitLab webhook, and Bitbucket App deployments.

Fixes #3176