### PR TITLE
chore: remove dead bandit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,3 @@ repos:
         language: system
         types_or: [python, pyi]
         args: [--fix, --show-fixes]
-
-  # - repo: https://github.com/PyCQA/bandit
-  #   rev: 1.7.10
-  #   hooks:
-  #     - id: bandit
-  #       args: [
-  #         "-c", "pyproject.toml",
-  #       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,10 +177,6 @@ lint.ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore import-position and unused-import in __init__.py (re-export modules).
 "__init__.py" = ["E402", "F401"]
-[tool.bandit]
-exclude_dirs = ["tests"]
-skips = ["B101"]
-tests = []
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
Removes the dead [tool.bandit] configuration and its commented-out pre-commit hook as requested in the issue.