### PR TITLE
fix(deps): declare certifi as a range per the security-pin policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "azure-devops==7.1.0b4",
   "azure-identity==1.25.0",
   "boto3==1.43.78",
-  "certifi==2024.8.30",
+  "certifi>=2026.7.22",
   "dynaconf>=3.2.13,<4",
   "fastapi>=0.141.1,<1",
   "GitPython>=3.1.59,<4",

--- a/tests/unittest/test_certifi_pin_policy.py
+++ b/tests/unittest/test_certifi_pin_policy.py
@@ -1,0 +1,34 @@
+"""Guard for the security-pin policy declared above ``dependencies`` in pyproject.toml.
+
+certifi is the CA trust store every outbound HTTPS call in pr-agent ultimately
+validates against. An ``==`` pin freezes that bundle for pip consumers, who then
+cannot pick up a rebuilt bundle -- one that drops a distrusted root, say -- without
+overriding our requirement. The policy comment in pyproject.toml says
+security-sensitive packages declare ranges for exactly this reason (#2523, #3194);
+this test is what keeps the comment honest, since nothing else checks it.
+
+This asserts the declared requirement only. Exact versions for this repo's own
+builds still come from uv.lock, so reproducibility is unaffected.
+"""
+import tomllib
+
+CERTIFI_POLICY = (
+    "certifi must declare a floor (>=), not an == pin: it is the CA trust store, and an exact "
+    "pin leaves pip consumers stuck on a stale certificate bundle. Exact versions for this "
+    "repo's own builds come from uv.lock. See the comment above [project].dependencies."
+)
+
+
+def _certifi_requirement(pytestconfig):
+    with open(pytestconfig.inipath, "rb") as f:
+        dependencies = tomllib.load(f)["project"]["dependencies"]
+
+    matches = [dep for dep in dependencies if dep.lower().startswith("certifi")]
+    assert len(matches) == 1, f"expected exactly one certifi requirement, found {matches!r}"
+    return matches[0]
+
+
+def test_certifi_is_not_exact_pinned(pytestconfig):
+    requirement = _certifi_requirement(pytestconfig)
+    assert "==" not in requirement, f"{requirement!r}: {CERTIFI_POLICY}"
+    assert ">=" in requirement, f"{requirement!r}: {CERTIFI_POLICY}"

--- a/uv.lock
+++ b/uv.lock
@@ -330,11 +330,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -2610,7 +2610,7 @@ requires-dist = [
     { name = "azure-devops", specifier = "==7.1.0b4" },
     { name = "azure-identity", specifier = "==1.25.0" },
     { name = "boto3", specifier = "==1.43.78" },
-    { name = "certifi", specifier = "==2024.8.30" },
+    { name = "certifi", specifier = ">=2026.7.22" },
     { name = "dynaconf", specifier = ">=3.2.13,<4" },
     { name = "fastapi", specifier = ">=0.141.1,<1" },
     { name = "giteapy", specifier = "==1.0.8" },


### PR DESCRIPTION
`pyproject.toml:39` declared `certifi==2024.8.30`, contradicting the policy comment four lines above it: security-sensitive packages declare `>=` floors so pip consumers can pull security patches on their own cadence (#2523).

certifi is the CA trust store. The exact pin hands pip consumers a certificate bundle from August 2024 that they cannot update without overriding our requirement — worth noting the trust store is the one dependency where "stale" means silently trusting roots the ecosystem has since distrusted, rather than a missing feature.

## Changes

- `certifi==2024.8.30` → `certifi>=2026.7.22` (2026.7.22 is the current release)
- `uv.lock` refreshed: `certifi 2024.8.30 -> 2026.7.22`, the only package the re-resolution touched
- A test asserting certifi stays a range rather than an `==` pin

### On the missing upper bound

The policy describes `>=patched,<next-major` ranges, but certifi is CalVer — there is no next major. A `<2027` cap would re-freeze the bundle at the next year boundary and reintroduce exactly this issue, so this follows the `certifi>=2026.7.22` form suggested in the issue. Happy to add a cap if you would rather keep the two-part shape literally.

### On the test

`pyproject.toml` states the policy in a comment and nothing checked it, which is how a 2024 pin survived. `tests/unittest/test_certifi_pin_policy.py` reads the declared requirement via `pytestconfig.inipath` and asserts it is a floor, not an `==` pin. It is deliberately scoped to certifi and asserts no specific version, so routine bumps do not touch it. Drop it if you would rather handle enforcement generally under #3192.

To be accurate about severity: OSV reports no open advisory against certifi 2024.8.30. The problem is the stale trust store and the policy violation, not a known CVE.

## Verification

- `uv sync --frozen` succeeds — the lock matches pyproject, so the Docker/CI build stays green
- `PYTHONPATH=. uv run pytest tests/unittest` → 4363 passed, 1 skipped, 1 xfailed
- New test confirmed failing against the old `certifi==2024.8.30` line and passing after the change
- `uv run ruff check` and `uv run pre-commit run --files pyproject.toml uv.lock tests/unittest/test_certifi_pin_policy.py` both clean
- uv 0.12.10 used for the lock refresh, matching `docker/Dockerfile`

Fixes #3194

🤖 Generated with [Claude Code](https://claude.com/claude-code)