### PR TITLE
refactor(help): select help rendering by provider capability

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -222,6 +222,10 @@ class BitbucketServerProvider(GitProvider):
             return False
         return True
 
+    def supports_markdown_tables(self) -> bool:
+        # Bitbucket Data Center renders Markdown tables in comments, but not GFM.
+        return True
+
     def set_pr(self, pr_url: str):
         self.workspace_slug, self.repo_slug, self.pr_num = self._parse_pr_url(pr_url)
         self.pr = self._get_pr()

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -184,6 +184,22 @@ class GitProvider(ABC):
     def supports_line_question_history(self) -> bool:
         return False
 
+    def supports_checkbox_commands(self) -> bool:
+        """Whether ticking a command checkbox in a published comment runs that command.
+
+        Providers whose entrypoint reacts to a comment edit by dispatching the marked
+        command override this; the default is no support, so tools render commands as
+        text instead of interactive checkboxes."""
+        return False
+
+    def supports_markdown_tables(self) -> bool:
+        """Whether comments render pipe-table markdown.
+
+        Only consulted for providers without `gfm_markdown`, so that tools can degrade to
+        a plain table instead of refusing to render. Providers that render Markdown tables
+        but not GitHub-flavored markdown override this."""
+        return False
+
     #Given a url (issues or PR/MR) - get the .git repo url to which they belong. Needs to be implemented by the provider.
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
         get_logger().warning("Not implemented! Returning empty url")

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -185,11 +185,10 @@ class GitProvider(ABC):
         return False
 
     def supports_checkbox_commands(self) -> bool:
-        """Whether ticking a command checkbox in a published comment runs that command.
+        """Whether a published comment renders command checkboxes as checkboxes.
 
-        Providers whose entrypoint reacts to a comment edit by dispatching the marked
-        command override this; the default is no support, so tools render commands as
-        text instead of interactive checkboxes."""
+        Providers that render `- [ ]` as a tickable box override this; the default is no
+        support, so tools render commands as text instead."""
         return False
 
     def supports_markdown_tables(self) -> bool:

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -125,6 +125,11 @@ class GithubProvider(GitProvider):
     def supports_line_question_history(self) -> bool:
         return True
 
+    def supports_checkbox_commands(self) -> bool:
+        # Only the GitHub app routes the comment-edit event a ticked checkbox produces
+        # (see pr_agent/servers/github_app.py).
+        return True
+
     def _get_owner_and_repo_path(self, given_url: str) -> str:
         try:
             repo_path = None

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -126,8 +126,6 @@ class GithubProvider(GitProvider):
         return True
 
     def supports_checkbox_commands(self) -> bool:
-        # Only the GitHub app routes the comment-edit event a ticked checkbox produces
-        # (see pr_agent/servers/github_app.py).
         return True
 
     def _get_owner_and_repo_path(self, given_url: str) -> str:

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -13,7 +13,7 @@ from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import ModelType, clip_tokens, get_max_tokens, load_yaml
 from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import BitbucketServerProvider, GithubProvider, get_git_provider_with_context
+from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
 
 
@@ -190,7 +190,8 @@ class PRHelpMessage:
                 else:
                     get_logger().info(f"Answer:\n{answer_str}")
             else:
-                if not isinstance(self.git_provider, BitbucketServerProvider) and not self.git_provider.is_supported("gfm_markdown"):
+                supports_gfm_markdown = self.git_provider.is_supported("gfm_markdown")
+                if not supports_gfm_markdown and not self.git_provider.supports_markdown_tables():
                     self.git_provider.publish_comment(
                         "The `Help` tool requires gfm markdown, which is not supported by your code platform.")
                     return
@@ -242,15 +243,16 @@ class PRHelpMessage:
                 checkbox_list.append("[*]")
                 checkbox_list.append("[*]")
 
-                if isinstance(self.git_provider, GithubProvider) and not get_settings().config.get('disable_checkboxes', False):
+                if (supports_gfm_markdown and self.git_provider.supports_checkbox_commands()
+                        and not get_settings().config.get('disable_checkboxes', False)):
                     pr_comment += "<table><tr align='left'><th align='left'>Tool</th><th align='left'>Description</th><th align='left'>Trigger Interactively :gem:</th></tr>"
                     for i in range(len(tool_names)):
                         pr_comment += f"\n<tr><td align='left'>\n\n<strong>{tool_names[i]}</strong></td>\n<td>{descriptions[i]}</td>\n<td>\n\n{checkbox_list[i]}\n</td></tr>"
                     pr_comment += "</table>\n\n"
                     pr_comment += """\n\n(1) Note that each tool can be [triggered automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) when a new PR is opened, or called manually by [commenting on a PR](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#online-usage)."""
                     pr_comment += """\n\n(2) Tools marked with [*] require additional parameters to be passed. For example, to invoke the `/ask` tool, you need to comment on a PR: `/ask "<question content>"`. See the relevant documentation for each tool for more details."""
-                elif isinstance(self.git_provider, BitbucketServerProvider):
-                    # only support basic commands in BBDC
+                elif not supports_gfm_markdown:
+                    # only basic commands, in a plain markdown table (e.g. BBDC)
                     pr_comment = generate_bbdc_table(tool_names[:4], descriptions[:4])
                 else:
                     pr_comment += "<table><tr align='left'><th align='left'>Tool</th><th align='left'>Command</th><th align='left'>Description</th></tr>"

--- a/tests/unittest/test_command_descriptions.py
+++ b/tests/unittest/test_command_descriptions.py
@@ -48,6 +48,14 @@ async def test_pr_help_table_uses_canonical_command_descriptions():
         def is_supported(_feature):
             return True
 
+        @staticmethod
+        def supports_checkbox_commands():
+            return False
+
+        @staticmethod
+        def supports_markdown_tables():
+            return False
+
         def publish_comment(self, comment):
             self.comment = comment
 

--- a/tests/unittest/test_pr_help_message_rendering.py
+++ b/tests/unittest/test_pr_help_message_rendering.py
@@ -1,0 +1,94 @@
+"""The /help walkthrough picks its rendering from provider capabilities, not provider classes."""
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+from pr_agent.tools.pr_help_message import PRHelpMessage
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+INTERACTIVE_MARKER = "Trigger Interactively"
+PLAIN_TABLE_MARKER = "| Tool  | Description |"
+UNSUPPORTED_MARKER = "requires gfm markdown"
+
+
+class StubProvider:
+    """A provider that is none of the concrete classes the tool used to branch on."""
+
+    def __init__(self, gfm_markdown: bool, markdown_tables: bool = False, checkbox_commands: bool = False):
+        self._gfm_markdown = gfm_markdown
+        self._markdown_tables = markdown_tables
+        self._checkbox_commands = checkbox_commands
+        self.published = []
+
+    def is_supported(self, capability: str) -> bool:
+        return self._gfm_markdown if capability == "gfm_markdown" else True
+
+    def supports_markdown_tables(self) -> bool:
+        return self._markdown_tables
+
+    def supports_checkbox_commands(self) -> bool:
+        return self._checkbox_commands
+
+    def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        self.published.append(pr_comment)
+
+
+async def run_walkthrough(provider) -> str:
+    tool = PRHelpMessage.__new__(PRHelpMessage)
+    tool.git_provider = provider
+    tool.question_str = ""
+    tool.return_as_string = False
+    await tool.run()
+    assert len(provider.published) == 1
+    return provider.published[0]
+
+
+@pytest.fixture
+def published_output():
+    snapshot = snapshot_settings(["config.publish_output", "config.disable_checkboxes"])
+    get_settings().set("config.publish_output", True)
+    yield
+    restore_settings(snapshot)
+
+
+@pytest.mark.parametrize(
+    "capabilities, expected, unexpected",
+    [
+        # gfm markdown plus checkbox commands is the only combination that offers the checkboxes
+        (dict(gfm_markdown=True, checkbox_commands=True), INTERACTIVE_MARKER, PLAIN_TABLE_MARKER),
+        (dict(gfm_markdown=True), "<table>", INTERACTIVE_MARKER),
+        # without gfm markdown, a provider that renders pipe tables gets the basic table
+        (dict(gfm_markdown=False, markdown_tables=True), PLAIN_TABLE_MARKER, "<table>"),
+        (dict(gfm_markdown=False), UNSUPPORTED_MARKER, "<table>"),
+    ],
+)
+async def test_rendering_follows_capabilities(published_output, capabilities, expected, unexpected):
+    comment = await run_walkthrough(StubProvider(**capabilities))
+    assert expected in comment
+    assert unexpected not in comment
+
+
+async def test_checkboxes_stay_disabled_by_configuration(published_output):
+    get_settings().set("config.disable_checkboxes", True)
+    comment = await run_walkthrough(StubProvider(gfm_markdown=True, checkbox_commands=True))
+    assert INTERACTIVE_MARKER not in comment
+    assert "<table>" in comment
+
+
+@pytest.mark.parametrize(
+    "provider_class, checkbox_commands, markdown_tables",
+    [
+        (GithubProvider, True, False),
+        (GitLabProvider, False, False),
+        (BitbucketProvider, False, False),
+        (BitbucketServerProvider, False, True),
+    ],
+)
+def test_providers_declare_the_capabilities_the_tool_reads(provider_class, checkbox_commands, markdown_tables):
+    provider = provider_class.__new__(provider_class)
+    assert provider.supports_checkbox_commands() is checkbox_commands
+    assert provider.supports_markdown_tables() is markdown_tables


### PR DESCRIPTION
## Summary

First slice of #3184, taking the file the issue flags as the messiest: `pr_help_message.py`, whose `:193` mixes an `isinstance` check with an `is_supported` one in a single condition. The `/help` walkthrough decided its rendering from `GithubProvider` / `BitbucketServerProvider` identity, so a provider registered through `register_git_provider()` can never reach the checkbox or plain-table branches, however capable it is.

Two predicates added to `GitProvider` (both default `False`, matching `supports_line_question_history` and the other capability predicates), and the three call sites now read them:

- `supports_checkbox_commands()` — true for GitHub, the only platform whose comments render `- [ ]` as a tickable box. It selects rendering only; nothing in-tree runs a command from a ticked box.
- `supports_markdown_tables()` — true for Bitbucket Data Center, which renders pipe tables but not `gfm_markdown`; consulted only where `gfm_markdown` is absent, so the tool degrades to `generate_bbdc_table()` instead of refusing.

Rendering is unchanged for every in-tree provider: GitHub still gets the interactive table (unless `disable_checkboxes`), GitLab/Azure/Gitea the HTML table, BBDC the plain table, and Bitbucket Cloud/Gerrit/CodeCommit/local/plain-diff the "requires gfm markdown" message.

Leaves the other three files of #3184 (`pr_description.py`, `pr_code_suggestions.py`, `ticket_pr_compliance_check.py`) free for whoever wants them, so this refs rather than closes the issue.

## Tests

`tests/unittest/test_pr_help_message_rendering.py` drives `PRHelpMessage.run()` with a stub that is none of the concrete provider classes, so it passes only because the branch reads capabilities: one case per rendering path plus `disable_checkboxes`, and a parametrized check that GitHub/GitLab/Bitbucket/BBDC declare the values the tool relies on.

The existing `test_pr_help_table_uses_canonical_command_descriptions` fake provider gained the two predicates; without them its `is_supported`-only surface no longer matches what the tool reads.

## Verification

- `PYTHONPATH=. uv run pytest tests/unittest -q` — 4371 passed, 1 skipped, 1 xfailed
- `uv run ruff check <changed files>` and `uv run pre-commit run --files <changed files>` — passed
- Sabotage: forcing the plain-table branch off (`elif False:`) fails exactly the BBDC-shaped case; restoring it returns the file to green.

Refs #3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

