### PR TITLE
fix(release): keep uv.lock in sync with version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,6 +255,8 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+
       - name: Flag missing PyPI publish
         if: needs.publish-pypi.result != 'success'
         env:
@@ -267,8 +269,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump pyproject.toml
-        run: python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
+      - name: Bump pyproject.toml and sync uv.lock
+        run: |
+          python scripts/set_pyproject_version.py "${{ needs.prepare.outputs.version }}"
+          uv lock
 
       - name: Commit & push bump (fast-forward only)
         id: commit
@@ -276,19 +280,19 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           PUBLISHED_SHA: ${{ needs.prepare.outputs.sha }}
         run: |
-          if git diff --quiet pyproject.toml; then
-            echo "pyproject.toml already at $VERSION on $PUBLISHED_SHA; nothing to commit."
+          if git diff --quiet pyproject.toml uv.lock; then
+            echo "pyproject.toml and uv.lock already at $VERSION on $PUBLISHED_SHA; nothing to commit."
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             echo "sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git add pyproject.toml
+          git add pyproject.toml uv.lock
           git commit -m "chore(release): bump version to $VERSION [skip ci]"
           if git push origin "HEAD:refs/heads/main"; then
             echo "bumped=true" >> "$GITHUB_OUTPUT"
             echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::main has moved past the published commit ($PUBLISHED_SHA); skipping the bump push rather than rebasing onto a commit that was not built. Bump pyproject.toml on main manually:  git checkout main && python scripts/set_pyproject_version.py $VERSION && git commit -am 'chore(release): bump version to $VERSION' && git push"
+            echo "::warning::main has moved past the published commit ($PUBLISHED_SHA); skipping the bump push rather than rebasing onto a commit that was not built. Bump pyproject.toml and uv.lock on main manually:  git checkout main && python scripts/set_pyproject_version.py $VERSION && uv lock && git commit -am 'chore(release): bump version to $VERSION' && git push"
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             echo "sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
           fi

--- a/tests/unittest/test_publish_workflow_security.py
+++ b/tests/unittest/test_publish_workflow_security.py
@@ -185,3 +185,19 @@ def test_release_version_cannot_inject_workflow_outputs(tmp_path: Path, line_bre
 
     assert result.returncode != 0
     assert output.read_text() == "existing-output\n"
+
+
+def test_release_finalize_keeps_uv_lock_in_sync() -> None:
+    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text())
+    finalize_steps = workflow["jobs"]["finalize"]["steps"]
+    bump_step = next(
+        step for step in finalize_steps if step.get("name") == "Bump pyproject.toml and sync uv.lock"
+    )
+    commit_step = next(
+        step for step in finalize_steps if step.get("name") == "Commit & push bump (fast-forward only)"
+    )
+
+    run = bump_step["run"]
+    assert run.index("scripts/set_pyproject_version.py") < run.index("uv lock")
+    assert "git diff --quiet pyproject.toml uv.lock" in commit_step["run"]
+    assert "git add pyproject.toml uv.lock" in commit_step["run"]


### PR DESCRIPTION
The v0.45.0 release exposed this issue. The automated post-release version bump updated `pyproject.toml` to `0.45.0`, while the root project entry in `uv.lock` remained at `0.43.0`:

https://github.com/The-PR-Agent/pr-agent/blob/630824dda44f1837468cdbb04ee10ad94f095eec/pyproject.toml#L7

https://github.com/The-PR-Agent/pr-agent/blob/630824dda44f1837468cdbb04ee10ad94f095eec/uv.lock#L2528

The release workflow updates `pyproject.toml` after publishing but doesn't regenerate `uv.lock`, allowing the two files to drift.

This PR keeps the release metadata synchronized by:

- installing `uv` in the `finalize` job;
- running `uv lock` after `scripts/set_pyproject_version.py`;
- checking and staging both `pyproject.toml` and `uv.lock`;
- updating the manual recovery instructions accordingly;
- adding focused regression coverage to ensure the version is updated before the lockfile is regenerated and both files are included in the release commit.

Related: #3153 pins the project-level `uv` version used by `setup-uv`.