### PR TITLE
feat(litellm): allow declaring adaptive-thinking models by id

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -343,24 +343,14 @@ class LiteLLMAIHandler(BaseAiHandler):
         self.support_reasoning_models = SUPPORT_REASONING_EFFORT_MODELS
 
         # Models that support extended thinking (config override replaces the built-in list when non-empty)
-        override = get_settings().config.get("claude_extended_thinking_models_override", []) or []
-        if override and not isinstance(override, list):
-            get_logger().warning(
-                "Invalid claude_extended_thinking_models_override in config; expected a list of model names. "
-                "Falling back to the built-in Claude extended-thinking model list."
-            )
-            override = []
-        elif override and not all(isinstance(model, str) and model.strip() for model in override):
-            get_logger().warning(
-                "Invalid claude_extended_thinking_models_override in config; "
-                "expected a list of model name strings. "
-                "Falling back to the built-in Claude extended-thinking model list."
-            )
-            override = []
-        # Store stripped names so exact-match checks against the model succeed even when the config
-        # entries contain surrounding whitespace (validation above already used model.strip()).
-        self.claude_extended_thinking_models = (
-            [model.strip() for model in override] if override else CLAUDE_EXTENDED_THINKING_MODELS
+        override = self._validated_model_name_list("claude_extended_thinking_models_override")
+        self.claude_extended_thinking_models = override or CLAUDE_EXTENDED_THINKING_MODELS
+
+        # Model ids to additionally treat as adaptive-only, for ids the built-in pattern cannot
+        # recognise (see _model_uses_adaptive_thinking). Additive rather than replacing, so a named
+        # model elsewhere in the same fallback chain keeps its own detection.
+        self.claude_adaptive_thinking_models_override = self._validated_model_name_list(
+            "claude_adaptive_thinking_models_override"
         )
 
         # Models that require streaming
@@ -579,6 +569,42 @@ class LiteLLMAIHandler(BaseAiHandler):
         kwargs["temperature"] = 1
 
         return kwargs
+
+    @staticmethod
+    def _validated_model_name_list(setting_name: str) -> list:
+        """Return a config list of model names, or an empty list when the value is malformed.
+
+        Shared by the extended- and adaptive-thinking overrides so a bad value degrades to the
+        built-in behaviour with one warning instead of raising. Names are stripped so exact-match
+        checks succeed even when the config entries carry surrounding whitespace.
+        """
+        value = get_settings().config.get(setting_name, []) or []
+        if not value:
+            return []
+        if not isinstance(value, list):
+            get_logger().warning(
+                f"Invalid {setting_name} in config; expected a list of model names. "
+                "Ignoring it and using the built-in Claude thinking model detection."
+            )
+            return []
+        if not all(isinstance(model, str) and model.strip() for model in value):
+            get_logger().warning(
+                f"Invalid {setting_name} in config; expected a list of model name strings. "
+                "Ignoring it and using the built-in Claude thinking model detection."
+            )
+            return []
+        return [model.strip() for model in value]
+
+    def _model_uses_adaptive_thinking(self, model: str) -> bool:
+        """Return whether `model` should receive the adaptive-thinking payload.
+
+        Extends `_is_claude_adaptive_thinking_model` with `claude_adaptive_thinking_models_override`,
+        so a model id that carries no recognisable model name -- a Bedrock
+        application-inference-profile ARN, for example -- can still be declared adaptive-only.
+        """
+        if isinstance(model, str) and model.strip() in self.claude_adaptive_thinking_models_override:
+            return True
+        return self._is_claude_adaptive_thinking_model(model)
 
     @staticmethod
     def _is_claude_adaptive_thinking_model(model: str) -> bool:
@@ -953,14 +979,14 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 kwargs["allowed_openai_params"] = ["reasoning_effort"]
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
-                if self._is_claude_adaptive_thinking_model(model) and get_settings().config.get(
+                if self._model_uses_adaptive_thinking(model) and get_settings().config.get(
                         "enable_claude_adaptive_thinking", False):
                     kwargs = self._configure_claude_adaptive_thinking(model, kwargs)
                 elif (
                     model in self.claude_extended_thinking_models
                     and get_settings().config.get("enable_claude_extended_thinking", False)
                 ):
-                    if self._is_claude_adaptive_thinking_model(model):
+                    if self._model_uses_adaptive_thinking(model):
                         get_logger().warning(
                             f"Skipping extended thinking for {model}: adaptive-only models reject "
                             f"budget_tokens. Enable config.enable_claude_adaptive_thinking instead."

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -102,6 +102,12 @@ enable_claude_adaptive_thinking = false
 # When non-empty, this list fully replaces the built-in defaults (see CLAUDE_EXTENDED_THINKING_MODELS
 # in pr_agent/algo/__init__.py). Leave empty to use the defaults.
 claude_extended_thinking_models_override = []
+# Optional: additionally treat these model ids as adaptive-only Claude models. Unlike the
+# extended-thinking override above, entries here are ADDED to the built-in pattern rather than
+# replacing it, so an id that carries no recognisable model name (for example a Bedrock
+# application-inference-profile ARN) can opt in without disabling detection for named models in
+# the same fallback chain. Only read when enable_claude_adaptive_thinking is true.
+claude_adaptive_thinking_models_override = []
 # Extract issue number from PR source branch name (e.g. feature/1-auth-google -> issue #1). When true, branch-derived
 # issue URLs are merged with tickets from the PR description for compliance. Set to false to restore description-only behaviour.
 # Note: Branch-name extraction is GitHub-only for now; other providers planned for later.

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -43,11 +43,14 @@ def _restore_litellm_globals():
                 os.environ[name] = value
 
 
-def _settings(reasoning_effort="medium", enabled=False, extended_enabled=False):
+def _settings(reasoning_effort="medium", enabled=False, extended_enabled=False,
+              adaptive_override=None):
     flags = {
         "enable_claude_adaptive_thinking": enabled,
         "enable_claude_extended_thinking": extended_enabled,
     }
+    if adaptive_override is not None:
+        flags["claude_adaptive_thinking_models_override"] = adaptive_override
     config = SimpleNamespace(
         reasoning_effort=reasoning_effort,
         ai_timeout=120,
@@ -72,11 +75,11 @@ def _response():
 
 
 async def _run_completion(monkeypatch, model, reasoning_effort="medium", enabled=False,
-                          extended_enabled=False, extended_override=None):
+                          extended_enabled=False, extended_override=None, adaptive_override=None):
     monkeypatch.setattr(
         litellm_handler,
         "get_settings",
-        lambda: _settings(reasoning_effort, enabled, extended_enabled),
+        lambda: _settings(reasoning_effort, enabled, extended_enabled, adaptive_override),
     )
     with patch(
         "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
@@ -207,3 +210,81 @@ async def test_non_adaptive_model_in_extended_override_still_gets_extended_think
 
     assert kwargs["thinking"]["type"] == "enabled"
     assert "budget_tokens" in kwargs["thinking"]
+
+
+# A Bedrock application-inference-profile ARN carries no model name, so the built-in pattern
+# cannot classify it. Synthetic account id and profile id on purpose.
+_PROFILE_ARN = (
+    "bedrock/converse/arn:aws:bedrock:eu-central-1:000000000000:"
+    "application-inference-profile/abc123def456"
+)
+
+
+def _handler_with_override(monkeypatch, override):
+    monkeypatch.setattr(
+        litellm_handler, "get_settings", lambda: _settings(adaptive_override=override)
+    )
+    return LiteLLMAIHandler()
+
+
+def test_opaque_model_id_is_not_detected_without_the_override(monkeypatch):
+    handler = _handler_with_override(monkeypatch, None)
+    assert LiteLLMAIHandler._is_claude_adaptive_thinking_model(_PROFILE_ARN) is False
+    assert handler._model_uses_adaptive_thinking(_PROFILE_ARN) is False
+
+
+def test_override_declares_an_opaque_model_id_adaptive(monkeypatch):
+    handler = _handler_with_override(monkeypatch, [_PROFILE_ARN])
+    assert handler._model_uses_adaptive_thinking(_PROFILE_ARN) is True
+
+
+def test_override_tolerates_surrounding_whitespace(monkeypatch):
+    handler = _handler_with_override(monkeypatch, [f"  {_PROFILE_ARN}  "])
+    assert handler._model_uses_adaptive_thinking(_PROFILE_ARN) is True
+
+
+def test_override_does_not_capture_unlisted_models(monkeypatch):
+    handler = _handler_with_override(monkeypatch, [_PROFILE_ARN])
+    assert handler._model_uses_adaptive_thinking("anthropic/claude-opus-4-6") is False
+
+
+def test_override_is_additive_and_keeps_built_in_detection(monkeypatch):
+    """The extended-thinking override replaces its list; this one must not."""
+    handler = _handler_with_override(monkeypatch, [_PROFILE_ARN])
+    assert handler._model_uses_adaptive_thinking("anthropic/claude-opus-4-8") is True
+
+
+@pytest.mark.parametrize("bad_override", ["not-a-list", [""], ["ok", 5], [None]])
+def test_malformed_override_falls_back_to_built_in_detection(monkeypatch, bad_override):
+    handler = _handler_with_override(monkeypatch, bad_override)
+    assert handler.claude_adaptive_thinking_models_override == []
+    assert handler._model_uses_adaptive_thinking(_PROFILE_ARN) is False
+    assert handler._model_uses_adaptive_thinking("anthropic/claude-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_overridden_opaque_model_receives_adaptive_payload(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        _PROFILE_ARN,
+        reasoning_effort="high",
+        enabled=True,
+        adaptive_override=[_PROFILE_ARN],
+    )
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"] == {"effort": "high"}
+    assert "temperature" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_overridden_model_sends_no_thinking_payload_while_feature_is_off(monkeypatch):
+    kwargs = await _run_completion(
+        monkeypatch,
+        _PROFILE_ARN,
+        enabled=False,
+        adaptive_override=[_PROFILE_ARN],
+    )
+
+    assert "thinking" not in kwargs
+    assert "output_config" not in kwargs

--- a/tests/unittest/test_litellm_run_details.py
+++ b/tests/unittest/test_litellm_run_details.py
@@ -188,6 +188,7 @@ def _bare_handler():
     handler.repetition_penalty = None
     handler.add_litellm_callbacks = False
     handler.claude_extended_thinking_models = []
+    handler.claude_adaptive_thinking_models_override = []
     handler.no_support_temperature_models = []
     handler.support_reasoning_models = []
     handler.user_message_only_models = []


### PR DESCRIPTION
Adaptive thinking is gated on `_is_claude_adaptive_thinking_model`, a regex over the model name. A Bedrock application-inference-profile ARN carries no model name, so a deployment that addresses models by profile ARN cannot enable the feature even though the underlying model is adaptive-only, and the flag silently does nothing.

Adds `config.claude_adaptive_thinking_models_override` so such an id can be declared adaptive-only. The list is additive to the built-in pattern, unlike `claude_extended_thinking_models_override` which replaces its list, so a named model elsewhere in the same fallback chain keeps its own detection. Validation is extracted into a shared `_validated_model_name_list` helper used by both overrides.

12 new tests covering detection, whitespace, additivity and malformed values; full unit suite passes (4372).
