### PR TITLE
Harden Dockerfiles for stable and predictable builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,64 +1,64 @@
 FROM python:3.12.14-slim AS base
 COPY --from=ghcr.io/astral-sh/uv:0.12.10 /uv /uvx /bin/
 
-RUN apt update && apt install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y git curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1
-ADD pyproject.toml uv.lock ./
-ADD docs docs
+COPY pyproject.toml uv.lock ./
+COPY docs docs
 RUN uv sync --frozen --no-install-project --no-dev
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 
 FROM base AS github_app
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py", "--forwarded-allow-ips", "*", "pr_agent.servers.github_app:app"]
 
 FROM base AS bitbucket_app
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "pr_agent/servers/bitbucket_app.py"]
 
 FROM base AS bitbucket_server_webhook
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "pr_agent/servers/bitbucket_server_webhook.py"]
 
 FROM base AS github_polling
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "pr_agent/servers/github_polling.py"]
 
 FROM base AS github_action
-ADD pr_agent pr_agent
-ADD github_action/entrypoint.sh /
+COPY pr_agent pr_agent
+COPY github_action/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 FROM base AS gitlab_webhook
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py", "--forwarded-allow-ips", "*", "pr_agent.servers.gitlab_webhook:app"]
 
 FROM base AS azure_devops_webhook
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "pr_agent/servers/azuredevops_server_webhook.py"]
 
 FROM base AS gitea_app
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 CMD ["python", "-m", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-c", "pr_agent/servers/gunicorn_config.py","pr_agent.servers.gitea_app:app"]
 
 FROM base AS mosaico_agent
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 EXPOSE 9000
 CMD ["python", "pr_agent/mosaico/server.py"]
 
 
 FROM base AS test
 RUN uv sync --frozen --no-install-project
-ADD pr_agent pr_agent
-ADD tests tests
-ADD .github/workflows/publish.yml .github/workflows/publish.yml
-ADD docker/mosaico docker/mosaico
+COPY pr_agent pr_agent
+COPY tests tests
+COPY .github/workflows/publish.yml .github/workflows/publish.yml
+COPY docker/mosaico docker/mosaico
 
 FROM base AS cli
-ADD pr_agent pr_agent
+COPY pr_agent pr_agent
 RUN uv sync --frozen --no-dev && ln -s /app/.venv/bin/pr-agent /usr/local/bin/pr-agent
 ENTRYPOINT ["python", "pr_agent/cli.py"]

--- a/docker/Dockerfile.lambda
+++ b/docker/Dockerfile.lambda
@@ -8,7 +8,8 @@ RUN dnf update -y && \
 # Build the locked environment at /opt/venv with uv; put its site-packages
 # on the Lambda runtime's import path alongside the task root via PYTHONPATH.
 ENV UV_COMPILE_BYTECODE=1 UV_PROJECT_ENVIRONMENT=/opt/venv
-ADD pyproject.toml uv.lock ./
+WORKDIR ${LAMBDA_TASK_ROOT}
+COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project --no-dev --extra lambda --python /var/lang/bin/python3.12
 ENV PYTHONPATH="/opt/venv/lib/python3.12/site-packages:${LAMBDA_TASK_ROOT}"
 COPY pr_agent/ ${LAMBDA_TASK_ROOT}/pr_agent/


### PR DESCRIPTION
Image builds should behave the same way every time, so each instruction uses a stable form with fixed behavior instead of an interactive or implicit one.

Replace `apt` with stable `apt-get` for scripting, since `apt` itself warns it "does not have a stable CLI interface" in scripts; use `COPY` instead of `ADD`, which can silently fetch remote URLs and auto-extract tar archives, for local files; and set `WORKDIR` explicitly in `Dockerfile.lambda` so the relative `COPY` destination no longer relies on the base image default.

Refs:
- https://github.com/hadolint/hadolint/wiki/DL3020
- https://github.com/hadolint/hadolint/wiki/DL3027
- https://github.com/hadolint/hadolint/wiki/DL3045