### PR TITLE
fix(providers): report code-suggestion publication failure

### DIFF
--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -214,12 +214,15 @@ class CodeCommitProvider(GitProvider):
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         counter = 1
+        publishable_count = 0
+        published_count = 0
         for suggestion in code_suggestions:
             # Verify that each suggestion has the required keys
             if not all(key in suggestion for key in ["body", "relevant_file", "relevant_lines_start"]):
                 get_logger().warning(f"Skipping code suggestion #{counter}: Each suggestion must have 'body', 'relevant_file', 'relevant_lines_start' keys")
                 continue
 
+            publishable_count += 1
             target_contexts = self._get_target_contexts_for_file(suggestion["relevant_file"])
             for target in target_contexts:
                 try:
@@ -236,15 +239,15 @@ class CodeCommitProvider(GitProvider):
                         annotation_file=suggestion["relevant_file"],
                         annotation_line=suggestion["relevant_lines_start"],
                     )
+                    published_count += 1
                 except Exception as e:
                     raise ValueError(f"CodeCommit Cannot publish code suggestions for PR: {self.pr_num}") from e
 
             counter += 1
 
-        # The calling function passes in a list of code suggestions, and this function publishes each suggestion one at a time.
-        # If we were to return False here, the calling function will attempt to publish the same list of code suggestions again, one at a time.
-        # Since this function publishes the suggestions one at a time anyway, we always return True here to avoid the retry.
-        return True
+        # A partial failure must not report failure: the caller republishes the whole
+        # list, which would post the already-accepted suggestions a second time.
+        return published_count > 0 or publishable_count == 0
 
     def publish_labels(self, labels):
         return [""]  # not implemented yet

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -387,8 +387,10 @@ class GerritProvider(GitProvider):
             '\n'.join(context) + '\n' if context else ''
         )
 
-    def publish_code_suggestions(self, code_suggestions: list):
+    def publish_code_suggestions(self, code_suggestions: list) -> bool:
         msg = []
+        publishable_count = 0
+        published_count = 0
         repo_root = pathlib.Path(self.repo_path).resolve()
         for suggestion in code_suggestions:
             # Validate suggestion structure before accessing keys
@@ -402,6 +404,8 @@ class GerritProvider(GitProvider):
             except ValueError:
                 get_logger().warning(f"Skipping suggestion with path traversal: {suggestion['relevant_file']}")
                 continue
+
+            publishable_count += 1
             description, code = self.split_suggestion(suggestion['body'])
             add_suggestion(
                 target_path,
@@ -417,8 +421,13 @@ class GerritProvider(GitProvider):
             msg.append(f'* {description}\n{full_path}')
 
         if msg:
-            add_comment(self.parsed_url, self.refspec, "\n".join(msg))
-            return True
+            try:
+                add_comment(self.parsed_url, self.refspec, "\n".join(msg))
+                published_count += 1
+            except Exception as e:
+                get_logger().exception("Failed to publish Gerrit code suggestions: {}", e)
+
+        return published_count > 0 or publishable_count == 0
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         if not is_temporary:

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -395,3 +395,118 @@ def test_disable_eyes_short_circuits_before_any_backend_call(provider_name: str)
     provider = provider_type.__new__(provider_type)
 
     assert provider.add_eyes_reaction(COMMENT_ID, disable_eyes=True) is None
+
+
+@pytest.mark.parametrize(
+    "provider_name",
+    [
+        name
+        for name, (cls, _) in PROVIDERS.items()
+        if "publish_code_suggestions" in cls.__dict__
+    ],
+)
+def test_publish_code_suggestions_declares_bool_return(provider_name: str):
+    provider_type, _ = PROVIDERS[provider_name]
+    hints = get_type_hints(provider_type.publish_code_suggestions)
+    assert hints.get("return") is bool
+
+
+def test_gerrit_publish_code_suggestions_returns_false_on_total_failure(monkeypatch, tmp_path):
+    provider = GerritProvider.__new__(GerritProvider)
+    provider.parsed_url = SimpleNamespace()
+    provider.refspec = "refs/changes/1"
+    provider.repo_path = str(tmp_path)
+    (tmp_path / "app.py").write_text("orig\n")
+
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.upload_patch",
+        lambda *_: "https://patch.example/1",
+    )
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.diff",
+        lambda *_, **__: "patch",
+    )
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.reset_local_changes",
+        lambda *_: None,
+    )
+
+    def _fail_comment(*_):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("pr_agent.git_providers.gerrit_provider.add_comment", _fail_comment)
+
+    suggestions = [{
+        "relevant_file": "app.py",
+        "body": "description\n```suggestion\nnew\n```",
+        "relevant_lines_start": 1,
+        "relevant_lines_end": 1,
+    }]
+    assert provider.publish_code_suggestions(suggestions) is False
+
+
+def test_gerrit_publish_code_suggestions_returns_true_on_success(monkeypatch, tmp_path):
+    provider = GerritProvider.__new__(GerritProvider)
+    provider.parsed_url = SimpleNamespace()
+    provider.refspec = "refs/changes/1"
+    provider.repo_path = str(tmp_path)
+    (tmp_path / "app.py").write_text("orig\n")
+
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.upload_patch",
+        lambda *_: "https://patch.example/1",
+    )
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.diff",
+        lambda *_, **__: "patch",
+    )
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.reset_local_changes",
+        lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "pr_agent.git_providers.gerrit_provider.add_comment",
+        lambda *_: None,
+    )
+
+    suggestions = [{
+        "relevant_file": "app.py",
+        "body": "description\n```suggestion\nnew\n```",
+        "relevant_lines_start": 1,
+        "relevant_lines_end": 1,
+    }]
+    assert provider.publish_code_suggestions(suggestions) is True
+
+
+def test_codecommit_publish_code_suggestions_returns_false_when_no_publishable_targets():
+    provider = CodeCommitProvider.__new__(CodeCommitProvider)
+    provider.pr_num = 123
+    provider.codecommit_client = MagicMock()
+    provider._get_target_contexts_for_file = MagicMock(return_value=[])
+
+    suggestions = [{
+        "body": "suggestion",
+        "relevant_file": "app.py",
+        "relevant_lines_start": 1,
+    }]
+    assert provider.publish_code_suggestions(suggestions) is False
+    provider.codecommit_client.publish_comment.assert_not_called()
+
+
+def test_codecommit_publish_code_suggestions_returns_true_on_success():
+    provider = CodeCommitProvider.__new__(CodeCommitProvider)
+    provider.pr_num = 123
+    provider.codecommit_client = MagicMock()
+    provider._get_target_contexts_for_file = MagicMock(return_value=[{
+        "repository_name": "repo",
+        "destination_commit": "dest",
+        "source_commit": "src",
+    }])
+
+    suggestions = [{
+        "body": "suggestion",
+        "relevant_file": "app.py",
+        "relevant_lines_start": 1,
+    }]
+    assert provider.publish_code_suggestions(suggestions) is True
+    provider.codecommit_client.publish_comment.assert_called_once()


### PR DESCRIPTION
Refs #3117.

Second invariant of #3117: `publish_code_suggestions` must report failure when every publishable suggestion failed. #3156 landed the predicate-truth half; this lands the return-value half for the two providers that are not already owned by other work.

**GitLab is deliberately out of scope** — open PR #3129 owns #3109. This PR touches no GitLab code, so the two can land in either order.

## Changes

- `GerritProvider.publish_code_suggestions` had no `-> bool` annotation and fell off the end returning `None` when nothing was published. It now declares `bool`, and a raised `add_comment` is logged and reported as failure instead of propagating out of a method the caller reads as a success flag.
- `CodeCommitProvider.publish_code_suggestions` ended in an unconditional `return True` whose comment argued that returning False would cause the caller to republish. That rationale is now stale: the failure signal is what gates the one-by-one retry and the `RuntimeError` in `pr_agent/tools/pr_code_suggestions.py`, so a run in which nothing landed reported success. It now counts publishable and published suggestions.
- Both use the shape already merged for Gitea (#2878) and Bitbucket (#2992): `return published_count > 0 or publishable_count == 0`, so a partial failure still reports success and does not trigger a republish of the suggestions that did land. The `ValueError` raised from the CodeCommit client exception path is unchanged.
- `tests/unittest/test_git_provider_method_contract.py` gains four tests plus a parametrised row pinning that every provider overriding `publish_code_suggestions` declares a `bool` return: Gerrit and CodeCommit each return `False` when every publishable suggestion failed and `True` when at least one landed.

## Validation

- `PYTHONPATH=. uv run pytest tests/unittest/test_git_provider_method_contract.py -q` → 189 passed (was 185).
- Full unit suite: `PYTHONPATH=. uv run pytest tests/unittest -q` → 4404 passed, 1 skipped, 1 xfailed.
- Sabotage run: with both provider fixes reverted and the new tests kept, 3 of the new tests fail (`assert None is bool`, the Gerrit exception propagating as `RuntimeError: network down`, and `assert True is False` on CodeCommit). Restored, all pass.
- `uv run ruff check --fix` and `uv run pre-commit run --files <touched>` clean.

## Scope / risk

Two provider return values plus tests. No configuration, prompt, workflow, dependency or API shape changes. #3117 stays open for the GitLab side, which #3129 covers.
