### PR TITLE
fix: allow certifi security updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "azure-devops==7.1.0b4",
   "azure-identity==1.25.0",
   "boto3==1.43.78",
-  "certifi==2024.8.30",
+  "certifi>=2026.7.22,<2027",
   "dynaconf>=3.2.13,<4",
   "fastapi>=0.141.1,<1",
   "GitPython>=3.1.59,<4",

--- a/uv.lock
+++ b/uv.lock
@@ -330,11 +330,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -2610,7 +2610,7 @@ requires-dist = [
     { name = "azure-devops", specifier = "==7.1.0b4" },
     { name = "azure-identity", specifier = "==1.25.0" },
     { name = "boto3", specifier = "==1.43.78" },
-    { name = "certifi", specifier = "==2024.8.30" },
+    { name = "certifi", specifier = ">=2026.7.22,<2027" },
     { name = "dynaconf", specifier = ">=3.2.13,<4" },
     { name = "fastapi", specifier = ">=0.141.1,<1" },
     { name = "giteapy", specifier = "==1.0.8" },


### PR DESCRIPTION
## Summary

- replace the stale exact `certifi` pin with the project's documented security-update range policy
- raise the minimum to the current vetted `2026.7.22` release and cap it below 2027
- refresh `uv.lock` so repository builds remain reproducible

## Validation

- `uvx uv@0.12.10 lock --check`
- pre-commit `check-toml`, `end-of-file-fixer`, `mixed-line-ending`, and `trailing-whitespace` hooks
- `git diff --check`

Closes #3194