### PR TITLE
fix(bitbucket): restore persistent comment links

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -375,6 +375,10 @@ class BitbucketProvider(GitProvider):
             return comment._cloud_comment
         return comment
 
+    def get_comment_url(self, comment):
+        comment = self._get_cloud_comment(comment)
+        return comment.data["links"]["html"]["href"]
+
     def supports_review_comment_identity(self) -> bool:
         return True
 

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -651,6 +651,33 @@ not a valid hunk
         assert comments[0].body == "## PR Review\n\nreview body"
         assert comments[0]._cloud_comment is comment
 
+    def test_persistent_review_update_links_status_to_existing_cloud_comment(self):
+        provider = BitbucketProvider.__new__(BitbucketProvider)
+        provider.pr = MagicMock()
+        provider.max_comment_length = 32_768
+        provider.get_latest_commit_url = MagicMock(return_value="https://bitbucket.org/acme/repo/commits/head")
+        provider.publish_comment = MagicMock(return_value={"id": 8})
+
+        header = "## PR Review"
+        identity = PRReviewIdentity.REGULAR.value
+        comment_url = "https://bitbucket.org/acme/repo/pull-requests/1#comment-7"
+        existing = MagicMock()
+        existing.raw = f"{header}\n\n{identity}\n\nprevious review"
+        existing.data = {"links": {"html": {"href": comment_url}}}
+        provider.pr.comments.return_value = [existing]
+
+        provider.publish_persistent_comment(
+            f"{header}\n\n{identity}\n\nupdated review",
+            initial_header=header,
+            final_update_message=True,
+            identity_marker=identity,
+        )
+
+        provider.publish_comment.assert_called_once_with(
+            f"**[Persistent review]({comment_url})** updated to latest commit "
+            "https://bitbucket.org/acme/repo/commits/head"
+        )
+
 class TestBitbucketServerProvider:
     @staticmethod
     def _code_suggestion(line: int):


### PR DESCRIPTION
## Summary

- restore Bitbucket Cloud persistent-comment URL resolution
- unwrap normalized Cloud comments before reading their API links
- add a regression test for repeated persistent reviews

Fixes #3225

## Root cause

Bitbucket Cloud comments are returned from `get_issue_comments()` as `SimpleNamespace` adapters. The shared persistent-comment implementation calls `get_comment_url()` after finding an existing identity comment. The Cloud provider inherited the base empty implementation, so the update notification rendered an empty Markdown link.

## Fix

Implement `BitbucketProvider.get_comment_url()` by unwrapping the Cloud comment and returning:

```python
comment.data["links"]["html"]["href"]
```

## Testing

- Bitbucket and review identity tests: 111 passed
- MOSAICO isolation/executor/A2A tests: 14 passed, 1 skipped
- fallback and suggestion lifecycle tests: 158 passed
- push/deduplication tests: 12 passed
- full unit suite: 4390 passed, 1 skipped, 1 xfailed
- Ruff passed
- pre-commit passed
- compileall passed
- package sdist/wheel build passed
- Docker test target build passed
- built-image regression passed

No live Bitbucket request or external CI result is claimed.
