### PR TITLE
fix(review): preserve findings after failed chunks

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -731,6 +731,9 @@ class PRReviewer:
         allow_resolution = (
             bool(self.prediction)
             and not bool(getattr(self.incremental, "is_incremental", False))
+            # A merged result with failed chunks is still partial, even when chunking left
+            # no additional token-budget files to report.
+            and not bool(self.review_failed_chunk_count)
             and not bool(self.remaining_files_list)
             and parsed.valid
             and current_findings is not None

--- a/tests/unittest/test_review_large_diff_chunking.py
+++ b/tests/unittest/test_review_large_diff_chunking.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pr_agent.algo.review_finding_state import ParsedReviewState, reconcile_review_findings
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_reviewer import PRReviewer
 from tests.unittest._settings_helpers import restore_settings, snapshot_settings
@@ -172,6 +173,41 @@ async def test_a_chunk_that_fails_does_not_lose_the_chunks_that_succeeded(chunki
     assert reviewer.prediction_data["review"]["score"] == "40"
     assert reviewer.review_chunk_count == 2
     assert reviewer.review_failed_chunk_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_chunk_blocks_persistent_finding_resolution(chunking_enabled):
+    """A partial review must stay partial for the finding-state lifecycle too."""
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[RuntimeError("model refused"), CHUNK_B])
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=("diff", ["b.py"])),
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], [])),
+    ):
+        await reviewer._prepare_prediction("model")
+
+    previous_state = reconcile_review_findings(
+        None,
+        [{"path": "a.py", "body": "old finding", "line_start": 3, "line_end": 4}],
+        allow_resolution=False,
+        head_sha="head-1",
+        timestamp="2026-09-09T00:00:00+00:00",
+    ).state
+    reviewer._review_finding_state_enabled = lambda: True
+    reviewer._load_review_finding_state = lambda: ParsedReviewState(
+        previous_state, present=True, valid=True
+    )
+    reviewer._review_head_sha = lambda: "head-2"
+    reviewer._review_run_id = lambda: "run-2"
+
+    reviewer._prepare_review_finding_state(reviewer.prediction_data)
+
+    assert reviewer._review_state_result is not None
+    assert reviewer._review_state_result.resolved_ids == ()
+    assert reviewer._review_state_result.state["last_run"]["complete"] is False
+    assert reviewer._review_state_result.state["findings"][0]["state"] == "ACTIVE"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A partially successful large-diff review could resolve persistent findings from a failed chunk when no token-budget files remained.

The reviewer already tracked `review_failed_chunk_count`, but the persistent finding-state transition did not use it when deciding whether resolution was safe.

## Change

- block finding resolution whenever any review chunk fails;
- keep successful chunk results and their merged review output;
- add a regression test covering the partial-chunk lifecycle.

## Validation

- focused reviewer/state tests: 27 passed
- related reviewer/state tests: 97 passed
- full unit suite: 4390 passed, 1 skipped, 1 xfailed
- Ruff and pre-commit passed
- Docker test, github_app, and mosaico_agent builds passed

Closes #3228

AI disclosure: Developed with assistance from Codex; the contributor reviewed the change and validation results.