### PR TITLE
build(deps): replace certifi exact pin with a range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "azure-devops==7.1.0b4",
   "azure-identity==1.25.0",
   "boto3==1.43.78",
-  "certifi==2024.8.30",
+  "certifi>=2026.7.22",
   "dynaconf>=3.2.13,<4",
   "fastapi>=0.141.1,<1",
   "GitPython>=3.1.59,<4",

--- a/uv.lock
+++ b/uv.lock
@@ -330,11 +330,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -2610,7 +2610,7 @@ requires-dist = [
     { name = "azure-devops", specifier = "==7.1.0b4" },
     { name = "azure-identity", specifier = "==1.25.0" },
     { name = "boto3", specifier = "==1.43.78" },
-    { name = "certifi", specifier = "==2024.8.30" },
+    { name = "certifi", specifier = ">=2026.7.22" },
     { name = "dynaconf", specifier = ">=3.2.13,<4" },
     { name = "fastapi", specifier = ">=0.141.1,<1" },
     { name = "giteapy", specifier = "==1.0.8" },


### PR DESCRIPTION
Closes #3194.

`pyproject.toml:28` states the policy:

> Security-sensitive packages below declare `>=patched,<next-major` ranges instead of `==` pins so pip consumers can pull security patches on their own cadence (#2523); the floor is the last vetted patched release.

Eleven lines later, `certifi==2024.8.30`. Since `certifi` is the CA trust store, the exact pin was handing pip consumers a root certificate bundle roughly two years stale, with no way to move off it without fighting the pin — the one package in the list where the pin costs the most.

## Change

```diff
-  "certifi==2024.8.30",
+  "certifi>=2026.7.22",
```

`certifi` uses CalVer and has no major-version boundary, so there is no meaningful `<next-major` half to add here; the specifier is a floor only, which matches the policy's "the floor is the last vetted patched release" wording. 2026.7.22 is the current release.

## Why `uv.lock` is in the diff

`uv.lock` pinned `certifi` at 2024.8.30 as well, so a `pyproject.toml`-only change would have left this repository's own builds — Docker, CI, `uv sync` — still shipping the 2024 bundle, and the manifest and lock inconsistent with each other. Regenerated with `uv lock --upgrade-package certifi`, so the diff touches nothing but `certifi` and its hashes.

## Checked

- No other pin of `certifi` anywhere in the repo; there are no separate `requirements*.txt` files.
- Nothing imports `certifi` directly. The SSL handling in `pr_agent/git_providers/git_provider.py` works off `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` and is unaffected.
- Lock regenerated with uv 0.12.10, the version this repo requires.
