### PR TITLE
test(docs): guard mkdocs and GitBook navs against drift

### DIFF
--- a/tests/unittest/test_docs_nav_parity.py
+++ b/tests/unittest/test_docs_nav_parity.py
@@ -1,0 +1,77 @@
+"""Guards for issue #3198: keep the two documentation navigations in step.
+
+The docs are rendered twice. `docs/mkdocs.yml` drives the mkdocs site, and
+`docs/docs/summary.md` is the GitBook table of contents, wired up in
+`docs/docs/.gitbook.yaml` as `summary: ./summary.md`. `extending_pr_agent.md`
+tells contributors to register every new page in both, so the two files are
+expected to list exactly the same set of pages — and nothing enforces that
+today. These tests do.
+"""
+
+import re
+from pathlib import Path
+
+DOCS = Path(__file__).resolve().parents[2] / "docs"
+PAGES = DOCS / "docs"
+MKDOCS = DOCS / "mkdocs.yml"
+SUMMARY = PAGES / "summary.md"
+
+# Pages that are deliberately outside both navigations.
+NOT_IN_NAV = {
+    # summary.md is a navigation file itself, not a page of the site.
+    "summary.md",
+    # An example best_practices.md for a Qodo Merge feature this package does
+    # not implement. It ships as a sample for users to copy, not as a docs
+    # page, and pr_agent/tools/pr_help_message.py excludes it by name for the
+    # same reason.
+    "usage-guide/EXAMPLE_BEST_PRACTICE.md",
+}
+
+
+def _mkdocs_pages() -> set[str]:
+    """Page paths listed in the mkdocs nav, ignoring commented-out entries."""
+    lines = [
+        line
+        for line in MKDOCS.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    return set(re.findall(r"'([^']+\.md)'", "\n".join(lines)))
+
+
+def _summary_pages() -> set[str]:
+    """Page paths linked from the GitBook summary."""
+    return set(re.findall(r"\(([^()]+\.md)\)", SUMMARY.read_text(encoding="utf-8")))
+
+
+def test_every_page_is_reachable_from_a_nav():
+    """No page under docs/docs is orphaned from both navigations."""
+    on_disk = {p.relative_to(PAGES).as_posix() for p in PAGES.rglob("*.md")}
+    reachable = _mkdocs_pages() | _summary_pages() | NOT_IN_NAV
+    assert not on_disk - reachable, (
+        "pages exist but no navigation points at them: "
+        f"{sorted(on_disk - reachable)}"
+    )
+
+
+def test_navs_list_the_same_pages():
+    """mkdocs.yml and summary.md must not drift apart."""
+    mkdocs, summary = _mkdocs_pages(), _summary_pages()
+    assert not mkdocs - summary, (
+        f"in mkdocs.yml but missing from summary.md: {sorted(mkdocs - summary)}"
+    )
+    assert not summary - mkdocs, (
+        f"in summary.md but missing from mkdocs.yml: {sorted(summary - mkdocs)}"
+    )
+
+
+def test_navs_do_not_point_at_missing_files():
+    """Every navigation entry resolves to a file that exists."""
+    for label, pages in (("mkdocs.yml", _mkdocs_pages()), ("summary.md", _summary_pages())):
+        missing = sorted(page for page in pages if not (PAGES / page).exists())
+        assert not missing, f"{label} references missing pages: {missing}"
+
+
+def test_declared_exclusions_still_exist():
+    """Keeps NOT_IN_NAV honest: a stale entry there would hide a real orphan."""
+    missing = sorted(name for name in NOT_IN_NAV if not (PAGES / name).exists())
+    assert not missing, f"NOT_IN_NAV lists files that no longer exist: {missing}"


### PR DESCRIPTION
Closes #3198.

#3198 proposed deleting `docs/docs/summary.md` and `docs/docs/usage-guide/EXAMPLE_BEST_PRACTICE.md` as orphans. Neither is orphaned, so this PR adds the guard the issue was really reaching for instead of the deletion.

## Why not delete

`summary.md` is the GitBook table of contents, wired up in `docs/docs/.gitbook.yaml`:

```yaml
structure:
  readme: ../README.md
  summary: ./summary.md
```

`docs/docs/usage-guide/extending_pr_agent.md` also tells contributors to register every new page in both files (lines 42 and 67). The docs are rendered twice, so `mkdocs.yml` is not the single source of truth and deleting `summary.md` would break the GitBook rendering.

`EXAMPLE_BEST_PRACTICE.md` is excluded on purpose too — `pr_agent/tools/pr_help_message.py:115` skips it by name. It ships as a sample for users to copy, not as a site page.

## What this adds

`tests/unittest/test_docs_nav_parity.py`, four checks:

1. no page under `docs/docs/` is orphaned from both navs;
2. `mkdocs.yml` and `summary.md` list the same pages;
3. neither nav points at a file that does not exist;
4. the two documented exclusions still exist, so a stale allowlist entry cannot hide a real orphan.

On `main` the two navs already agree: 39 pages each, nothing missing on either side, no links to absent files. Nothing has drifted — but nothing prevented it either, which is the gap this closes.

## Verified the tests fail when they should

Each fault introduced separately, then reverted:

| Fault | Failure message |
| --- | --- |
| page on disk, in neither nav | `pages exist but no navigation points at them` |
| page added to `mkdocs.yml` only | `in mkdocs.yml but missing from summary.md: ['core-abilities/brand_new.md']` |
| nav entry pointing at a deleted file | `mkdocs.yml references missing pages: ['core-abilities/brand_new.md']` |

If you would still rather drop `EXAMPLE_BEST_PRACTICE.md` as part of #3175, that is easy to layer on top: remove the exclusion in `pr_help_message.py` in the same change, and drop the entry from `NOT_IN_NAV` here.