### PR TITLE
fix(github): report total inline suggestion fallback failure

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -694,7 +694,7 @@ class GithubProvider(GitProvider):
                 get_logger().info(
                     f"Persistent inline comments: all {skipped} suggestion(s) "
                     f"already posted; nothing to publish")
-                return
+                return True
             comments = deduped
         else:
             comments = [
@@ -713,6 +713,7 @@ class GithubProvider(GitProvider):
                 for body_fp, code_fp in pending_fingerprints:
                     store.add(body_fp)
                     store.add(code_fp)
+            return True
         except Exception as e:
             get_logger().info("Initially failed to publish inline comments as committable")
 
@@ -722,7 +723,8 @@ class GithubProvider(GitProvider):
                 raise e # will end up with publishing the comments one by one
 
             try:
-                self._publish_inline_comments_fallback_with_verification(comments)
+                published_count = self._publish_inline_comments_fallback_with_verification(comments)
+                return bool(published_count)
             except Exception as e:
                 get_logger().error(f"Failed to publish inline code comments fallback, error: {e}")
                 raise
@@ -887,11 +889,13 @@ class GithubProvider(GitProvider):
         then publish all the remaining valid comments in a single review.
         For invalid comments, also try removing the suggestion part and posting the comment just on the first line.
         """
+        published_count = 0
         verified_comments, invalid_comments = self._verify_code_comments(comments)
 
         # publish as a group the verified comments
         if verified_comments:
             self.pr.create_review(commit=self.last_commit_id, comments=verified_comments)
+            published_count += len(verified_comments)
 
         # try to publish one by one the invalid comments as a one-line code comment
         if invalid_comments and get_settings().github.try_fix_invalid_inline_comments:
@@ -899,9 +903,10 @@ class GithubProvider(GitProvider):
             fixed_comments_as_one_liner = self._try_fix_invalid_inline_comments(invalid_comments_list)
             for comment in fixed_comments_as_one_liner:
                 try:
-                    self.publish_inline_comments([comment], disable_fallback=True)
-                    get_logger().info(f"Published invalid comment as a single line comment: {comment}")
-                except:
+                    if self.publish_inline_comments([comment], disable_fallback=True):
+                        published_count += 1
+                        get_logger().info(f"Published invalid comment as a single line comment: {comment}")
+                except Exception:
                     get_logger().error(f"Failed to publish invalid comment as a single line comment: {comment}")
 
             dropped_count = len(invalid_comments) - len(fixed_comments_as_one_liner)
@@ -920,6 +925,7 @@ class GithubProvider(GitProvider):
                 f"Dropped {len(invalid_comments)} invalid comments "
                 f"(try_fix_invalid_inline_comments is off). Paths: {dropped_paths}"
             )
+        return published_count
 
     def _verify_code_comment(self, comment: dict):
         is_verified = False
@@ -1029,8 +1035,7 @@ class GithubProvider(GitProvider):
             post_parameters_list.append(post_parameters)
 
         try:
-            self.publish_inline_comments(post_parameters_list)
-            return True
+            return bool(self.publish_inline_comments(post_parameters_list))
         except Exception as e:
             get_logger().error(f"Failed to publish code suggestion, error: {e}")
             return False

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -312,6 +312,7 @@ def test_publish_code_suggestions_multi_line_payload_shape():
 
     def capture(comments, disable_fallback=False):
         captured["comments"] = comments
+        return True
 
     provider.publish_inline_comments = capture
 
@@ -414,6 +415,209 @@ def test_publish_code_suggestions_returns_false_on_publish_error():
         "relevant_lines_start": 1, "relevant_lines_end": 2,
     }])
     assert result is False
+
+
+def test_publish_code_suggestions_422_fallback_all_dropped_returns_false(monkeypatch):
+    """Regression test for #3223: When the 422 fallback drops all comments
+    (0 verified, 0 repaired), publish_code_suggestions must return False so caller
+    can trigger retry logic."""
+    fake_pr = _FakePR(raise_on_first=_FakeGithubException(status=422))
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    # All comments are rejected during verification
+    monkeypatch.setattr(
+        provider,
+        "_verify_code_comments",
+        lambda comments: ([], [(c, Exception("invalid")) for c in comments]),
+    )
+    # No invalid comment can be repaired
+    monkeypatch.setattr(
+        provider,
+        "_try_fix_invalid_inline_comments",
+        lambda invalid_list: [],
+    )
+
+    suggestions = [{
+        "body": "```suggestion\nsuggestion\n```",
+        "relevant_file": "src/foo.py",
+        "relevant_lines_start": 10,
+        "relevant_lines_end": 12,
+    }]
+
+    result = provider.publish_code_suggestions(suggestions)
+    assert result is False
+    # Only the initial failing create_review call occurred; 0 fallback comments posted
+    assert len(fake_pr.create_review_calls) == 1
+
+
+def test_publish_code_suggestions_422_fallback_partial_success_returns_true(monkeypatch):
+    """When 422 fallback successfully publishes at least one comment, return True
+    to prevent duplicate comment creation by whole-batch retries."""
+    fake_pr = _FakePR(raise_on_first=_FakeGithubException(status=422))
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    # 1 verified comment, 1 invalid comment
+    def fake_verify(comments):
+        return [comments[0]], [(comments[1], Exception("invalid"))]
+
+    monkeypatch.setattr(provider, "_verify_code_comments", fake_verify)
+    monkeypatch.setattr(provider, "_try_fix_invalid_inline_comments", lambda invalid_list: [])
+
+    suggestions = [
+        {
+            "body": "```suggestion\nfirst\n```",
+            "relevant_file": "src/foo.py",
+            "relevant_lines_start": 1,
+            "relevant_lines_end": 2,
+        },
+        {
+            "body": "```suggestion\nsecond\n```",
+            "relevant_file": "src/foo.py",
+            "relevant_lines_start": 5,
+            "relevant_lines_end": 6,
+        },
+    ]
+
+    result = provider.publish_code_suggestions(suggestions)
+    assert result is True
+    # 1 initial failed batch call, 1 successful fallback call with the verified comment
+    assert len(fake_pr.create_review_calls) == 2
+    assert len(fake_pr.create_review_calls[1]["comments"]) == 1
+
+
+def test_publish_code_suggestions_422_fallback_repaired_comment_success(monkeypatch):
+    """When initial batch gets 422, verification rejects, but repairing succeeds and
+    individual publish succeeds, return True."""
+    fake_pr = _FakePR(raise_on_first=_FakeGithubException(status=422))
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    settings = SimpleNamespace(
+        github=SimpleNamespace(try_fix_invalid_inline_comments=True),
+        get=lambda key, default=None: default,
+    )
+    monkeypatch.setattr(gh_module, "get_settings", lambda: settings)
+
+    monkeypatch.setattr(
+        provider,
+        "_verify_code_comments",
+        lambda comments: ([], [(comments[0], Exception("invalid"))]),
+    )
+    repaired = [{"body": "fixed single line", "path": "src/foo.py", "line": 10, "side": "RIGHT"}]
+    monkeypatch.setattr(provider, "_try_fix_invalid_inline_comments", lambda invalid: repaired)
+
+    suggestions = [{
+        "body": "```suggestion\nmulti\nline\n```",
+        "relevant_file": "src/foo.py",
+        "relevant_lines_start": 10,
+        "relevant_lines_end": 12,
+    }]
+
+    result = provider.publish_code_suggestions(suggestions)
+    assert result is True
+    # Call 1: initial batch -> raises 422
+    # Call 2: repaired comment via publish_inline_comments([comment], disable_fallback=True) -> succeeds
+    assert len(fake_pr.create_review_calls) == 2
+    assert fake_pr.create_review_calls[1]["comments"] == repaired
+
+
+def test_publish_code_suggestions_422_fallback_repaired_comment_failure_returns_false(monkeypatch):
+    """When repaired payload is generated but publishing that repaired comment fails,
+    it must NOT count as published, and publish_code_suggestions must return False."""
+    fake_pr = _FakePR(raise_on_first=_FakeGithubException(status=422))
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    settings = SimpleNamespace(
+        github=SimpleNamespace(try_fix_invalid_inline_comments=True),
+        get=lambda key, default=None: default,
+    )
+    monkeypatch.setattr(gh_module, "get_settings", lambda: settings)
+
+    monkeypatch.setattr(
+        provider,
+        "_verify_code_comments",
+        lambda comments: ([], [(comments[0], Exception("invalid"))]),
+    )
+    repaired = [{"body": "fixed single line", "path": "src/foo.py", "line": 10, "side": "RIGHT"}]
+    monkeypatch.setattr(provider, "_try_fix_invalid_inline_comments", lambda invalid: repaired)
+
+    calls = 0
+
+    def fail_repaired(commit=None, comments=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _FakeGithubException(status=422)
+        # with disable_fallback=True, this re-raises from publish_inline_comments
+        raise _FakeGithubException(status=422)
+
+    fake_pr.create_review = fail_repaired
+
+    suggestions = [{
+        "body": "```suggestion\nmulti\nline\n```",
+        "relevant_file": "src/foo.py",
+        "relevant_lines_start": 10,
+        "relevant_lines_end": 12,
+    }]
+
+    result = provider.publish_code_suggestions(suggestions)
+    assert result is False
+    assert calls == 2
+
+
+def test_publish_code_suggestions_normal_success():
+    """Clean create_review call without 422 must return True."""
+    fake_pr = _FakePR()
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    suggestions = [{
+        "body": "normal",
+        "relevant_file": "src/foo.py",
+        "relevant_lines_start": 1,
+        "relevant_lines_end": 1,
+    }]
+
+    result = provider.publish_code_suggestions(suggestions)
+    assert result is True
+    assert len(fake_pr.create_review_calls) == 1
+
+
+def test_persistent_dedup_all_skipped_returns_true(monkeypatch):
+    """When persistent_inline_comments is enabled and all comments are duplicates,
+    publish_inline_comments and publish_code_suggestions must return True without
+    calling create_review."""
+    fake_pr = _FakePR()
+    provider = _make_provider(pr=fake_pr)
+    _stub_validation_passthrough(provider)
+
+    settings = SimpleNamespace(
+        get=lambda key, default=None: True if key == "config.persistent_inline_comments" else default,
+        github=SimpleNamespace(try_fix_invalid_inline_comments=False),
+    )
+    monkeypatch.setattr(gh_module, "get_settings", lambda: settings)
+
+    store = MagicMock()
+    store.seen.return_value = True
+    monkeypatch.setattr(gh_module, "get_inline_comment_store", lambda prov: store)
+
+    comments = [{"path": "src/foo.py", "body": "already posted", "line": 5}]
+    res_inline = provider.publish_inline_comments(comments)
+    assert res_inline is True
+    assert len(fake_pr.create_review_calls) == 0
+
+    suggestions = [{
+        "body": "already posted",
+        "relevant_file": "src/foo.py",
+        "relevant_lines_start": 5,
+        "relevant_lines_end": 5,
+    }]
+    res_suggestions = provider.publish_code_suggestions(suggestions)
+    assert res_suggestions is True
+    assert len(fake_pr.create_review_calls) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Title

fix(github): report total inline suggestion fallback failure

# Description

Fixes #3223

## Summary

Fix GitHub code-suggestion publication reporting when the initial batch review fails with HTTP 422 and the verification fallback drops every comment.

Previously, `GithubProvider.publish_code_suggestions()` returned `True` whenever `publish_inline_comments()` completed without raising, even if the 422 fallback ultimately published zero comments. This caused `PRCodeSuggestions` to treat the run as successful and skip its existing retry path.

## Changes

* Track the number of comments actually published by `_publish_inline_comments_fallback_with_verification()`.
* Return `False` when the 422 fallback publishes zero comments.
* Preserve `True` for partial fallback success to avoid duplicate retries of suggestions that already landed.
* Preserve successful no-op behavior for persistent inline-comment dedup when all suggestions were already posted.
* Make `publish_code_suggestions()` return the actual result from `publish_inline_comments()` instead of unconditionally returning `True`.
* Add regression tests covering total fallback failure, partial success, repaired-comment success/failure, normal success, and persistent dedup-only behavior.

## Scope

This change is intentionally limited to the GitHub provider.

It does not modify:

* GitLab or other providers
* the caller retry policy in `PRCodeSuggestions`
* pre-submission validation/drop semantics
* provider-wide publication contracts

## Validation

* `tests/unittest/test_github_provider_comments.py`: 39 passed
* `tests/unittest/test_inline_comment_dedup.py`: 41 passed
* GitHub fallback verification tests: 4 passed
* Relevant PR code-suggestion tests: 170 passed
* Ruff: passed
* Pre-commit: passed
* `git diff --check`: clean
