### PR TITLE
fix(claude): warn when thinking is enabled but no model in the chain matches

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -343,6 +343,39 @@ model_id = "your-application-inference-profile-arn"
 
 The `litellm.model_id` parameter applies only to classic `bedrock/` calls made through the `bedrock-runtime` APIs. It does not apply to `bedrock_mantle/`; for cost allocation with the Mantle Chat Completions and Responses APIs, use [Amazon Bedrock Projects](https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-projects.html).
 
+#### Claude 5 thinking with an application inference profile ARN
+
+Claude Sonnet 5 on Bedrock is invoked through an inference profile rather than a direct
+foundation-model id. When that profile is an application inference profile, its ARN is an
+opaque value that carries no model name. Thinking configuration in PR-Agent is gated on
+recognizing the model, so the opaque ARN can never match: `enable_claude_adaptive_thinking`
+requires a recognized Claude 5 model name in the id, and `enable_claude_extended_thinking`
+requires exact membership in `claude_extended_thinking_models`. PR-Agent logs a warning in
+that case, so the unconfigured state is no longer silent.
+
+Address the model by name and pass the profile ARN through `litellm.model_id`, which is what
+the invocation actually uses:
+
+```toml
+[config] # in configuration.toml
+model = "bedrock/converse/eu.anthropic.claude-sonnet-5"
+fallback_models = ["bedrock/converse/eu.anthropic.claude-sonnet-5"]
+enable_claude_adaptive_thinking = true # requires a recognizable claude 5 model name in `model`
+
+[litellm]
+model_id = "arn:aws:bedrock:eu-central-1:<account-id>:application-inference-profile/<profile-id>"
+```
+
+Cost attribution is preserved through the application inference profile, and because `model`
+is the named id, the adaptive-thinking payload is applied and kept intact.
+
+Two caveats. First, ARNs only fail the detection when the suffix is opaque: an ARN that
+embeds the model family, for example `...:inference-profile/us.anthropic.claude-sonnet-5`,
+normalises to a string the adaptive regex does match. The miss is specific to application
+inference profiles with an opaque hex suffix. Second, `litellm.model_id` is a single global
+value applied to every model whose id contains `bedrock/`, so this configuration cannot point
+different models at different profiles within one fallback chain without per-call handling.
+
 #### Using a Custom VPC Endpoint (PrivateLink)
 
 To route Bedrock traffic through a VPC interface endpoint instead of the public `bedrock-runtime` endpoint, set `AWS_BEDROCK_RUNTIME_ENDPOINT` either as an environment variable or in `[aws]`:
@@ -692,6 +725,11 @@ built-in defaults.
     `claude_extended_thinking_models_override` anyway, PR-Agent skips the extended-thinking payload
     for it and logs a warning rather than sending a request the provider would reject — use
     `enable_claude_adaptive_thinking` for those models instead.
+
+Both thinking gates only fire when the model id itself is recognizable: an opaque id such as a
+Bedrock application inference profile ARN matches neither gate, and PR-Agent logs a warning
+instead of silently sending nothing. See [Claude 5 thinking with an application inference
+profile ARN](#claude-5-thinking-with-an-application-inference-profile-arn).
 
 ## Output token limit
 

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -953,12 +953,15 @@ class LiteLLMAIHandler(BaseAiHandler):
                                 kwargs["allowed_openai_params"] = ["reasoning_effort"]
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
-                if self._is_claude_adaptive_thinking_model(model) and get_settings().config.get(
-                        "enable_claude_adaptive_thinking", False):
+                adaptive_thinking_enabled = get_settings().config.get(
+                    "enable_claude_adaptive_thinking", False)
+                extended_thinking_enabled = get_settings().config.get(
+                    "enable_claude_extended_thinking", False)
+                if self._is_claude_adaptive_thinking_model(model) and adaptive_thinking_enabled:
                     kwargs = self._configure_claude_adaptive_thinking(model, kwargs)
                 elif (
                     model in self.claude_extended_thinking_models
-                    and get_settings().config.get("enable_claude_extended_thinking", False)
+                    and extended_thinking_enabled
                 ):
                     if self._is_claude_adaptive_thinking_model(model):
                         get_logger().warning(
@@ -967,6 +970,15 @@ class LiteLLMAIHandler(BaseAiHandler):
                         )
                     else:
                         kwargs = self._configure_claude_extended_thinking(model, kwargs)
+                elif adaptive_thinking_enabled or extended_thinking_enabled:
+                    get_logger().warning(
+                        f"No thinking configuration applied for model {model}: adaptive thinking "
+                        f"requires a recognized claude 5 model name in the id and extended "
+                        f"thinking requires exact membership in claude_extended_thinking_models. "
+                        f"Ids that embed no model name, such as Bedrock application inference "
+                        f"profile ARNs, never match; address the model by name with "
+                        f"litellm.model_id carrying the ARN instead."
+                    )
 
                 # Optional output token limit; 0 = unset. Without max_tokens some
                 # providers apply a low service-side default (Bedrock Converse: 4096,

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -971,14 +971,17 @@ class LiteLLMAIHandler(BaseAiHandler):
                     else:
                         kwargs = self._configure_claude_extended_thinking(model, kwargs)
                 elif adaptive_thinking_enabled or extended_thinking_enabled:
-                    get_logger().warning(
+                    message = (
                         f"No thinking configuration applied for model {model}: adaptive thinking "
                         f"requires a recognized claude 5 model name in the id and extended "
-                        f"thinking requires exact membership in claude_extended_thinking_models. "
-                        f"Ids that embed no model name, such as Bedrock application inference "
-                        f"profile ARNs, never match; address the model by name with "
-                        f"litellm.model_id carrying the ARN instead."
+                        f"thinking requires exact membership in claude_extended_thinking_models."
                     )
+                    if "arn:aws:bedrock:" in model:
+                        message += (
+                            " For a Bedrock inference profile, address the model by name and pass "
+                            "the ARN with litellm.model_id."
+                        )
+                    get_logger().warning(message)
 
                 # Optional output token limit; 0 = unset. Without max_tokens some
                 # providers apply a low service-side default (Bedrock Converse: 4096,

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -261,3 +261,24 @@ async def test_extended_enabled_with_no_matching_model_warns(monkeypatch):
     assert "thinking" not in kwargs
     logger.warning.assert_called_once()
     assert "opus-4-6" in logger.warning.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_non_arn_model_warns_without_bedrock_advice(monkeypatch):
+    """The Bedrock remedy must stay gated to Bedrock ids: a plain provider id that reaches the
+    warning branch only gets the generic message, never the litellm.model_id ARN advice."""
+    logger = MagicMock()
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_logger",
+               return_value=logger):
+        kwargs = await _run_completion(
+            monkeypatch,
+            "openai/gpt-4o",
+            enabled=True,
+        )
+
+    assert "thinking" not in kwargs
+    logger.warning.assert_called_once()
+    message = logger.warning.call_args.args[0]
+    assert "gpt-4o" in message
+    assert "litellm.model_id" not in message
+    assert "arn" not in message

--- a/tests/unittest/test_litellm_claude_adaptive_thinking.py
+++ b/tests/unittest/test_litellm_claude_adaptive_thinking.py
@@ -207,3 +207,57 @@ async def test_non_adaptive_model_in_extended_override_still_gets_extended_think
 
     assert kwargs["thinking"]["type"] == "enabled"
     assert "budget_tokens" in kwargs["thinking"]
+
+
+@pytest.mark.asyncio
+async def test_opaque_arn_with_adaptive_enabled_warns_and_skips_payload(monkeypatch):
+    """An opaque application inference profile ARN carries no model name, so the adaptive
+    payload must be skipped and a warning logged instead of failing silently (see #3216)."""
+    logger = MagicMock()
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_logger",
+               return_value=logger):
+        kwargs = await _run_completion(
+            monkeypatch,
+            "bedrock/converse/arn:aws:bedrock:eu-central-1:000000000000:application-inference-profile/abc123def456",
+            enabled=True,
+        )
+
+    assert "thinking" not in kwargs
+    assert "output_config" not in kwargs
+    logger.warning.assert_called_once()
+    assert "abc123def456" in logger.warning.call_args.args[0]
+    assert "litellm.model_id" in logger.warning.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_family_embedding_arn_still_gets_adaptive_payload(monkeypatch):
+    """An ARN that embeds the model family normalises to a matching id, so adaptive thinking
+    applies; the miss is specific to opaque suffixes (see #3216)."""
+    kwargs = await _run_completion(
+        monkeypatch,
+        "bedrock/converse/arn:aws:bedrock:eu-central-1:000000000000:inference-profile/us.anthropic.claude-sonnet-5",
+        enabled=True,
+    )
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"] == {"effort": "medium"}
+
+
+@pytest.mark.asyncio
+async def test_extended_enabled_with_no_matching_model_warns(monkeypatch):
+    """Extended thinking enabled with an empty override list leaves no matching model, so the
+    warning fires even though the adaptive model gate is not involved (see #3216)."""
+    logger = MagicMock()
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_logger",
+               return_value=logger):
+        kwargs = await _run_completion(
+            monkeypatch,
+            "anthropic/claude-opus-4-6",
+            enabled=False,
+            extended_enabled=True,
+            extended_override=[],
+        )
+
+    assert "thinking" not in kwargs
+    logger.warning.assert_called_once()
+    assert "opus-4-6" in logger.warning.call_args.args[0]


### PR DESCRIPTION
## What

Item 1 of the agreed scope for #3216: kill the silent thinking-config failure class. When `enable_claude_adaptive_thinking` or `enable_claude_extended_thinking` is on but no model in the chain matches (e.g. an opaque Bedrock application inference profile ARN), PR-Agent now logs a warning naming the model instead of silently sending no thinking payload. Also documents the `model_id` split for `bedrock/converse/` inference profiles.

Part 2 (a repo-side gate to force adaptive by ARN) stays intentionally out of scope: it cannot be merged alone because litellm downgrades `{"type": "adaptive"}` to the legacy `budget_tokens` shape for ARN ids, which Bedrock rejects with a 400. The warning is the safe, dependency-free half.

Refs #3216 per the assigned scope.

## Changes

- `pr_agent/algo/ai_handlers/litellm_ai_handler.py`: hoisted the two thinking flags, and added an `elif` when either flag is enabled but neither the adaptive nor the extended branch fired. It logs a warning that names the model and states both gates (adaptive requires a recognized claude 5 name in the id, extended requires exact membership in `claude_extended_thinking_models`). The Bedrock remedy, pointing at the `model = "<name>"` + `litellm.model_id = "<arn>"` configuration, is gated to ids containing `arn:aws:bedrock:` so plain provider models only get the generic warning.
- `tests/unittest/test_litellm_claude_adaptive_thinking.py`: four new tests. Opaque ARN with adaptive enabled warns and sends no payload. Family-embedding ARN (`.../us.anthropic.claude-sonnet-5`) still applies adaptive thinking, locking the documented opaque-suffix detail. Extended enabled with an empty override list warns too, covering the non-adaptive side of the gate. A plain provider id gets the generic warning without the Bedrock ARN advice.
- `docs/docs/usage-guide/changing_a_model.md`: new Bedrock subsection "Claude 5 thinking with an application inference profile ARN" with the two key config lines, the fallback-chain caveat (litellm.model_id is a single global value applied to every `bedrock/` id), and the opaque-suffix detail. A one-line pointer added to the Anthropic dedicated params section.

## Testing

Full unit suite: 4454 passed, 1 skipped, 1 xfailed. Ruff and pre-commit clean on the touched files.