### PR TITLE
refactor: remove 14 dead functions in the tool layer (#3182)

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import difflib
-import hashlib
 import html
 import json
 import os
@@ -10,8 +9,6 @@ import re
 import string
 import sys
 import textwrap
-import time
-import traceback
 from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 from enum import Enum
@@ -23,7 +20,6 @@ import html2text
 import requests
 import yaml
 from pydantic import BaseModel
-from starlette_context import context
 
 from pr_agent.algo import MAX_TOKENS
 from pr_agent.algo.git_patch_processing import (
@@ -34,7 +30,7 @@ from pr_agent.algo.git_patch_processing import (
 from pr_agent.algo.run_details import get_run_details
 from pr_agent.algo.token_handler import TokenEncoder
 from pr_agent.algo.types import FilePatchInfo
-from pr_agent.config_loader import get_settings, get_verbosity_level, global_settings
+from pr_agent.config_loader import get_settings, get_verbosity_level
 from pr_agent.log import get_logger
 
 _ENCODED_USER_TEXT_PREFIX = "__pr_agent_encoded_text__:"
@@ -223,14 +219,6 @@ class PRDescriptionHeader(str, Enum):
     FILE_WALKTHROUGH = "File Walkthrough"
 
 
-def get_setting(key: str) -> Any:
-    try:
-        key = key.upper()
-        return context.get("settings", global_settings).get(key, global_settings.get(key, None))
-    except Exception:
-        return global_settings.get(key, None)
-
-
 def as_review_text(value) -> str:
     """Flatten a review field the model returned as a list or mapping into readable text.
 
@@ -273,18 +261,6 @@ def emphasize_header(text: str, only_markdown=False, reference_link=None) -> str
     except Exception as e:
         get_logger().exception(f"Failed to emphasize header: {e}")
         return text
-
-
-def unique_strings(input_list: List[str]) -> List[str]:
-    if not input_list or not isinstance(input_list, list):
-        return input_list
-    seen = set()
-    unique_list = []
-    for item in input_list:
-        if item not in seen:
-            unique_list.append(item)
-            seen.add(item)
-    return unique_list
 
 
 def _expand_minute_suffix(text: str) -> str:
@@ -1645,64 +1621,6 @@ def find_line_number_of_relevant_line_in_file(diff_files: List[FilePatchInfo],
                             break
     return position, absolute_position
 
-def get_rate_limit_status(github_token) -> dict:
-    GITHUB_API_URL = get_settings(use_context=False).get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/")  # "https://api.github.com"
-    # GITHUB_API_URL = "https://api.github.com"
-    RATE_LIMIT_URL = f"{GITHUB_API_URL}/rate_limit"
-    HEADERS = {
-        "Accept": "application/vnd.github.v3+json",
-        "Authorization": f"token {github_token}"
-    }
-
-    response = requests.get(RATE_LIMIT_URL, headers=HEADERS)
-    try:
-        rate_limit_info = response.json()
-        if rate_limit_info.get('message') == 'Rate limiting is not enabled.':  # for github enterprise
-            return {'resources': {}}
-        response.raise_for_status()  # Check for HTTP errors
-    except:  # retry
-        time.sleep(0.1)
-        response = requests.get(RATE_LIMIT_URL, headers=HEADERS)
-        return response.json()
-    return rate_limit_info
-
-
-def validate_rate_limit_github(github_token, installation_id=None, threshold=0.1) -> bool:
-    try:
-        rate_limit_status = get_rate_limit_status(github_token)
-        if installation_id:
-            get_logger().debug(f"installation_id: {installation_id}, Rate limit status: {rate_limit_status['rate']}")
-    # validate that the rate limit is not exceeded
-        # validate that the rate limit is not exceeded
-        for key, value in rate_limit_status['resources'].items():
-            if value['remaining'] < value['limit'] * threshold:
-                get_logger().error(f"key: {key}, value: {value}")
-                return False
-        return True
-    except Exception as e:
-        get_logger().error(f"Error in rate limit {e}",
-                           artifact={"traceback": traceback.format_exc()})
-        return True
-
-
-def validate_and_await_rate_limit(github_token):
-    try:
-        rate_limit_status = get_rate_limit_status(github_token)
-        # validate that the rate limit is not exceeded
-        for key, value in rate_limit_status['resources'].items():
-            if value['remaining'] < value['limit'] // 80:
-                get_logger().error(f"key: {key}, value: {value}")
-                sleep_time_sec = value['reset'] - datetime.now().timestamp()
-                sleep_time_hour = sleep_time_sec / 3600.0
-                get_logger().error(f"Rate limit exceeded. Sleeping for {sleep_time_hour} hours")
-                if sleep_time_sec > 0:
-                    time.sleep(sleep_time_sec + 1)
-                rate_limit_status = get_rate_limit_status(github_token)
-        return rate_limit_status
-    except:
-        get_logger().error("Error in rate limit")
-        return None
-
 
 def github_action_output(output_data: dict, key_name: str):
     try:
@@ -1897,25 +1815,6 @@ def is_value_no(value):
     if value_str == 'no' or value_str == 'none' or value_str == 'false':
         return True
     return False
-
-
-def set_pr_string(repo_name, pr_number):
-    return f"{repo_name}#{pr_number}"
-
-
-def string_to_uniform_number(s: str) -> float:
-    """
-    Convert a string to a uniform number in the range [0, 1].
-    The uniform distribution is achieved by the nature of the SHA-256 hash function, which produces a uniformly distributed hash value over its output space.
-    """
-    # Generate a hash of the string
-    hash_object = hashlib.sha256(s.encode())
-    # Convert the hash to an integer
-    hash_int = int(hash_object.hexdigest(), 16)
-    # Normalize the integer to the range [0, 1]
-    max_hash_int = 2 ** 256 - 1
-    uniform_number = float(hash_int) / max_hash_int
-    return uniform_number
 
 
 def process_description(description_full: str) -> Tuple[str, List]:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -787,15 +787,6 @@ class PRCodeSuggestions:
             new_comment = git_provider.publish_comment(pr_comment, **({"as_thread": True} if as_thread else {}))
         return new_comment
 
-    def extract_link(self, s):
-        r = re.compile(r"<!--.*?-->")
-        match = r.search(s)
-
-        up_to_commit_txt = ""
-        if match:
-            up_to_commit_txt = f" up to commit {match.group(0)[4:-3].strip()}"
-        return up_to_commit_txt
-
     async def _prepare_prediction(self, model: str) -> dict:
         self.patches_diff = get_pr_diff(self.git_provider,
                                         self.token_handler,

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -543,35 +543,6 @@ class PRDescription:
             return original_prediction
 
 
-    async def extend_additional_files(self, remaining_files_list) -> str:
-        prediction = self.prediction
-        try:
-            original_prediction_dict = load_yaml(self.prediction, keys_fix_yaml=self.keys_fix)
-            prediction_extra = "pr_files:"
-            for file in remaining_files_list:
-                extra_file_yaml = f"""\
-- filename: |
-    {file}
-  changes_summary: |
-    ...
-  changes_title: |
-    ...
-  label: |
-    additional files (token-limit)
-"""
-                prediction_extra = prediction_extra + "\n" + extra_file_yaml.strip()
-            prediction_extra_dict = load_yaml(prediction_extra, keys_fix_yaml=self.keys_fix)
-            # merge the two dictionaries
-            if isinstance(original_prediction_dict, dict) and isinstance(prediction_extra_dict, dict):
-                original_prediction_dict["pr_files"].extend(prediction_extra_dict["pr_files"])
-                new_yaml = yaml.dump(original_prediction_dict)
-                if load_yaml(new_yaml, keys_fix_yaml=self.keys_fix):
-                    prediction = new_yaml
-            return prediction
-        except Exception as e:
-            get_logger().error(f"Error extending additional files {self.pr_id}: {e}")
-            return self.prediction
-
     async def _get_prediction(self, model: str, patches_diff: str, prompt="pr_description_prompt") -> str:
         variables = copy.deepcopy(self.vars)
         variables["diff"] = patches_diff  # update diff

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -17,19 +17,6 @@ from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
 
 
-def extract_header(snippet):
-    res = ''
-    lines = snippet.split('===Snippet content===')[0].split('\n')
-    highest_header = ''
-    highest_level = float('inf')
-    for line in lines[::-1]:
-        line = line.strip()
-        if line.startswith('Header '):
-            highest_header = line.split(': ')[1]
-    if highest_header:
-        res = f"#{highest_header.lower().replace(' ', '-')}"
-    return res
-
 class PRHelpMessage:
     def __init__(self, pr_url: str, args=None, ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler, return_as_string=False):
         self.git_provider = get_git_provider_with_context(pr_url)
@@ -266,26 +253,6 @@ class PRHelpMessage:
         except Exception as e:
             get_logger().exception(f"Error while running PRHelpMessage: {e}")
         return ""
-
-    async def prepare_relevant_snippets(self, sim_results):
-        # Get relevant snippets
-        relevant_snippets_full = []
-        relevant_pages_full = []
-        relevant_snippets_full_header = []
-        th = 0.75
-        for s in sim_results:
-            page = s[0].metadata['source']
-            content = s[0].page_content
-            score = s[1]
-            relevant_snippets_full.append(content)
-            relevant_snippets_full_header.append(extract_header(content))
-            relevant_pages_full.append(page)
-        # build the snippets string
-        relevant_snippets_str = ""
-        for i, s in enumerate(relevant_snippets_full):
-            relevant_snippets_str += f"Snippet {i+1}:\n\n{s}\n\n"
-            relevant_snippets_str += "-------------------\n\n"
-        return relevant_pages_full, relevant_snippets_full_header, relevant_snippets_str
 
 
 def generate_bbdc_table(column_arr_1, column_arr_2):

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -1189,29 +1189,6 @@ class PRReviewer:
 
         return question_str, answer_str
 
-    def _get_previous_review_comment(self):
-        """
-        Get the previous review comment if it exists.
-        """
-        try:
-            if hasattr(self.git_provider, "get_previous_review"):
-                return self.git_provider.get_previous_review(
-                    full=not self.incremental.is_incremental,
-                    incremental=self.incremental.is_incremental,
-                )
-        except Exception as e:
-            get_logger().exception(f"Failed to get previous review comment, error: {e}")
-
-    def _remove_previous_review_comment(self, comment):
-        """
-        Remove the previous review comment if it exists.
-        """
-        try:
-            if comment:
-                self.git_provider.remove_comment(comment)
-        except Exception as e:
-            get_logger().exception(f"Failed to remove previous review comment, error: {e}")
-
     def _can_run_incremental_review(self) -> bool:
         """
         Checks if we can run incremental review according the various configurations and previous review.

--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -673,7 +673,3 @@ async def extract_and_cache_pr_tickets(git_provider, vars):
     else:
         get_logger().info("Using cached tickets", artifact={"tickets": related_tickets})
         vars['related_tickets'] = related_tickets
-
-
-def check_tickets_relevancy():
-    return True


### PR DESCRIPTION
## What

Change A of the scope split confirmed on #3182: delete the fourteen private helpers and tool layer functions that have zero references in `pr_agent/`, `tests/`, `pr_agent/settings/` and `docs/`. Pure deletions; no behavioural change.

The public `GitProvider` surface (the four `generate_link_to_relevant_line_number` implementations and the other ten methods) stays untouched, per the v1 API caveat and the deferral to #3183 and #3181.

## Removed

- `pr_agent/algo/utils.py`: `get_setting`, `unique_strings`, `validate_and_await_rate_limit`, `set_pr_string`, `string_to_uniform_number`, `get_rate_limit_status`, `validate_rate_limit_github`
- `pr_agent/tools/pr_code_suggestions.py`: `extract_link`
- `pr_agent/tools/pr_description.py`: `extend_additional_files`
- `pr_agent/tools/pr_help_message.py`: `prepare_relevant_snippets`, `extract_header`
- `pr_agent/tools/pr_reviewer.py`: `_get_previous_review_comment`, `_remove_previous_review_comment`
- `pr_agent/tools/ticket_pr_compliance_check.py`: `check_tickets_relevancy`

Ran `ruff check --fix` as suggested: dropped the orphaned imports this leaves behind, including `time` and `traceback` in `utils.py`. One duplicated comment line inside `validate_rate_limit_github` was also removed as part of the deletion.

Net diff: 200 lines removed, 1 inserted.

## Testing

- Full unit suite: 4450 passed, 1 skipped, 1 xfailed.
- Ruff and pre-commit clean on all six touched files.