### PR TITLE
feat(telemetry): expose a native prometheus scrape endpoint

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -336,7 +336,7 @@ Telemetry is disabled by default. To enable it, set in `configuration.toml`:
 ```toml
 [otel]
 is_enabled = true
-exporter_type = "console" # "console", "otlp", or "none"
+exporter_type = "console" # "console", "otlp", "prometheus", or "none"
 service_name = "pr-agent"
 environment = "development" # e.g. "development", "staging", "production"
 ```
@@ -362,6 +362,29 @@ otlp_protocol = "grpc" # default: "http"
 
 This is the recommended topology for fleets: point every PR-Agent instance at the same collector and aggregate there. Each process creates its own exporter connection; use the `service_name` and `environment` resource attributes to slice instances apart on the backend.
 
+### Exposing native Prometheus metrics
+
+Instead of pushing to a collector, set `exporter_type = "prometheus"` to expose a native `GET /metrics` scrape endpoint on the gunicorn-served apps (`github_app`, `gitlab_webhook`, `azuredevops_server_webhook`, `gitea_app`). The command counter is translated into the Prometheus text format, and every gunicorn worker's values are merged at scrape time, so counters stay correct across the process workers:
+
+```toml
+[otel]
+exporter_type = "prometheus"
+prometheus_multiproc_dir = "/tmp/pr-agent-prometheus" # shared, writable by every worker
+```
+
+1. The exporter is metrics-only: command spans are not exported in this mode.
+2. `/metrics` is mounted only when this exporter is selected, so nothing is exposed by default. It does not depend on an OTLP collector or endpoint.
+3. gunicorn registers and deregisters workers' state files automatically (`when_ready`/`child_exit`); a worker that dies mid-scrape leaves only a stale file, which is ignored once it is marked dead.
+4. Metric families are created from the first data point's label set. Later attributes that do not fit the family are dropped, and missing ones are back-filled with an empty string, so a scrape never breaks on drifting label cardinality.
+5. The exporter ships with PR-Agent (it depends on `prometheus-client`); no extra package is required. Scrape it like any exporter:
+
+```yaml
+scrape_configs:
+  - job_name: pr-agent
+    static_configs:
+      - targets: ["pr-agent:3000"]
+```
+
 Privacy controls (both off by default):
 
 - `include_pr_url = true` attaches PR URLs to spans. Off by default because URLs expose private repo names.
@@ -373,6 +396,7 @@ Notes:
 - PR-Agent keeps its own OpenTelemetry providers and never registers the process-global one, so embedding PR-Agent in an application that already uses OpenTelemetry will not interfere with the host's telemetry. Pending spans and metrics are flushed automatically on process exit.
 - Each OTLP export call is bounded by `otlp_timeout` (default 3 seconds, retries included), so an unreachable collector cannot hang CLI exit or request completion. Raise it for slow collectors at the cost of longer worst-case stalls.
 - If `exporter_type = "otlp"` is set but no endpoint is configured, telemetry is disabled entirely (fail closed) — it never falls back to another exporter, so a missing secret cannot redirect telemetry into process logs.
+- With `exporter_type = "prometheus"`, `prometheus_multiproc_dir` must be a shared directory writable by every worker; it defaults to `/tmp/pr-agent-prometheus`. In non-gunicorn (single-process) deployments the exporter works without it and simply serves the process's own registry.
 - **Serverless deployments** (e.g. the AWS Lambda webhooks) are supported: buffered spans and metrics are force-flushed at the end of every handled request, because frozen execution environments stop background export threads and are reaped without running exit handlers. No extra configuration is needed.
 
 ## Bringing per-repo context files to PR-Agent

--- a/docs/docs/usage-guide/configuration_reference.md
+++ b/docs/docs/usage-guide/configuration_reference.md
@@ -496,11 +496,12 @@ _This section only documents commented-out examples; see the [TOML source](https
 | Key | Default | Description |
 | --- | --- | --- |
 | `is_enabled` | false | disabled by default; set to true to enable telemetry |
-| `exporter_type` | "console" | "console", "otlp", or "none" |
+| `exporter_type` | "console" | "console", "otlp", "prometheus", or "none" |
 | `service_name` | "pr-agent" |  |
 | `environment` | "development" | "development", "staging", "production", etc. |
 | `otlp_timeout` | 3 | seconds; hard deadline per OTLP export call (incl. retries). Bounds CLI-exit/request stalls when the collector is unreachable; batches slower than this are dropped. |
 | `otlp_protocol` | "http" | "http" (default; exporter ships with pr-agent) or "grpc" (requires the otel-grpc extra: pip install pr-agent[otel-grpc]) |
+| `prometheus_multiproc_dir` | "/tmp/pr-agent-prometheus" | shared dir for the prometheus exporter's per-worker state files; required when exporter_type = "prometheus" (multiprocess gunicorn deployments); created 0700 and must stay owned by the run user (symlink or foreign-owner paths are refused) |
 | `include_pr_url` | false | set to true to attach PR URLs to spans (may expose private repo names) |
 | `include_error_details` | false | set to true to attach exception messages and rejected-command text to spans (may expose PR URLs, repo names, or other request content) |
 

--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -27,6 +27,7 @@ from pr_agent.git_providers.azuredevops_provider import AZURE_AGENT_RESPONSE_MAR
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.servers.utils import basic_auth_matches, get_pr_commands
+from pr_agent.telemetry.prometheus import attach_metrics_endpoint, prometheus_metrics_enabled
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 security = HTTPBasic(auto_error=False)
@@ -301,6 +302,8 @@ async def root():
 
 def start():
     app = FastAPI(middleware=[Middleware(RawContextMiddleware)])
+    if prometheus_metrics_enabled():
+        attach_metrics_endpoint(router)
     app.include_router(router)
     uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "3000")))
 

--- a/pr_agent/servers/gitea_app.py
+++ b/pr_agent/servers/gitea_app.py
@@ -14,6 +14,7 @@ from pr_agent.config_loader import get_settings, global_settings
 from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.servers.utils import get_pr_commands, push_trigger_slot, verify_signature
+from pr_agent.telemetry.prometheus import attach_metrics_endpoint, prometheus_metrics_enabled
 
 # Setup logging and router
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
@@ -212,6 +213,8 @@ def should_process_pr_logic(body) -> bool:
 
 # FastAPI app setup
 middleware = [Middleware(RawContextMiddleware)]
+if prometheus_metrics_enabled():
+    attach_metrics_endpoint(router)
 app = FastAPI(middleware=middleware)
 app.include_router(router)
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -19,6 +19,7 @@ from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.servers.utils import get_pr_commands, push_trigger_slot, verify_signature
+from pr_agent.telemetry.prometheus import attach_metrics_endpoint, prometheus_metrics_enabled
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -524,6 +525,8 @@ if get_settings().github_app.override_deployment_type:
     get_settings().set("GITHUB.DEPLOYMENT_TYPE", "app")
 # get_settings().set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
 middleware = [Middleware(RawContextMiddleware)]
+if prometheus_metrics_enabled():
+    attach_metrics_endpoint(router)
 app = FastAPI(middleware=middleware)
 app.include_router(router)
 

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -23,6 +23,7 @@ from pr_agent.git_providers.utils import apply_repo_settings
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.secret_providers import get_secret_provider, validate_secret_provider_setting
 from pr_agent.servers.utils import get_pr_commands, push_trigger_slot
+from pr_agent.telemetry.prometheus import attach_metrics_endpoint, prometheus_metrics_enabled
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 router = APIRouter()
@@ -497,6 +498,8 @@ if not gitlab_url:
     raise ValueError("GITLAB.URL is not set")
 get_settings().config.git_provider = "gitlab"
 middleware = [Middleware(RawContextMiddleware)]
+if prometheus_metrics_enabled():
+    attach_metrics_endpoint(router)
 app = FastAPI(middleware=middleware)
 app.include_router(router)
 

--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -1,8 +1,6 @@
 import gc
 import os
 
-# from prometheus_client import multiprocess
-
 # Sample Gunicorn configuration file.
 
 #
@@ -280,6 +278,33 @@ def when_ready(server):
     # object it visits. Freezing moves everything allocated so far into a permanent
     # generation the collector never traverses, keeping those pages shared.
     gc.freeze()
+    _prepare_prometheus()
+
+
+def _prepare_prometheus():
+    """Provision the multiprocess state dir before any worker imports prometheus_client.
+
+    prometheus_client decides at import time whether metrics are multiprocess-capable,
+    so the dir must exist (and PROMETHEUS_MULTIPROC_DIR be set) in the master before the
+    first worker fork — workers import the client lazily and inherit the env var.
+    """
+    from pr_agent.config_loader import get_settings
+    from pr_agent.telemetry.prometheus_multiproc import ensure_prometheus_multiproc_dir
+    from pr_agent.telemetry.types import ExporterType
+
+    settings = get_settings()
+    if settings.get("OTEL.IS_ENABLED", False) and settings.get("OTEL.EXPORTER_TYPE") == ExporterType.PROMETHEUS:
+        ensure_prometheus_multiproc_dir(str(settings.get("OTEL.PROMETHEUS_MULTIPROC_DIR", "/tmp/pr-agent-prometheus")))
+
+
+def child_exit(server, worker):
+    """Called in the master when a worker exits; drop the worker's stale state files."""
+    # Imported lazily: the master only ever sees prometheus_client at exit time, never
+    # while importing the app under preload_app (which would break multiprocess mode in
+    # the forked workers).
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)
 
 
 def post_fork(server, worker):

--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -299,6 +299,10 @@ def _prepare_prometheus():
 
 def child_exit(server, worker):
     """Called in the master when a worker exits; drop the worker's stale state files."""
+    from pr_agent.telemetry.prometheus_multiproc import prometheus_multiproc_dir
+
+    if not prometheus_multiproc_dir():
+        return
     # Imported lazily: the master only ever sees prometheus_client at exit time, never
     # while importing the app under preload_app (which would break multiprocess mode in
     # the forked workers).

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -473,7 +473,7 @@ service_name = "pr-agent"
 environment = "development" # "development", "staging", "production", etc.
 otlp_timeout = 3 # seconds; hard deadline per OTLP export call (incl. retries). Bounds CLI-exit/request stalls when the collector is unreachable; batches slower than this are dropped.
 otlp_protocol = "http" # "http" (default; exporter ships with pr-agent) or "grpc" (requires the otel-grpc extra: pip install pr-agent[otel-grpc])
-prometheus_multiproc_dir = "/tmp/pr-agent-prometheus" # shared dir for the prometheus exporter's per-worker state files; required when exporter_type = "prometheus" (multiprocess gunicorn deployments)
+prometheus_multiproc_dir = "/tmp/pr-agent-prometheus" # shared dir for the prometheus exporter's per-worker state files; required when exporter_type = "prometheus" (multiprocess gunicorn deployments); created 0700 and must stay owned by the run user (symlink or foreign-owner paths are refused)
 include_pr_url = false # set to true to attach PR URLs to spans (may expose private repo names)
 include_error_details = false # set to true to attach exception messages and rejected-command text to spans (may expose PR URLs, repo names, or other request content)
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -468,11 +468,12 @@ rules = [] # e.g. [{ max_hunks = 3, model = "gpt-5.6-luna" }, { max_hunks = 15, 
 [otel]
 # Keys map to settings.get("OTEL.*") via section-key dot notation.
 is_enabled = false # disabled by default; set to true to enable telemetry
-exporter_type = "console" # "console", "otlp", or "none"
+exporter_type = "console" # "console", "otlp", "prometheus", or "none"
 service_name = "pr-agent"
 environment = "development" # "development", "staging", "production", etc.
 otlp_timeout = 3 # seconds; hard deadline per OTLP export call (incl. retries). Bounds CLI-exit/request stalls when the collector is unreachable; batches slower than this are dropped.
 otlp_protocol = "http" # "http" (default; exporter ships with pr-agent) or "grpc" (requires the otel-grpc extra: pip install pr-agent[otel-grpc])
+prometheus_multiproc_dir = "/tmp/pr-agent-prometheus" # shared dir for the prometheus exporter's per-worker state files; required when exporter_type = "prometheus" (multiprocess gunicorn deployments)
 include_pr_url = false # set to true to attach PR URLs to spans (may expose private repo names)
 include_error_details = false # set to true to attach exception messages and rejected-command text to spans (may expose PR URLs, repo names, or other request content)
 

--- a/pr_agent/telemetry/config.py
+++ b/pr_agent/telemetry/config.py
@@ -1,9 +1,10 @@
 from pr_agent.algo.utils import get_version
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
+from pr_agent.telemetry.prometheus_multiproc import ensure_prometheus_multiproc_dir
 from pr_agent.telemetry.types import ExporterType, OtlpProtocol, TelemetryConfig
 
-VALID_EXPORTER_TYPES = {ExporterType.CONSOLE, ExporterType.OTLP, ExporterType.NONE}
+VALID_EXPORTER_TYPES = {ExporterType.CONSOLE, ExporterType.OTLP, ExporterType.PROMETHEUS, ExporterType.NONE}
 VALID_OTLP_PROTOCOLS = {OtlpProtocol.HTTP, OtlpProtocol.GRPC}
 
 
@@ -42,13 +43,23 @@ def get_otel_config() -> TelemetryConfig:
         return TelemetryConfig()
 
     # Fail closed: opted-in telemetry content was consented for the OTLP destination
-    # only — never redirect it to another exporter (console = process logs).
+    # only — never redirect it to another exporter (console = process logs;
+    # prometheus = a local scrape endpoint the operator explicitly selected).
     if exporter_type == ExporterType.OTLP and not otlp_endpoint:
         get_logger().warning(
             "OTEL.EXPORTER_TYPE is 'otlp' but OTEL.OTLP_ENDPOINT is not configured. "
             "Telemetry disabled — not falling back to another exporter."
         )
         return TelemetryConfig()
+
+    # A multiprocess scrape must write per-pid state files into a shared dir.
+    # The env var has to be set before prometheus_client is imported in any
+    # worker (gunicorn master also provisions it in `when_ready`).
+    prometheus_multiproc_dir = None
+    if exporter_type == ExporterType.PROMETHEUS:
+        prometheus_multiproc_dir = ensure_prometheus_multiproc_dir(
+            str(settings.get("OTEL.PROMETHEUS_MULTIPROC_DIR", "/tmp/pr-agent-prometheus"))
+        )
 
     return TelemetryConfig(
         is_enabled=True,
@@ -59,7 +70,8 @@ def get_otel_config() -> TelemetryConfig:
         otlp_endpoint=otlp_endpoint,
         otlp_headers=_parse_otlp_headers(otlp_headers_raw) if otlp_headers_raw else None,
         otlp_timeout=int(settings.get("OTEL.OTLP_TIMEOUT", 3)),
-        otlp_protocol=otlp_protocol
+        otlp_protocol=otlp_protocol,
+        prometheus_multiproc_dir=prometheus_multiproc_dir,
     )
 
 

--- a/pr_agent/telemetry/meter.py
+++ b/pr_agent/telemetry/meter.py
@@ -73,6 +73,12 @@ def _create_metric_exporter(config):
         if config.otlp_headers:
             kwargs["headers"] = config.otlp_headers
         return OTLPMetricExporter(**kwargs)
+    elif config.exporter_type == ExporterType.PROMETHEUS:
+        # Imported lazily so the gunicorn master (preload_app) never pulls in
+        # prometheus_client before the multiprocess dir is provisioned.
+        from pr_agent.telemetry.prometheus import PrometheusMetricExporter
+
+        return PrometheusMetricExporter()
     return None
 
 

--- a/pr_agent/telemetry/prometheus.py
+++ b/pr_agent/telemetry/prometheus.py
@@ -1,0 +1,209 @@
+"""Native Prometheus scrape endpoint for the OpenTelemetry command telemetry.
+
+When ``OTEL.EXPORTER_TYPE = "prometheus"`` the ``pr_agent.commands`` counter
+stays an OpenTelemetry instrument; this module translates the SDK's aggregated
+data points into ``prometheus_client`` metric objects instead of shipping them
+to a collector.
+
+Gunicorn runs with ``preload_app = True`` (fork model), so the translation
+happens on the worker side: each worker's values land in its own
+multiprocess state file under ``PROMETHEUS_MULTIPROC_DIR``, and ``/metrics``
+serves a ``MultiProcessCollector`` that merges every worker's file.
+
+prometheus_client decides at import time whether metrics are multiprocess-aware
+(from ``PROMETHEUS_MULTIPROC_DIR``), and gunicorn's master imports the app
+before ``when_ready`` provisions that directory. This module therefore never
+imports prometheus_client at module level: everything touching it is deferred
+to the worker or to a scrape request, so a master process merely importing the
+app can neither create metrics in the wrong mode nor see a stale directory.
+
+``opentelemetry-exporter-prometheus`` is deliberately not a dependency: its
+``PrometheusMetricReader`` documents "No multiprocessing support", which is the
+requirement this module exists for, and it ships as a 0.x pre-release.
+"""
+
+import re
+from typing import Any, Dict, Tuple
+
+from opentelemetry.sdk.metrics.export import (
+    Gauge as OTelGauge,
+)
+from opentelemetry.sdk.metrics.export import (
+    Histogram as OTelHistogram,
+)
+from opentelemetry.sdk.metrics.export import (
+    MetricExporter,
+    MetricExportResult,
+    Sum,
+)
+from starlette.responses import Response
+
+from pr_agent.config_loader import get_settings
+from pr_agent.log import get_logger
+from pr_agent.telemetry.types import ExporterType
+
+_NAME_INVALID_CHARS = re.compile(r"[^a-zA-Z0-9_:]")
+
+_prometheus_client = None
+_prometheus_registry = None
+
+
+def _client() -> Any:
+    """Import prometheus_client on first use (never during app import in the master)."""
+    global _prometheus_client
+    if _prometheus_client is None:
+        import prometheus_client
+
+        # The multiprocess dir/env is provisioned by config/`when_ready` before
+        # any worker reaches this point, so the client picks the right mode here.
+        _prometheus_client = prometheus_client
+    return _prometheus_client
+
+
+def prometheus_metrics_enabled() -> bool:
+    """True when the [otel] prometheus exporter is selected and telemetry is on."""
+    settings = get_settings()
+    return bool(settings.get("OTEL.IS_ENABLED", False)) and (
+        settings.get("OTEL.EXPORTER_TYPE") == ExporterType.PROMETHEUS
+    )
+
+
+def prometheus_registry():
+    """The registry metric objects are created on (single-process view)."""
+    return _registry()
+
+
+def _registry():
+    global _prometheus_registry
+    if _prometheus_registry is None:
+        _prometheus_registry = _client().CollectorRegistry(auto_describe=False)
+    return _prometheus_registry
+
+
+def prometheus_response() -> Response:
+    """Render ``/metrics`` for this process.
+
+    Uses a ``MultiProcessCollector`` when prometheus_client imported in
+    multiprocess mode (workers under gunicorn with PROMETHEUS_MULTIPROC_DIR
+    set); otherwise serves this process's own registry (single-process
+    deployments such as plain `uvicorn`).
+    """
+    client = _client()
+    # prometheus_client decides its storage mode when `values` is first imported
+    # (from PROMETHEUS_MULTIPROC_DIR); MultiProcessValue is chosen per worker.
+    import prometheus_client.multiprocess
+    import prometheus_client.values as prometheus_values
+
+    if prometheus_values.ValueClass._multiprocess:
+        registry = client.CollectorRegistry()
+        prometheus_client.multiprocess.MultiProcessCollector(registry)
+    else:
+        registry = _registry()
+    return Response(
+        content=client.generate_latest(registry), media_type=client.CONTENT_TYPE_LATEST
+    )
+
+
+def attach_metrics_endpoint(router) -> None:
+    """Attach a lazy ``GET /metrics`` route to a FastAPI router.
+
+    The route raises no prometheus_client import at registration time — the
+    gunicorn master (which imports the app under ``preload_app``) must never
+    import it before ``when_ready`` provisions the multiprocess directory. The
+    heavy import happens on the first request, inside the serving worker.
+    """
+
+    def _metrics_endpoint():
+        return prometheus_response()
+
+    router.add_api_route(
+        "/metrics", _metrics_endpoint, methods=["GET"], include_in_schema=False
+    )
+
+
+class PrometheusMetricExporter(MetricExporter):
+    """Translate SDK `MetricsData` into prometheus_client metrics.
+
+    Designed for use with ``PeriodicExportingMetricReader`` (DELTA temporality
+    for counters, accumulating per worker). Increments land in the worker's
+    multiprocess state file when prometheus_client imported in multiprocess mode.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # metric name -> (label_names, prometheus_client metric object)
+        self._counters: Dict[str, Tuple] = {}
+        self._gauges: Dict[str, Tuple] = {}
+
+    def export(self, metrics_data, timeout_millis=10_000, **kwargs) -> MetricExportResult:
+        try:
+            for resource_metric in metrics_data.resource_metrics:
+                for scope_metric in resource_metric.scope_metrics:
+                    for metric in scope_metric.metrics:
+                        self._translate(metric)
+        except Exception as e:
+            get_logger().warning(f"Failed to export metrics to Prometheus: {e}")
+            return MetricExportResult.FAILURE
+        return MetricExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis=10_000) -> bool:
+        return True
+
+    def shutdown(self, timeout_millis=30_000, **kwargs) -> None:
+        pass
+
+    def _translate(self, metric) -> None:
+        name = _sanitize_metric_name(metric.name)
+        help_text = metric.description or metric.name
+        if isinstance(metric.data, Sum):
+            if metric.data.is_monotonic:
+                for point in metric.data.data_points:
+                    obj, labels = self._metric(self._counters, "Counter", name, help_text, point)
+                    obj.labels(**labels).inc(point.value)
+            else:
+                for point in metric.data.data_points:
+                    obj, labels = self._metric(self._gauges, "Gauge", name, help_text, point)
+                    obj.labels(**labels).set(point.value)
+        elif isinstance(metric.data, OTelGauge):
+            for point in metric.data.data_points:
+                obj, labels = self._metric(self._gauges, "Gauge", name, help_text, point)
+                obj.labels(**labels).set(point.value)
+        elif isinstance(metric.data, OTelHistogram):
+            get_logger().warning(
+                f"Skipping histogram metric '{metric.name}': Prometheus histograms are "
+                f"not exported yet (no command telemetry uses one today)."
+            )
+        else:
+            get_logger().warning(
+                f"Skipping unsupported metric '{metric.name}' of type {type(metric.data)}."
+            )
+
+    def _metric(self, cache, metric_class_name, name, help_text, point):
+        labels = _point_labels(point)
+        entry = cache.get(name)
+        if entry is None:
+            client = _client()
+            metric_class = getattr(client, metric_class_name)
+            label_names = tuple(sorted(labels))
+            metric_object = metric_class(
+                name, help_text, labelnames=label_names, registry=_registry()
+            )
+            entry = cache[name] = (label_names, metric_object)
+        label_names, metric_object = entry
+        # A family's label set is fixed on the first data point; drop later
+        # attributes we cannot attach and back-fill missing ones with "".
+        normalized = {label: labels.get(label, "") for label in label_names}
+        return metric_object, normalized
+
+
+def _sanitize_metric_name(name: str) -> str:
+    return _NAME_INVALID_CHARS.sub("_", name)
+
+
+def _sanitize_label_key(key: str) -> str:
+    key = _NAME_INVALID_CHARS.sub("_", key)
+    return "_" + key if key[0].isdigit() else key
+
+
+def _point_labels(point) -> dict:
+    return {_sanitize_label_key(key): str(value) for key, value in point.attributes.items()}

--- a/pr_agent/telemetry/prometheus_multiproc.py
+++ b/pr_agent/telemetry/prometheus_multiproc.py
@@ -1,0 +1,35 @@
+"""Prometheus multiprocess state-directory setup.
+
+`prometheus_client` decides whether metrics are multiprocess-capable when its
+`metrics` module is first imported, by looking at the `PROMETHEUS_MULTIPROC_DIR`
+environment variable. Under gunicorn's fork model (`preload_app = True`) the
+state directory must therefore exist and the variable be set *before* any
+worker imports prometheus_client.
+
+This module imports nothing but the standard library so it is safe to call from
+the gunicorn master (via `gunicorn_config.when_ready`) and from
+`pr_agent.telemetry.config`, both before any worker has imported
+prometheus_client.
+"""
+
+import os
+
+PROMETHEUS_MULTIPROC_DIR_ENV = "PROMETHEUS_MULTIPROC_DIR"
+
+
+def ensure_prometheus_multiproc_dir(path: str) -> str:
+    """Set ``PROMETHEUS_MULTIPROC_DIR`` and create the directory.
+
+    Returns the normalized path. Idempotent; safe to call from the gunicorn
+    master and from each worker's first telemetry init.
+    """
+    env = PROMETHEUS_MULTIPROC_DIR_ENV
+    if path:
+        os.environ[env] = path
+    os.makedirs(os.environ[env], exist_ok=True)
+    return os.environ[env]
+
+
+def prometheus_multiproc_dir() -> str | None:
+    """The configured multiprocess state directory, if any."""
+    return os.environ.get(PROMETHEUS_MULTIPROC_DIR_ENV)

--- a/pr_agent/telemetry/prometheus_multiproc.py
+++ b/pr_agent/telemetry/prometheus_multiproc.py
@@ -18,16 +18,34 @@ PROMETHEUS_MULTIPROC_DIR_ENV = "PROMETHEUS_MULTIPROC_DIR"
 
 
 def ensure_prometheus_multiproc_dir(path: str) -> str:
-    """Set ``PROMETHEUS_MULTIPROC_DIR`` and create the directory.
+    """Set ``PROMETHEUS_MULTIPROC_DIR`` and create or validate the directory.
 
     Returns the normalized path. Idempotent; safe to call from the gunicorn
     master and from each worker's first telemetry init.
+
+    The state files hold per-pid metric data that any local user with read
+    access could observe, so a predictable default inside a world-writable
+    prefix like /tmp must not be redirected or shared: a symlink is refused,
+    the directory is created (and tightened to) 0700, and a path owned by
+    another user is rejected instead of followed.
     """
     env = PROMETHEUS_MULTIPROC_DIR_ENV
     if path:
         os.environ[env] = path
-    os.makedirs(os.environ[env], exist_ok=True)
-    return os.environ[env]
+    target = os.environ[env]
+    if os.path.islink(target):
+        raise RuntimeError(
+            f"Refusing to use a symlinked prometheus multiprocess state directory: {target!r}"
+        )
+    os.makedirs(target, mode=0o700, exist_ok=True)
+    st = os.stat(target)
+    if st.st_uid != os.getuid():
+        raise RuntimeError(
+            f"Prometheus multiprocess state directory {target!r} is owned by uid {st.st_uid}, "
+            f"not the current user's uid {os.getuid()}"
+        )
+    os.chmod(target, 0o700)
+    return target
 
 
 def prometheus_multiproc_dir() -> str | None:

--- a/pr_agent/telemetry/tracer.py
+++ b/pr_agent/telemetry/tracer.py
@@ -72,4 +72,9 @@ def _create_exporter(config):
         if config.otlp_headers:
             kwargs['headers'] = config.otlp_headers
         return OTLPSpanExporter(**kwargs)
+    elif config.exporter_type == ExporterType.PROMETHEUS:
+        get_logger().warning(
+            "OTEL.EXPORTER_TYPE is 'prometheus' (metrics only); spans are not exported."
+        )
+        return None
     return None

--- a/pr_agent/telemetry/types.py
+++ b/pr_agent/telemetry/types.py
@@ -6,6 +6,7 @@ class ExporterType:
     """Canonical exporter type values for OTEL.EXPORTER_TYPE."""
     OTLP = "otlp"
     CONSOLE = "console"
+    PROMETHEUS = "prometheus"
     NONE = "none"
 
 
@@ -26,3 +27,4 @@ class TelemetryConfig:
     otlp_headers: Optional[Dict[str, str]] = None
     otlp_timeout: int = 3  # seconds; hard deadline per export call, retries included
     otlp_protocol: str = OtlpProtocol.HTTP
+    prometheus_multiproc_dir: Optional[str] = None  # shared dir for multiprocess metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ dependencies = [
   "opentelemetry-api==1.43.0",
   "opentelemetry-sdk==1.43.0",
   "opentelemetry-exporter-otlp-proto-http==1.43.0",
+  # Prometheus scrape endpoint for [otel] command telemetry (native /metrics on
+  # the webhook apps). Multiprocess-capable; see pr_agent/telemetry/prometheus.py.
+  "prometheus-client==0.21.1",
 ]
 
 [project.urls]

--- a/tests/unittest/test_config_reference.py
+++ b/tests/unittest/test_config_reference.py
@@ -23,7 +23,7 @@ def _documented_keys(text: str) -> Counter:
 
 def test_config_reference_covers_every_active_key():
     keys = _toml_keys(CONFIG_TOML.read_text(encoding="utf-8"))
-    assert sum(keys.values()) == 297
+    assert sum(keys.values()) == 298
 
     assert {
         "model",

--- a/tests/unittest/test_gunicorn_config.py
+++ b/tests/unittest/test_gunicorn_config.py
@@ -1,3 +1,7 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
 from pr_agent.servers import gunicorn_config
@@ -174,3 +178,38 @@ def test_when_ready_freezes_gc(monkeypatch):
     monkeypatch.setattr(gunicorn_config.gc, "freeze", lambda: calls.append(True))
     gunicorn_config.when_ready(server=None)
     assert calls == [True]
+
+
+def _fake_prometheus_client(monkeypatch):
+    """Stub prometheus_client so the gate tests never import the real module.
+
+    Importing the real module would let it read PROMETHEUS_MULTIPROC_DIR and
+    permanently decide the process-wide storage mode, which collides with the
+    telemetry suite's import-time decision. A fake module keeps the test
+    isolated and still exercises child_exit's own import plus the gate.
+    """
+    multiproc_module = ModuleType("prometheus_client.multiprocess")
+    multiproc_module.mark_process_dead = Mock()
+    client_module = ModuleType("prometheus_client")
+    client_module.multiprocess = multiproc_module
+    monkeypatch.setitem(sys.modules, "prometheus_client", client_module)
+    monkeypatch.setitem(sys.modules, "prometheus_client.multiprocess", multiproc_module)
+    return multiproc_module
+
+
+def test_child_exit_skips_prometheus_without_multiproc_dir(monkeypatch):
+    fake_multiprocess = _fake_prometheus_client(monkeypatch)
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+
+    gunicorn_config.child_exit(server=None, worker=SimpleNamespace(pid=123))
+
+    fake_multiprocess.mark_process_dead.assert_not_called()
+
+
+def test_child_exit_marks_worker_dead_when_multiproc_dir_set(monkeypatch, tmp_path):
+    fake_multiprocess = _fake_prometheus_client(monkeypatch)
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    gunicorn_config.child_exit(server=None, worker=SimpleNamespace(pid=456))
+
+    fake_multiprocess.mark_process_dead.assert_called_once_with(456)

--- a/tests/unittest/test_telemetry_config.py
+++ b/tests/unittest/test_telemetry_config.py
@@ -8,6 +8,7 @@ and — importantly — that the *shipped* defaults in
 configuration when run through the real validation logic.
 """
 
+import os
 import tomllib
 from pathlib import Path
 
@@ -143,6 +144,36 @@ def test_otlp_timeout_defaults_and_reads_setting(monkeypatch):
     assert get_otel_config().otlp_timeout == 10
 
 
+def test_prometheus_settings_provision_state_dir(monkeypatch, tmp_path):
+    state_dir = tmp_path / "prometheus-state"
+    _use_settings(monkeypatch, {
+        **VALID_ENABLED_SETTINGS,
+        "OTEL.EXPORTER_TYPE": "prometheus",
+        "OTEL.PROMETHEUS_MULTIPROC_DIR": str(state_dir),
+    })
+
+    config = get_otel_config()
+
+    assert config.is_enabled is True
+    assert config.exporter_type == ExporterType.PROMETHEUS
+    assert config.prometheus_multiproc_dir == str(state_dir)
+    assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == str(state_dir)
+    assert state_dir.is_dir(), "the multiprocess state dir must be created eagerly"
+
+
+def test_prometheus_without_endpoint_is_not_fail_closed(monkeypatch):
+    """Prometheus is a local scrape endpoint the operator explicitly selected,
+    so it must not require an OTLP endpoint like the 'otlp' exporter does."""
+    _use_settings(monkeypatch, {**VALID_ENABLED_SETTINGS, "OTEL.EXPORTER_TYPE": "prometheus"})
+
+    with capture_loguru(level="WARNING") as captured:
+        config = get_otel_config()
+
+    assert config.is_enabled is True
+    assert config.exporter_type == ExporterType.PROMETHEUS
+    assert captured == [], "prometheus must not emit a fail-closed warning"
+
+
 def test_otlp_protocol_defaults_to_http_and_reads_setting(monkeypatch):
     _use_settings(monkeypatch, dict(VALID_ENABLED_SETTINGS))
     assert get_otel_config().otlp_protocol == "http"
@@ -230,6 +261,7 @@ def test_shipped_configuration_toml_otel_section_values():
     assert configuration["environment"] == "development"
     assert configuration["otlp_timeout"] == 3
     assert configuration["otlp_protocol"] == "http", "the default transport must not need an extra"
+    assert configuration["prometheus_multiproc_dir"] == "/tmp/pr-agent-prometheus"
     assert configuration["include_pr_url"] is False, "PR URLs must be opt-in (privacy)"
     assert configuration["include_error_details"] is False, "error details must be opt-in (privacy)"
 

--- a/tests/unittest/test_telemetry_exporter_types.py
+++ b/tests/unittest/test_telemetry_exporter_types.py
@@ -32,7 +32,9 @@ def _reset_telemetry():
 
 
 def test_valid_exporter_types_equals_constant_set():
-    assert VALID_EXPORTER_TYPES == {ExporterType.CONSOLE, ExporterType.OTLP, ExporterType.NONE}
+    assert VALID_EXPORTER_TYPES == {
+        ExporterType.CONSOLE, ExporterType.OTLP, ExporterType.PROMETHEUS, ExporterType.NONE
+    }
 
 
 def test_disabled_tracer_is_noop_never_global(monkeypatch):
@@ -64,6 +66,7 @@ def test_exporter_type_constant_values():
     users put in configuration.toml."""
     assert ExporterType.OTLP == "otlp"
     assert ExporterType.CONSOLE == "console"
+    assert ExporterType.PROMETHEUS == "prometheus"
     assert ExporterType.NONE == "none"
 
 
@@ -83,6 +86,22 @@ def test_span_exporter_none():
 
 def test_metric_exporter_none():
     assert _create_metric_exporter(make_config(exporter_type=ExporterType.NONE)) is None
+
+
+def test_span_exporter_prometheus_is_none():
+    """The prometheus exporter is metrics-only: spans are silently dropped."""
+    with capture_loguru(level="WARNING") as captured:
+        exporter = _create_exporter(make_config(exporter_type=ExporterType.PROMETHEUS))
+
+    assert exporter is None
+    assert "metrics only" in "\n".join(captured)
+
+
+def test_metric_exporter_prometheus():
+    from pr_agent.telemetry.prometheus import PrometheusMetricExporter
+
+    exporter = _create_metric_exporter(make_config(exporter_type=ExporterType.PROMETHEUS))
+    assert isinstance(exporter, PrometheusMetricExporter)
 
 
 def test_span_exporter_unknown_returns_none():

--- a/tests/unittest/test_telemetry_prometheus.py
+++ b/tests/unittest/test_telemetry_prometheus.py
@@ -1,0 +1,130 @@
+"""Tests for the native Prometheus exporter and its `/metrics` endpoint.
+
+The whole module runs with ``PROMETHEUS_MULTIPROC_DIR`` set (multiprocess
+mode), mirroring a gunicorn worker: prometheus_client decides its storage mode
+at import time from that env var, and the exporter defers the import to first
+use. Nothing else in the telemetry suite imports prometheus_client, so the
+env var above drives every process-global decision here.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+from pr_agent.telemetry.prometheus import (
+    PrometheusMetricExporter,
+    attach_metrics_endpoint,
+    prometheus_metrics_enabled,
+    prometheus_response,
+)
+from pr_agent.telemetry.prometheus_multiproc import ensure_prometheus_multiproc_dir
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _multiproc_env(tmp_path_factory):
+    """Set the multiprocess state dir before the first prometheus_client import."""
+    state_dir = tmp_path_factory.mktemp("prometheus-multiproc")
+    ensure_prometheus_multiproc_dir(str(state_dir))
+    yield str(state_dir)
+
+
+def _counter_provider():
+    reader = PeriodicExportingMetricReader(PrometheusMetricExporter())
+    provider = MeterProvider(metric_readers=[reader])
+    return provider, reader
+
+
+def test_counter_export_renders_prometheus_text():
+    provider, reader = _counter_provider()
+    counter = provider.get_meter("prometheus-test").create_counter(
+        "pr_agent.commands", unit="{command}", description="PR-Agent commands executed"
+    )
+    counter.add(3, {"pr_agent.command": "review", "provider.name": "github"})
+    reader.collect()
+
+    body = prometheus_response().body.decode()
+    # The OTel name "pr_agent.commands" is sanitized (dots -> underscores) and
+    # Prometheus appends the counter's _total suffix.
+    assert "# TYPE pr_agent_commands_total counter" in body
+    assert "# HELP pr_agent_commands_total PR-Agent commands executed" in body
+    assert 'pr_agent_commands_total{pr_agent_command="review",provider_name="github"} 3.0' in body
+
+
+def test_multiple_workers_aggregate_at_scrape_time():
+    """Run the exporter in two fresh interpreter processes (as gunicorn workers
+    would), each recording one command, and assert /metrics merges them."""
+    child_code = "; ".join([
+        "from opentelemetry.sdk.metrics import MeterProvider",
+        "from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader",
+        "from pr_agent.telemetry.prometheus import PrometheusMetricExporter",
+        "provider = MeterProvider(metric_readers=[PeriodicExportingMetricReader(PrometheusMetricExporter())])",
+        "counter = provider.get_meter('mp-test').create_counter("
+        "'pr_agent.commands', unit='{command}', description='PR-Agent commands executed')",
+        "counter.add(1, {'pr_agent.command': 'review'})",
+        "provider.shutdown()",
+    ])
+    for _ in range(2):
+        subprocess.run([sys.executable, "-c", child_code], check=True, capture_output=True)
+
+    body = prometheus_response().body.decode()
+    # Both workers' files are merged into one series at scrape time; the
+    # parent's own in-process contribution (different label set) also shows.
+    assert 'pr_agent_commands_total{pr_agent_command="review"} 2.0' in body
+    assert 'pr_agent_command="review",provider_name="github"}' in body
+
+
+def test_attach_metrics_endpoint_registers_lazy_get_route():
+    from fastapi import APIRouter
+
+    router = APIRouter()
+    attach_metrics_endpoint(router)
+
+    assert len(router.routes) == 1
+    route = router.routes[0]
+    assert route.path == "/metrics"
+    assert "GET" in route.methods
+    assert route.include_in_schema is False
+    # The endpoint resolves prometheus_client only on request — registering the
+    # route must not pull it in (a gunicorn master importing the app would
+    # otherwise lock in the wrong multiprocess mode before `when_ready`).
+    assert callable(route.endpoint)
+
+
+def test_prometheus_metrics_enabled_reads_settings(monkeypatch):
+    from pr_agent.telemetry import prometheus as prometheus_module
+
+    class FakeSettings:
+        def __init__(self, values):
+            self._values = values
+
+        def get(self, key, default=None):
+            return self._values.get(key, default)
+
+    monkeypatch.setattr(prometheus_module, "get_settings", lambda: FakeSettings({}))
+    assert prometheus_metrics_enabled() is False
+
+    monkeypatch.setattr(prometheus_module, "get_settings", lambda: FakeSettings(
+        {"OTEL.IS_ENABLED": True, "OTEL.EXPORTER_TYPE": "prometheus"}))
+    assert prometheus_metrics_enabled() is True
+
+    monkeypatch.setattr(prometheus_module, "get_settings", lambda: FakeSettings(
+        {"OTEL.IS_ENABLED": True, "OTEL.EXPORTER_TYPE": "otlp"}))
+    assert prometheus_metrics_enabled() is False
+
+
+def test_importing_prometheus_bridge_does_not_import_prometheus_client():
+    """The module must never import prometheus_client at import time — a gunicorn
+    master that imports the app under preload_app would otherwise decide the
+    non-multiprocess storage mode before when_ready provisions the state dir."""
+    env = {k: v for k, v in os.environ.items() if k != "PROMETHEUS_MULTIPROC_DIR"}
+    code = (
+        "import sys; "
+        "from pr_agent.telemetry.prometheus import prometheus_metrics_enabled, "
+        "attach_metrics_endpoint; "
+        "assert 'prometheus_client' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, capture_output=True, env=env)

--- a/tests/unittest/test_telemetry_prometheus.py
+++ b/tests/unittest/test_telemetry_prometheus.py
@@ -62,8 +62,7 @@ def test_multiple_workers_aggregate_at_scrape_time():
         "from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader",
         "from pr_agent.telemetry.prometheus import PrometheusMetricExporter",
         "provider = MeterProvider(metric_readers=[PeriodicExportingMetricReader(PrometheusMetricExporter())])",
-        "counter = provider.get_meter('mp-test').create_counter("
-        "'pr_agent.commands', unit='{command}', description='PR-Agent commands executed')",
+        "counter = provider.get_meter('mp-test').create_counter('pr_agent.commands', unit='{command}', description='PR-Agent commands executed')",
         "counter.add(1, {'pr_agent.command': 'review'})",
         "provider.shutdown()",
     ])

--- a/tests/unittest/test_telemetry_prometheus_multiproc.py
+++ b/tests/unittest/test_telemetry_prometheus_multiproc.py
@@ -1,0 +1,59 @@
+"""Tests for the prometheus multiprocess state directory provisioning.
+
+The state directory is the one piece of the exporter the gunicorn master
+touches before workers import prometheus_client, and a predictable default in
+a world-writable prefix like /tmp must not be redirectable to a foreign
+location or shared with other users. These tests lock in the symlink and
+ownership refusals and the 0700 creation.
+"""
+
+import os
+import stat
+
+import pytest
+
+from pr_agent.telemetry.prometheus_multiproc import (
+    PROMETHEUS_MULTIPROC_DIR_ENV,
+    ensure_prometheus_multiproc_dir,
+)
+
+
+def test_fresh_dir_created_0700_and_env_set(tmp_path, monkeypatch):
+    monkeypatch.setenv(PROMETHEUS_MULTIPROC_DIR_ENV, "stale")
+    state_dir = tmp_path / "prometheus-state"
+
+    result = ensure_prometheus_multiproc_dir(str(state_dir))
+
+    assert result == str(state_dir)
+    assert os.environ[PROMETHEUS_MULTIPROC_DIR_ENV] == str(state_dir)
+    assert state_dir.is_dir()
+    assert stat.S_IMODE(state_dir.stat().st_mode) == 0o700
+
+
+def test_existing_owned_dir_accepted_and_tightened_to_0700(tmp_path):
+    state_dir = tmp_path / "prometheus-state"
+    state_dir.mkdir(mode=0o755)
+
+    ensure_prometheus_multiproc_dir(str(state_dir))
+
+    assert stat.S_IMODE(state_dir.stat().st_mode) == 0o700
+
+
+def test_symlink_is_refused(tmp_path):
+    real = tmp_path / "real-state"
+    real.mkdir()
+    link = tmp_path / "prometheus-state"
+    link.symlink_to(real)
+
+    with pytest.raises(RuntimeError, match="symlinked"):
+        ensure_prometheus_multiproc_dir(str(link))
+
+
+def test_dir_owned_by_foreign_uid_is_refused(tmp_path, monkeypatch):
+    state_dir = tmp_path / "prometheus-state"
+    state_dir.mkdir()
+    foreign_uid = os.getuid() + 1
+    monkeypatch.setattr("pr_agent.telemetry.prometheus_multiproc.os.getuid", lambda: foreign_uid)
+
+    with pytest.raises(RuntimeError, match="owned by uid"):
+        ensure_prometheus_multiproc_dir(str(state_dir))

--- a/uv.lock
+++ b/uv.lock
@@ -2492,6 +2492,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -2571,6 +2572,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel-grpc'", specifier = "==1.43.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.43.0" },
     { name = "opentelemetry-sdk", specifier = "==1.43.0" },
+    { name = "prometheus-client", specifier = "==0.21.1" },
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
@@ -2619,6 +2621,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/14/7d0f567991f3a9af8d1cd4f619040c93b68f09a02b6d0b6ab1b2d1ded5fe/prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb", size = 78551, upload-time = "2024-12-03T14:59:12.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/c2/ab7d37426c179ceb9aeb109a85cda8948bb269b7561a0be870cc656eefe4/prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301", size = 54682, upload-time = "2024-12-03T14:59:10.935Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Implements #3191: an opt-in native Prometheus scrape endpoint for the OpenTelemetry command telemetry.

Telemetry stays disabled by default and the exporter is **only active when `OTEL.EXPORTER_TYPE = "prometheus"`** — nothing is exposed or changed out of the box. In that mode the `pr_agent.commands` counter (and any future gauge instruments) is rendered as `GET /metrics` on the gunicorn-served webhook apps: `github_app`, `gitlab_webhook`, `azuredevops_server_webhook`, and `gitea_app`.

Gunicorn runs with `preload_app = True`, so counters must aggregate correctly across workers. The exporter translates each worker's DELTA aggregates into `prometheus_client` metrics on the worker side, writes them to per-pid state files under a shared `PROMETHEUS_MULTIPROC_DIR`, and `/metrics` merges every worker's file with a `MultiProcessCollector` at scrape time. gunicorn provisions the state directory in `when_ready` (before the first fork) and deregisters workers in `child_exit`, so counters stay accurate through worker churn.

1. **Dependency change (flagged as requested).** This PR adds `prometheus-client==0.21.1` to the base dependency set and no other runtime dependency.
2. **Why not `opentelemetry-exporter-prometheus`?** The maintainer's suggested approach named that package, but its `PrometheusMetricReader` **documents no multiprocessing support**, and the only published versions are 0.x pre-releases. Since multiprocess aggregation under gunicorn is the core requirement of the issue, expecting a `MetricExporter` to plug into the existing `PeriodicExportingMetricReader` (my earlier suggestion in the issue comments was based on an inaccurate assumption about that package), I implemented a small in-house bridge on `prometheus_client` directly. It is ~120 lines, metric-naming and label rules match the OpenMetrics format, and it reuses the existing `PeriodicExportingMetricReader` + push-on-release flow. Happy to revisit if maintainers prefer a different dependency strategy.
3. The endpoint is mounted only when the prometheus exporter is selected, so a default deployment exposes no new surface and requires no collector configuration.
4. The exporter is command-metrics only: spans are not exported in this mode (a startup warning makes that explicit). The reader-fork lifecycle gap noted as point 5 in the issue is a separate bug and is intentionally left out of this PR.
5. A single-process deployment (plain `uvicorn`, no gunicorn) works without the state directory and serves its own in-process registry.

## Configuration

```toml
[otel]
is_enabled = true
exporter_type = "prometheus"          # "console" | "otlp" | "prometheus" | "none"
prometheus_multiproc_dir = "/tmp/pr-agent-prometheus"  # shared, writable by every worker
```

The directory can be mounted as a volume for durability; `when_ready` creates it when missing. Example scrape config:

```yaml
scrape_configs:
  - job_name: pr-agent
    static_configs:
      - targets: ["pr-agent:3000"]
```

## How this was verified

1. Unit tests translate an OTel counter into the Prometheus text format through the real `MeterProvider` + `PeriodicExportingMetricReader` path, including name sanitization (`pr_agent.commands` → `pr_agent_commands_total`) and label-key sanitization (`provider.name` → `provider_name`).
2. A multiprocess end-to-end test runs the exporter in two fresh interpreter processes (as gunicorn workers would) and asserts `/metrics` merges both workers' state files.
3. The exporter-type validation, tracer/meter agreement, config provisioning of the state dir, and shipped defaults are covered in the telemetry tests.
4. A test verifies the module can be imported without importing `prometheus_client` (gunicorn master safety under `preload_app`).
5. Full unit suite: 4459 passed;`ruff` and pre-commit hooks clean.

closes #3191