### PR TITLE
refactor: select PR chat link by provider capability

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -191,6 +191,10 @@ class GitProvider(ABC):
         support, so tools render commands as text instead."""
         return False
 
+    def supports_pr_chat(self) -> bool:
+        """Whether this provider is compatible with the linked PR-Agent browser-extension chat experience."""
+        return False
+
     def supports_markdown_tables(self) -> bool:
         """Whether comments render pipe-table markdown.
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -128,6 +128,9 @@ class GithubProvider(GitProvider):
     def supports_checkbox_commands(self) -> bool:
         return True
 
+    def supports_pr_chat(self) -> bool:
+        return True
+
     def _get_owner_and_repo_path(self, given_url: str) -> str:
         try:
             repo_path = None

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -43,10 +43,7 @@ from pr_agent.algo.utils import (
     show_run_details,
 )
 from pr_agent.config_loader import get_settings, get_verbosity_level
-from pr_agent.git_providers import (
-    GithubProvider,
-    get_git_provider_with_context,
-)
+from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.git_providers.git_provider import GitProvider, IncrementalPR, get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
@@ -329,7 +326,7 @@ class PRCodeSuggestions:
 
                     # add usage guide
                     if (get_settings().pr_code_suggestions.enable_chat_text and get_settings().config.is_auto_command
-                            and isinstance(self.git_provider, GithubProvider)):
+                            and self.git_provider.supports_pr_chat()):
                         pr_body += "\n\n>💡 Need additional feedback ? start a [PR chat](https://chromewebstore.google.com/detail/ephlnjeghhogofkifjloamocljapahnl) \n\n"
                     if get_settings().pr_code_suggestions.enable_help_text:
                         pr_body += "<hr>\n\n<details> <summary><strong>💡 Tool usage guide:</strong></summary><hr> \n\n"

--- a/tests/unittest/test_pr_code_suggestions_pr_chat.py
+++ b/tests/unittest/test_pr_code_suggestions_pr_chat.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers.git_provider import GitProvider
+from pr_agent.git_providers.github_provider import GithubProvider
+from pr_agent.tools import pr_code_suggestions as pr_code_suggestions_module
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+_TRACKED_SETTINGS = (
+    "config.publish_output",
+    "config.publish_output_progress",
+    "config.is_auto_command",
+    "pr_code_suggestions.commitable_code_suggestions",
+    "pr_code_suggestions.demand_code_suggestions_self_review",
+    "pr_code_suggestions.enable_chat_text",
+    "pr_code_suggestions.enable_help_text",
+    "pr_code_suggestions.persistent_comment",
+    "pr_code_suggestions.dual_publishing_score_threshold",
+)
+
+
+class _CustomProvider(GitProvider):
+    """Minimal external provider that inherits the default chat capability."""
+
+    def is_supported(self, capability: str) -> bool:
+        return False
+
+    def get_files(self) -> list:
+        return []
+
+    def get_diff_files(self) -> list:
+        return []
+
+    def publish_description(self, pr_title: str, pr_body: str):
+        pass
+
+    def publish_code_suggestions(self, code_suggestions: list) -> bool:
+        return False
+
+    def get_languages(self):
+        return {}
+
+    def get_pr_branch(self):
+        return ""
+
+    def get_user_id(self):
+        return ""
+
+    def get_pr_description_full(self) -> str:
+        return ""
+
+    def get_repo_settings(self):
+        return b""
+
+    def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        pass
+
+    def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, original_suggestion=None):
+        pass
+
+    def publish_inline_comments(self, comments: list[dict]):
+        pass
+
+    def remove_initial_comment(self):
+        pass
+
+    def remove_comment(self, comment):
+        pass
+
+    def get_issue_comments(self):
+        return []
+
+    def publish_labels(self, labels):
+        pass
+
+    def get_pr_labels(self, update=False):
+        return []
+
+    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+        return False
+
+    def get_commit_messages(self) -> str:
+        return ""
+
+
+
+def test_git_provider_supports_pr_chat_defaults_to_false():
+    assert _CustomProvider().supports_pr_chat() is False
+
+
+def test_github_provider_supports_pr_chat_is_true():
+    assert GithubProvider.supports_pr_chat(MagicMock()) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("supports_pr_chat", "expect_link"), [(True, True), (False, False)])
+async def test_pr_chat_link_depends_on_provider_capability(monkeypatch, supports_pr_chat, expect_link):
+    snapshot = snapshot_settings(_TRACKED_SETTINGS)
+    try:
+        provider = MagicMock()
+        provider.get_files.return_value = ["file.py"]
+        provider.is_supported.side_effect = lambda capability: capability == "gfm_markdown"
+        provider.supports_pr_chat.return_value = supports_pr_chat
+        provider.should_publish_improve_as_thread.return_value = False
+
+        tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+        tool.pr_url = "https://example.invalid/pr/1"
+        tool.progress = "progress"
+        tool.progress_response = None
+        tool.git_provider = provider
+        tool.incremental = SimpleNamespace(is_incremental=False)
+        tool.generate_summarized_suggestions = MagicMock(return_value="## Suggestions")
+
+        async def _fake_retry(*_args, **_kwargs):
+            return {"code_suggestions": [{"label": "style", "suggestion_content": "clean up"}]}
+
+        monkeypatch.setattr(pr_code_suggestions_module, "retry_with_fallback_models", _fake_retry)
+
+        settings = get_settings()
+        settings.config.publish_output = True
+        settings.config.publish_output_progress = False
+        settings.config.is_auto_command = True
+        settings.pr_code_suggestions.commitable_code_suggestions = False
+        settings.pr_code_suggestions.demand_code_suggestions_self_review = False
+        settings.pr_code_suggestions.enable_chat_text = True
+        settings.pr_code_suggestions.enable_help_text = False
+        settings.pr_code_suggestions.persistent_comment = False
+        settings.pr_code_suggestions.dual_publishing_score_threshold = 0
+
+        await tool.run()
+
+        published_body = provider.publish_comment.call_args.args[0]
+        provider.supports_pr_chat.assert_called_once_with()
+        assert ("start a [PR chat]" in published_body) is expect_link
+    finally:
+        restore_settings(snapshot)


### PR DESCRIPTION
## What changed
- add an opt-in `supports_pr_chat()` capability to `GitProvider`
- enable it for `GithubProvider`
- use the capability instead of `isinstance(..., GithubProvider)` when adding the PR-Agent browser-extension chat link
- cover the default, GitHub, and custom-provider behavior

This is the `pr_code_suggestions.py` slice of #3184. It intentionally leaves the other call sites for separate PRs.

## Why
The chat-link behavior is a provider capability, not a provider identity check. An opt-in default keeps existing non-GitHub behavior unchanged while allowing compatible external providers to participate without inheriting from `GithubProvider`.

## Test plan
- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_code_suggestions_pr_chat.py tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_lifecycle.py tests/unittest/test_git_provider_method_contract.py -q` (338 passed)
- `uv run ruff check pr_agent/git_providers/git_provider.py pr_agent/git_providers/github_provider.py pr_agent/tools/pr_code_suggestions.py tests/unittest/test_pr_code_suggestions_pr_chat.py`
- `git diff --check`

Closes the `pr_code_suggestions.py` slice of #3184.
