### PR TITLE
chore(github): upgrade PyGithub to 2.x and migrate off deprecated auth classes

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from github import Auth, Github, GithubException, GithubIntegration
+from github import Auth, Github, GithubException, GithubIntegration, GithubRetry
 from github.Issue import Issue
 from retry.api import retry_call
 from starlette_context import context
@@ -1378,8 +1378,9 @@ class GithubProvider(GitProvider):
         if self.deployment_type == 'app':
             try:
                 private_key = get_settings().github.private_key
-                # The app id is an integer in the settings toml, but PyJWT >=2.11 requires a
-                # string `iss` claim, and PyGithub 1.59 passes it through raw (#2955).
+                # The app id is an integer in the settings toml. PyJWT >=2.11 requires a
+                # string `iss` claim; PyGithub 2.7+ normalizes an int app id to a string
+                # upstream (#2955, PyGithub#3272), so the cast is harmless on the 2.10 pin.
                 app_id = str(get_settings().github.app_id)
             except AttributeError as e:
                 raise ValueError("GitHub app ID and private key are required when using GitHub app deployment") from e
@@ -1399,7 +1400,21 @@ class GithubProvider(GitProvider):
                     "https://github.com/Codium-ai/pr-agent#method-2-run-from-source") from e
             self.auth = Auth.Token(token)
         if self.auth:
-            return Github(auth=self.auth, base_url=self.base_url)
+            github_config = get_settings().github
+            # PyGithub 2.x defaults to pacing and retries (0.25s between requests, 1s between
+            # writes, 10 retries); these had no equivalent on 1.59. The settings mirror the
+            # 1.59 behaviour, so the upgrade stays behaviour-neutral unless an operator opts in.
+            seconds_between_requests = github_config.get("seconds_between_requests", 0)
+            seconds_between_writes = github_config.get("seconds_between_writes", 0)
+            api_retries = github_config.get("api_retries", 0)
+            retry = GithubRetry(total=api_retries) if api_retries else None
+            return Github(
+                auth=self.auth,
+                base_url=self.base_url,
+                seconds_between_requests=seconds_between_requests,
+                seconds_between_writes=seconds_between_writes,
+                retry=retry,
+            )
         else:
             raise ValueError("Could not authenticate to GitHub")
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from github import AppAuthentication, Auth, Github, GithubException, GithubIntegration
+from github import Auth, Github, GithubException, GithubIntegration
 from github.Issue import Issue
 from retry.api import retry_call
 from starlette_context import context
@@ -463,8 +463,10 @@ class GithubProvider(GitProvider):
             return cached
         try:
             integration = GithubIntegration(
-                integration_id=str(get_settings().github.app_id),
-                private_key=get_settings().github.private_key,
+                auth=Auth.AppAuth(
+                    app_id=str(get_settings().github.app_id),
+                    private_key=get_settings().github.private_key,
+                ),
                 base_url=self.base_url,
             )
             slug = (getattr(integration.get_app(), "slug", "") or "").strip()
@@ -1383,8 +1385,10 @@ class GithubProvider(GitProvider):
                 raise ValueError("GitHub app ID and private key are required when using GitHub app deployment") from e
             if not self.installation_id:
                 raise ValueError("GitHub app installation ID is required when using GitHub app deployment")
-            auth = AppAuthentication(app_id=app_id, private_key=private_key,
-                                     installation_id=self.installation_id)
+            auth = Auth.AppInstallationAuth(
+                Auth.AppAuth(app_id=app_id, private_key=private_key),
+                installation_id=self.installation_id,
+            )
             self.auth = auth
         elif self.deployment_type == 'user':
             try:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -290,6 +290,13 @@ enable_help_text=false
 # The type of deployment to create. Valid values are 'app' or 'user'.
 deployment_type = "user"
 ratelimit_retries = 5
+# PyGithub 2.x enables request pacing and transient retries by default (0.25s
+# between requests, 1s between writes, 10 retries); PyGithub 1.59 applied none.
+# The defaults below mirror the 1.59 behaviour, so the 2.x upgrade stays neutral
+# unless an operator opts in. Raise them to throttle or retry on the GitHub API.
+seconds_between_requests = 0 # seconds between API requests; 0 = no pacing (1.59 behaviour)
+seconds_between_writes = 0 # seconds between write calls; 0 = no pacing (1.59 behaviour)
+api_retries = 0 # max retries per request with backoff; 0 = no retries (1.59 behaviour)
 polling_request_timeout = 10 # total seconds for comment-history fallback; positive values capped at 60
 base_url = "https://api.github.com"
 publish_inline_comments_fallback_with_verification = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "loguru==0.7.2",
   "msrest==0.7.1",
   "openai>=1.55.3",
-  "PyGithub==1.59.*",
+  "PyGithub>=2.10,<3",
   "PyJWT>=2.13.0,<3",
   "PyYAML==6.0.1",
   "python-gitlab==8.3.0",

--- a/tests/unittest/test_github_app_auth.py
+++ b/tests/unittest/test_github_app_auth.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -8,10 +10,12 @@ from pr_agent.git_providers.github_provider import GithubProvider
 
 class TestGithubAppAuth:
     def test_integer_app_id_produces_valid_jwt(self):
-        """GitHub App ids are integers in the settings toml, but PyJWT >=2.11 rejects a
-        non-string `iss` claim and PyGithub 1.59 passes the id through raw (#2955,
-        previously #2210; fixed upstream in PyGithub#3272, which we don't ship yet).
-        The provider must cast to str before building the authentication.
+        """GitHub App ids are integers in the settings toml. PyJWT >=2.11 rejects a
+        non string `iss` claim and PyGithub 1.59 passed the id through raw (#2955,
+        previously #2210; upstream fixed the pass through in PyGithub#3272, which
+        landed in 2.7.0, so the 2.10 pin ships it). The provider keeps casting to
+        str before building the authentication, which is thus harmless on the 2.10
+        pin while it stays a hard requirement for the older 1.59 behaviour.
         """
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         private_key_pem = key.private_bytes(
@@ -45,6 +49,74 @@ class TestGithubAppAuth:
         finally:
             for name, value in original.items():
                 settings.set(name, value)
+
+    def test_client_defaults_to_no_pacing_and_no_retry(self, monkeypatch):
+        """PyGithub 2.x turns on pacing and 10 retries by default; PR-Agent must
+        stay behaviour-neutral unless configured. The [github] settings mirror the
+        1.59 defaults and the client constructor applies them explicitly
+        (https://github.com/The-PR-Agent/pr-agent/pull/3240)."""
+        settings = get_settings()
+        original = {
+            "GITHUB.DEPLOYMENT_TYPE": settings.get("GITHUB.DEPLOYMENT_TYPE", None),
+            "GITHUB.USER_TOKEN": settings.get("GITHUB.USER_TOKEN", None),
+        }
+        settings.set("GITHUB.DEPLOYMENT_TYPE", "user")
+        settings.set("GITHUB.USER_TOKEN", "stub-token")
+        captured = {}
+
+        def fake_github(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("pr_agent.git_providers.github_provider.Github", fake_github)
+        provider = GithubProvider.__new__(GithubProvider)
+        provider.installation_id = None
+        provider.base_url = "https://api.github.com"
+        try:
+            provider._get_github_client()
+        finally:
+            for name, value in original.items():
+                settings.set(name, value)
+
+        assert captured["seconds_between_requests"] == 0
+        assert captured["seconds_between_writes"] == 0
+        assert captured["retry"] is None
+
+    def test_pacing_and_retry_settings_reach_the_client(self, monkeypatch):
+        """Operators may opt into PyGithub 2.x throttling and backoff via the
+        [github] settings; each knob must land on the constructor (PR #3240)."""
+        settings = get_settings()
+        original = {
+            "GITHUB.DEPLOYMENT_TYPE": settings.get("GITHUB.DEPLOYMENT_TYPE", None),
+            "GITHUB.USER_TOKEN": settings.get("GITHUB.USER_TOKEN", None),
+            "GITHUB.SECONDS_BETWEEN_REQUESTS": settings.get("GITHUB.SECONDS_BETWEEN_REQUESTS", None),
+            "GITHUB.SECONDS_BETWEEN_WRITES": settings.get("GITHUB.SECONDS_BETWEEN_WRITES", None),
+            "GITHUB.API_RETRIES": settings.get("GITHUB.API_RETRIES", None),
+        }
+        settings.set("GITHUB.DEPLOYMENT_TYPE", "user")
+        settings.set("GITHUB.USER_TOKEN", "stub-token")
+        settings.set("GITHUB.SECONDS_BETWEEN_REQUESTS", 0.25)
+        settings.set("GITHUB.SECONDS_BETWEEN_WRITES", 1.0)
+        settings.set("GITHUB.API_RETRIES", 4)
+        captured = {}
+
+        def fake_github(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("pr_agent.git_providers.github_provider.Github", fake_github)
+        provider = GithubProvider.__new__(GithubProvider)
+        provider.installation_id = None
+        provider.base_url = "https://api.github.com"
+        try:
+            provider._get_github_client()
+        finally:
+            for name, value in original.items():
+                settings.set(name, value)
+
+        assert captured["seconds_between_requests"] == 0.25
+        assert captured["seconds_between_writes"] == 1.0
+        assert captured["retry"].total == 4
 
     def test_is_bot_user_reads_github_section_setting(self):
         """is_bot_user must honor `ignore_bot_pr` from the [github] section

--- a/tests/unittest/test_review_persistent_comment_authorship.py
+++ b/tests/unittest/test_review_persistent_comment_authorship.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from github import GithubException
+from github import Auth, GithubException
 
 from pr_agent.algo.review_finding_state import append_review_state, reconcile_review_findings
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
@@ -367,9 +367,11 @@ def test_a_transient_app_login_failure_is_retried(monkeypatch):
     monkeypatch.setattr(get_settings(), "github", SimpleNamespace(
         app_id="1", private_key="key", deployment_type="app"), raising=False)
     attempts = []
+    auths = []
 
     def integration(**kwargs):
         attempts.append(1)
+        auths.append(kwargs["auth"])
         if len(attempts) == 1:
             raise RuntimeError("connection reset")
         return SimpleNamespace(get_app=lambda: SimpleNamespace(slug="pr-agent"))
@@ -379,6 +381,7 @@ def test_a_transient_app_login_failure_is_retried(monkeypatch):
     assert provider._resolve_app_login() == ""
     assert provider._resolve_app_login() == "pr-agent[bot]"
     assert len(attempts) == 2
+    assert all(isinstance(auth, Auth.AppAuth) for auth in auths)
 
 
 def test_a_resolved_app_login_is_cached(monkeypatch):
@@ -389,9 +392,11 @@ def test_a_resolved_app_login_is_cached(monkeypatch):
     monkeypatch.setattr(get_settings(), "github", SimpleNamespace(
         app_id="1", private_key="key", deployment_type="app"), raising=False)
     attempts = []
+    auths = []
 
     def integration(**kwargs):
         attempts.append(1)
+        auths.append(kwargs["auth"])
         return SimpleNamespace(get_app=lambda: SimpleNamespace(slug="pr-agent"))
 
     monkeypatch.setattr("pr_agent.git_providers.github_provider.GithubIntegration", integration)
@@ -399,6 +404,7 @@ def test_a_resolved_app_login_is_cached(monkeypatch):
     assert provider._resolve_app_login() == "pr-agent[bot]"
     assert provider._resolve_app_login() == "pr-agent[bot]"
     assert len(attempts) == 1
+    assert all(isinstance(auth, Auth.AppAuth) for auth in auths)
 
 
 def test_an_app_that_never_resolves_stays_unproven(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -2637,7 +2637,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
-    { name = "pygithub", specifier = "==1.59.*" },
+    { name = "pygithub", specifier = ">=2.10,<3" },
     { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-gitlab", specifier = "==8.3.0" },
     { name = "pyyaml", specifier = "==6.0.1" },
@@ -2994,17 +2994,18 @@ wheels = [
 
 [[package]]
 name = "pygithub"
-version = "1.59.1"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pynacl" },
     { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/30/203d3420960853e399de3b85d6613cea1cf17c1cf7fc9716f7ee7e17e0fc/PyGithub-1.59.1.tar.gz", hash = "sha256:c44e3a121c15bf9d3a5cc98d94c9a047a5132a9b01d22264627f58ade9ddc217", size = 3295328, upload-time = "2023-08-03T09:43:01.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9b/195603d5371861005a3467c5e4afd02fd0698795a2aa36dc41498b9d879d/pygithub-2.10.0.tar.gz", hash = "sha256:90ff24ef1cd1bd57124c2a3869cafee9d7b066909129ecdaba2c2d1903bc118d", size = 2750952, upload-time = "2026-08-20T10:05:08.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/71/aff5465d9e3d448a5d4beab1dc7c8dec72037e3ae7e0d856ee08538dc934/PyGithub-1.59.1-py3-none-any.whl", hash = "sha256:3d87a822e6c868142f0c2c4bf16cce4696b5a7a4d142a7bd160e1bdf75bc54a9", size = 342171, upload-time = "2023-08-03T09:43:00.046Z" },
+    { url = "https://files.pythonhosted.org/packages/91/71/f314841697a1d52af3e1ea7c5e1c3f09685b64ae4c58ff16b605a866255d/pygithub-2.10.0-py3-none-any.whl", hash = "sha256:192ada2a76e4afc7d6b37e500c9bfeba1731e6506697445a5ba1c4af8bf0b924", size = 455554, upload-time = "2026-08-20T10:05:06.991Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Implements #3193: moves the PyGithub pin from `==1.59.*` to `>=2.10,<3` and migrates the two call sites (plus the import) that use APIs PyGithub deprecated back in the 1.59 era.

1. **Migrated call sites.** Per the issue scope, the change touches exactly the three locations already identified:
   - `pr_agent/git_providers/github_provider.py:14` drops the `AppAuthentication` import (no longer referenced after the migration).
   - `GithubIntegration(integration_id=..., private_key=..., base_url=...)` now passes `auth=Auth.AppAuth(app_id=..., private_key=...)` on the app-JWT path, with `base_url` unchanged.
   - `AppAuthentication(app_id=..., private_key=..., installation_id=...)` now uses `Auth.AppInstallationAuth(Auth.AppAuth(...), installation_id=...)` on the installation-token path, so `provider.auth._app_auth` stays the wrapped `AppAuth` that `test_github_app_auth.py` relies on for JWT creation.
2. **Pin.** `PyGithub>=2.10,<3`; the lockfile diff is limited to the PyGithub version/hashes.
3. **Framing.** This is deprecation cleanup ahead of PyGithub 3.x, not a fix for anything currently broken. Both deprecated forms still work on 2.10, but they raise `DeprecationWarning` from the app-auth path.
4. **Auth migration pinned by tests.** The `GithubIntegration` stubs in `test_review_persistent_comment_authorship.py` now capture and assert that the new `auth` kwarg is an `Auth.AppAuth`, so the migration cannot silently regress to the deprecated constructor.
5. **Pacing and retries are a choice, not a surprise.** PyGithub 2.x turns on request pacing and automatic retries by default (0.25s between requests, 1s between writes, 10 retries), behaviour 1.59 did not have. The `[github]` settings now mirror the 1.59 behaviour (`seconds_between_requests = 0`, `seconds_between_writes = 0`, `api_retries = 0`) and `_get_github_client` passes them to the `Github(...)` constructor explicitly, so the upgrade stays behaviour neutral unless an operator opts in. The app-auth docstring in `test_github_app_auth.py` and the `str()` comment in the provider were refreshed to match 2.x behaviour: PyGithub#3272 landed in 2.7.0, so the cast is now a harmless guarantee rather than the load-bearing requirement it was on 1.59.

## Why this is the right replacement shape

The `Auth.AppAuth` swap alone would be correct at the `GithubIntegration` site (the app JWT needed for `GET /app`), but the deployment path issues an installation-scoped token, so it needs `Auth.AppInstallationAuth` wrapping `Auth.AppAuth`. `Auth.AppAuth` alone would not work there, a correction to the issue's original suggestion.

## Verification

1. `tests/unittest/test_github_app_auth.py`, `tests/unittest/test_review_persistent_comment_authorship.py` and `tests/unittest/test_github_provider_import.py` pass on the 2.10.0 pin.
2. Running those tests with `-W error::DeprecationWarning:github` produces no github-module deprecation warnings, confirming the old auth path is gone from our call sites.
3. Full unit suite: 4452 passed, 1 skipped, 1 xfailed. The baseline on main is 4450; the two new tests cover the client pacing defaults (no pacing, no retries) and the configurable overrides flowing into the constructor. The app-related e2e path still requires the GitHub App credentials as noted in the issue.

closes #3193