### PR TITLE
ci: verify uv.lock freshness

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,6 +16,12 @@ jobs:
       - id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - id: uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+
+      - name: Check uv.lock
+        run: uv lock --check
+
       - id: dockerx
         name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve dependency management by introducing a check for the `uv.lock` file. The most important changes are:

Dependency management:

* Added the `astral-sh/setup-uv` action to set up the `uv` tool for Python dependency management in the workflow (`.github/workflows/build-and-test.yaml`).
* Added a step to run `uv lock --check`, ensuring that the `uv.lock` file is up to date and consistent with dependency specifications (`.github/workflows/build-and-test.yaml`).