### PR TITLE
perf(gitlab): avoid redundant project fetches for file reads

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -732,7 +732,7 @@ class GitLabProvider(GitProvider):
 
     def get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:
-            file_obj = self.gl.projects.get(self.id_project).files.get(file_path, branch)
+            file_obj = self.gl.projects.get(self.id_project, lazy=True).files.get(file_path, branch)
             content = file_obj.decode()
             return decode_if_bytes(content)
         except GitlabGetError:

--- a/tests/unittest/test_gitlab_file_read_efficiency.py
+++ b/tests/unittest/test_gitlab_file_read_efficiency.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pr_agent.git_providers.gitlab_provider import GitLabProvider
+
+
+def test_get_pr_file_content_uses_lazy_project_handle():
+    provider = GitLabProvider.__new__(GitLabProvider)
+    provider.id_project = "group/repo"
+
+    file_obj = MagicMock()
+    file_obj.decode.return_value = b"hello\n"
+    project = MagicMock()
+    project.files.get.return_value = file_obj
+    projects = MagicMock()
+    projects.get.return_value = project
+    provider.gl = SimpleNamespace(projects=projects)
+
+    assert provider.get_pr_file_content("src/app.py", "deadbeef") == "hello\n"
+
+    projects.get.assert_called_once_with("group/repo", lazy=True)
+    project.files.get.assert_called_once_with("src/app.py", "deadbeef")


### PR DESCRIPTION
## Summary

Use a lazy python-gitlab project handle in `GitLabProvider.get_pr_file_content()` so each file-content lookup no longer fetches project metadata first.

`projects.get(id)` performs a project API request before `files.get(...)`; this path only needs the project identifier to address the repository file endpoint. `projects.get(id, lazy=True)` preserves the same file read while avoiding that redundant round trip.

## Scope

- GitLab provider only.
- No cache or lifecycle changes.
- Missing-file and decoding behavior stay unchanged.
- Adds a focused regression test that asserts the lazy project lookup and file request arguments.

## Expected impact

For every fully loaded GitLab file revision, this removes one project-metadata request. A normal full diff loads both base and head content for each eligible file, so the file-content phase drops from two HTTP requests per revision (project metadata + file) to one (file only).

## Validation

CI/unit tests will validate the focused regression and full suite on this branch.