### PR TITLE
fix(codecommit): update the persistent review comment instead of creating another

### DIFF
--- a/pr_agent/git_providers/codecommit_client.py
+++ b/pr_agent/git_providers/codecommit_client.py
@@ -277,3 +277,81 @@ class CodeCommitClient:
             raise ValueError("Boto3 client error calling post_comment_for_pull_request") from e
         except Exception as e:
             raise ValueError("Error calling post_comment_for_pull_request") from e
+
+    def get_comments_for_pull_request(self, pr_number: int) -> list[dict]:
+        """
+        Get comments for a pull request in CodeCommit.
+
+        Args:
+        - pr_number: number of the pull request
+
+        Returns:
+        - List of raw comment dicts
+
+        Boto3 Documentation:
+        - aws codecommit get_comments_for_pull_request
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/get_comments_for_pull_request.html
+        """
+        if self.boto_client is None:
+            self._connect_boto_client()
+
+        comments = []
+        try:
+            try:
+                paginator = self.boto_client.get_paginator("get_comments_for_pull_request")
+            except Exception:
+                paginator = None
+
+            if paginator is not None:
+                for page in paginator.paginate(pullRequestId=str(pr_number)):
+                    for data in page.get("commentsForPullRequestData", []):
+                        comments.extend(data.get("comments", []))
+            else:
+                next_token = None
+                while True:
+                    kwargs = {"pullRequestId": str(pr_number)}
+                    if next_token:
+                        kwargs["nextToken"] = next_token
+                    response = self.boto_client.get_comments_for_pull_request(**kwargs)
+                    for data in response.get("commentsForPullRequestData", []):
+                        comments.extend(data.get("comments", []))
+                    next_token = response.get("nextToken")
+                    if not next_token:
+                        break
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == 'PullRequestDoesNotExistException':
+                raise ValueError(f"CodeCommit cannot retrieve comments: PR number does not exist: {pr_number}") from e
+            raise ValueError(f"CodeCommit cannot retrieve comments for PR: {pr_number}: boto client error") from e
+        except Exception as e:
+            raise ValueError(f"CodeCommit cannot retrieve comments for PR: {pr_number}") from e
+
+        return comments
+
+    def update_comment(self, comment_id: str, content: str):
+        """
+        Update the content of an existing comment in CodeCommit.
+
+        Args:
+        - comment_id: The ID of the comment to update
+        - content: The new content of the comment
+
+        Returns:
+        - None
+
+        Boto3 Documentation:
+        - aws codecommit update_comment
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/update_comment.html
+        """
+        if self.boto_client is None:
+            self._connect_boto_client()
+
+        try:
+            self.boto_client.update_comment(commentId=str(comment_id), content=content)
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == 'CommentDoesNotExistException':
+                raise ValueError(f"Comment does not exist: {comment_id}") from e
+            if e.response["Error"]["Code"] == 'CommentContentRequiredException':
+                raise ValueError("Comment content is required") from e
+            raise ValueError("Boto3 client error calling update_comment") from e
+        except Exception as e:
+            raise ValueError("Error calling update_comment") from e

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -57,6 +57,15 @@ class CodeCommitFile:
         self.destination_commit = destination_commit
 
 
+class CodeCommitComment:
+    """A CodeCommit pull request comment exposed with the `.body` shape GitProvider expects."""
+
+    def __init__(self, json: dict):
+        self.id = json.get("commentId", "")
+        self.body = json.get("content", "") or ""
+        self.deleted = bool(json.get("deleted", False))
+
+
 class CodeCommitProvider(GitProvider):
     """
     This class implements the GitProvider interface for AWS CodeCommit repositories.
@@ -79,7 +88,6 @@ class CodeCommitProvider(GitProvider):
 
     def is_supported(self, capability: str) -> bool:
         if capability in [
-            "get_issue_comments",
             "create_inline_comment",
             "publish_inline_comments",
             "get_labels",
@@ -325,8 +333,72 @@ class CodeCommitProvider(GitProvider):
     def get_user_id(self):
         return -1  # not implemented yet
 
-    def get_issue_comments(self):
-        raise NotImplementedError("CodeCommit provider does not support issue comments yet")
+    def get_issue_comments(self) -> list[CodeCommitComment]:
+        try:
+            pr_num = getattr(self, "pr_num", None)
+            raw_comments = self.codecommit_client.get_comments_for_pull_request(pr_num)
+            comments = []
+            for raw in raw_comments:
+                comment = CodeCommitComment(raw)
+                if not comment.deleted:
+                    comments.append(comment)
+            return comments
+        except Exception as e:
+            pr_num = getattr(self, "pr_num", None)
+            get_logger().warning(f"Failed to get issue comments for PR {pr_num}: {e}")
+            return []
+
+    def edit_comment(self, comment, body: str) -> bool:
+        try:
+            comment_id = getattr(comment, "id", None)
+            if comment_id is None and isinstance(comment, dict):
+                comment_id = comment.get("id") or comment.get("commentId")
+            if comment_id is None:
+                comment_id = comment
+
+            body = CodeCommitProvider._remove_markdown_html(body)
+            body = CodeCommitProvider._add_additional_newlines(body)
+
+            self.codecommit_client.update_comment(str(comment_id), body)
+            return True
+        except Exception as e:
+            get_logger().warning(f"Failed to edit comment {comment}: {e}")
+            return False
+
+    def supports_review_comment_identity(self) -> bool:
+        """Identity markers survive the CodeCommit body normalisation.
+
+        ``_remove_markdown_html`` only strips ``details``/``summary`` tags, and
+        ``_add_additional_newlines`` does not touch a marker that already sits on its
+        own blank-line-separated line, so a marker written on publish is still there
+        to be matched on the next run.
+        """
+        return True
+
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_header: str,
+                                   update_header: bool = True,
+                                   name='review',
+                                   final_update_message=True,
+                                   as_thread: bool = False,
+                                   identity_marker: str | None = None,
+                                   legacy_initial_header: str | None = None):
+        """Update the previous persistent comment instead of creating another one.
+
+        The base implementation creates a new comment on every run. CodeCommit can
+        list pull request comments and update one by id, so route through the shared
+        persistent path now that ``get_issue_comments`` and ``edit_comment`` exist.
+        """
+        return self.publish_persistent_comment_full(
+            pr_comment,
+            initial_header,
+            update_header,
+            name,
+            final_update_message,
+            as_thread=as_thread,
+            identity_marker=identity_marker,
+            legacy_initial_header=legacy_initial_header,
+        )
 
     def get_repo_settings(self):
         # a local ".pr_agent.toml" settings file is optional

--- a/tests/unittest/test_codecommit_client.py
+++ b/tests/unittest/test_codecommit_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from pr_agent.git_providers.codecommit_client import CodeCommitClient
 
@@ -164,3 +164,85 @@ class TestCodeCommitProvider:
             ("repo-one", "source-one", "destination-one"),
             ("repo-two", "source-two", "destination-two"),
         ]
+
+    def test_get_comments_for_pull_request_with_paginator(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+
+        api.boto_client.get_paginator.return_value.paginate.return_value = [
+            {
+                "commentsForPullRequestData": [
+                    {
+                        "comments": [
+                            {"commentId": "c1", "content": "first comment", "deleted": False},
+                            {"commentId": "c2", "content": "second comment", "deleted": True},
+                        ]
+                    }
+                ]
+            },
+            {
+                "commentsForPullRequestData": [
+                    {
+                        "comments": [
+                            {"commentId": "c3", "content": "third comment", "deleted": False},
+                        ]
+                    }
+                ]
+            },
+        ]
+
+        comments = api.get_comments_for_pull_request(321)
+
+        api.boto_client.get_paginator.assert_called_once_with("get_comments_for_pull_request")
+        assert len(comments) == 3
+        assert comments[0]["commentId"] == "c1"
+        assert comments[1]["commentId"] == "c2"
+        assert comments[2]["commentId"] == "c3"
+
+    def test_get_comments_for_pull_request_manual_pagination(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+        api.boto_client.get_paginator.side_effect = Exception("No paginator")
+
+        api.boto_client.get_comments_for_pull_request.side_effect = [
+            {
+                "commentsForPullRequestData": [
+                    {
+                        "comments": [
+                            {"commentId": "c1", "content": "first comment"},
+                        ]
+                    }
+                ],
+                "nextToken": "token123",
+            },
+            {
+                "commentsForPullRequestData": [
+                    {
+                        "comments": [
+                            {"commentId": "c2", "content": "second comment"},
+                        ]
+                    }
+                ],
+            },
+        ]
+
+        comments = api.get_comments_for_pull_request(321)
+
+        assert len(comments) == 2
+        assert comments[0]["commentId"] == "c1"
+        assert comments[1]["commentId"] == "c2"
+        assert api.boto_client.get_comments_for_pull_request.call_args_list == [
+            call(pullRequestId="321"),
+            call(pullRequestId="321", nextToken="token123"),
+        ]
+
+    def test_update_comment(self):
+        api = CodeCommitClient()
+        api.boto_client = MagicMock()
+
+        api.update_comment("comment-123", "updated content")
+
+        api.boto_client.update_comment.assert_called_once_with(
+            commentId="comment-123",
+            content="updated content",
+        )

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -3,7 +3,14 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from pr_agent.algo.types import EDIT_TYPE
-from pr_agent.git_providers.codecommit_provider import CodeCommitFile, CodeCommitProvider, PullRequestCCMimic
+from pr_agent.algo.utils import PRReviewIdentity, add_pr_review_identity, comment_matches_identity
+from pr_agent.git_providers.codecommit_provider import (
+    CodeCommitComment,
+    CodeCommitFile,
+    CodeCommitProvider,
+    PullRequestCCMimic,
+)
+from pr_agent.git_providers.git_provider import GitProvider
 
 
 class TestCodeCommitFile:
@@ -454,3 +461,155 @@ class TestCodeCommitProvider:
         input = "## PR Feedback\n<details><summary>Code feedback:</summary>\nfile foo\n</summary>\n"
         expect = "## PR Feedback\nCode feedback:\nfile foo\n\n"
         assert CodeCommitProvider._remove_markdown_html(input) == expect
+
+    def test_get_issue_comments_maps_fields_and_filters_deleted(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.pr_num = 123
+        provider.codecommit_client = MagicMock()
+        provider.codecommit_client.get_comments_for_pull_request.return_value = [
+            {"commentId": "c1", "content": "hello", "deleted": False},
+            {"commentId": "c2", "content": "deleted comment", "deleted": True},
+            {"commentId": "c3", "content": "world"},
+        ]
+
+        comments = provider.get_issue_comments()
+
+        assert len(comments) == 2
+        assert comments[0].id == "c1"
+        assert comments[0].body == "hello"
+        assert comments[0].deleted is False
+        assert comments[1].id == "c3"
+        assert comments[1].body == "world"
+        assert comments[1].deleted is False
+        provider.codecommit_client.get_comments_for_pull_request.assert_called_once_with(123)
+
+    def test_get_issue_comments_swallows_client_exceptions(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.pr_num = 123
+        provider.codecommit_client = MagicMock()
+        provider.codecommit_client.get_comments_for_pull_request.side_effect = ValueError("AWS request failed")
+
+        comments = provider.get_issue_comments()
+
+        assert comments == []
+
+    def test_edit_comment_normalises_body_and_calls_client(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.codecommit_client = MagicMock()
+        comment = CodeCommitComment({"commentId": "comm-42", "content": "old"})
+
+        result = provider.edit_comment(
+            comment,
+            "## Review\n<details><summary>Summary</summary>\nline1\nline2\n</details>",
+        )
+
+        assert result is True
+        provider.codecommit_client.update_comment.assert_called_once_with(
+            "comm-42",
+            "## Review\n\nSummary\n\nline1\n\nline2\n\n",
+        )
+
+    def test_edit_comment_accepts_dict_or_scalar_id(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.codecommit_client = MagicMock()
+
+        assert provider.edit_comment({"commentId": "dict-1"}, "body") is True
+        provider.codecommit_client.update_comment.assert_called_with("dict-1", "body")
+
+        assert provider.edit_comment({"id": "dict-2"}, "body") is True
+        provider.codecommit_client.update_comment.assert_called_with("dict-2", "body")
+
+        assert provider.edit_comment("scalar-3", "body") is True
+        provider.codecommit_client.update_comment.assert_called_with("scalar-3", "body")
+
+    def test_edit_comment_returns_false_on_client_error(self):
+        provider = object.__new__(CodeCommitProvider)
+        provider.codecommit_client = MagicMock()
+        provider.codecommit_client.update_comment.side_effect = ValueError("AWS update failed")
+
+        result = provider.edit_comment("comm-42", "updated content")
+
+        assert result is False
+
+    def test_identity_marker_survives_codecommit_body_normalisation(self):
+        """supports_review_comment_identity() is only honest if the marker round-trips.
+
+        CodeCommit rewrites every body it publishes. If normalisation ate the hidden
+        identity marker, the next run could not match it and persistence would silently
+        degrade back to creating comments.
+        """
+        marker = PRReviewIdentity.REGULAR.value
+        body = add_pr_review_identity("## PR Review\n\nSome findings.", marker)
+
+        normalised = CodeCommitProvider._remove_markdown_html(body)
+        normalised = CodeCommitProvider._add_additional_newlines(normalised)
+
+        assert marker in normalised
+        assert comment_matches_identity(normalised, marker)
+
+    def test_publish_persistent_comment_routes_to_the_persistent_path(self):
+        assert (
+            CodeCommitProvider.publish_persistent_comment
+            is not GitProvider.publish_persistent_comment
+        )
+
+    def test_publish_persistent_comment_updates_existing_review_regression_3157(self):
+        """Regression test for upstream issue #3157:
+
+        A second non-incremental review on CodeCommit should update the existing persistent
+        review comment rather than creating an additional comment (creates=1, updates=1,
+        instead of creates=2, updates=0).
+        """
+        provider = object.__new__(CodeCommitProvider)
+        provider.repo_name = "test-repo"
+        provider.pr_num = 100
+        provider.pr = PullRequestCCMimic("Test PR", [])
+        provider.pr.source_commit = "src-sha"
+        provider.pr.destination_commit = "dest-sha"
+
+        comments_store = []
+        counts = {"creates": 0, "updates": 0}
+
+        def fake_publish_comment(repo_name, pr_number, destination_commit, source_commit, comment, **kwargs):
+            counts["creates"] += 1
+            cid = f"comment-{len(comments_store) + 1}"
+            comments_store.append({"commentId": cid, "content": comment, "deleted": False})
+
+        def fake_get_comments(pr_number):
+            return list(comments_store)
+
+        def fake_update_comment(comment_id, content):
+            counts["updates"] += 1
+            for c in comments_store:
+                if c["commentId"] == comment_id:
+                    c["content"] = content
+                    return
+            raise ValueError(f"Comment {comment_id} not found")
+
+        fake_client = MagicMock()
+        fake_client.publish_comment.side_effect = fake_publish_comment
+        fake_client.get_comments_for_pull_request.side_effect = fake_get_comments
+        fake_client.update_comment.side_effect = fake_update_comment
+        provider.codecommit_client = fake_client
+
+        initial_header = "## PR Review"
+        first_review = "## PR Review\n\nFirst analysis."
+
+        # First run: no existing review comment -> 1 create, 0 updates
+        provider.publish_persistent_comment(
+            first_review,
+            initial_header=initial_header,
+            final_update_message=False,
+        )
+        assert counts["creates"] == 1
+        assert counts["updates"] == 0
+
+        # Second run: existing review comment present -> creates stays 1, updates becomes 1
+        second_review = "## PR Review\n\nUpdated analysis."
+        provider.publish_persistent_comment(
+            second_review,
+            initial_header=initial_header,
+            final_update_message=False,
+        )
+        assert counts["creates"] == 1
+        assert counts["updates"] == 1

--- a/tests/unittest/test_git_provider_method_contract.py
+++ b/tests/unittest/test_git_provider_method_contract.py
@@ -234,7 +234,7 @@ METHOD_CONTRACTS = (
         check_supported=_is_comment_sequence,
         tiers=_tiers(
             supported=("github", "gitlab", "gitea", "gerrit", "azure-devops", "bitbucket-server", "bitbucket"),
-            not_implemented=("codecommit", "local"),
+            not_implemented=("local",),
         ),
         # Implementations narrow the base `Iterable` (a paginated list, a list of SDK objects),
         # so the return annotation is checked by behaviour rather than by equality.


### PR DESCRIPTION
Fixes #3157.

## The bug

Rerunning a non-incremental `/review` on a CodeCommit pull request, with the default `pr_reviewer.persistent_comment=true`, publishes a **new** comment every time instead of updating the previous persistent review comment. Every other persistent-comment provider updates in place.

Reproduced on the CodeCommit provider path:

```text
current main: creates=2, updates=0
this branch:  creates=1, updates=1
```

## Why it happens

`publish_persistent_comment_full` finds the previous comment by listing PR comments and then edits it. `CodeCommitProvider` implemented neither side of that:

- `get_issue_comments` raised `NotImplementedError`, and `get_issue_comments` was listed as an unsupported capability;
- there was no `edit_comment` at all.

So there was nothing to find and nothing to update, and the only reachable behaviour was creating another comment.

## The change

Provider-local, no shared base class touched.

**`codecommit_client.py`**
- `get_comments_for_pull_request(pr_number)` — paginates the CodeCommit [`get_comments_for_pull_request`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/get_comments_for_pull_request.html) API (paginator when available, `nextToken` loop otherwise) and flattens the nested `commentsForPullRequestData[*].comments[*]` response.
- `update_comment(comment_id, content)` — wraps [`update_comment`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/update_comment.html).

Both follow the existing `publish_comment` style: lazy boto client, `ClientError` handling, `raise ValueError(...) from e`.

**`codecommit_provider.py`**
- `CodeCommitComment` exposes `commentId`/`content` as the `.id`/`.body` shape `GitProvider` expects.
- `get_issue_comments` returns non-deleted comments, and on **any** client failure logs a warning and returns `[]` rather than raising — a provider that cannot list comments must degrade to creating one, not fail the whole review.
- `edit_comment` applies the same `_remove_markdown_html` + `_add_additional_newlines` normalisation `publish_comment` applies (CodeCommit does not render GFM), and returns `False` on failure so `publish_persistent_comment_full` sees a failed update rather than a silently discarded body.
- `publish_persistent_comment` routes to `publish_persistent_comment_full` now that both halves exist.
- `get_issue_comments` removed from the unsupported-capability list.
- `supports_review_comment_identity()` returns `True`, with a test that proves the hidden identity marker actually survives CodeCommit body normalisation rather than just asserting the predicate.

Multi-target creation semantics are untouched: `publish_comment` still posts per target context, and persistence updates a single comment by id.

## Tests

`tests/unittest/test_codecommit_client.py` and `tests/unittest/test_codecommit_provider.py`:

- comment listing flattens the nested response, maps the fields, and filters `deleted: true`;
- listing failure returns `[]` and does not raise;
- `edit_comment` calls `update_comment` with the normalised body, accepts object/dict/scalar ids, returns `False` on client error;
- the identity marker round-trips through both normalisation steps;
- **regression test for #3157**: a fake client counting creates and updates asserts run 1 → `creates=1, updates=0`, run 2 → `creates=1, updates=1`.

The contract row in `test_git_provider_method_contract.py` moves `codecommit` out of `not_implemented` for `get_issue_comments`.

Full unit suite: **4466 passed, 1 skipped, 1 xfailed**. `ruff check` clean on every touched file.

## Relationship to #3254

Independent, and deliberately so. #3254 fixes the shared base-class default. This branch is provider-local and shares no changed lines with it — it applies cleanly on `main` today and does not need #3254 to work. I verified the reverse direction too and said so on #3157: #3254 alone does **not** fix this issue, because without the two methods added here CodeCommit still cannot list or edit a comment and still falls back to creating one.

Either can merge first.