### PR TITLE
fix: keep truncated comments within character limit

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -773,7 +773,14 @@ class GitProvider(ABC):
             return -1
 
     def limit_output_characters(self, output: str, max_chars: int):
-        return output[:max_chars] + '...' if len(output) > max_chars else output
+        """Truncate output to max_chars, including the truncation suffix."""
+        if len(output) <= max_chars:
+            return output
+        if max_chars <= 0:
+            return ""
+        suffix = "..."
+        suffix = suffix[:max_chars]
+        return output[:max_chars - len(suffix)] + suffix
 
 
 def get_main_pr_language(languages, files) -> str:

--- a/tests/unittest/test_github_provider_comments.py
+++ b/tests/unittest/test_github_provider_comments.py
@@ -55,6 +55,30 @@ def _make_provider(pr=None, max_chars=65000):
     return p
 
 
+@pytest.mark.parametrize(
+    ("output", "max_chars", "expected"),
+    [
+        pytest.param("short", 10, "short", id="short"),
+        pytest.param("exact", 5, "exact", id="exact"),
+        pytest.param("x" * 20, 10, ("x" * 7) + "...", id="truncated"),
+        pytest.param("abcdef", -1, "", id="negative-limit"),
+        pytest.param("abcdef", 0, "", id="zero-limit"),
+        pytest.param("abcdef", 1, ".", id="one-character-limit"),
+        pytest.param("abcdef", 2, "..", id="two-character-limit"),
+        pytest.param("abcdef", 3, "...", id="three-character-limit"),
+        pytest.param("😀" * 5, 4, "😀...", id="unicode-code-points"),
+    ],
+)
+def test_limit_output_characters_respects_total_limit(output, max_chars, expected):
+    provider = _make_provider()
+
+    result = provider.limit_output_characters(output, max_chars)
+
+    assert result == expected
+    if max_chars >= 0:
+        assert len(result) <= max_chars
+
+
 def test_edit_comment_returns_false_on_github_failure():
     provider = _make_provider()
     comment = MagicMock()
@@ -172,8 +196,8 @@ def test_create_inline_comment_limits_body_length(monkeypatch):
     payload = provider.create_inline_comment(long_body, "f.py", "line")
 
     assert payload["body"].endswith("...")
-    # limit_output_characters: output[:max_chars] + '...'
-    assert payload["body"] == "A" * 10 + "..."
+    assert payload["body"] == "A" * 7 + "..."
+    assert len(payload["body"]) == provider.max_comment_chars
 
 
 def test_create_inline_comment_does_not_truncate_short_body(monkeypatch):


### PR DESCRIPTION
## Summary

- count the `...` truncation marker inside `max_chars`
- define bounded behavior for zero and tiny character budgets
- cover exact, truncated, and non-ASCII inputs

## Why

`limit_output_characters` currently slices to `max_chars` and then appends `...`.
For example, a caller requesting at most 10 characters receives 13 when truncation
is needed.

This change makes `max_chars` describe the final returned length. Text that already
fits remains unchanged.

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_github_provider_comments.py -q` (48 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (4464 passed, 1 skipped, 1 xfailed)
- `uv run ruff check pr_agent/git_providers/git_provider.py tests/unittest/test_github_provider_comments.py` (passed)
