### PR TITLE
fix(gpt5): map reasoning_effort 'max' to 'xhigh' for OpenAI models

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -839,12 +839,15 @@ class LiteLLMAIHandler(BaseAiHandler):
                         get_logger().info(f"GPT-6 Astra does not support reasoning_effort='{effort}'; using 'low'")
                         effort = ReasoningEffort.LOW.value
                     elif not is_gpt6_astra and effort == ReasoningEffort.MAX.value:
-                        # OpenAI's GPT-5 models name their top level 'xhigh' and reject 'max'
-                        # outright. 'max' is this project's own alias for "the most reasoning
-                        # available", already translated on the Grok and OpenRouter paths, so
-                        # translate it here too instead of forwarding a value the API refuses.
+                        # 'max' is this project's own alias for "the most reasoning available",
+                        # already translated on the Grok and OpenRouter paths. GPT-5.2 and later
+                        # name that level 'xhigh'; litellm reports supports_xhigh_reasoning_effort
+                        # false for gpt-5 and gpt-5.1, so those stay unsupported either way.
                         # GPT-6 Astra accepts 'max' natively and is left untouched.
-                        get_logger().info("GPT-5 models name their top reasoning level 'xhigh'; using 'xhigh' for reasoning_effort='max'")
+                        get_logger().info(
+                            "GPT-5 models name their top reasoning level 'xhigh'; "
+                            "using 'xhigh' for reasoning_effort='max'"
+                        )
                         effort = ReasoningEffort.XHIGH.value
 
                     thinking_kwargs_gpt5 = {

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -838,6 +838,14 @@ class LiteLLMAIHandler(BaseAiHandler):
                     if is_gpt6_astra and effort in (ReasoningEffort.NONE.value, ReasoningEffort.MINIMAL.value):
                         get_logger().info(f"GPT-6 Astra does not support reasoning_effort='{effort}'; using 'low'")
                         effort = ReasoningEffort.LOW.value
+                    elif not is_gpt6_astra and effort == ReasoningEffort.MAX.value:
+                        # OpenAI's GPT-5 models name their top level 'xhigh' and reject 'max'
+                        # outright. 'max' is this project's own alias for "the most reasoning
+                        # available", already translated on the Grok and OpenRouter paths, so
+                        # translate it here too instead of forwarding a value the API refuses.
+                        # GPT-6 Astra accepts 'max' natively and is left untouched.
+                        get_logger().info("GPT-5 models name their top reasoning level 'xhigh'; using 'xhigh' for reasoning_effort='max'")
+                        effort = ReasoningEffort.XHIGH.value
 
                     thinking_kwargs_gpt5 = {
                         "reasoning_effort": effort,

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -235,8 +235,8 @@ class TestLiteLLMReasoningEffort:
             mock_logger.info.assert_any_call("Using reasoning_effort='xhigh' for GPT-5 model")
 
     @pytest.mark.asyncio
-    async def test_gpt5_valid_reasoning_effort_max(self, monkeypatch, mock_logger):
-        """Test GPT-5 with valid reasoning_effort='max' from config."""
+    async def test_gpt5_reasoning_effort_max_is_mapped_to_xhigh(self, monkeypatch, mock_logger):
+        """GPT-5 rejects 'max'; the handler must send its top level 'xhigh' instead."""
         fake_settings = create_mock_settings("max")
         monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
 
@@ -254,9 +254,9 @@ class TestLiteLLMReasoningEffort:
             )
 
             call_kwargs = mock_completion.call_args[1]
-            assert call_kwargs["reasoning_effort"] == "max"
+            assert call_kwargs["reasoning_effort"] == "xhigh"
             assert "reasoning_effort" in call_kwargs["allowed_openai_params"]
-            mock_logger.info.assert_any_call("Using reasoning_effort='max' for GPT-5 model")
+            mock_logger.info.assert_any_call("Using reasoning_effort='xhigh' for GPT-5 model")
 
     @pytest.mark.asyncio
     async def test_gpt5_valid_reasoning_effort_minimal(self, monkeypatch, mock_logger):


### PR DESCRIPTION
Fixes #3237.

### The failure

With `reasoning_effort = "max"` and a `gpt-5*` model, **every** request fails:

```
Using reasoning_effort='max' for GPT-5 model
Error during LLM inference: litellm.BadRequestError: OpenAIException -
Unsupported value: 'reasoning_effort' does not support 'max' with this model.
Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.
```

`fallback_models` cannot rescue it, because `reasoning_effort` is global config rather than per-model — the reporter's fallback chain hit the identical rejection.

### Root cause

The GPT-5 branch in `litellm_ai_handler.py` validates the configured value against `ReasoningEffort` and then forwards it **verbatim**, together with `allowed_openai_params=["reasoning_effort"]`. That flag is what makes this fatal: it explicitly instructs LiteLLM to pass the parameter through, disabling the guard that would otherwise drop a value the provider does not support. So the request reaches OpenAI carrying `max`, and OpenAI refuses it.

`max` is this project's own alias for "the highest reasoning level available" — it is not an OpenAI value, and every other code path already translates it before the request goes out:

- the Grok clamp maps `max` → `xhigh` (or `high`) against the registered levels;
- the OpenRouter path maps `max` → `xhigh` in `extra_body["reasoning"]["effort"]`, with a comment saying so.

The OpenAI path was the one that did not, which is why this is the only provider where `max` is unusable.

### The change

Map `max` → `xhigh` on the GPT-5 OpenAI/Azure path, mirroring the two existing mappings. `gpt-6-astra` accepts `max` natively (`test_litellm_forwards_astra_reasoning` asserts it round-trips through `get_optional_params`), so that model is explicitly excluded and its behaviour is unchanged.

### Tests

`test_gpt5_valid_reasoning_effort_max` pinned the broken value — it asserted the handler sends `max` to a model that rejects it, so the bug was under test as if it were the contract. It is renamed to `test_gpt5_reasoning_effort_max_is_mapped_to_xhigh` and now asserts the mapping. The GPT-6 Astra parametrisations covering `max` are untouched and still pass, which is the guard that this change did not leak into Astra.

Full unit suite: 4455 passed, 1 skipped, 1 xfailed. `ruff check` clean on both touched files.