### PR TITLE
fix(help): run question-mode /help without requiring an OpenAI key

### DIFF
--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -99,14 +99,6 @@ class PRHelpMessage:
             if self.question_str:
                 get_logger().info(f'Answering a PR question about the PR {self.git_provider.pr_url} ')
 
-                if not get_settings().get('openai.key'):
-                    if get_settings().config.publish_output:
-                        self.git_provider.publish_comment(
-                            "The `Help` tool chat feature requires an OpenAI API key for calculating embeddings")
-                    else:
-                        get_logger().error("The `Help` tool chat feature requires an OpenAI API key for calculating embeddings")
-                    return
-
                 # current path
                 docs_path= Path(__file__).parent.parent.parent / 'docs' / 'docs'
                 # get all the 'md' files inside docs_path and its subdirectories

--- a/tests/unittest/test_pr_help_question_mode.py
+++ b/tests/unittest/test_pr_help_question_mode.py
@@ -1,0 +1,70 @@
+"""Question-mode /help runs on the configured model, with or without an OpenAI key.
+
+The question path loads the documentation corpus and calls the configured model
+handler; it calculates no embeddings, so an absent ``openai.key`` must not stop
+it for users running a non-OpenAI provider.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_help_message import PRHelpMessage
+from tests.unittest._settings_helpers import SENTINEL, restore_settings, snapshot_settings
+
+OPENAI_KEY_MARKER = "requires an OpenAI API key"
+
+MODEL_ANSWER = """\
+response: |
+  Set `pr_reviewer` options in your configuration file.
+relevant_sections:
+- file_name: "usage-guide/automations_and_usage.md"
+  relevant_section_header_string: "Configuration options"
+"""
+
+
+class StubProvider:
+    def __init__(self):
+        self.pr_url = "https://example.com/org/repo/pull/1"
+        self.published = []
+
+    def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        self.published.append(pr_comment)
+
+
+def _make_help_tool(provider) -> PRHelpMessage:
+    tool = PRHelpMessage.__new__(PRHelpMessage)
+    tool.git_provider = provider
+    tool.question_str = "How do I configure automatic reviews?"
+    tool.return_as_string = False
+    tool.vars = {"question": tool.question_str, "snippets": ""}
+    tool.token_handler = MagicMock()
+    tool.token_handler.count_tokens.return_value = 100
+    return tool
+
+
+@pytest.fixture
+def published_output_without_openai_key():
+    snapshot = snapshot_settings(["config.publish_output", "openai.key"])
+    get_settings().set("config.publish_output", True)
+    # ``restore_settings`` removes a key whose value is SENTINEL; use it to
+    # clear ``openai.key`` for the duration of the test.
+    restore_settings({"openai.key": SENTINEL})
+    yield
+    restore_settings(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_question_mode_reaches_the_model_without_an_openai_key(published_output_without_openai_key):
+    provider = StubProvider()
+    tool = _make_help_tool(provider)
+
+    with patch("pr_agent.tools.pr_help_message.retry_with_fallback_models",
+               new=AsyncMock(return_value=MODEL_ANSWER)) as model_call:
+        await tool.run()
+
+    assert model_call.await_count == 1, "the configured model handler must be invoked"
+    assert len(provider.published) == 1
+    assert OPENAI_KEY_MARKER not in provider.published[0]
+    assert "Set `pr_reviewer` options" in provider.published[0]


### PR DESCRIPTION
Closes #3260

### What

Question-mode `/help "..."` returned early with

> The `Help` tool chat feature requires an OpenAI API key for calculating embeddings

whenever `OPENAI.KEY` was unset, even for a fully configured non-OpenAI provider.

### Why the guard is wrong

The question path calculates no embeddings. It globs `docs/docs/**/*.md`, builds the `snippets` prompt variable, and calls `retry_with_fallback_models(self._prepare_prediction, ...)` — the configured model handler, which already owns provider-specific credential validation. Embedding-backed code lives in `pr_agent/tools/pr_similar_issue.py`, which reads `openai.key` for exactly that reason; `pr_help_message.py` does not.

So the guard blocks a supported configuration and explains it with a mechanism the path does not use.

### Change

- Remove the `openai.key` guard from the question branch of `PRHelpMessage.run()`. Invalid provider configuration now surfaces through the model handler's normal error path.
- Static `/help` (no question) is untouched, including the `gfm_markdown` capability check.

### Test plan

New `tests/unittest/test_pr_help_question_mode.py` clears `openai.key` via the existing SENTINEL snapshot helper, patches `retry_with_fallback_models`, and asserts the handler is awaited and the answer published without the OpenAI message.

- Against `main` the test fails (`await_count == 0`) — it pins the reported bug, not the fix.
- With the change: `4456 passed, 1 skipped, 1 xfailed` on the full unit suite; `ruff check` clean on both touched files.
