### PR TITLE
fix(help): allow question mode without an OpenAI key

### DIFF
--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -99,14 +99,6 @@ class PRHelpMessage:
             if self.question_str:
                 get_logger().info(f'Answering a PR question about the PR {self.git_provider.pr_url} ')
 
-                if not get_settings().get('openai.key'):
-                    if get_settings().config.publish_output:
-                        self.git_provider.publish_comment(
-                            "The `Help` tool chat feature requires an OpenAI API key for calculating embeddings")
-                    else:
-                        get_logger().error("The `Help` tool chat feature requires an OpenAI API key for calculating embeddings")
-                    return
-
                 # current path
                 docs_path= Path(__file__).parent.parent.parent / 'docs' / 'docs'
                 # get all the 'md' files inside docs_path and its subdirectories

--- a/tests/unittest/test_pr_help_message_rendering.py
+++ b/tests/unittest/test_pr_help_message_rendering.py
@@ -147,7 +147,7 @@ async def test_question_uses_configured_handler_error_path_without_openai_key(
     await tool.run()
 
     assert [call["model"] for call in handler.calls] == ["anthropic/claude-3-5-sonnet-20240620"]
-    assert all("requires an OpenAI API key" not in comment for comment in tool.git_provider.published)
+    assert tool.git_provider.published == []
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/test_pr_help_message_rendering.py
+++ b/tests/unittest/test_pr_help_message_rendering.py
@@ -1,4 +1,4 @@
-"""The /help walkthrough picks its rendering from provider capabilities, not provider classes."""
+"""Regression tests for provider-independent /help behavior."""
 
 import pytest
 
@@ -7,6 +7,7 @@ from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
 from pr_agent.git_providers.bitbucket_server_provider import BitbucketServerProvider
 from pr_agent.git_providers.github_provider import GithubProvider
 from pr_agent.git_providers.gitlab_provider import GitLabProvider
+from pr_agent.tools import pr_help_message as pr_help_message_module
 from pr_agent.tools.pr_help_message import PRHelpMessage
 from tests.unittest._settings_helpers import restore_settings, snapshot_settings
 
@@ -19,6 +20,7 @@ class StubProvider:
     """A provider that is none of the concrete classes the tool used to branch on."""
 
     def __init__(self, gfm_markdown: bool, markdown_tables: bool = False, checkbox_commands: bool = False):
+        self.pr_url = "https://example.com/org/repo/pull/1"
         self._gfm_markdown = gfm_markdown
         self._markdown_tables = markdown_tables
         self._checkbox_commands = checkbox_commands
@@ -37,6 +39,25 @@ class StubProvider:
         self.published.append(pr_comment)
 
 
+class StubAiHandler:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    async def chat_completion(self, *, model, temperature, system, user):
+        self.calls.append({"model": model, "system": system, "user": user})
+        if self.error:
+            raise self.error
+        return self.response, "stop"
+
+
+class StubTokenHandler:
+    @staticmethod
+    def count_tokens(text):
+        return len(text)
+
+
 async def run_walkthrough(provider) -> str:
     tool = PRHelpMessage.__new__(PRHelpMessage)
     tool.git_provider = provider
@@ -47,12 +68,86 @@ async def run_walkthrough(provider) -> str:
     return provider.published[0]
 
 
+def build_question_tool(tmp_path, monkeypatch, handler):
+    package_root = tmp_path / "package"
+    docs_path = package_root / "docs" / "docs"
+    review_doc = docs_path / "tools" / "review.md"
+    review_doc.parent.mkdir(parents=True)
+    review_doc.write_text("# Automatic review\n\nEnable automatic review in the repository settings.", encoding="utf-8")
+
+    source_path = package_root / "pr_agent" / "tools" / "pr_help_message.py"
+    monkeypatch.setattr(pr_help_message_module, "Path", lambda _: source_path)
+
+    tool = PRHelpMessage.__new__(PRHelpMessage)
+    tool.git_provider = StubProvider(gfm_markdown=True)
+    tool.ai_handler = handler
+    tool.question_str = "How do I configure automatic reviews?"
+    tool.return_as_string = False
+    tool.vars = {"question": tool.question_str, "snippets": ""}
+    tool.token_handler = StubTokenHandler()
+    return tool
+
+
 @pytest.fixture
 def published_output():
     snapshot = snapshot_settings(["config.publish_output", "config.disable_checkboxes"])
     get_settings().set("config.publish_output", True)
     yield
     restore_settings(snapshot)
+
+
+@pytest.fixture
+def non_openai_question_settings():
+    keys = [
+        "config.model",
+        "config.fallback_models",
+        "model_routing.enable",
+        "openai.key",
+        "openai.deployment_id",
+    ]
+    snapshot = snapshot_settings(keys)
+    settings = get_settings()
+    settings.set("config.model", "anthropic/claude-3-5-sonnet-20240620")
+    settings.set("config.fallback_models", [])
+    settings.set("model_routing.enable", False)
+    settings.set("openai.key", None)
+    settings.set("openai.deployment_id", None)
+    yield
+    restore_settings(snapshot)
+
+
+async def test_question_reaches_configured_handler_without_openai_key(
+    published_output, non_openai_question_settings, tmp_path, monkeypatch
+):
+    handler = StubAiHandler(
+        response=(
+            "response: Enable automatic review in the repository settings.\n"
+            "relevant_sections:\n"
+            "  - file_name: /tools/review.md\n"
+            "    relevant_section_header_string: Automatic review\n"
+        )
+    )
+    tool = build_question_tool(tmp_path, monkeypatch, handler)
+
+    await tool.run()
+
+    assert [call["model"] for call in handler.calls] == ["anthropic/claude-3-5-sonnet-20240620"]
+    assert tool.question_str in handler.calls[0]["user"]
+    assert "Enable automatic review in the repository settings." in handler.calls[0]["user"]
+    assert "Enable automatic review in the repository settings." in tool.git_provider.published[0]
+    assert "requires an OpenAI API key" not in tool.git_provider.published[0]
+
+
+async def test_question_uses_configured_handler_error_path_without_openai_key(
+    published_output, non_openai_question_settings, tmp_path, monkeypatch
+):
+    handler = StubAiHandler(error=RuntimeError("provider credentials missing"))
+    tool = build_question_tool(tmp_path, monkeypatch, handler)
+
+    await tool.run()
+
+    assert [call["model"] for call in handler.calls] == ["anthropic/claude-3-5-sonnet-20240620"]
+    assert all("requires an OpenAI API key" not in comment for comment in tool.git_provider.published)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3260

## Summary

- Let question-mode `/help` reach the configured model handler when `openai.key` is unset.
- Keep static `/help` unchanged and cover both successful and failing configured-provider calls.

This overlaps #3261. This version additionally verifies that the configured non-OpenAI handler receives the documentation prompt and that provider failures do not restore the obsolete OpenAI-key message.

## Result

With an Anthropic model configured and no `openai.key`, `/help "How do I configure automatic reviews?"` reaches the configured handler and can publish its answer. Provider errors stay on the existing handler-owned error path.

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_help_message_rendering.py -q` (11 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (4457 passed, 1 skipped, 1 xfailed)
- `uv run pre-commit run --files pr_agent/tools/pr_help_message.py tests/unittest/test_pr_help_message_rendering.py` (passed)
