### PR TITLE
fix(tickets): match hyphens and periods in cross-repo issue references

### DIFF
--- a/pr_agent/tools/ticket_pr_compliance_check.py
+++ b/pr_agent/tools/ticket_pr_compliance_check.py
@@ -15,7 +15,9 @@ from pr_agent.log import get_logger
 
 # Compile the regex pattern once, outside the function
 GITHUB_TICKET_PATTERN = re.compile(
-     r'(https://github[^/]+/[^/]+/[^/]+/issues/\d+)|(\b(\w+)/(\w+)#(\d+)\b)|(#\d+)'
+    r'(https://github[^/]+/[^/]+/[^/]+/issues/\d+)'
+    r'|((?<![\w./-])([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)/([A-Za-z0-9._-]+)#(\d+)\b)'
+    r'|(#\d+)'
 )
 # Option A: issue number at start of branch or after /, followed by - or end (e.g. feature/1-test-issue, 123-fix)
 BRANCH_ISSUE_PATTERN = re.compile(r"(?:^|/)(\d{1,6})(?=-|$)")

--- a/tests/unittest/test_github_issue_reference_extraction.py
+++ b/tests/unittest/test_github_issue_reference_extraction.py
@@ -105,4 +105,3 @@ def test_regression_full_url_still_wins():
 def test_regression_mid_token_does_not_match_cross_repo():
     assert _links("see x/my-org/my-repo#42") == [f"{BASE}/{REPO}/issues/42"]
     assert _links("see x/other/project#12345") == [f"{BASE}/{REPO}/issues/12345"]
-

--- a/tests/unittest/test_github_issue_reference_extraction.py
+++ b/tests/unittest/test_github_issue_reference_extraction.py
@@ -64,3 +64,45 @@ def test_a_full_url_is_not_bounded():
 def test_a_cross_repo_shorthand_is_not_bounded():
     """Control: owner/repo#123 names its repository, so it is unambiguous too."""
     assert _links("Fixes other/project#12345") == [f"{BASE}/other/project/issues/12345"]
+
+
+@pytest.mark.parametrize(
+    ("shorthand", "expected_url"),
+    [
+        ("my-org/repo#42", f"{BASE}/my-org/repo/issues/42"),
+        ("org/my-repo#42", f"{BASE}/org/my-repo/issues/42"),
+        ("my-org/my-repo#42", f"{BASE}/my-org/my-repo/issues/42"),
+    ],
+)
+def test_cross_repo_with_hyphens(shorthand, expected_url):
+    assert _links(f"Fixes {shorthand}") == [expected_url]
+
+
+@pytest.mark.parametrize(
+    ("shorthand", "expected_url"),
+    [
+        ("org/my.repo#7", f"{BASE}/org/my.repo/issues/7"),
+        ("org/my_repo#7", f"{BASE}/org/my_repo/issues/7"),
+    ],
+)
+def test_cross_repo_with_period_and_underscore_in_repo_name(shorthand, expected_url):
+    assert _links(f"Fixes {shorthand}") == [expected_url]
+
+
+def test_cross_repo_this_repo_own_name():
+    assert _links("Fixes The-PR-Agent/pr-agent#3081") == [f"{BASE}/The-PR-Agent/pr-agent/issues/3081"]
+
+
+def test_regression_bare_shorthand_resolves_against_current_repo():
+    assert _links("Fixes #42") == [f"{BASE}/{REPO}/issues/42"]
+
+
+def test_regression_full_url_still_wins():
+    url = f"{BASE}/some-org/some-repo/issues/99"
+    assert _links(f"Fixes {url}") == [url]
+
+
+def test_regression_mid_token_does_not_match_cross_repo():
+    assert _links("see x/my-org/my-repo#42") == [f"{BASE}/{REPO}/issues/42"]
+    assert _links("see x/other/project#12345") == [f"{BASE}/{REPO}/issues/12345"]
+


### PR DESCRIPTION
## Summary

Fixes #3263. A cross-repository issue reference containing a hyphen resolved against the **wrong repository** rather than being skipped.

## Root cause

`GITHUB_TICKET_PATTERN`'s cross-repo alternative was `\b(\w+)/(\w+)#(\d+)\b`. `\w` is `[A-Za-z0-9_]`, but GitHub owners may contain hyphens and repository names may contain hyphens, periods and underscores.

The consequence is not a missed match. `\b` lets the match restart after the hyphen, the cross-repo alternative fails, and the reference falls through to the bare `#\d+` alternative — which `extract_ticket_links_from_pr_description` resolves against `repo_path`, the current repository:

```python
extract_ticket_links_from_pr_description("Fixes my-org/my-repo#42", "current/repo")
# -> ['https://github.com/current/repo/issues/42']
```

`require_ticket_analysis_review` then fetches issue 42 of the *current* repo and feeds its title and body into the compliance review as though it were the ticket the author named. Notably the pattern could not express a reference to this project itself: `The-PR-Agent/pr-agent#3081` resolved to the current repo too.

`myorg/myrepo#42` always worked, which is why this went unnoticed — the shape that fails is the one with a hyphen, and that is the common one.

## Changes

`pr_agent/tools/ticket_pr_compliance_check.py` — the regex constant only, nothing else:

- owner: `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*`, GitHub's rule — alphanumeric segments joined by single hyphens, never leading or trailing one;
- repository: `[A-Za-z0-9._-]+`;
- the leading `\b` becomes an explicit left guard `(?<![\w./-])`. This is load-bearing: `\b` is precisely what allowed the match to start mid-token, so without the guard `x/my-org/my-repo#42` would match from the wrong offset once the classes are widened.

Group order and numbering are unchanged — `extract_ticket_links_from_pr_description` indexes `match[0]`..`match[5]` positionally, so the internal grouping added is non-capturing. No extraction logic, no `MAX_SHORTHAND_ISSUE_DIGITS`, no `BRANCH_ISSUE_PATTERN`.

## Tests

`tests/unittest/test_github_issue_reference_extraction.py` is extended, not rewritten. New cases, all red on `main`:

- a hyphen in the owner, in the repository, and in both;
- a period and an underscore in the repository name;
- `The-PR-Agent/pr-agent#3081`, this project's own name;
- a match must not start mid-token: `see x/my-org/my-repo#42` resolves as the bare `#42` and not as some `x/my-org` link.

Regression controls kept green: a bare `#42` still resolves against `repo_path`, a full URL still takes precedence, and `other/project#12345` still works.

On the original regex the new tests report **6 failed, 20 passed**, so they pin the bug rather than merely describing it.

## Test plan

```
PYTHONPATH=. uv run pytest tests/unittest -q
4464 passed, 1 skipped, 1 xfailed in 102.11s

uv run ruff check pr_agent/tools/ticket_pr_compliance_check.py tests/unittest/test_github_issue_reference_extraction.py
All checks passed!
```

## Note

@IsmaelMartinez raised this in review of #3082 as deserving its own issue; #3263 is that issue and this is the fix. One judgement call worth surfacing: `org/repo-#1` now yields `repo-`. GitHub does accept a trailing hyphen in a repository name, so widening it further would be wrong and narrowing it would reject a legal name — but say the word if you would rather the repository group mirrored the owner's no-trailing-hyphen rule.