### PR TITLE
fix(help): let question-mode prediction errors reach the fallback loop

### DIFF
--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -57,7 +57,7 @@ class PRHelpMessage:
             return response
         except Exception as e:
             get_logger().error(f"Error while preparing prediction: {e}")
-            return ""
+            raise
 
     def parse_args(self, args):
         if args and len(args) > 0:

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -1,0 +1,81 @@
+import pytest
+
+from pr_agent.algo.pr_processing import retry_with_fallback_models
+from pr_agent.config_loader import get_settings
+from pr_agent.tools.pr_help_message import PRHelpMessage
+from tests.unittest._settings_helpers import restore_settings, snapshot_settings
+
+_TRACKED_KEYS = (
+    "config.model",
+    "config.fallback_models",
+    "openai.deployment_id",
+    "openai.fallback_deployments",
+)
+
+
+class FakeAiHandler:
+    def __init__(self, behavior_by_model: dict[str, tuple[str, str] | Exception]):
+        self.behavior_by_model = behavior_by_model
+        self.calls = []
+
+    async def chat_completion(self, model: str, temperature: float, system: str, user: str):
+        self.calls.append(model)
+        outcome = self.behavior_by_model.get(model)
+        if isinstance(outcome, Exception):
+            raise outcome
+        if outcome is None:
+            raise RuntimeError(f"Unexpected model call: {model}")
+        return outcome
+
+
+def _build_pr_help_tool(fake_ai_handler: FakeAiHandler) -> PRHelpMessage:
+    tool = PRHelpMessage.__new__(PRHelpMessage)
+    tool.ai_handler = fake_ai_handler
+    tool.question_str = "How do I configure PR-Agent?"
+    tool.return_as_string = False
+    tool.vars = {
+        "question": tool.question_str,
+        "snippets": "fake docs snippet",
+    }
+    return tool
+
+
+@pytest.fixture
+def fallback_settings():
+    snapshot = snapshot_settings(_TRACKED_KEYS)
+    get_settings().set("config.model", "primary-model")
+    get_settings().set("config.fallback_models", ["fallback-model"])
+    get_settings().set("openai.deployment_id", None)
+    get_settings().set("openai.fallback_deployments", [])
+    yield
+    restore_settings(snapshot)
+
+
+async def test_fallback_attempted_when_primary_model_fails(fallback_settings):
+    fake_handler = FakeAiHandler({
+        "primary-model": RuntimeError("primary model failed"),
+        "fallback-model": ("fallback answer response", "stop"),
+    })
+    tool = _build_pr_help_tool(fake_handler)
+
+    response = await retry_with_fallback_models(tool._prepare_prediction)
+
+    assert response == "fallback answer response"
+    assert fake_handler.calls == ["primary-model", "fallback-model"]
+
+
+async def test_exception_propagates_when_all_models_fail(fallback_settings):
+    primary_error = RuntimeError("primary model failed")
+    fallback_error = ValueError("fallback model failed")
+    fake_handler = FakeAiHandler({
+        "primary-model": primary_error,
+        "fallback-model": fallback_error,
+    })
+    tool = _build_pr_help_tool(fake_handler)
+
+    with pytest.raises(Exception) as exc_info:
+        await retry_with_fallback_models(tool._prepare_prediction)
+
+    assert fake_handler.calls == ["primary-model", "fallback-model"]
+    assert "Failed to generate prediction with any model" in str(exc_info.value)
+    assert exc_info.value.__cause__ is fallback_error


### PR DESCRIPTION
Fixes #3265.

### The bug

`PRHelpMessage._prepare_prediction` wrapped its whole body in `except Exception`, logged, and returned `""`. The shared `retry_with_fallback_models` loop in `pr_agent/algo/pr_processing.py` only advances to the next model when the callback *raises* — a returned value is recorded as success:

```python
result = await f(model)
except Exception as e:
    ...
else:
    record_model_used(model, is_fallback=i > 0)
    return result
```

So a primary-model failure returned `""`, `config.fallback_models` were never attempted, `load_yaml("")` yielded no `relevant_sections`, and `/help "question"` published `Could not find relevant information to answer the question.` — which reads as *the docs do not cover this*, not *your model call failed*.

### The change

One line: log and re-raise instead of returning `""`. The loop now tries each configured fallback, and raises `Failed to generate prediction with any model of [...]` only when every model has failed. `PRHelpMessage.run()` already has an outer `except Exception` that logs it, so an all-models failure is logged as an error rather than published as a misleading answer.

Nothing else is touched — no other tool, no formatting.

### Test plan

New `tests/unittest/test_pr_help_message_fallback.py`, offline, with a fake handler:

1. primary raises, fallback succeeds — asserts the fallback response is returned and both models were called, in order;
2. every model raises — asserts the exception propagates out of `retry_with_fallback_models` with the failing model's error as `__cause__`.

Both fail on `main` (`assert '' == 'fallback answer response'` and `DID NOT RAISE`) and pass with the fix — I ran them against the unpatched file to confirm they catch the regression rather than the fix.

Full unit suite: `PYTHONPATH=. uv run pytest tests/unittest -q` — 4457 passed, 1 skipped, 1 xfailed. `ruff check` clean on both touched files.
