### PR TITLE
docs: repair four dead outbound links

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -616,7 +616,7 @@ For more detailed configuration options, see:
     ...
     ```
 
-    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/repository/docker/pragent/pr-agent/tags). Resolve the digest for the version you are pinning with `docker buildx imagetools inspect pragent/pr-agent:0.41.0-github_action --format '{{.Manifest.Digest}}'`, then use it in place of the tag:
+    For enhanced security, you can also specify the Docker image by its [digest](https://hub.docker.com/r/pragent/pr-agent/tags). Resolve the digest for the version you are pinning with `docker buildx imagetools inspect pragent/pr-agent:0.41.0-github_action --format '{{.Manifest.Digest}}'`, then use it in place of the tag:
     ```yaml
     ...
         steps:

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -105,7 +105,7 @@ duplicate_examples=true # will duplicate the examples in the prompt, to help the
 api_base = "http://localhost:11434" # or whatever port you're running Ollama on
 ```
 
-By default, Ollama uses a context window size of 2048 tokens. In most cases this is not enough to cover pr-agent prompt and pull-request diff. Context window size can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. For example, to set the default context length to 8K, use: `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`. More information you can find on the [official ollama faq](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size).
+By default, Ollama uses a context window size of 2048 tokens. In most cases this is not enough to cover pr-agent prompt and pull-request diff. Context window size can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. For example, to set the default context length to 8K, use: `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`. More information you can find on the [official ollama faq](https://docs.ollama.com/faq#how-can-i-specify-the-context-window-size).
 
 Please note that the `custom_model_max_tokens` setting should be configured in accordance with the `OLLAMA_CONTEXT_LENGTH`. Failure to do so may result in unexpected model output.
 

--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -89,11 +89,11 @@ Loading the global settings file is controlled by the `use_global_settings_file`
 use_global_settings_file = false
 ```
 
-For example, in the GitHub organization `qodo-ai`:
+For example, in a GitHub organization named `my-org`:
 
-- The file [`https://github.com/the-pr-agent/pr-agent-settings/.pr_agent.toml`](https://github.com/the-pr-agent/pr-agent-settings/blob/main/.pr_agent.toml)  serves as a global configuration file for all the repos in the GitHub organization `qodo-ai`.
+- The file `my-org/pr-agent-settings/.pr_agent.toml` (read from that repository's default branch) serves as a global configuration file for all the repos in the organization.
 
-- The repo [`https://github.com/the-pr-agent/pr-agent`](https://github.com/the-pr-agent/pr-agent/blob/main/.pr_agent.toml) inherits the global configuration file from `pr-agent-settings`.
+- A repository such as `my-org/my-repo` inherits that global configuration file, and may override any of its values in its own `.pr_agent.toml`.
 
 ## Project/Group level configuration file
 


### PR DESCRIPTION
## What changed

Repairs the four genuine dead outbound links found in #3269:

- move the Ollama FAQ reference from the deleted `docs/faq.md` to the current docs site, preserving and verifying the context-window anchor;
- use Docker Hub's public `/r/.../tags` route instead of its logged-in `/repository/docker/.../tags` UI route;
- replace two links to the nonexistent `the-pr-agent/pr-agent-settings` repository with neutral `my-org` path examples.

## Verification

- replacement Ollama URL: HTTP 200; `how-can-i-specify-the-context-window-size` anchor exists
- replacement Docker Hub URL: HTTP 200
- removed settings-repository URL: HTTP 404 under `the-pr-agent`, `The-PR-Agent`, `qodo-ai`, and `Codium-ai`
- pre-commit on the three changed Markdown files: all applicable hooks passed

This intentionally leaves the GTM part of #3269 untouched pending the remove-vs-wire-up decision requested there.

Closes the dead-link part of #3269.