### PR TITLE
fix(gpt5): clamp reasoning_effort 'max' where xhigh is unsupported

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -835,13 +835,31 @@ class LiteLLMAIHandler(BaseAiHandler):
                         # 'max' is this project's own alias for "the most reasoning available",
                         # already translated on the Grok and OpenRouter paths. GPT-5.2 and later
                         # name that level 'xhigh'; litellm reports supports_xhigh_reasoning_effort
-                        # false for gpt-5 and gpt-5.1, so those stay unsupported either way.
+                        # false for gpt-5 and gpt-5.1, so those are clamped to 'high' instead.
                         # GPT-6 Astra accepts 'max' natively and is left untouched.
-                        get_logger().info(
-                            "GPT-5 models name their top reasoning level 'xhigh'; "
-                            "using 'xhigh' for reasoning_effort='max'"
-                        )
-                        effort = ReasoningEffort.XHIGH.value
+                        lookup_model = model_base.removesuffix('_thinking')
+                        try:
+                            supports_xhigh = litellm.get_model_info(lookup_model).get(
+                                "supports_xhigh_reasoning_effort"
+                            )
+                        except Exception:
+                            # An unknown model is not evidence that 'xhigh' is unsupported; keep it.
+                            get_logger().debug(
+                                f"litellm.get_model_info could not resolve model '{lookup_model}'"
+                            )
+                            supports_xhigh = None
+                        if supports_xhigh is False:
+                            effort = ReasoningEffort.HIGH.value
+                            get_logger().info(
+                                f"{lookup_model} does not support reasoning_effort='xhigh'; "
+                                "using 'high' for reasoning_effort='max'"
+                            )
+                        else:
+                            effort = ReasoningEffort.XHIGH.value
+                            get_logger().info(
+                                "GPT-5 models name their top reasoning level 'xhigh'; "
+                                "using 'xhigh' for reasoning_effort='max'"
+                            )
 
                     thinking_kwargs_gpt5 = {
                         "reasoning_effort": effort,

--- a/tests/unittest/test_litellm_reasoning_effort.py
+++ b/tests/unittest/test_litellm_reasoning_effort.py
@@ -235,28 +235,43 @@ class TestLiteLLMReasoningEffort:
             mock_logger.info.assert_any_call("Using reasoning_effort='xhigh' for GPT-5 model")
 
     @pytest.mark.asyncio
-    async def test_gpt5_reasoning_effort_max_is_mapped_to_xhigh(self, monkeypatch, mock_logger):
-        """GPT-5 rejects 'max'; the handler must send its top level 'xhigh' instead."""
+    @pytest.mark.parametrize(
+        ("model", "model_info", "expected_effort"),
+        [
+            ("azure/openai/gpt-5.2_thinking", {"supports_xhigh_reasoning_effort": True}, "xhigh"),
+            ("openai/azure/gpt-5.1-codex", {"supports_xhigh_reasoning_effort": False}, "high"),
+            ("gpt-5.2", {}, "xhigh"),
+            ("gpt-5.2", LookupError("unavailable"), "xhigh"),
+        ],
+    )
+    async def test_gpt5_reasoning_effort_max_uses_xhigh_metadata(
+        self, monkeypatch, mock_logger, model, model_info, expected_effort,
+    ):
+        """Clamp max according to LiteLLM's xhigh metadata without losing the fallback."""
         fake_settings = create_mock_settings("max")
         monkeypatch.setattr(litellm_handler, "get_settings", lambda: fake_settings)
+        lookups = []
 
+        def get_model_info(lookup_model):
+            lookups.append(lookup_model)
+            if isinstance(model_info, Exception):
+                raise model_info
+            return model_info
+
+        monkeypatch.setattr(litellm, "get_model_info", get_model_info)
         with patch(
-            'pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion',
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
             new_callable=AsyncMock,
         ) as mock_completion:
             mock_completion.return_value = create_mock_acompletion_response()
 
             handler = LiteLLMAIHandler()
-            await handler.chat_completion(
-                model="gpt-5.6",
-                system="test system",
-                user="test user"
-            )
+            await handler.chat_completion(model=model, system="test system", user="test user")
 
-            call_kwargs = mock_completion.call_args[1]
-            assert call_kwargs["reasoning_effort"] == "xhigh"
-            assert "reasoning_effort" in call_kwargs["allowed_openai_params"]
-            mock_logger.info.assert_any_call("Using reasoning_effort='xhigh' for GPT-5 model")
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["reasoning_effort"] == expected_effort
+        assert "reasoning_effort" in call_kwargs["allowed_openai_params"]
+        assert lookups == ["gpt-5.2" if "gpt-5.2" in model else "gpt-5.1-codex"]
 
     @pytest.mark.asyncio
     async def test_gpt5_valid_reasoning_effort_minimal(self, monkeypatch, mock_logger):


### PR DESCRIPTION
Closes #3271. Stacks on #3259 — the first two commits here are that PR's; the third is this change. Reviewing the last commit alone (`78eb004`) gives the whole of this fix, and this becomes a one-commit diff once #3259 lands.

#3259 translates this project's `max` alias to `xhigh` on the direct GPT-5 path. As #3271 notes, that is right for GPT-5.2 and later and wrong for the two older models, which do not accept `xhigh` either: it swaps one rejected value for another. This clamps to `high` where litellm says `xhigh` is unsupported.

**Registry reading**, verified locally on litellm 1.100.0, identical under the fetched and the bundled map:

| model | `supports_xhigh_reasoning_effort` |
|---|---|
| gpt-5 | False |
| gpt-5-mini | False |
| gpt-5.1 | False |
| gpt-5.1-codex | False |
| gpt-5.2 | True |
| gpt-5.5 | True |
| gpt-5.1-codex-max | True |

So the set is wider than the issue names — `gpt-5-mini` and `gpt-5.1-codex` are affected too, which is the argument for reading the metadata rather than listing model names.

**What it does.** On `reasoning_effort='max'` down the GPT-5 branch, it looks the model up with `litellm.get_model_info` (stripping a `_thinking` suffix, which the surrounding code already treats as a decoration rather than part of the model id) and sends `high` only when the registry answers `False` outright. `True`, a missing key, and a lookup that raises all keep `xhigh`: an unknown model is not evidence that `xhigh` is unsupported, and silently downgrading a model litellm has not heard of yet would be the same class of bug in the other direction.

**Test plan.** `test_gpt5_reasoning_effort_max_uses_xhigh_metadata` is parametrised over the four cases — supported, unsupported, key absent, lookup raises — and asserts both the effort that goes out and the exact string the lookup was made with, so the `_thinking` stripping and the provider-prefix stripping are pinned rather than incidental.

- `PYTHONPATH=. uv run pytest tests/unittest/test_litellm_reasoning_effort.py -q` — 245 passed
- full unit suite — 4458 passed
- `uv run ruff check` on both touched files — clean
