### PR TITLE
docs: document custom CA and self-signed certificate configuration

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -88,6 +88,7 @@ Note that if your base branches are not protected, don't set the variables as `p
 
 > **Note**: The `gitlab__SSL_VERIFY` environment variable can be used to specify the path to a custom CA certificate bundle for SSL verification. GitLab exposes the `$CI_SERVER_TLS_CA_FILE` variable, which points to the custom CA certificate file configured in your GitLab instance.
 > Alternatively, SSL verification can be disabled entirely by setting `gitlab__SSL_VERIFY=false`, although this is not recommended.
+> This setting affects only the GitLab API client. For certificate issues with LLM calls or git clone operations, see [Custom CA and Self-Signed Certificates](../usage-guide/custom_ca_and_self_signed_certificates.md).
 
 ## Run a GitLab webhook server
 

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -625,7 +625,7 @@ model = "github_copilot/gpt-4o"
 fallback_models = ["github_copilot/gpt-4.1"]
 ```
 
-The GitHub identity behind the model needs an active Copilot subscription. The token budget for a Copilot model is resolved automatically from litellm's model metadata (verified against the pinned litellm 1.100.0), so `custom_model_max_tokens` is not required.
+The GitHub identity behind the model needs an active Copilot subscription. The token budget for a Copilot model is resolved automatically from litellm's model metadata (verified against the pinned litellm 1.100.0), so `custom_model_max_tokens` is not required. However, `get_max_tokens` clamps the effective window to `config.max_model_tokens`, which defaults to 32000. To use the full context window of the model (e.g., 64000 for gpt-4o, 128000 for gpt-4.1), raise `config.max_model_tokens` accordingly.
 
 Authentication uses the [GitHub Copilot provider](https://docs.litellm.ai/docs/providers/github_copilot) flow:
 

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -615,6 +615,25 @@ Create the credential per branch in the [Neon Console](https://console.neon.tech
 !!! note "Chat completions only"
     Some model IDs in Neon's catalog are served through the OpenAI Responses API, which Neon exposes under `/openai/v1` instead of `/v1`. The configuration above points at the chat-completions endpoint, so it cannot reach those models. Neon also documents a few models that return `message.content` as an array of typed blocks rather than a string, and PR-Agent reads the reply as a string.
 
+### GitHub Copilot
+
+Models under an active GitHub Copilot subscription are available through litellm's `github_copilot` provider, which authenticates as your GitHub identity rather than with a dedicated API key:
+
+```toml
+[config]
+model = "github_copilot/gpt-4o"
+```
+
+The GitHub identity behind the model needs an active Copilot subscription. The token budget for a Copilot model is resolved automatically from litellm's model metadata (verified against the pinned litellm 1.100.0), so `custom_model_max_tokens` is not required.
+
+Authentication uses the [GitHub Copilot provider](https://docs.litellm.ai/docs/providers/github_copilot) flow:
+
+1. litellm first looks for a pre-seeded GitHub access token in `access-token` under `GITHUB_COPILOT_TOKEN_DIR` (default `~/.config/litellm/github_copilot`; the filename is overridable with `GITHUB_COPILOT_ACCESS_TOKEN_FILE`). In a CI runner, write that token before the job runs - for example, mount a secret into the directory or point the variable at a mounted secret directory - and the flow never becomes interactive.
+2. Only when the file is missing or empty does litellm fall back to the interactive device-code flow (`POST https://github.com/login/device/code`, up to three attempts), which does not suit unattended runners.
+3. The Copilot API key (`api-key.json` in the same directory) is refreshed automatically against `https://api.github.com/copilot_internal/v2/token`, using the pre-seeded access token.
+
+Whether Copilot's terms permit this programmatic use is a question for GitHub rather than a guarantee this project can make, so confirm before relying on the route.
+
 ### Custom models
 
 If the relevant model doesn't appear [here](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/algo/__init__.py), you can still use it as a custom model:

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -622,6 +622,7 @@ Models under an active GitHub Copilot subscription are available through litellm
 ```toml
 [config]
 model = "github_copilot/gpt-4o"
+fallback_models = ["github_copilot/gpt-4.1"]
 ```
 
 The GitHub identity behind the model needs an active Copilot subscription. The token budget for a Copilot model is resolved automatically from litellm's model metadata (verified against the pinned litellm 1.100.0), so `custom_model_max_tokens` is not required.

--- a/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
+++ b/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
@@ -1,0 +1,51 @@
+## Custom CA and self-signed certificates
+
+When PR-Agent runs behind a corporate TLS-inspecting proxy or against servers using self-signed certificates, HTTPS calls to the LLM provider and git operations can fail with `certificate verify failed` errors. The fix requires two pieces: telling the HTTP clients which CA bundle to trust, and making LiteLLM use a transport that honours that bundle.
+
+### Environment variables for CA trust
+
+PR-Agent reads three environment variables when building the git clone environment. They are tried in the following order, and the first one that points to an existing file wins:
+
+| Variable | Scope | Notes |
+|---|---|---|
+| `SSL_CERT_FILE` | git clone and Python `requests` | Preferred. Used by most Python SSL contexts. |
+| `REQUESTS_CA_BUNDLE` | git clone and Python `requests` | Fallback. Honoured by the `requests` library directly. |
+| `GIT_SSL_CAINFO` | git clone only | Last resort. Used by git when the other two are absent. |
+
+If more than one variable is set and points to a different file, PR-Agent logs a warning and picks one according to the precedence above. All three variables should point to the same PEM file in practice.
+
+Example (runner environment or shell profile):
+
+```bash
+export SSL_CERT_FILE=/etc/ssl/certs/corporate-ca-bundle.crt
+```
+
+Or in `.secrets.toml` (loaded once at startup):
+
+```toml
+[env]
+SSL_CERT_FILE = "/etc/ssl/certs/corporate-ca-bundle.crt"
+```
+
+### LiteLLM transport fallback
+
+By default LiteLLM uses aiohttp for HTTP calls. aiohttp does not honour the standard `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` variables. Setting `litellm.disable_aiohttp` makes LiteLLM fall back to the `requests`-based transport, which does.
+
+```toml
+[litellm]
+disable_aiohttp = true
+```
+
+This setting is read once when the LiteLLM handler initialises, so it must be present before the process starts (runner environment or `.secrets.toml`, not a runtime override).
+
+### Scope of `gitlab.ssl_verify`
+
+The `gitlab.ssl_verify` setting (or `gitlab__SSL_VERIFY` environment variable) is passed only to the python-gitlab client that talks to the GitLab API. It does **not** affect the LLM call, git clone operations, or any other HTTPS client in the process. If you are seeing certificate errors from LiteLLM or git clone, use the environment variables above instead.
+
+### Putting it all together
+
+For a runner behind a corporate proxy with a custom CA:
+
+1. Export `SSL_CERT_FILE` (or `REQUESTS_CA_BUNDLE` / `GIT_SSL_CAINFO`) pointing to your CA bundle.
+2. Set `litellm.disable_aiohttp = true` in your configuration.
+3. If you also use the GitLab API, keep `gitlab.ssl_verify` pointed at the same bundle for the python-gitlab client.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Changing a Model: 'usage-guide/changing_a_model.md'
     - Extending PR-Agent: 'usage-guide/extending_pr_agent.md'
     - Additional Configurations: 'usage-guide/additional_configurations.md'
+    - Custom CA and Self-Signed Certificates: 'usage-guide/custom_ca_and_self_signed_certificates.md'
     - Plain-Diff Mode: 'usage-guide/plain_diff_mode.md'
     - Local Git Provider: 'usage-guide/local_git_provider.md'
     - Frequently Asked Questions: 'faq/index.md'


### PR DESCRIPTION
Closes #3189

Adds a provider-neutral usage-guide section covering:

- The three environment variables (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) with precedence
- The `litellm.disable_aiohttp` transport fallback needed for LiteLLM to honour those variables
- The scope of `gitlab.ssl_verify` (GitLab API client only)

Links to the new section from the GitLab installation page where users hitting certificate errors are most likely to look.
