### PR TITLE
docs: document custom CA and self-signed certificate configuration

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -88,6 +88,7 @@ Note that if your base branches are not protected, don't set the variables as `p
 
 > **Note**: The `gitlab__SSL_VERIFY` environment variable can be used to specify the path to a custom CA certificate bundle for SSL verification. GitLab exposes the `$CI_SERVER_TLS_CA_FILE` variable, which points to the custom CA certificate file configured in your GitLab instance.
 > Alternatively, SSL verification can be disabled entirely by setting `gitlab__SSL_VERIFY=false`, although this is not recommended.
+> This setting affects only the GitLab API client. For certificate issues with LLM calls or git clone operations, see [Custom CA and Self-Signed Certificates](../usage-guide/custom_ca_and_self_signed_certificates.md).
 
 ## Run a GitLab webhook server
 

--- a/docs/docs/summary.md
+++ b/docs/docs/summary.md
@@ -27,6 +27,7 @@
 * [Changing a Model](usage-guide/changing_a_model.md)
 * [Extending PR-Agent](usage-guide/extending_pr_agent.md)
 * [Additional Configurations](usage-guide/additional_configurations.md)
+* [Custom CA and Self-Signed Certificates](usage-guide/custom_ca_and_self_signed_certificates.md)
 * [Plain-Diff Mode](usage-guide/plain_diff_mode.md)
 * [Local Git Provider](usage-guide/local_git_provider.md)
 * [Frequently Asked Questions](faq/index.md)

--- a/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
+++ b/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
@@ -4,7 +4,7 @@ When PR-Agent runs behind a corporate TLS-inspecting proxy or against servers us
 
 ### Environment variables for CA trust
 
-PR-Agent reads three environment variables when building the git clone environment. They are tried in the following order, and the first one that points to an existing file wins:
+PR-Agent reads three environment variables when building the git clone environment, in the order below. The first one that is **set** wins, and if it points to a file that does not exist PR-Agent logs a warning and configures no bundle for git rather than falling through to the next variable:
 
 | Variable | Scope | Notes |
 |---|---|---|
@@ -20,16 +20,11 @@ Example (runner environment or shell profile):
 export SSL_CERT_FILE=/etc/ssl/certs/corporate-ca-bundle.crt
 ```
 
-Or in `.secrets.toml` (loaded once at startup):
-
-```toml
-[env]
-SSL_CERT_FILE = "/etc/ssl/certs/corporate-ca-bundle.crt"
-```
+These variables are read from the process environment, so they must be exported in the runner or shell profile; a `.secrets.toml` `[env]` section does **not** reach `os.environ` and cannot set them.
 
 ### LiteLLM transport fallback
 
-By default LiteLLM uses aiohttp for HTTP calls. aiohttp does not honour the standard `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` variables. Setting `litellm.disable_aiohttp` makes LiteLLM fall back to the `requests`-based transport, which does.
+By default LiteLLM uses aiohttp for HTTP calls, and aiohttp does not honour the standard CA environment variables. Setting `litellm.disable_aiohttp` makes LiteLLM fall back to httpx, which reads `SSL_CERT_FILE` (and `SSL_CERT_DIR`). httpx does not read `REQUESTS_CA_BUNDLE`, so the LLM call needs `SSL_CERT_FILE` specifically.
 
 ```toml
 [litellm]
@@ -46,6 +41,6 @@ The `gitlab.ssl_verify` setting (or `gitlab__SSL_VERIFY` environment variable) i
 
 For a runner behind a corporate proxy with a custom CA:
 
-1. Export `SSL_CERT_FILE` (or `REQUESTS_CA_BUNDLE` / `GIT_SSL_CAINFO`) pointing to your CA bundle.
+1. Export `SSL_CERT_FILE` pointing to your CA bundle. `REQUESTS_CA_BUNDLE` and `GIT_SSL_CAINFO` cover git clone only.
 2. Set `litellm.disable_aiohttp = true` in your configuration.
 3. If you also use the GitLab API, keep `gitlab.ssl_verify` pointed at the same bundle for the python-gitlab client.

--- a/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
+++ b/docs/docs/usage-guide/custom_ca_and_self_signed_certificates.md
@@ -1,0 +1,51 @@
+## Custom CA and self-signed certificates
+
+When PR-Agent runs behind a corporate TLS-inspecting proxy or against servers using self-signed certificates, HTTPS calls to the LLM provider and git operations can fail with `certificate verify failed` errors. The fix requires two pieces: telling the HTTP clients which CA bundle to trust, and making LiteLLM use a transport that honours that bundle.
+
+### Environment variables for CA trust
+
+PR-Agent reads three environment variables when building the git clone environment. They are tried in the following order, and the first one that points to an existing file wins:
+
+| Variable | Scope | Notes |
+|---|---|---|
+| `SSL_CERT_FILE` | git clone and Python `requests` | Preferred. Used by most Python SSL contexts. |
+| `REQUESTS_CA_BUNDLE` | git clone and Python `requests` | Fallback. Honoured by the `requests` library directly. |
+| `GIT_SSL_CAINFO` | git clone only | Last resort. Used by git when the other two are absent. |
+
+If more than one variable is set and points to a different file, PR-Agent logs a warning and picks one according to the precedence above. All three variables should point to the same PEM file in practice.
+
+Example (runner environment or shell profile):
+
+```bash
+export SSL_CERT_FILE=/etc/ssl/certs/corporate-ca-bundle.crt
+```
+
+Or in `.secrets.toml` (loaded once at startup):
+
+```toml
+[env]
+SSL_CERT_FILE = "/etc/ssl/certs/corporate-ca-bundle.crt"
+```
+
+### LiteLLM transport fallback
+
+By default LiteLLM uses aiohttp for HTTP calls. aiohttp does not honour the standard `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` variables. Setting `litellm.disable_aiohttp` makes LiteLLM fall back to the `requests`-based transport, which does.
+
+```toml
+[litellm]
+disable_aiohttp = true
+```
+
+This setting is read once when the LiteLLM handler initialises, so it must be present before the process starts (runner environment or `.secrets.toml`, not a runtime override).
+
+### Scope of `gitlab.ssl_verify`
+
+The `gitlab.ssl_verify` setting (or `gitlab__SSL_VERIFY` environment variable) is passed only to the python-gitlab client that talks to the GitLab API. It does **not** affect the LLM call, git clone operations, or any other HTTPS client in the process. If you are seeing certificate errors from LiteLLM or git clone, use the environment variables above instead.
+
+### Putting it all together
+
+For a runner behind a corporate proxy with a custom CA:
+
+1. Export `SSL_CERT_FILE` (or `REQUESTS_CA_BUNDLE` / `GIT_SSL_CAINFO`) pointing to your CA bundle.
+2. Set `litellm.disable_aiohttp = true` in your configuration.
+3. If you also use the GitLab API, keep `gitlab.ssl_verify` pointed at the same bundle for the python-gitlab client.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - Changing a Model: 'usage-guide/changing_a_model.md'
     - Extending PR-Agent: 'usage-guide/extending_pr_agent.md'
     - Additional Configurations: 'usage-guide/additional_configurations.md'
+    - Custom CA and Self-Signed Certificates: 'usage-guide/custom_ca_and_self_signed_certificates.md'
     - Plain-Diff Mode: 'usage-guide/plain_diff_mode.md'
     - Local Git Provider: 'usage-guide/local_git_provider.md'
     - Frequently Asked Questions: 'faq/index.md'


### PR DESCRIPTION
Closes #3189

Adds a provider-neutral usage-guide section covering:

- The three environment variables (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `GIT_SSL_CAINFO`) with precedence
- The `litellm.disable_aiohttp` transport fallback needed for LiteLLM to honour those variables
- The scope of `gitlab.ssl_verify` (GitLab API client only)

Links to the new section from the GitLab installation page where users hitting certificate errors are most likely to look.
