### PR TITLE
docs(similar_issue): refresh page with experimental status and backend caveats

### DIFF
--- a/docs/docs/tools/similar_issues.md
+++ b/docs/docs/tools/similar_issues.md
@@ -1,6 +1,6 @@
 ## Overview
 
-> **Note**: `/similar_issue` is an **experimental** feature. It works only on GitHub, carries a disproportionately large share of the project's dependency and configuration surface for a single-provider tool, and is therefore excluded from the v1 stability guarantees. Its backends are not equally exercised: the pinecone flow is the least-tested, followed by lancedb, with qdrant receiving the most coverage.
+> **Note**: `/similar_issue` is an **experimental** feature. It works only on GitHub, carries a disproportionately large share of the project's dependency and configuration surface for a single-provider tool, and is therefore excluded from the v1 stability guarantees. Its backends are not equally exercised: the lancedb flow has no tests of its own, and no backend is tested against its real driver.
 
 The similar issue tool retrieves the most similar issues to the current issue.
 It can be invoked manually by commenting on any PR:
@@ -52,10 +52,11 @@ gcp-starter pod tier is no longer supported.
 created. An existing index is opened by name and is never recreated, so moving an
 existing deployment to the new configuration does not lose the stored vectors.
 
-!!! note "Pinecone is the least-tested backend"
+!!! note "Backend coverage is uneven"
 
-    The pinecone indexing path depends on the forked `pinecone-datasets` dependency and has no
-    regression tests that run in CI. Expect it to be more brittle than the qdrant or lancedb flows.
+    No backend is exercised against its real driver: the `similar-issue` dependency group is
+    not installed in CI, so the pinecone tests run against a faked module and the qdrant tests
+    never construct a client. The lancedb flow has no tests of its own at all.
 
 !!! note "Default vector database"
 

--- a/docs/docs/tools/similar_issues.md
+++ b/docs/docs/tools/similar_issues.md
@@ -1,5 +1,7 @@
 ## Overview
 
+> **Note**: `/similar_issue` is an **experimental** feature. It works only on GitHub, carries a disproportionately large share of the project's dependency and configuration surface for a single-provider tool, and is therefore excluded from the v1 stability guarantees. Its backends are not equally exercised: the pinecone flow is the least-tested, followed by lancedb, with qdrant receiving the most coverage.
+
 The similar issue tool retrieves the most similar issues to the current issue.
 It can be invoked manually by commenting on any PR:
 
@@ -50,6 +52,11 @@ gcp-starter pod tier is no longer supported.
 created. An existing index is opened by name and is never recreated, so moving an
 existing deployment to the new configuration does not lose the stored vectors.
 
+!!! note "Pinecone is the least-tested backend"
+
+    The pinecone indexing path depends on the forked `pinecone-datasets` dependency and has no
+    regression tests that run in CI. Expect it to be more brittle than the qdrant or lancedb flows.
+
 !!! note "Default vector database"
 
     `vectordb` defaults to `lancedb`, which works with no external credentials. To use
@@ -75,7 +82,7 @@ vectordb = "qdrant"
 
 You can get a free managed Qdrant instance from [Qdrant Cloud](https://cloud.qdrant.io/).
 
-Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-v2`.
+Qdrant points are stored in a collection named `codium-ai-pr-agent-issues-v2`, derived by appending a `-v2` suffix to the shared index name (`codium-ai-pr-agent-issues`). The suffix is an implementation detail of the Qdrant backend only; pinecone and lancedb use the unsuffixed name.
 
 !!! note "Upgrading an index created before the point-id fix"
 


### PR DESCRIPTION
Refs #3200

Refreshes the `/similar_issue` docs page as agreed in the issue (Option 2):

- Marks the tool as **experimental**, GitHub-only, and excluded from v1 stability guarantees
- Adds the caveat that **pinecone is the least-tested backend** (the indexing path depends on the forked `pinecone-datasets` dependency with no CI regression tests)
- Refreshes the stale Qdrant collection name description: `codium-ai-pr-agent-issues-v2` is now explained as derived from the shared index name, and the v2 suffix is scoped to the qdrant backend only

Per the maintainer's note, the experimental labelling and v1 scoping note outside this docs page stay with the maintainer.

