### PR TITLE
chore(ci): add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,88 @@
+version: 2
+
+updates:
+  # Python. `uv` rather than `pip`: it resolves through the uv CLI and rewrites
+  # pyproject.toml alongside uv.lock, so the declared pins here — which carry
+  # policy, not just versions — do not drift away from the lock file.
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      python-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
+    commit-message:
+      prefix: chore(deps)
+
+  # GitHub Actions. Every `uses:` here is `@<sha>  # vX.Y.Z` on one line, which
+  # is the format Dependabot rewrites, comment included.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
+    ignore:
+      # .github/workflows/pr-agent-review.yaml pins this action to a commit on
+      # `main`, not to a release. There is no version to bump to, and the
+      # documented behaviour for an untagged sha is to move it to whatever HEAD
+      # happens to be. Moving the self-review action is a deliberate act.
+      - dependency-name: Codium-ai/pr-agent
+    commit-message:
+      prefix: chore(ci)
+
+  # Base images. The docker file fetcher matches any file whose name contains
+  # "dockerfile", so `/` picks up Dockerfile.github_action_dockerhub and
+  # `/docker` picks up both Dockerfile and Dockerfile.lambda.
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /docker
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    ignore:
+      # Dockerfile.github_action_dockerhub builds FROM this project's own
+      # published image, tracked by a stage tag rather than a version.
+      - dependency-name: pragent/pr-agent
+    commit-message:
+      prefix: chore(docker)
+
+  # Hook revisions in .pre-commit-config.yaml. The `local` repo has no upstream
+  # and is left alone by the ecosystem.
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(pre-commit)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
         exclude: ^uv\.lock$ # lock file, 686 KB and generated
@@ -28,7 +28,7 @@ repos:
         exclude: ^tests/unittest/test_extend_patch\.py$ # trailing space; stripping it breaks the test.
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
## Problem

There is no version-update automation, so routine dependency currency depends on a maintainer noticing drift. Issue #3192 found 29 of 41 direct Python dependencies behind; the repository also has pinned Actions, Docker base images, and pre-commit hooks.

## Approach

Add a single Dependabot configuration for the repository's four dependency surfaces:

- **uv** for `pyproject.toml` + `uv.lock`, so the manifest pins and their policy comments stay in sync with the lock file
- **GitHub Actions** for all workflows
- **Docker** for the root and `docker/` directories; Dependabot's case-insensitive `dockerfile` matcher covers the three named Dockerfiles
- **pre-commit** for the two upstream hook repositories

Each ecosystem runs weekly with a deliberately small open-PR limit. Python and Actions updates are grouped into `minor-and-patch` and `major` PRs so breaking upgrades remain independently reviewable.

Two non-versioned self-references are excluded:

- `Codium-ai/pr-agent@<sha>  # main` is a commit on a branch rather than a release
- `pragent/pr-agent:github_action` is this project's own stage-tagged image

The two external pre-commit revisions move from mutable tags to the ecosystem's documented `<sha>  # frozen: <tag>` form. The local hook has no upstream and is unchanged.

## Test plan

- `uv run pre-commit run --files .github/dependabot.yml .pre-commit-config.yaml`
  - YAML validation passes
  - all applicable repository hooks pass
- Confirmed both frozen SHAs resolve to the stated tags through the GitHub API:
  - `pre-commit/pre-commit-hooks` `v6.0.0` → `3e8a8703264a2f4a69428a0aa4dcb512790b2c8c`
  - `rhysd/actionlint` `v1.7.12` → `914e7df21a07ef503a81201c76d2b11c789d3fca`

## Scope / risk

This turns on PR creation only; it does not auto-merge or change runtime behavior. Actual update compatibility remains reviewable in the generated PRs. Individual upgrade work remains tracked in #3193, #3194, and #3195.

Closes #3192
