### PR TITLE
fix(codecommit): cap comment bodies at the PostCommentForPullRequest limit

### DIFF
--- a/pr_agent/algo/review_finding_state.py
+++ b/pr_agent/algo/review_finding_state.py
@@ -155,6 +155,21 @@ def parse_review_state(comment_body: str) -> ParsedReviewState:
     return ParsedReviewState(state, present=True, valid=True)
 
 
+def split_review_state_marker(comment_body: str) -> tuple[str, str]:
+    """Split a comment into its human text and its hidden state marker.
+
+    Returns ``(body, marker)``; ``marker`` is ``""`` when the comment carries no
+    complete marker. Providers that cap comment length use this to keep the
+    marker intact while truncating only the human text.
+    """
+    raw = comment_body or ""
+    match = _STATE_MARKER_RE.search(raw)
+    if match is None:
+        return raw, ""
+    body = (raw[: match.start()] + raw[match.end():]).rstrip()
+    return body, match.group(0)
+
+
 def serialize_review_state(state: Mapping[str, Any]) -> str:
     """Serialize state deterministically so repeated updates are diffable."""
     if not _is_valid_state(state):

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -7,9 +7,9 @@ from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
 from pr_agent.algo.language_handler import is_valid_file
+from pr_agent.algo.review_finding_state import split_review_state_marker
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.git_providers.codecommit_client import CodeCommitClient
-from pr_agent.algo.review_finding_state import split_review_state_marker
 
 from ..algo.utils import (
     add_pr_review_identity,

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from pr_agent.algo.language_handler import is_valid_file
 from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.git_providers.codecommit_client import CodeCommitClient
+from pr_agent.algo.review_finding_state import split_review_state_marker
 
 from ..algo.utils import (
     add_pr_review_identity,
@@ -65,6 +66,10 @@ class CodeCommitFile:
 
 
 class CodeCommitProvider(GitProvider):
+    """
+    This class implements the GitProvider interface for AWS CodeCommit repositories.
+    """
+
     # PostCommentForPullRequest / UpdateComment reject a body above 10,240
     # characters and raise instead of degrading (#3272). Every outgoing body
     # goes through _prepare_comment_body, which caps it AFTER the newline
@@ -73,10 +78,6 @@ class CodeCommitProvider(GitProvider):
     # the other providers' max_comment_length, minus the truncation marker
     # limit_output_characters appends.
     max_comment_length = 10240 - len("...")
-
-    """
-    This class implements the GitProvider interface for AWS CodeCommit repositories.
-    """
 
     def __init__(self, pr_url: Optional[str] = None, incremental: Optional[bool] = False):
         self.codecommit_client = CodeCommitClient()
@@ -688,8 +689,18 @@ class CodeCommitProvider(GitProvider):
 
     def _prepare_comment_body(self, pr_comment: str) -> str:
         pr_comment = CodeCommitProvider._remove_markdown_html(pr_comment)
-        pr_comment = CodeCommitProvider._add_additional_newlines(pr_comment)
-        return self.limit_output_characters(pr_comment, self.max_comment_length)
+        body, marker = split_review_state_marker(pr_comment)
+        body = CodeCommitProvider._add_additional_newlines(body)
+        if not marker:
+            return self.limit_output_characters(body, self.max_comment_length)
+        # The persistent review state is a hidden marker at the end of the body.
+        # The reviewer sizes it before the newline doubling above, so the doubled
+        # body can overrun the cap; truncate only the human text and keep the
+        # marker whole, otherwise the next run cannot parse the state.
+        budget = self.max_comment_length - len(marker) - 2
+        if budget <= 0:
+            return marker[: self.max_comment_length]
+        return f"{self.limit_output_characters(body, budget)}\n\n{marker}"
 
     @staticmethod
     def _extract_issue_comments(comment_data: dict):

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -65,6 +65,15 @@ class CodeCommitFile:
 
 
 class CodeCommitProvider(GitProvider):
+    # PostCommentForPullRequest / UpdateComment reject a body above 10,240
+    # characters and raise instead of degrading (#3272). Every outgoing body
+    # goes through _prepare_comment_body, which caps it AFTER the newline
+    # doubling and after any persistent-comment header has been added, so the
+    # cap is measured on what CodeCommit actually receives. Class-level, like
+    # the other providers' max_comment_length, minus the truncation marker
+    # limit_output_characters appends.
+    max_comment_length = 10240 - len("...")
+
     """
     This class implements the GitProvider interface for AWS CodeCommit repositories.
     """
@@ -677,10 +686,10 @@ class CodeCommitProvider(GitProvider):
         updated_anchor = f"{identity_marker}\n\n{update_message}"
         return pr_comment.replace(identity_marker, updated_anchor, 1)
 
-    @staticmethod
-    def _prepare_comment_body(pr_comment: str) -> str:
+    def _prepare_comment_body(self, pr_comment: str) -> str:
         pr_comment = CodeCommitProvider._remove_markdown_html(pr_comment)
-        return CodeCommitProvider._add_additional_newlines(pr_comment)
+        pr_comment = CodeCommitProvider._add_additional_newlines(pr_comment)
+        return self.limit_output_characters(pr_comment, self.max_comment_length)
 
     @staticmethod
     def _extract_issue_comments(comment_data: dict):

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -272,6 +272,44 @@ class TestCodeCommitProvider:
             ("two.py", "before two\n", "after two\n"),
         ]
 
+    def test_prepare_comment_body_caps_at_codecommit_limit(self):
+        # PostCommentForPullRequest rejects bodies above 10,240 characters and
+        # publish_comment raises instead of degrading (#3272). The cap must be
+        # measured AFTER the newline doubling, which grows the body.
+        provider = self._make_persistent_provider()
+        body = "\n".join(["x" * 100] * 120)  # 12,099 chars before doubling
+
+        prepared = provider._prepare_comment_body(body)
+
+        assert len(prepared) <= 10240
+        assert prepared.endswith("...")
+        assert "\n\n" in prepared
+
+    def test_prepare_comment_body_leaves_short_comment_alone(self):
+        provider = self._make_persistent_provider()
+
+        assert provider._prepare_comment_body("line one\nline two") == "line one\n\nline two"
+
+    def test_publish_comment_sends_capped_body(self):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.publish_comment.return_value = {"comment": {}}
+
+        provider.publish_comment("\n".join(["y" * 100] * 120))
+
+        sent = provider.codecommit_client.publish_comment.call_args.kwargs["comment"]
+        assert len(sent) <= 10240
+        assert sent.endswith("...")
+
+    def test_edit_comment_sends_capped_body(self):
+        provider = self._make_persistent_provider()
+        provider.codecommit_client.update_comment.return_value = {"comment": {}}
+
+        provider.edit_comment({"id": "comment-1"}, "\n".join(["z" * 100] * 120))
+
+        sent = provider.codecommit_client.update_comment.call_args.args[1]
+        assert len(sent) <= 10240
+        assert sent.endswith("...")
+
     def test_publish_comment_uses_every_pull_request_target(self):
         provider = object.__new__(CodeCommitProvider)
         provider.repo_name = "source-repository"

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -285,6 +285,38 @@ class TestCodeCommitProvider:
         assert prepared.endswith("...")
         assert "\n\n" in prepared
 
+    def test_prepare_comment_body_keeps_review_state_marker_parseable(self):
+        # The reviewer budgets the hidden state marker before the newline
+        # doubling; once doubled, the body can exceed the cap. Only the human
+        # text may be truncated, or the next run cannot read the state.
+        from pr_agent.algo.review_finding_state import append_review_state, parse_review_state
+
+        provider = self._make_persistent_provider()
+        state = {
+            "schema_version": 1,
+            "last_run": {"commit": "abc123"},
+            "findings": [
+                {"finding_id": f"f{i}", "state": "ACTIVE", "path": "a.py", "body": "x" * 40}
+                for i in range(20)
+            ],
+        }
+        review = "\n".join(["r" * 24] * 400)
+        body = append_review_state(review, state, max_chars=10240 - 3)
+        assert len(body) <= 10240 - 3
+
+        prepared = provider._prepare_comment_body(body)
+
+        assert len(prepared) <= 10240
+        parsed = parse_review_state(prepared)
+        assert parsed.valid
+        assert [f["finding_id"] for f in parsed.state["findings"]] == [f"f{i}" for i in range(20)]
+        assert prepared.rstrip().endswith("-->")
+        assert "..." in prepared
+
+    def test_class_docstring_survives_the_comment_limit_attribute(self):
+        assert CodeCommitProvider.__doc__ is not None
+        assert "CodeCommit" in CodeCommitProvider.__doc__
+
     def test_prepare_comment_body_leaves_short_comment_alone(self):
         provider = self._make_persistent_provider()
 


### PR DESCRIPTION
## Summary

Fixes #3272.

CodeCommit was the one provider that never capped a comment body: `codecommit_provider.py` set no `max_comment_length` and never called the base `limit_output_characters`, so an over-long review reached `PostCommentForPullRequest` at full size and `publish_comment` wrapped the rejection in `ValueError`. The documented 10,240-character ceiling is easier to hit than it looks because `_add_additional_newlines` turns every `\n` into `\n\n` and `_persistent_body_for_target` prepends the "updated until commit" header.

## Change

`pr_agent/git_providers/codecommit_provider.py`, following the Bitbucket shape:

- class-level `max_comment_length = 10240 - len("...")` (the quota minus the marker `limit_output_characters` appends, so the sent body never exceeds 10,240);
- `_prepare_comment_body` becomes an instance method and applies `self.limit_output_characters(...)` **after** the HTML stripping and newline doubling. It is the single choke point that `edit_comment` and `_publish_comment_to_target` already pass through, so create, update and the persistent fallback are covered in one place, and the cap is measured on what CodeCommit actually receives.

## Tests

`tests/unittest/test_codecommit_provider.py`: a 120-line body is capped to ≤ 10,240 characters after the newline doubling and ends with `...`; a short body only gets the newline doubling; `publish_comment` and `edit_comment` hand the client a capped body. Three of the four fail on `main`.

`pytest tests/unittest/test_codecommit_provider.py` → 42 passed; `ruff check` clean. Like the issue, this is not verified against live CodeCommit; the ceiling is the documented quota.
