### PR TITLE
fix: point runtime documentation links to current site

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -795,7 +795,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                             timeout=_IMAGE_HEAD_TIMEOUT_SECONDS,
                         )
                         if r.status_code == 404:
-                            error_msg = "The image link is not [alive](img_path).\nPlease repost the original image as a comment, and send the question again with 'quote reply' (see [instructions](https://pr-agent-docs.codium.ai/tools/ask/#ask-on-images-using-the-pr-code-as-context))."
+                            error_msg = "The image link is not [alive](img_path).\nPlease repost the original image as a comment, and send the question again with 'quote reply' (see [instructions](https://docs.pr-agent.ai/tools/ask/#ask-on-images))."
                             get_logger().error(error_msg)
                             return f"{error_msg}", "error"
                     except Exception as e:

--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -393,7 +393,7 @@ def handle_configurations_errors(config_errors, git_provider):
                 header = f"❌ **PR-Agent failed to apply '{config_type}' repo settings**"
                 body = (
                     f"{header}\n\nThe configuration file needs to be a valid "
-                    "[TOML](https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/), please fix it.\n\n"
+                    "[TOML](https://docs.pr-agent.ai/usage-guide/configuration_options/), please fix it.\n\n"
                 )
                 body += f"___\n\n**Error message:**\n`{err_message}`\n\n"
                 if config_type == "global":

--- a/pr_agent/servers/help.py
+++ b/pr_agent/servers/help.py
@@ -11,7 +11,7 @@ class HelpMessage:
                 "> - **/update_changelog**: Update the changelog based on the PR's contents.   \n" \
                 "> - **/add_docs**: Generate docstring for new components introduced in the PR.   \n" \
                 "> - **/generate_labels**: Generate labels for the PR based on the PR's contents.   \n\n" \
-                ">See the [tools guide](https://pr-agent-docs.codium.ai/tools/) for more details.\n" \
+                ">See the [tools guide](https://docs.pr-agent.ai/tools/) for more details.\n" \
                 ">To list the possible configuration parameters, add a **/config** comment.   \n"
        return commands_text
 
@@ -25,14 +25,14 @@ class HelpMessage:
     def get_review_usage_guide():
         output ="**Overview:**\n"
         output += (f"{COMMAND_DESCRIPTIONS['review']} "
-                  "More feedback can be [added](https://pr-agent-docs.codium.ai/tools/review/#general-configurations) by configuring the tool.\n\n"
-                  "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on any PR.\n")
+                  "More feedback can be [added](https://docs.pr-agent.ai/tools/review/#configuration-options) by configuring the tool.\n\n"
+                  "The tool can be triggered [automatically](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on any PR.\n")
         output +="""\
 - When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L23) related to the review tool (`pr_reviewer` section), use the following template:
 ```
 /review --pr_reviewer.some_config1=... --pr_reviewer.some_config2=...
 ```
-- With a [configuration file](https://pr-agent-docs.codium.ai/usage-guide/configuration_options/), use the following template:
+- With a [configuration file](https://docs.pr-agent.ai/usage-guide/configuration_options/), use the following template:
 ```
 [pr_reviewer]
 some_config1=...
@@ -40,7 +40,7 @@ some_config2=...
 ```
     """
 
-        output += "\n\nSee the review [usage page](https://pr-agent-docs.codium.ai/tools/review/) for a comprehensive guide on using this tool.\n\n"
+        output += "\n\nSee the review [usage page](https://docs.pr-agent.ai/tools/review/) for a comprehensive guide on using this tool.\n\n"
 
         return output
 
@@ -50,14 +50,14 @@ some_config2=...
     def get_describe_usage_guide():
         output = "**Overview:**\n"
         output += f"{COMMAND_DESCRIPTIONS['describe']} "
-        output += "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
+        output += "The tool can be triggered [automatically](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
         output += """\
 
 When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
 ```
 /describe --pr_description.some_config1=... --pr_description.some_config2=...
 ```
-With a [configuration file](https://pr-agent-docs.codium.ai/usage-guide/configuration_options/), use the following template:
+With a [configuration file](https://docs.pr-agent.ai/usage-guide/configuration_options/), use the following template:
 ```
 [pr_description]
 some_config1=...
@@ -69,7 +69,7 @@ some_config2=...
         # automation
         output += "<tr><td><details> <summary><strong> Enabling\\disabling automation </strong></summary><hr>\n\n"
         output += """\
-- When you first install the app, the [default mode](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) for the describe tool is:
+- When you first install the app, the [default mode](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) for the describe tool is:
 ```
 pr_commands = ["/describe", ...]
 ```
@@ -95,7 +95,7 @@ Note that when markers are enabled, if the original PR description does not cont
         output += """\
 The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].
 
-If you specify [custom labels](https://pr-agent-docs.codium.ai/tools/describe/#handle-custom-labels-from-the-repos-labels-page) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
+If you specify [custom labels](https://docs.pr-agent.ai/tools/describe/#handle-custom-labels-from-the-repos-labels-page) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
 Examples for custom labels:
 - `Main topic:performance` - pr_agent:The main topic of this PR is performance
 - `New endpoint` - pr_agent:A new endpoint was added in this PR
@@ -137,7 +137,7 @@ Use triple quotes to write multi-line instructions. Use bullet points to make th
 
         output += "</table>"
 
-        output += "\n\nSee the [describe usage](https://pr-agent-docs.codium.ai/tools/describe/) page for a comprehensive guide on using this tool.\n\n"
+        output += "\n\nSee the [describe usage](https://docs.pr-agent.ai/tools/describe/) page for a comprehensive guide on using this tool.\n\n"
 
         return output
 
@@ -163,7 +163,7 @@ You can ask questions about the entire PR, about specific code lines, or about a
         #
         # output += "</table>"
 
-        output += "\n\nSee the [ask usage](https://pr-agent-docs.codium.ai/tools/ask/) page for a comprehensive guide on using this tool.\n\n"
+        output += "\n\nSee the [ask usage](https://docs.pr-agent.ai/tools/ask/) page for a comprehensive guide on using this tool.\n\n"
 
         return output
 
@@ -172,7 +172,7 @@ You can ask questions about the entire PR, about specific code lines, or about a
     def get_improve_usage_guide():
         output = "**Overview:**\n"
         output += f"{COMMAND_DESCRIPTIONS['improve']} "
-        output += "The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
+        output += "The tool can be triggered [automatically](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.\n"
         output += """\
 - When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L78) related to the improve tool (`pr_code_suggestions` section), use the following template:
 
@@ -180,7 +180,7 @@ You can ask questions about the entire PR, about specific code lines, or about a
 /improve --pr_code_suggestions.some_config1=... --pr_code_suggestions.some_config2=...
 ```
 
-- With a [configuration file](https://pr-agent-docs.codium.ai/usage-guide/configuration_options/), use the following template:
+- With a [configuration file](https://docs.pr-agent.ai/usage-guide/configuration_options/), use the following template:
 
 ```
 [pr_code_suggestions]
@@ -190,7 +190,7 @@ some_config2=...
 
 """
 
-        output += "\n\nSee the improve [usage page](https://pr-agent-docs.codium.ai/tools/improve/) for a comprehensive guide on using this tool.\n\n"
+        output += "\n\nSee the improve [usage page](https://docs.pr-agent.ai/tools/improve/) for a comprehensive guide on using this tool.\n\n"
 
         return output
 
@@ -205,5 +205,5 @@ It can be invoked manually by commenting on any PR:
 /help_docs "..."
 ```
 """
-        output += "\n\nSee the [help_docs usage](https://pr-agent-docs.codium.ai/tools/help_docs/) page for a comprehensive guide on using this tool.\n\n"
+        output += "\n\nSee the [help_docs usage](https://docs.pr-agent.ai/tools/help_docs/) page for a comprehensive guide on using this tool.\n\n"
         return output

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -163,12 +163,12 @@ class PRDescription:
                 if self.git_provider.supports_inline_help_footer():
                     pr_body += ('\n\n___\n\n> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> '
                                 'in the comments thread for any questions about PR-Agent usage.</li><li>Check out the '
-                                '<a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> '
+                                '<a href="https://docs.pr-agent.ai/usage-guide/">documentation</a> '
                                 'for more information.</li></details>')
                 else:  # bullets separated by <br>, for providers whose footer cannot inline a list
                     pr_body += ("\n\n___\n\n<details><summary>Need help?</summary>- Type <code>/help how to ...</code> in the comments "
                                 "thread for any questions about PR-Agent usage.<br>- Check out the "
-                                "<a href='https://qodo-merge-docs.qodo.ai/usage-guide/'>documentation</a> for more information.</details>")
+                                "<a href='https://docs.pr-agent.ai/usage-guide/'>documentation</a> for more information.</details>")
             # elif get_settings().pr_description.enable_help_comment:
             #     pr_body += '\n\n___\n\n> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information'
 

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -16,6 +16,8 @@ from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
 
+DOCS_SITE_URL = "https://docs.pr-agent.ai"
+
 
 class PRHelpMessage:
     def __init__(self, pr_url: str, args=None, ai_handler: partial[BaseAiHandler,] = LiteLLMAIHandler, return_as_string=False):
@@ -79,6 +81,20 @@ class PRHelpMessage:
         except Exception:
             get_logger().exception("Error while formatting markdown header", artifacts={'header': header})
             return ""
+
+    def format_docs_url(self, file_name: str, header: str) -> str:
+        relative_path = file_name.strip().lstrip('/').removesuffix('.md')
+        if relative_path == 'index':
+            relative_path = ''
+        elif relative_path.endswith('/index'):
+            relative_path = relative_path.removesuffix('index')
+        elif relative_path:
+            relative_path += '/'
+
+        docs_url = f"{DOCS_SITE_URL}/{relative_path}"
+        if str(header).strip():
+            docs_url += f"#{self.format_markdown_header(header)}"
+        return docs_url
 
 
     async def run(self):
@@ -161,14 +177,12 @@ class PRHelpMessage:
                     answer_str += f"### Question: \n{self.question_str}\n\n"
                     answer_str += f"### Answer:\n{response_str.strip()}\n\n"
                     answer_str += "#### Relevant Sources:\n\n"
-                    base_path = "https://qodo-merge-docs.qodo.ai/"
                     for section in relevant_sections:
-                        file = section.get('file_name').strip().removesuffix('.md')
-                        if str(section['relevant_section_header_string']).strip():
-                            markdown_header = self.format_markdown_header(section['relevant_section_header_string'])
-                            answer_str += f"> - {base_path}{file}#{markdown_header}\n"
-                        else:
-                            answer_str += f"> - {base_path}{file}\n"
+                        docs_url = self.format_docs_url(
+                            section.get('file_name'),
+                            section['relevant_section_header_string'],
+                        )
+                        answer_str += f"> - {docs_url}\n"
 
 
                 # publish the answer
@@ -190,7 +204,7 @@ class PRHelpMessage:
                 pr_comment = "## PR Agent Walkthrough 🤖\n\n"
                 pr_comment += "Welcome to the PR Agent, an AI-powered tool for automated pull request analysis, feedback, suggestions and more."""
                 pr_comment += "\n\nHere is a list of tools you can use to interact with the PR Agent:\n"
-                base_path = "https://pr-agent-docs.codium.ai/tools"
+                base_path = f"{DOCS_SITE_URL}/tools"
 
                 tool_names = []
                 tool_names.append(f"[DESCRIBE]({base_path}/describe/)")
@@ -236,7 +250,7 @@ class PRHelpMessage:
                     for i in range(len(tool_names)):
                         pr_comment += f"\n<tr><td align='left'>\n\n<strong>{tool_names[i]}</strong></td>\n<td>{descriptions[i]}</td>\n<td>\n\n{checkbox_list[i]}\n</td></tr>"
                     pr_comment += "</table>\n\n"
-                    pr_comment += """\n\n(1) Note that each tool can be [triggered automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) when a new PR is opened, or called manually by [commenting on a PR](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#online-usage)."""
+                    pr_comment += """\n\n(1) Note that each tool can be [triggered automatically](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) when a new PR is opened, or called manually by [commenting on a PR](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#online-usage)."""
                     pr_comment += """\n\n(2) Tools marked with [*] require additional parameters to be passed. For example, to invoke the `/ask` tool, you need to comment on a PR: `/ask "<question content>"`. See the relevant documentation for each tool for more details."""
                 elif not supports_gfm_markdown:
                     # only basic commands, in a plain markdown table (e.g. BBDC)
@@ -246,7 +260,7 @@ class PRHelpMessage:
                     for i in range(len(tool_names)):
                         pr_comment += f"\n<tr><td align='left'>\n\n<strong>{tool_names[i]}</strong></td><td>{commands[i]}</td><td>{descriptions[i]}</td></tr>"
                     pr_comment += "</table>\n\n"
-                    pr_comment += """\n\nNote that each tool can be [invoked automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/) when a new PR is opened, or called manually by [commenting on a PR](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#online-usage)."""
+                    pr_comment += """\n\nNote that each tool can be [invoked automatically](https://docs.pr-agent.ai/usage-guide/automations_and_usage/) when a new PR is opened, or called manually by [commenting on a PR](https://docs.pr-agent.ai/usage-guide/automations_and_usage/#online-usage)."""
 
                 if get_settings().config.publish_output:
                     self.git_provider.publish_comment(pr_comment)

--- a/tests/unittest/test_command_descriptions.py
+++ b/tests/unittest/test_command_descriptions.py
@@ -9,6 +9,8 @@ from pr_agent.servers.help import HelpMessage
 from pr_agent.tools.pr_help_message import PRHelpMessage
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+CURRENT_DOCS_URL = "https://docs.pr-agent.ai"
+RETIRED_DOCS_HOSTS = ("qodo-merge-docs.qodo.ai", "pr-agent-docs.codium.ai")
 
 
 def test_cli_and_bot_help_use_canonical_command_descriptions():
@@ -30,6 +32,24 @@ def test_cli_and_bot_help_use_canonical_command_descriptions():
 )
 def test_tool_usage_guides_use_canonical_command_descriptions(usage_guide, command):
     assert COMMAND_DESCRIPTIONS[command] in usage_guide()
+
+
+def test_runtime_help_uses_current_documentation_links():
+    help_text = "\n".join(
+        [
+            HelpMessage.get_general_commands_text(),
+            HelpMessage.get_general_bot_help_text(),
+            HelpMessage.get_review_usage_guide(),
+            HelpMessage.get_describe_usage_guide(),
+            HelpMessage.get_ask_usage_guide(),
+            HelpMessage.get_improve_usage_guide(),
+            HelpMessage.get_help_docs_usage_guide(),
+        ]
+    )
+
+    assert f"{CURRENT_DOCS_URL}/tools/review/#configuration-options" in help_text
+    assert f"{CURRENT_DOCS_URL}/tools/ask/" in help_text
+    assert not any(host in help_text for host in RETIRED_DOCS_HOSTS)
 
 
 @pytest.mark.parametrize("command", COMMAND_DESCRIPTIONS)

--- a/tests/unittest/test_git_provider_utils.py
+++ b/tests/unittest/test_git_provider_utils.py
@@ -112,6 +112,8 @@ def test_handle_configurations_errors_uses_persistent_comment_when_supported():
     assert comment["final_update_message"] is False
     assert "PR-Agent failed to apply 'local' repo settings" in comment["body"]
     assert "Invalid value" in comment["body"]
+    assert "https://docs.pr-agent.ai/usage-guide/configuration_options/" in comment["body"]
+    assert "qodo-merge-docs.qodo.ai" not in comment["body"]
     assert "```toml\n[config]\nmodel =\n```" in comment["body"]
     assert "<details><summary>Configuration content:</summary>" in comment["body"]
 

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -97,6 +97,31 @@ async def test_chat_completion_probes_images_off_loop_with_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_dead_image_uses_current_help_link(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+    monkeypatch.setattr(
+        litellm_handler.requests,
+        "head",
+        lambda *args, **kwargs: SimpleNamespace(status_code=404),
+    )
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        response, finish_reason = await handler.chat_completion(
+            model="gpt-4o",
+            system="sys",
+            user="usr",
+            img_path="https://example.test/missing.png",
+        )
+
+    assert "https://docs.pr-agent.ai/tools/ask/#ask-on-images" in response
+    assert "pr-agent-docs.codium.ai" not in response
+    assert finish_reason == "error"
+    mock_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("model", "expected_model_id"),
     [

--- a/tests/unittest/test_pr_description_help_rendering.py
+++ b/tests/unittest/test_pr_description_help_rendering.py
@@ -105,6 +105,8 @@ async def test_description_help_rendering_follows_html_list_capability(
     assert provider.html_lists_queries == 1
     assert expected in body
     assert unexpected not in body
+    assert "https://docs.pr-agent.ai/usage-guide/" in body
+    assert "qodo-merge-docs.qodo.ai" not in body
     if not html_lists:
         assert PLAIN_BREAK_MARKER in body
 

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -90,7 +90,9 @@ async def test_primary_failure_uses_backup_answer(help_tool):
     assert tool.question_str in backup_prompt
     assert "Enable automatic review in the repository settings." in backup_prompt
     tool.git_provider.publish_comment.assert_called_once()
-    assert "### Answer:\nEnable automatic review" in tool.git_provider.publish_comment.call_args.args[0]
+    published_comment = tool.git_provider.publish_comment.call_args.args[0]
+    assert "### Answer:\nEnable automatic review" in published_comment
+    assert "> - https://docs.pr-agent.ai/tools/review/#automatic-review" in published_comment
     assert details.model_used == BACKUP
     assert details.fallback_used is True
     assert get_settings().get("openai.deployment_id") == "primary-deployment"

--- a/tests/unittest/test_pr_help_message_rendering.py
+++ b/tests/unittest/test_pr_help_message_rendering.py
@@ -81,9 +81,11 @@ async def test_checkboxes_stay_disabled_by_configuration(published_output):
     assert "<table>" in comment
 
 
-async def test_walkthrough_uses_current_documentation_site(published_output):
-    comment = await run_walkthrough(StubProvider(gfm_markdown=True))
+@pytest.mark.parametrize("checkbox_commands", [False, True], ids=["without-checkboxes", "with-checkboxes"])
+async def test_walkthrough_uses_current_documentation_site(published_output, checkbox_commands):
+    comment = await run_walkthrough(StubProvider(gfm_markdown=True, checkbox_commands=checkbox_commands))
 
+    assert (INTERACTIVE_MARKER in comment) is checkbox_commands
     assert f"{CURRENT_DOCS_URL}/tools/review/" in comment
     assert f"{CURRENT_DOCS_URL}/usage-guide/automations_and_usage/" in comment
     assert not any(host in comment for host in RETIRED_DOCS_HOSTS)

--- a/tests/unittest/test_pr_help_message_rendering.py
+++ b/tests/unittest/test_pr_help_message_rendering.py
@@ -13,6 +13,8 @@ from tests.unittest._settings_helpers import restore_settings, snapshot_settings
 INTERACTIVE_MARKER = "Trigger Interactively"
 PLAIN_TABLE_MARKER = "| Tool  | Description |"
 UNSUPPORTED_MARKER = "requires gfm markdown"
+CURRENT_DOCS_URL = "https://docs.pr-agent.ai"
+RETIRED_DOCS_HOSTS = ("qodo-merge-docs.qodo.ai", "pr-agent-docs.codium.ai")
 
 
 class StubProvider:
@@ -77,6 +79,28 @@ async def test_checkboxes_stay_disabled_by_configuration(published_output):
     comment = await run_walkthrough(StubProvider(gfm_markdown=True, checkbox_commands=True))
     assert INTERACTIVE_MARKER not in comment
     assert "<table>" in comment
+
+
+async def test_walkthrough_uses_current_documentation_site(published_output):
+    comment = await run_walkthrough(StubProvider(gfm_markdown=True))
+
+    assert f"{CURRENT_DOCS_URL}/tools/review/" in comment
+    assert f"{CURRENT_DOCS_URL}/usage-guide/automations_and_usage/" in comment
+    assert not any(host in comment for host in RETIRED_DOCS_HOSTS)
+
+
+@pytest.mark.parametrize(
+    ("file_name", "header", "expected"),
+    [
+        ("/index.md", "", f"{CURRENT_DOCS_URL}/"),
+        ("/tools/review.md", "Automatic review", f"{CURRENT_DOCS_URL}/tools/review/#automatic-review"),
+        ("/faq/index.md", "Frequently asked questions", f"{CURRENT_DOCS_URL}/faq/#frequently-asked-questions"),
+    ],
+)
+def test_question_source_urls_use_canonical_documentation_paths(file_name, header, expected):
+    tool = PRHelpMessage.__new__(PRHelpMessage)
+
+    assert tool.format_docs_url(file_name, header) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related to #2329

Several runtime messages still emitted links to the former Qodo/Codium documentation domains. This updates those links to `docs.pr-agent.ai` in help output, description footers, configuration errors, and the dead-image response.

Question-mode `/help` citations now also convert documentation corpus paths to canonical site URLs:

```text
/index.md -> https://docs.pr-agent.ai/
/tools/review.md + "Automatic review" -> https://docs.pr-agent.ai/tools/review/#automatic-review
/faq/index.md -> https://docs.pr-agent.ai/faq/
```

The patch also updates two fragments to their current headings: Review configuration uses `#configuration-options`, and image help uses `#ask-on-images`.

## Testing

- Focused runtime-link tests: 117 passed
- Full unit suite: 7,526 passed, 33 skipped, 1 xfailed
- Ruff: passed for every changed Python file
- Pre-commit: all applicable hooks passed for the changed files
- Runtime source scan: no former documentation hosts remain under `pr_agent/**/*.py`
