### PR TITLE
fix(plain-diff): preserve partial suggestion output

### DIFF
--- a/pr_agent/git_providers/plain_diff_provider.py
+++ b/pr_agent/git_providers/plain_diff_provider.py
@@ -7,6 +7,7 @@ from unidiff.errors import UnidiffParseError
 
 from pr_agent.algo.language_handler import build_language_file_matcher
 from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.utils import format_pr_code_suggestions_header, show_run_details
 from pr_agent.config_loader import _find_repository_root, get_settings
 from pr_agent.git_providers.diff_parsing import parse_unified_diff, reconstruct_base_file, to_hunk_only_patch
 from pr_agent.git_providers.git_provider import GitProvider
@@ -141,6 +142,9 @@ class PlainDiffGitProvider(GitProvider):
             return False
         return True
 
+    def supports_code_suggestions_artifact(self) -> bool:
+        return True
+
     def get_languages(self):
         # Return {language-name: percentage}, matching the hosted providers.
         # sort_files_by_main_languages() keys on language NAMES (it maps each
@@ -186,6 +190,18 @@ class PlainDiffGitProvider(GitProvider):
         # them to a (non-existent) hosting platform.
         if not code_suggestions:
             return True
+        return self.publish_code_suggestions_artifact(code_suggestions)
+
+    def publish_code_suggestions_artifact(
+            self, code_suggestions: list, artifact_footer: str = "",
+            no_suggestions_message: str = "No code suggestions found for the PR.") -> bool:
+        if not code_suggestions:
+            content = f"{format_pr_code_suggestions_header()}\n\n{no_suggestions_message}{artifact_footer}"
+            if get_settings().get("config.output_run_details", False):
+                content += show_run_details(self.is_supported("gfm_markdown"))
+            self._write_output(content)
+            return True
+
         sections = ["## Code suggestions", ""]
         for s in code_suggestions:
             relevant_file = s.get("relevant_file", "")
@@ -196,7 +212,8 @@ class PlainDiffGitProvider(GitProvider):
                 sections.append(f"### {location}")
             sections.append(s.get("body", ""))
             sections.append("")
-        self._write_output("\n".join(sections).rstrip() + "\n")
+        content = "\n".join(sections).rstrip() + artifact_footer + "\n"
+        self._write_output(content)
         return True
 
     # ---- unsupported publish operations (no-op or NotImplementedError) ----

--- a/tests/unittest/test_plain_diff_provider.py
+++ b/tests/unittest/test_plain_diff_provider.py
@@ -4,6 +4,7 @@ from pr_agent.algo.types import EDIT_TYPE
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import _GIT_PROVIDERS
 from pr_agent.git_providers.plain_diff_provider import PlainDiffGitProvider
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 
 # Diff-mode settings keys these tests mutate on the process-wide singleton.
 _SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path",
@@ -264,9 +265,11 @@ def test_publish_code_suggestions_renders_to_stdout(cfg, capsys):
     # render the suggestions to stdout.
     assert provider.publish_code_suggestions(suggestions) is True
     out = capsys.readouterr().out
-    assert "Code suggestions" in out
-    assert "foo.py:2-2" in out
-    assert "use a constant" in out
+    assert out == (
+        "## Code suggestions\n\n"
+        "### foo.py:2-2\n"
+        "**Suggestion:** use a constant\n\n"
+    )
 
 
 def test_publish_code_suggestions_empty_is_noop(cfg, capsys):
@@ -275,6 +278,61 @@ def test_publish_code_suggestions_empty_is_noop(cfg, capsys):
     provider = PlainDiffGitProvider(None)
     assert provider.publish_code_suggestions([]) is True
     assert capsys.readouterr().out.strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_partial_improve_keeps_suggestions_and_coverage_in_one_output(cfg, capsys, tmp_path):
+    output = tmp_path / "suggestions.md"
+    cfg("plain_diff.content", DIFF)
+    cfg("plain_diff.output_path", str(output))
+    provider = PlainDiffGitProvider(None)
+    assert provider.supports_code_suggestions_artifact() is True
+    tool = object.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.failed_chunk_count = 1
+    tool.total_chunk_count = 2
+    tool.progress_response = None
+    tool._output_published = False
+    tool._validate_suggestion = lambda *args: (True, "", True)
+
+    await tool.push_inline_code_suggestions({"code_suggestions": [{
+        "relevant_file": "foo.py",
+        "relevant_lines_start": 2,
+        "relevant_lines_end": 2,
+        "suggestion_content": "Use a constant",
+        "improved_code": "",
+        "existing_code": "line2-changed",
+        "label": "maintainability",
+        "score": 8,
+    }]})
+
+    content = output.read_text(encoding="utf-8")
+    stdout = capsys.readouterr().out
+    for rendered in (content, stdout):
+        assert rendered.count("Use a constant") == 1
+        assert rendered.count("foo.py:2-2") == 1
+        assert rendered.count("1 of 2 analysis chunks failed") == 1
+        assert rendered.index("Use a constant") < rendered.index("1 of 2 analysis chunks failed")
+
+
+@pytest.mark.asyncio
+async def test_partial_improve_without_suggestions_keeps_coverage_in_artifact(cfg, capsys, tmp_path):
+    output = tmp_path / "suggestions.md"
+    cfg("plain_diff.content", DIFF)
+    cfg("plain_diff.output_path", str(output))
+    provider = PlainDiffGitProvider(None)
+    tool = object.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.failed_chunk_count = 1
+    tool.total_chunk_count = 2
+
+    await tool.publish_no_suggestions()
+
+    content = output.read_text(encoding="utf-8")
+    stdout = capsys.readouterr().out
+    for rendered in (content, stdout):
+        assert rendered.count("No code suggestions found in the successfully analyzed chunks.") == 1
+        assert rendered.count("1 of 2 analysis chunks failed") == 1
 
 
 def test_incremental_review_disabled(cfg):


### PR DESCRIPTION
## Summary

- make Plain Diff use the existing standalone suggestion-artifact contract
- compose committable suggestions and the partial-coverage notice before writing `--output`
- preserve successful-only formatting and cover partial runs with and without suggestions

## Result

```text
## Code suggestions

### foo.py:1-1
**Suggestion:** Use a constant [maintainability, importance: 8]

⚠️ **Suggestion coverage:** 1 of 2 analysis chunks failed; the suggestions above are based on the successful chunks only.
```

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_plain_diff_provider.py tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_plain_diff_mode_e2e.py tests/unittest/test_cli_plain_diff_mode.py tests/unittest/test_local_git_provider.py tests/unittest/test_git_provider_method_contract.py -q`
- `PYTHONPATH=. uv run pytest tests/unittest -q`
- `uv run pre-commit run --files pr_agent/git_providers/plain_diff_provider.py tests/unittest/test_plain_diff_provider.py`

Fixes #3286
