### PR TITLE
fix(cli): validate output artifact options

### DIFF
--- a/docs/docs/usage-guide/plain_diff_mode.md
+++ b/docs/docs/usage-guide/plain_diff_mode.md
@@ -27,7 +27,7 @@ python -m pr_agent.cli --diff-file changes.diff --output review.md review
 | `--stdin` | Read a unified diff from stdin |
 | `--diff-file <path>` | Read a unified diff from a file |
 | `--output <path>` | Write Markdown produced by a compatible Plain Diff command to a file in addition to stdout |
-| `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` only) |
+| `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` or `review_pr` only) |
 
 `--stdin` and `--diff-file` are mutually exclusive. At least one must be provided to
 enter plain-diff mode; omitting both falls back to the normal `--pr_url` flow.
@@ -63,9 +63,10 @@ the input is a standalone diff.
    for that file. The review still runs; it simply has less context.
 
 4. **Output** — the result is written to stdout. If `--output <path>` is given, it is
-   also written to that file (UTF-8, overwritten on each run). For `review`, if
-   `--json-output <path>` is given, the parsed review plus a `usage` object with the
-   run's accumulated token counts is also written to that file as JSON.
+   also written to that file (UTF-8, overwritten on each run). For `review` or
+   `review_pr`, if `--json-output <path>` is given, the parsed review plus a
+   `usage` object with the run's accumulated token counts is also written to that
+   file as JSON.
 
 No platform token, no PR URL, and no internet access are required for the diff processing
 step itself. An LLM API key is still needed unless you configure a local model.

--- a/docs/docs/usage-guide/plain_diff_mode.md
+++ b/docs/docs/usage-guide/plain_diff_mode.md
@@ -26,15 +26,18 @@ python -m pr_agent.cli --diff-file changes.diff --output review.md review
 |---|---|
 | `--stdin` | Read a unified diff from stdin |
 | `--diff-file <path>` | Read a unified diff from a file |
-| `--output <path>` | Write the result to a file in addition to stdout |
-| `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` command) |
+| `--output <path>` | Write Markdown from `review`, `describe`, `improve`, or `ask` to a file in addition to stdout |
+| `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` only) |
 
 `--stdin` and `--diff-file` are mutually exclusive. At least one must be provided to
 enter plain-diff mode; omitting both falls back to the normal `--pr_url` flow.
+Output options must appear before the command. For example, use
+`--stdin --output result.md review`, not `--stdin review --output result.md`.
 
 ### Supported commands
 
-`review`, `improve`, `describe`, and `ask` are supported. Because there is no hosting
+`review`, `improve`, `describe`, and `ask` are supported, along with their
+`review_pr`, `improve_code`, `describe_pr`, and `ask_question` aliases. Because there is no hosting
 platform to push to, `improve` renders its code suggestions as a single markdown
 document to stdout (and to `--output`, if given) instead of as committable inline
 suggestions. Commands that require live platform interaction (such as

--- a/docs/docs/usage-guide/plain_diff_mode.md
+++ b/docs/docs/usage-guide/plain_diff_mode.md
@@ -26,7 +26,7 @@ python -m pr_agent.cli --diff-file changes.diff --output review.md review
 |---|---|
 | `--stdin` | Read a unified diff from stdin |
 | `--diff-file <path>` | Read a unified diff from a file |
-| `--output <path>` | Write Markdown from `review`, `describe`, `improve`, or `ask` to a file in addition to stdout |
+| `--output <path>` | Write Markdown produced by a compatible Plain Diff command to a file in addition to stdout |
 | `--json-output <path>` | Write the parsed review and token usage to a JSON file (`review` only) |
 
 `--stdin` and `--diff-file` are mutually exclusive. At least one must be provided to
@@ -42,6 +42,11 @@ platform to push to, `improve` renders its code suggestions as a single markdown
 document to stdout (and to `--output`, if given) instead of as committable inline
 suggestions. Commands that require live platform interaction (such as
 `update_changelog` or `similar_issue`) are not meaningful in this mode.
+
+Existing command variants that publish Markdown without additional platform
+state (`auto_review`, `config`, `settings`, and `help`) also honor `--output`.
+`answer` does not: it requires issue-comment history, which is unavailable when
+the input is a standalone diff.
 
 ## How it works
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -19,19 +19,35 @@ log_level = os.environ.get("LOG_LEVEL", "INFO")
 setup_logger(log_level)
 
 _PLAIN_DIFF_MARKDOWN_COMMANDS = frozenset({
-    "review", "review_pr",
+    "review", "review_pr", "auto_review",
     "describe", "describe_pr",
     "improve", "improve_code",
     "ask", "ask_question",
+    "config", "settings", "help",
 })
 _PLAIN_DIFF_JSON_COMMANDS = frozenset({"review", "review_pr"})
 _OUTPUT_OPTIONS = ("--output", "--json-output")
 
 
+def _resolve_output_option(parser, arg):
+    option_text = arg.partition("=")[0]
+    if option_text in _OUTPUT_OPTIONS:
+        return option_text
+    if not option_text.startswith("--") or not parser.allow_abbrev:
+        return None
+
+    # argparse has no public API for resolving one option spelling. Reuse its
+    # own option table so misplaced options follow the parser's abbreviation
+    # rules and future ambiguous prefixes are left untouched.
+    matches = parser._get_option_tuples(option_text)
+    if len(matches) == 1 and matches[0][1] in _OUTPUT_OPTIONS:
+        return matches[0][1]
+    return None
+
+
 def _validate_output_options(parser, args, diff_mode):
     for arg in getattr(args, "rest", []):
-        option = next((name for name in _OUTPUT_OPTIONS
-                       if arg == name or arg.startswith(f"{name}=")), None)
+        option = _resolve_output_option(parser, arg)
         if option:
             parser.error(
                 f"{option} must appear before the command "
@@ -110,7 +126,7 @@ def set_parser():
     parser.add_argument("--stdin", action="store_true", default=False,
                         help="Read a unified diff from stdin (plain-diff local mode)")
     parser.add_argument("--output", dest="output", type=str, default=None,
-                        help=("Write Plain Diff review/describe/improve/ask Markdown to this file "
+                        help=("Write Plain Diff Markdown output to this file "
                               "(place before the command)"))
     parser.add_argument("--json-output", dest="json_output", type=str, default=None,
                         help=("Write a Plain Diff review and token usage to this JSON file "

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -18,6 +18,45 @@ from pr_agent.log import get_logger, setup_logger
 log_level = os.environ.get("LOG_LEVEL", "INFO")
 setup_logger(log_level)
 
+_PLAIN_DIFF_MARKDOWN_COMMANDS = frozenset({
+    "review", "review_pr",
+    "describe", "describe_pr",
+    "improve", "improve_code",
+    "ask", "ask_question",
+})
+_PLAIN_DIFF_JSON_COMMANDS = frozenset({"review", "review_pr"})
+_OUTPUT_OPTIONS = ("--output", "--json-output")
+
+
+def _validate_output_options(parser, args, diff_mode):
+    for arg in getattr(args, "rest", []):
+        option = next((name for name in _OUTPUT_OPTIONS
+                       if arg == name or arg.startswith(f"{name}=")), None)
+        if option:
+            parser.error(
+                f"{option} must appear before the command "
+                f"(for example: --stdin {option} result review)"
+            )
+
+    output = getattr(args, "output", None)
+    json_output = getattr(args, "json_output", None)
+    for option, value in (("--output", output), ("--json-output", json_output)):
+        if value is not None and not value:
+            parser.error(f"{option} requires a non-empty path")
+
+    command = args.command.lstrip("/").lower()
+    if output is not None:
+        if not diff_mode:
+            parser.error("--output is only supported in plain-diff mode (--stdin or --diff-file)")
+        if command not in _PLAIN_DIFF_MARKDOWN_COMMANDS:
+            parser.error(f"--output is not supported for plain-diff command '{command}'")
+
+    if json_output is not None:
+        if not diff_mode:
+            parser.error("--json-output is only supported in plain-diff mode (--stdin or --diff-file)")
+        if command not in _PLAIN_DIFF_JSON_COMMANDS:
+            parser.error("--json-output is only supported for plain-diff review commands (review or review_pr)")
+
 
 def set_parser():
     parser = argparse.ArgumentParser(description='AI based pull request analyzer', usage=
@@ -71,9 +110,11 @@ def set_parser():
     parser.add_argument("--stdin", action="store_true", default=False,
                         help="Read a unified diff from stdin (plain-diff local mode)")
     parser.add_argument("--output", dest="output", type=str, default=None,
-                        help="Write the result to this file (in addition to stdout)")
+                        help=("Write Plain Diff review/describe/improve/ask Markdown to this file "
+                              "(place before the command)"))
     parser.add_argument("--json-output", dest="json_output", type=str, default=None,
-                        help="Write the parsed review and token usage to this JSON file")
+                        help=("Write a Plain Diff review and token usage to this JSON file "
+                              "(place before the review command)"))
     parser.add_argument('command', type=str, help='The', choices=commands, default='review')
     parser.add_argument('rest', nargs=argparse.REMAINDER, default=[])
     return parser
@@ -93,11 +134,10 @@ def run(inargs=None, args=None):
     if not args:
         args = parser.parse_args(inargs)
     diff_mode = getattr(args, "stdin", False) or getattr(args, "diff_file", None)
-    if getattr(args, "json_output", None) and not diff_mode:
-        parser.error("--json-output is only supported in plain-diff mode (--stdin or --diff-file)")
+    if diff_mode and args.stdin and args.diff_file:
+        parser.error("--stdin and --diff-file are mutually exclusive")
+    _validate_output_options(parser, args, diff_mode)
     if diff_mode:
-        if args.stdin and args.diff_file:
-            parser.error("--stdin and --diff-file are mutually exclusive")
         if args.diff_file:
             try:
                 with open(args.diff_file, "r", encoding="utf-8") as fh:

--- a/tests/unittest/test_cli_plain_diff_mode.py
+++ b/tests/unittest/test_cli_plain_diff_mode.py
@@ -3,7 +3,7 @@ import io
 
 import pytest
 
-from pr_agent.cli import commands, run, set_parser
+from pr_agent.cli import _resolve_output_option, commands, run, set_parser
 from pr_agent.config_loader import get_settings
 
 # Keys run() mutates on the process-wide settings singleton, directly or via the
@@ -28,26 +28,45 @@ _DIFF = (
     "@@ -1,3 +1,3 @@\n"
     " line1\n-line2\n+line2-changed\n line3\n"
 )
+_REVIEW_MARKER = "plain-diff auto-review output"
+_CANNED_REVIEW = f"""\
+review:
+  estimated_effort_to_review_[1-5]: '1'
+  score: '90'
+  relevant_tests: 'No'
+  key_issues_to_review:
+    - relevant_file: foo.py
+      issue_header: '{_REVIEW_MARKER}'
+      issue_content: 'Verify the changed line.'
+      start_line: 2
+      end_line: 2
+  security_concerns: 'No'
+"""
+_OUTPUT_OPTION_PREFIXES = [
+    (option[:length], option)
+    for option in ("--output", "--json-output")
+    for length in range(3, len(option) + 1)
+]
 
 _MARKDOWN_COMMANDS = [
     "review",
     "review_pr",
+    "auto_review",
     "describe",
     "describe_pr",
     "improve",
     "improve_code",
     "ask",
     "ask_question",
-]
-
-_NON_MARKDOWN_COMMANDS = [
-    "auto_review",
-    "answer",
-    "ask_line",
-    "update_changelog",
     "config",
     "settings",
     "help",
+]
+
+_NON_MARKDOWN_COMMANDS = [
+    "answer",
+    "ask_line",
+    "update_changelog",
     "similar_issue",
     "add_docs",
     "generate_labels",
@@ -128,6 +147,28 @@ def test_parser_stdin_flag():
     parser = set_parser()
     args = parser.parse_args(["--stdin", "review"])
     assert args.stdin is True
+
+
+@pytest.mark.parametrize(
+    ("option_spelling", "option"),
+    _OUTPUT_OPTION_PREFIXES,
+)
+def test_parser_accepts_unambiguous_output_abbreviations_before_command(
+    option_spelling, option,
+):
+    parser = set_parser()
+    args = parser.parse_args(["--stdin", option_spelling, "result", "review"])
+
+    destination = option[2:].replace("-", "_")
+    assert getattr(args, destination) == "result"
+
+
+def test_misplaced_output_abbreviation_must_be_unambiguous():
+    parser = set_parser()
+    parser.add_argument("--outcome")
+
+    assert _resolve_output_option(parser, "--out=value") is None
+    assert _resolve_output_option(parser, "--output=value") == "--output"
 
 
 def test_missing_diff_file_fails_fast(tmp_path, capsys):
@@ -218,7 +259,7 @@ def test_markdown_output_rejects_unsupported_plain_diff_commands_before_read(
 
 @pytest.mark.parametrize("command", _MARKDOWN_COMMANDS)
 @pytest.mark.parametrize("input_mode", ["stdin", "file"])
-def test_markdown_output_accepts_documented_plain_diff_commands(
+def test_markdown_output_accepts_compatible_plain_diff_commands(
     command, input_mode, monkeypatch, tmp_path,
 ):
     captured = {}
@@ -241,6 +282,48 @@ def test_markdown_output_accepts_documented_plain_diff_commands(
         "request": [command],
         "output_path": str(output),
     }
+
+
+@pytest.mark.parametrize("command", ["config", "settings", "help"])
+def test_compatible_non_model_commands_write_markdown_artifacts(
+    command, monkeypatch, tmp_path,
+):
+    monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
+    output = tmp_path / f"{command}.md"
+
+    run(inargs=["--stdin", "--output", str(output), command])
+
+    assert output.read_text(encoding="utf-8").strip()
+
+
+def test_auto_review_writes_markdown_artifact_with_stubbed_model(
+    monkeypatch, tmp_path,
+):
+    async def fake_chat_completion(self, model, system, user, temperature=0.2, **kwargs):
+        return _CANNED_REVIEW, "stop"
+
+    monkeypatch.setattr(
+        "pr_agent.algo.ai_handlers.litellm_ai_handler.LiteLLMAIHandler.chat_completion",
+        fake_chat_completion,
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
+    output = tmp_path / "auto-review.md"
+
+    run(inargs=["--stdin", "--output", str(output), "auto_review"])
+
+    assert _REVIEW_MARKER in output.read_text(encoding="utf-8")
+
+
+def test_answer_output_is_rejected_without_creating_artifact(monkeypatch, tmp_path, capsys):
+    input_args = _rejecting_input_args("stdin", monkeypatch)
+    output = tmp_path / "answer.md"
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[*input_args, "--output", str(output), "answer"])
+
+    assert exc_info.value.code == 2
+    assert "--output is not supported for" in capsys.readouterr().err
+    assert not output.exists()
 
 
 @pytest.mark.parametrize("command", ["review", "review_pr"])
@@ -281,20 +364,24 @@ def test_json_output_rejects_non_review_commands_before_read(
 
 
 @pytest.mark.parametrize(
-    ("trailing_args", "option"),
-    [
-        (["--output", "out.md"], "--output"),
-        (["--output=out.md"], "--output"),
-        (["--json-output", "out.json"], "--json-output"),
-        (["--json-output=out.json"], "--json-output"),
-    ],
+    ("option_spelling", "option"),
+    _OUTPUT_OPTION_PREFIXES,
 )
-def test_output_options_after_command_fail_before_read(trailing_args, option, monkeypatch, capsys):
+@pytest.mark.parametrize("value_form", ["separate", "equals"])
+def test_output_options_after_command_fail_before_read(
+    option_spelling, option, value_form, monkeypatch, capsys,
+):
     class UnreadableStdin:
         def read(self):
             pytest.fail("stdin must not be read for misplaced output options")
 
     monkeypatch.setattr("sys.stdin", UnreadableStdin())
+    value = "out.json" if option == "--json-output" else "out.md"
+    trailing_args = (
+        [option_spelling, value]
+        if value_form == "separate"
+        else [f"{option_spelling}={value}"]
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         run(inargs=["--stdin", "review", *trailing_args])

--- a/tests/unittest/test_cli_plain_diff_mode.py
+++ b/tests/unittest/test_cli_plain_diff_mode.py
@@ -1,13 +1,100 @@
+import builtins
+import io
+
 import pytest
 
-from pr_agent.cli import run, set_parser
+from pr_agent.cli import commands, run, set_parser
 from pr_agent.config_loader import get_settings
 
 # Keys run() mutates on the process-wide settings singleton, directly or via the
 # diff-mode CLI path. Snapshotted and restored around every test (autouse) so
 # state never leaks, even when run() sets keys the test never touches itself.
-_SETTINGS_KEYS = ["plain_diff.content", "plain_diff.output_path", "plain_diff.json_output_path",
-                  "config.git_provider", "config.publish_output"]
+_SETTINGS_KEYS = [
+    "plain_diff.content",
+    "plain_diff.output_path",
+    "plain_diff.json_output_path",
+    "config.git_provider",
+    "config.publish_output",
+    "config.cli_mode",
+    "config.config_branch",
+    "config.extra_config_url",
+]
+
+_DIFF = (
+    "diff --git a/foo.py b/foo.py\n"
+    "index 1111111..2222222 100644\n"
+    "--- a/foo.py\n"
+    "+++ b/foo.py\n"
+    "@@ -1,3 +1,3 @@\n"
+    " line1\n-line2\n+line2-changed\n line3\n"
+)
+
+_MARKDOWN_COMMANDS = [
+    "review",
+    "review_pr",
+    "describe",
+    "describe_pr",
+    "improve",
+    "improve_code",
+    "ask",
+    "ask_question",
+]
+
+_NON_MARKDOWN_COMMANDS = [
+    "auto_review",
+    "answer",
+    "ask_line",
+    "update_changelog",
+    "config",
+    "settings",
+    "help",
+    "similar_issue",
+    "add_docs",
+    "generate_labels",
+]
+
+
+def test_output_command_matrix_covers_cli_commands():
+    assert set(_MARKDOWN_COMMANDS) | set(_NON_MARKDOWN_COMMANDS) == set(commands)
+    assert set(_MARKDOWN_COMMANDS).isdisjoint(_NON_MARKDOWN_COMMANDS)
+
+
+def _rejecting_input_args(input_mode, monkeypatch):
+    class UnreadableStdin:
+        def read(self):
+            pytest.fail("stdin must not be read for invalid output options")
+
+    if input_mode == "stdin":
+        monkeypatch.setattr("sys.stdin", UnreadableStdin())
+        return ["--stdin"]
+
+    original_open = builtins.open
+
+    def guarded_open(path, *args, **kwargs):
+        if path == "changes.diff":
+            pytest.fail("the diff file must not be opened for invalid output options")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", guarded_open)
+    return ["--diff-file", "changes.diff"]
+
+
+def _valid_input_args(input_mode, monkeypatch, tmp_path):
+    if input_mode == "stdin":
+        monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
+        return ["--stdin"]
+
+    diff_file = tmp_path / "changes.diff"
+    diff_file.write_text(_DIFF, encoding="utf-8")
+    return ["--diff-file", str(diff_file)]
+
+
+def _fail_if_agent_constructed(monkeypatch):
+    class NeverAgent:
+        def __init__(self):
+            pytest.fail("PRAgent must not be constructed for invalid output options")
+
+    monkeypatch.setattr("pr_agent.cli.PRAgent", NeverAgent)
 
 
 @pytest.fixture(autouse=True)
@@ -56,27 +143,186 @@ def test_missing_diff_file_fails_fast(tmp_path, capsys):
 def test_json_output_outside_diff_mode_fails_fast(capsys):
     """Reject --json-output in hosted-provider mode via parser.error instead of
     silently dropping the explicitly requested artifact."""
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         run(inargs=["--pr_url", "https://example/pr/1", "--json-output", "out.json", "review"])
+    assert exc_info.value.code == 2
     err = capsys.readouterr().err
     assert "--json-output is only supported in plain-diff mode" in err
 
 
-_DIFF = (
-    "diff --git a/foo.py b/foo.py\n"
-    "index 1111111..2222222 100644\n"
-    "--- a/foo.py\n"
-    "+++ b/foo.py\n"
-    "@@ -1,3 +1,3 @@\n"
-    " line1\n-line2\n+line2-changed\n line3\n"
+@pytest.mark.parametrize(
+    "target_args",
+    [
+        ["--pr_url", "https://example/pr/1"],
+        ["--issue_url", "https://example/issue/1"],
+        [],
+    ],
 )
+def test_markdown_output_outside_plain_diff_fails_before_dispatch(target_args, monkeypatch, capsys):
+    _fail_if_agent_constructed(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[*target_args, "--output", "out.md", "review"])
+
+    assert exc_info.value.code == 2
+    assert "--output is only supported in plain-diff mode" in capsys.readouterr().err
+
+
+def test_markdown_output_rejects_local_git_mode_before_dispatch(monkeypatch, capsys):
+    _fail_if_agent_constructed(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[
+            "--pr_url", "main",
+            "--output", "out.md",
+            "review",
+            "--config.git_provider=local",
+        ])
+
+    assert exc_info.value.code == 2
+    assert "--output is only supported in plain-diff mode" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("option", ["--output", "--json-output"])
+@pytest.mark.parametrize("spelling", ["equals", "separate"])
+@pytest.mark.parametrize("mode", ["hosted", "stdin"])
+def test_empty_output_paths_fail_before_input_or_dispatch(
+    option, spelling, mode, monkeypatch, capsys,
+):
+    _fail_if_agent_constructed(monkeypatch)
+    target_args = ["--pr_url", "https://example/pr/1"]
+    if mode == "stdin":
+        target_args = _rejecting_input_args("stdin", monkeypatch)
+    option_args = [f"{option}="] if spelling == "equals" else [option, ""]
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[*target_args, *option_args, "review"])
+
+    assert exc_info.value.code == 2
+    assert f"{option} requires a non-empty path" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("command", _NON_MARKDOWN_COMMANDS)
+@pytest.mark.parametrize("input_mode", ["stdin", "file"])
+def test_markdown_output_rejects_unsupported_plain_diff_commands_before_read(
+    command, input_mode, monkeypatch, capsys,
+):
+    input_args = _rejecting_input_args(input_mode, monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[*input_args, "--output", "out.md", command])
+
+    assert exc_info.value.code == 2
+    assert "--output is not supported for" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("command", _MARKDOWN_COMMANDS)
+@pytest.mark.parametrize("input_mode", ["stdin", "file"])
+def test_markdown_output_accepts_documented_plain_diff_commands(
+    command, input_mode, monkeypatch, tmp_path,
+):
+    captured = {}
+
+    class FakeAgent:
+        async def handle_request(self, target, request, notify=None):
+            captured["target"] = target
+            captured["request"] = request
+            captured["output_path"] = get_settings().plain_diff.output_path
+            return True
+
+    monkeypatch.setattr("pr_agent.cli.PRAgent", FakeAgent)
+    input_args = _valid_input_args(input_mode, monkeypatch, tmp_path)
+
+    output = tmp_path / "result.md"
+    run(inargs=[*input_args, "--output", str(output), command])
+
+    assert captured == {
+        "target": "local_diff",
+        "request": [command],
+        "output_path": str(output),
+    }
+
+
+@pytest.mark.parametrize("command", ["review", "review_pr"])
+@pytest.mark.parametrize("input_mode", ["stdin", "file"])
+def test_json_output_accepts_review_aliases(command, input_mode, monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeAgent:
+        async def handle_request(self, target, request, notify=None):
+            captured["request"] = request
+            captured["json_output_path"] = get_settings().plain_diff.json_output_path
+            return True
+
+    monkeypatch.setattr("pr_agent.cli.PRAgent", FakeAgent)
+    input_args = _valid_input_args(input_mode, monkeypatch, tmp_path)
+
+    output = tmp_path / "review.json"
+    run(inargs=[*input_args, "--json-output", str(output), command])
+
+    assert captured == {
+        "request": [command],
+        "json_output_path": str(output),
+    }
+
+
+@pytest.mark.parametrize("command", [*_NON_MARKDOWN_COMMANDS, *_MARKDOWN_COMMANDS[2:]])
+@pytest.mark.parametrize("input_mode", ["stdin", "file"])
+def test_json_output_rejects_non_review_commands_before_read(
+    command, input_mode, monkeypatch, capsys,
+):
+    input_args = _rejecting_input_args(input_mode, monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=[*input_args, "--json-output", "out.json", command])
+
+    assert exc_info.value.code == 2
+    assert "--json-output is only supported for plain-diff review commands" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("trailing_args", "option"),
+    [
+        (["--output", "out.md"], "--output"),
+        (["--output=out.md"], "--output"),
+        (["--json-output", "out.json"], "--json-output"),
+        (["--json-output=out.json"], "--json-output"),
+    ],
+)
+def test_output_options_after_command_fail_before_read(trailing_args, option, monkeypatch, capsys):
+    class UnreadableStdin:
+        def read(self):
+            pytest.fail("stdin must not be read for misplaced output options")
+
+    monkeypatch.setattr("sys.stdin", UnreadableStdin())
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(inargs=["--stdin", "review", *trailing_args])
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert f"{option} must appear before the command" in err
+
+
+def test_near_match_after_command_remains_a_tool_argument(monkeypatch):
+    captured = {}
+
+    class FakeAgent:
+        async def handle_request(self, target, request, notify=None):
+            captured["request"] = request
+            return True
+
+    monkeypatch.setattr("pr_agent.cli.PRAgent", FakeAgent)
+    monkeypatch.setattr("sys.stdin", io.StringIO(_DIFF))
+
+    run(inargs=["--stdin", "review", "--output-format=markdown"])
+
+    assert captured["request"] == ["review", "--output-format=markdown"]
 
 
 def test_diff_mode_forces_publish_output(cfg, monkeypatch):
     """Diff mode must force config.publish_output=True so stdout/--output is
     never suppressed by a config/env that disabled publishing."""
-    import io
-
     cfg("config.publish_output", False)
     captured = {}
 
@@ -92,8 +338,6 @@ def test_diff_mode_forces_publish_output(cfg, monkeypatch):
 
 
 def test_diff_mode_sets_json_output_path(cfg, monkeypatch, tmp_path):
-    import io
-
     captured = {}
 
     class FakeAgent:


### PR DESCRIPTION
Fixes #3288

## What changed

- validate `--output` and `--json-output` against the selected input mode and command before reading a diff or dispatching PR-Agent
- reject output options captured after the command, including unambiguous argparse abbreviations, with placement guidance while preserving unrelated tool arguments
- reject explicitly empty output paths before input is read or dispatch begins
- preserve existing Markdown artifact output for `auto_review`, `config`, `settings`, and `help`
- document the supported Plain Diff output commands, compatibility writers, and aliases

`--output` remains available for the documented Plain Diff `review`, `describe`, `improve`, and `ask` families, plus the existing compatible writers above. `answer` remains rejected because it requires issue-comment history, which is unavailable for standalone diffs. Structured JSON remains available for `review`/`review_pr` only. Invalid combinations and empty destinations retain argparse's status-2 contract.

Example post-fix result for `--diff-file changes.diff --json-output description.json describe`:

```text
stderr: cli.py: error: --json-output is only supported for plain-diff review commands (review or review_pr)
exit status: 2
```

## Testing

- `PYTHONPATH=. uv run pytest -q tests/unittest/test_cli_plain_diff_mode.py tests/unittest/test_plain_diff_mode_e2e.py tests/unittest/test_plain_diff_provider.py` (174 passed)
- `PYTHONPATH=. uv run pytest -q tests/unittest/test_cli*.py tests/unittest/test_command_descriptions.py tests/unittest/test_plain_diff_mode_e2e.py tests/unittest/test_plain_diff_provider.py` (292 passed)
- `PYTHONPATH=. uv run pytest -q tests/unittest` (7,662 passed, 33 skipped, 1 xfailed)
- `uv run ruff check pr_agent/cli.py tests/unittest/test_cli_plain_diff_mode.py` (passed)
- `uv run pre-commit run --files pr_agent/cli.py tests/unittest/test_cli_plain_diff_mode.py docs/docs/usage-guide/plain_diff_mode.md` (passed)
