### PR TITLE
perf(review): reuse prepared diff chunks

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import traceback
+from dataclasses import dataclass
 from typing import Callable, List, Tuple
 
 from pr_agent.algo.git_patch_processing import (
@@ -29,6 +30,23 @@ OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD = 1000
 MAX_EXTRA_LINES = 10
 
 
+@dataclass
+class PreparedPRDiff:
+    """The single-call diff and compressed file data prepared for one model attempt.
+
+    The compressed file data is request-scoped. It is only reused by a caller that keeps the
+    same token handler and model, so fallback attempts still rebuild their model-specific budget.
+    """
+
+    diff: str
+    remaining_files_list: list
+    file_dict: dict | None = None
+    files_by_name: dict | None = None
+    model: str | None = None
+    add_line_numbers_to_hunks: bool = False
+    token_handler: TokenHandler | None = None
+
+
 def cap_and_log_extra_lines(value, direction) -> int:
     try:
         value = int(value)
@@ -47,7 +65,8 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
                 add_line_numbers_to_hunks: bool = False,
                 disable_extra_lines: bool = False,
                 large_pr_handling=False,
-                return_remaining_files=False):
+                return_remaining_files=False,
+                return_prepared=False):
     if disable_extra_lines:
         PATCH_EXTRA_LINES_BEFORE = 0
         PATCH_EXTRA_LINES_AFTER = 0
@@ -76,7 +95,12 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
         get_logger().info(f"Tokens: {total_tokens}, total tokens under limit: {get_max_tokens(model)}, "
                           f"returning full diff.")
-        return "\n".join(patches_extended)
+        full_diff = "\n".join(patches_extended)
+        if return_prepared:
+            return PreparedPRDiff(full_diff, [], model=model,
+                                  add_line_numbers_to_hunks=add_line_numbers_to_hunks,
+                                  token_handler=token_handler)
+        return full_diff
 
     # if we are over the limit, start pruning (If we got here, we will not extend the patches with extra lines)
     get_logger().info(f"Tokens: {total_tokens}, total tokens over limit: {get_max_tokens(model)}, "
@@ -139,6 +163,21 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
 
     get_logger().debug(f"After pruning, added_list_str: {added_list_str}, modified_list_str: {modified_list_str}, "
                        f"deleted_list_str: {deleted_list_str}")
+    if return_prepared:
+        files_by_name = {
+            file.filename: file
+            for language in pr_languages
+            for file in language["files"]
+        }
+        return PreparedPRDiff(
+            final_diff,
+            remaining_files_list,
+            file_dict,
+            files_by_name,
+            model=model,
+            add_line_numbers_to_hunks=add_line_numbers_to_hunks,
+            token_handler=token_handler,
+        )
     if not return_remaining_files:
         return final_diff
     else:
@@ -161,6 +200,107 @@ def get_pr_diff_multiple_patchs(git_provider: GitProvider, token_handler: TokenH
         pr_generate_compressed_diff(pr_languages, token_handler, model, add_line_numbers_to_hunks, large_pr_handling=True)
 
     return patches_compressed_list, total_tokens_list, deleted_files_list, remaining_files_list, file_dict, files_in_patches_list
+
+
+def _pack_pr_multi_diffs(file_dict: dict,
+                         token_handler: TokenHandler,
+                         model: str,
+                         max_calls: int,
+                         return_remaining_files: bool):
+    patches = []
+    final_diff_list = []
+    files_in_patches = set()
+    total_tokens = token_handler.prompt_tokens
+    call_number = 1
+
+    for filename, data in file_dict.items():
+        if call_number > max_calls:
+            if get_verbosity_level() >= 2:
+                get_logger().info(f"Reached max calls ({max_calls})")
+            break
+
+        patch = data["patch"]
+        new_patch_tokens = data["tokens"]
+
+        if patch and (token_handler.prompt_tokens + new_patch_tokens) > get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD:
+            if get_settings().config.get("large_patch_policy", "skip") == "skip":
+                get_logger().warning(f"Patch too large, skipping: {filename}")
+                continue
+            if get_settings().config.get("large_patch_policy") == "clip":
+                delta_tokens = get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD - token_handler.prompt_tokens
+                patch_clipped = clip_tokens(patch, delta_tokens, delete_last_line=True,
+                                             num_input_tokens=new_patch_tokens)
+                new_patch_tokens = token_handler.count_tokens(patch_clipped)
+                if patch_clipped and (token_handler.prompt_tokens + new_patch_tokens) > get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD:
+                    get_logger().warning(f"Patch too large, skipping: {filename}")
+                    continue
+                get_logger().info(f"Clipped large patch for file: {filename}")
+                patch = patch_clipped
+            else:
+                get_logger().warning(f"Patch too large, skipping: {filename}")
+                continue
+
+        if patch and (total_tokens + new_patch_tokens > get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD):
+            final_diff_list.append("\n".join(patches))
+            patches = []
+            total_tokens = token_handler.prompt_tokens
+            call_number += 1
+            if call_number > max_calls:
+                if get_verbosity_level() >= 2:
+                    get_logger().info(f"Reached max calls ({max_calls})")
+                break
+            if get_verbosity_level() >= 2:
+                get_logger().info(f"Call number: {call_number}")
+
+        if patch:
+            patches.append(patch)
+            files_in_patches.add(filename)
+            total_tokens += new_patch_tokens
+            if get_verbosity_level() >= 2:
+                get_logger().info(f"Tokens: {total_tokens}, last filename: {filename}")
+
+    if patches:
+        final_diff_list.append("\n".join(patches).strip())
+
+    if not return_remaining_files:
+        return final_diff_list
+
+    remaining_files_list = [
+        filename for filename in file_dict
+        if filename not in files_in_patches
+    ]
+    return final_diff_list, remaining_files_list
+
+
+def _get_pr_multi_diffs_from_prepared(prepared_diff: PreparedPRDiff,
+                                      token_handler: TokenHandler,
+                                      model: str,
+                                      max_calls: int,
+                                      return_remaining_files: bool):
+    """Pack already transformed file patches without repeating preparation work.
+
+    ``get_pr_diff`` and the review chunking path use the same model-specific token handler and
+    line-number format. Reusing its compressed file dictionary preserves the existing packing
+    and large-patch policy while avoiding a second provider fetch, patch conversion, and token
+    count for every file.
+    """
+    file_dict = {}
+    for filename, data in (prepared_diff.file_dict or {}).items():
+        patch = data["patch"]
+        tokens = data["tokens"]
+        file = (prepared_diff.files_by_name or {}).get(filename)
+        if file and file.ai_file_summary and get_settings().get("config.enable_ai_metadata", False):
+            patch = add_ai_summary_top_patch(file, patch)
+            tokens = token_handler.count_tokens(patch)
+        file_dict[filename] = {**data, "patch": patch, "tokens": tokens}
+
+    return _pack_pr_multi_diffs(
+        file_dict,
+        token_handler,
+        model,
+        max_calls,
+        return_remaining_files,
+    )
 
 
 def pr_generate_extended_diff(pr_languages: list,
@@ -396,7 +536,8 @@ def get_pr_multi_diffs(git_provider: GitProvider,
                        model: str,
                        max_calls: int = 5,
                        add_line_numbers: bool = True,
-                       return_remaining_files: bool = False):
+                       return_remaining_files: bool = False,
+                       prepared_diff: PreparedPRDiff | None = None):
     """
     Retrieves the diff files from a Git provider, sorts them by main language, and generates patches for each file.
     The patches are split into multiple groups based on the maximum number of tokens allowed for the given model.
@@ -409,12 +550,30 @@ def get_pr_multi_diffs(git_provider: GitProvider,
         return_remaining_files (bool, optional): Also return the files the token budget left out, in the
             same shape as `get_pr_diff`. Files without a patch, and delete-only files, are not reported:
             nothing was omitted for them. Defaults to False.
+        prepared_diff (PreparedPRDiff, optional): Reuse compressed file data prepared by a preceding
+            `get_pr_diff` call for the same model attempt. Defaults to None.
 
     Returns:
         List[str]: A list of final diff strings, split into multiple groups based on the maximum number of tokens allowed for the given model.
         With `return_remaining_files`, a tuple of that list and the list of omitted file names.
 
     """
+    if (
+        prepared_diff is not None
+        and prepared_diff.file_dict is not None
+        and prepared_diff.model == model
+        and add_line_numbers
+        and prepared_diff.add_line_numbers_to_hunks == add_line_numbers
+        and prepared_diff.token_handler is token_handler
+    ):
+        return _get_pr_multi_diffs_from_prepared(
+            prepared_diff,
+            token_handler,
+            model,
+            max_calls,
+            return_remaining_files,
+        )
+
     diff_files = git_provider.get_diff_files()
 
     # Sort files by main language

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -602,17 +602,11 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     for lang in pr_languages:
         sorted_files.extend(sorted(lang['files'], key=lambda x: x.tokens, reverse=True))
 
-    patches = []
-    final_diff_list = []
-    files_in_patches = set()  # files that made it into a chunk
-    total_tokens = token_handler.prompt_tokens
-    call_number = 1
+    # Build the same transformed file dictionary used by the prepared path, preserving the
+    # descending token order established above. The shared packer then owns chunk boundaries,
+    # large-patch policy, and remaining-file tracking for both paths.
+    file_dict = {}
     for file in sorted_files:
-        if call_number > max_calls:
-            if get_verbosity_level() >= 2:
-                get_logger().info(f"Reached max calls ({max_calls})")
-            break
-
         original_file_content_str = file.base_file
         new_file_content_str = file.head_file
         patch = file.patch
@@ -634,66 +628,19 @@ def get_pr_multi_diffs(git_provider: GitProvider,
         if file.ai_file_summary and get_settings().get("config.enable_ai_metadata", False):
             patch = add_ai_summary_top_patch(file, patch)
         new_patch_tokens = token_handler.count_tokens(patch)
+        file_dict[file.filename] = {
+            'patch': patch,
+            'tokens': new_patch_tokens,
+            'edit_type': file.edit_type,
+        }
 
-        if patch and (token_handler.prompt_tokens + new_patch_tokens) > get_max_tokens(
-                model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD:
-            if get_settings().config.get('large_patch_policy', 'skip') == 'skip':
-                get_logger().warning(f"Patch too large, skipping: {file.filename}")
-                continue
-            elif get_settings().config.get('large_patch_policy') == 'clip':
-                delta_tokens = get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD - token_handler.prompt_tokens
-                patch_clipped = clip_tokens(patch, delta_tokens, delete_last_line=True, num_input_tokens=new_patch_tokens)
-                new_patch_tokens = token_handler.count_tokens(patch_clipped)
-                if patch_clipped and (token_handler.prompt_tokens + new_patch_tokens) > get_max_tokens(
-                        model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD:
-                    get_logger().warning(f"Patch too large, skipping: {file.filename}")
-                    continue
-                else:
-                    get_logger().info(f"Clipped large patch for file: {file.filename}")
-                    patch = patch_clipped
-            else:
-                get_logger().warning(f"Patch too large, skipping: {file.filename}")
-                continue
-
-        if patch and (total_tokens + new_patch_tokens > get_max_tokens(model) - OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD):
-            final_diff = "\n".join(patches)
-            final_diff_list.append(final_diff)
-            patches = []
-            total_tokens = token_handler.prompt_tokens
-            call_number += 1
-            if call_number > max_calls: # avoid creating new patches
-                if get_verbosity_level() >= 2:
-                    get_logger().info(f"Reached max calls ({max_calls})")
-                break
-            if get_verbosity_level() >= 2:
-                get_logger().info(f"Call number: {call_number}")
-
-        if patch:
-            patches.append(patch)
-            files_in_patches.add(file.filename)
-            total_tokens += new_patch_tokens
-            if get_verbosity_level() >= 2:
-                get_logger().info(f"Tokens: {total_tokens}, last filename: {file.filename}")
-
-    # Add the last chunk
-    if patches:
-        final_diff = "\n".join(patches)
-        final_diff_list.append(final_diff.strip())
-
-    if not return_remaining_files:
-        return final_diff_list
-
-    remaining_files_list = []
-    for file in sorted_files:
-        if file.filename in files_in_patches or file.filename in remaining_files_list:
-            continue
-        # a file with no patch, or with a delete-only patch, has nothing to review:
-        # the token budget is not what kept it out of the diff
-        if not file.patch or handle_patch_deletions(file.patch, file.base_file, file.head_file,
-                                                    file.filename, file.edit_type) is None:
-            continue
-        remaining_files_list.append(file.filename)
-    return final_diff_list, remaining_files_list
+    return _pack_pr_multi_diffs(
+        file_dict,
+        token_handler,
+        model,
+        max_calls,
+        return_remaining_files,
+    )
 
 
 def add_ai_metadata_to_diff_files(git_provider, pr_description_files):

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -18,6 +18,7 @@ from pr_agent.algo.inline_comment_dedup import (
     key_issue_location_fingerprint,
 )
 from pr_agent.algo.pr_processing import (
+    PreparedPRDiff,
     add_ai_metadata_to_diff_files,
     get_pr_diff,
     get_pr_multi_diffs,
@@ -765,21 +766,28 @@ class PRReviewer:
                 get_settings().pr_review_prompt.user,
                 model,
             )
-        output = get_pr_diff(self.git_provider,
-                             self.token_handler,
-                             model,
-                             add_line_numbers_to_hunks=True,
-                             disable_extra_lines=False,
-                             return_remaining_files=True,)
-        if isinstance(output, tuple):
+        chunking_enabled = get_settings().pr_reviewer.get("enable_large_pr_chunking", False)
+        diff_kwargs = {
+            "add_line_numbers_to_hunks": True,
+            "disable_extra_lines": False,
+            "return_remaining_files": True,
+        }
+        if chunking_enabled:
+            diff_kwargs["return_prepared"] = True
+        output = get_pr_diff(self.git_provider, self.token_handler, model, **diff_kwargs)
+        if isinstance(output, PreparedPRDiff):
+            self.patches_diff = output.diff
+            self.remaining_files_list = output.remaining_files_list
+        elif isinstance(output, tuple):
             self.patches_diff, self.remaining_files_list = output
         else:
             self.patches_diff = output
             self.remaining_files_list = []
 
         # a non-empty remaining_files_list means the token budget truncated the diff
-        if self.remaining_files_list and get_settings().pr_reviewer.get("enable_large_pr_chunking", False):
-            if await self._prepare_chunked_prediction(model):
+        if self.remaining_files_list and chunking_enabled:
+            prepared_diff = output if isinstance(output, PreparedPRDiff) else None
+            if await self._prepare_chunked_prediction(model, prepared_diff):
                 return
 
         if self.patches_diff:
@@ -789,18 +797,24 @@ class PRReviewer:
             get_logger().warning(f"Empty diff for PR: {self.pr_url}")
             self.prediction = None
 
-    async def _prepare_chunked_prediction(self, model: str) -> bool:
+    async def _prepare_chunked_prediction(self, model: str,
+                                          prepared_diff: PreparedPRDiff | None = None) -> bool:
         """Review a too-large diff in chunks and merge the per-chunk verdicts.
 
         Returns False when chunking does not apply, leaving the single-call flow in place.
         """
+        multi_diff_kwargs = {
+            "max_calls": get_settings().pr_reviewer.get("max_number_of_calls", 3),
+            "add_line_numbers": True,
+            "return_remaining_files": True,
+        }
+        if prepared_diff is not None:
+            multi_diff_kwargs["prepared_diff"] = prepared_diff
         patches_diff_list, remaining_files_list = get_pr_multi_diffs(
             self.git_provider,
             self.token_handler,
             model,
-            max_calls=get_settings().pr_reviewer.get("max_number_of_calls", 3),
-            add_line_numbers=True,
-            return_remaining_files=True)
+            **multi_diff_kwargs)
         if len(patches_diff_list) < 2:
             get_logger().info("Large-diff chunking produced a single chunk, reviewing the PR in one call")
             return False

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -48,9 +48,13 @@ def test_prepared_pr_diff_reuses_compressed_files_without_changing_chunks(monkey
     settings.config.large_patch_policy = "skip"
     settings.config.verbosity_level = 0
 
-    hunk = "@@ -1 +1 @@\n-old\n+" + ("alpha " * 60)
+    hunk_sizes = (20, 40, 60, 80)
+    hunks = [
+        "@@ -1 +1 @@\n-old\n+" + ("alpha " * size)
+        for size in hunk_sizes
+    ]
     files = [
-        FilePatchInfo("old\n", "new\n", hunk, f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
+        FilePatchInfo("old\n", "new\n", hunks[index], f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
         for index in range(4)
     ]
     provider = FakeProvider(files)
@@ -71,6 +75,8 @@ def test_prepared_pr_diff_reuses_compressed_files_without_changing_chunks(monkey
 
         assert isinstance(prepared, pr_processing.PreparedPRDiff)
         assert prepared.file_dict
+        expected_order = [f"file_{index}.py" for index in range(3, -1, -1)]
+        assert list(prepared.file_dict) == expected_order
         calls_after_prepare = token_handler.count_calls
         prepared_chunks = pr_processing.get_pr_multi_diffs(
             provider,
@@ -83,7 +89,7 @@ def test_prepared_pr_diff_reuses_compressed_files_without_changing_chunks(monkey
         )
 
         fresh_provider = FakeProvider([
-            FilePatchInfo("old\n", "new\n", hunk, f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
+            FilePatchInfo("old\n", "new\n", hunks[index], f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
             for index in range(4)
         ])
         fresh_chunks = pr_processing.get_pr_multi_diffs(
@@ -96,6 +102,11 @@ def test_prepared_pr_diff_reuses_compressed_files_without_changing_chunks(monkey
         )
 
         assert prepared_chunks == fresh_chunks
+        prepared_diff_list, _ = prepared_chunks
+        combined_chunks = "\n".join(prepared_diff_list)
+        assert [combined_chunks.index(filename) for filename in expected_order] == sorted(
+            combined_chunks.index(filename) for filename in expected_order
+        )
         assert token_handler.count_calls == calls_after_prepare
         assert (provider.diff_calls, provider.language_calls) == (1, 1)
     finally:

--- a/tests/unittest/test_pr_processing_core.py
+++ b/tests/unittest/test_pr_processing_core.py
@@ -13,20 +13,143 @@ from pr_agent.servers.utils import RateLimitExceeded
 class FakeTokenHandler:
     def __init__(self, prompt_tokens=100):
         self.prompt_tokens = prompt_tokens
+        self.count_calls = 0
 
     def count_tokens(self, patch):
+        self.count_calls += 1
         return len(patch.split())
 
 
 class FakeProvider:
     def __init__(self, files):
         self.files = files
+        self.diff_calls = 0
+        self.language_calls = 0
 
     def get_diff_files(self):
+        self.diff_calls += 1
         return self.files
 
     def get_languages(self):
+        self.language_calls += 1
         return {"Python": 100}
+
+
+def test_prepared_pr_diff_reuses_compressed_files_without_changing_chunks(monkeypatch):
+    settings = get_settings()
+    original = {
+        "patch_extra_lines_before": settings.config.patch_extra_lines_before,
+        "patch_extra_lines_after": settings.config.patch_extra_lines_after,
+        "large_patch_policy": settings.config.get("large_patch_policy", "skip"),
+        "verbosity_level": settings.config.verbosity_level,
+    }
+    settings.config.patch_extra_lines_before = 0
+    settings.config.patch_extra_lines_after = 0
+    settings.config.large_patch_policy = "skip"
+    settings.config.verbosity_level = 0
+
+    hunk = "@@ -1 +1 @@\n-old\n+" + ("alpha " * 60)
+    files = [
+        FilePatchInfo("old\n", "new\n", hunk, f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
+        for index in range(4)
+    ]
+    provider = FakeProvider(files)
+    token_handler = FakeTokenHandler(prompt_tokens=100)
+
+    monkeypatch.setattr(pr_processing, "sort_files_by_main_languages", lambda languages, files: [{"files": files}])
+    monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: 1_700)
+
+    try:
+        prepared = pr_processing.get_pr_diff(
+            provider,
+            token_handler,
+            "tiny-model",
+            add_line_numbers_to_hunks=True,
+            return_remaining_files=True,
+            return_prepared=True,
+        )
+
+        assert isinstance(prepared, pr_processing.PreparedPRDiff)
+        assert prepared.file_dict
+        calls_after_prepare = token_handler.count_calls
+        prepared_chunks = pr_processing.get_pr_multi_diffs(
+            provider,
+            token_handler,
+            "tiny-model",
+            max_calls=3,
+            add_line_numbers=True,
+            return_remaining_files=True,
+            prepared_diff=prepared,
+        )
+
+        fresh_provider = FakeProvider([
+            FilePatchInfo("old\n", "new\n", hunk, f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
+            for index in range(4)
+        ])
+        fresh_chunks = pr_processing.get_pr_multi_diffs(
+            fresh_provider,
+            FakeTokenHandler(prompt_tokens=100),
+            "tiny-model",
+            max_calls=3,
+            add_line_numbers=True,
+            return_remaining_files=True,
+        )
+
+        assert prepared_chunks == fresh_chunks
+        assert token_handler.count_calls == calls_after_prepare
+        assert (provider.diff_calls, provider.language_calls) == (1, 1)
+    finally:
+        for key, value in original.items():
+            setattr(settings.config, key, value)
+
+
+@pytest.mark.parametrize(
+    ("prepared_model", "requested_model", "prepared_line_numbers", "requested_line_numbers"),
+    [
+        ("tiny-model", "other-model", True, True),
+        ("tiny-model", "tiny-model", False, False),
+    ],
+)
+def test_prepared_pr_diff_is_not_reused_across_model_or_patch_format(
+    monkeypatch, prepared_model, requested_model, prepared_line_numbers, requested_line_numbers
+):
+    settings = get_settings()
+    original_verbosity_level = settings.config.verbosity_level
+    settings.config.verbosity_level = 0
+    hunk = "@@ -1 +1 @@\n-old\n+" + ("alpha " * 60)
+    files = [
+        FilePatchInfo("old\n", "new\n", hunk, f"file_{index}.py", edit_type=EDIT_TYPE.MODIFIED)
+        for index in range(4)
+    ]
+    provider = FakeProvider(files)
+    token_handler = FakeTokenHandler(prompt_tokens=100)
+    monkeypatch.setattr(pr_processing, "sort_files_by_main_languages", lambda languages, files: [{"files": files}])
+    monkeypatch.setattr(pr_processing, "get_max_tokens", lambda model: 1_700)
+
+    try:
+        prepared = pr_processing.get_pr_diff(
+            provider,
+            token_handler,
+            prepared_model,
+            add_line_numbers_to_hunks=prepared_line_numbers,
+            return_remaining_files=True,
+            return_prepared=True,
+        )
+        assert isinstance(prepared, pr_processing.PreparedPRDiff)
+
+        pr_processing.get_pr_multi_diffs(
+            provider,
+            token_handler,
+            requested_model,
+            max_calls=3,
+            add_line_numbers=requested_line_numbers,
+            return_remaining_files=True,
+            prepared_diff=prepared,
+        )
+
+        assert (provider.diff_calls, provider.language_calls) == (2, 2)
+    finally:
+        settings.config.verbosity_level = original_verbosity_level
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/test_review_large_diff_chunking.py
+++ b/tests/unittest/test_review_large_diff_chunking.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pr_agent.algo.pr_processing import PreparedPRDiff
 from pr_agent.algo.review_finding_state import ParsedReviewState, reconcile_review_findings
 from pr_agent.config_loader import get_settings
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -121,6 +122,29 @@ async def test_a_truncated_diff_is_reviewed_chunk_by_chunk_and_merged(chunking_e
     assert reviewer.review_chunk_count == 2
     assert reviewer.review_failed_chunk_count == 0
     # the coverage footer keeps reporting what even chunking could not fit
+    assert reviewer.remaining_files_list == ["still_left_out.py"]
+
+
+@pytest.mark.asyncio
+async def test_chunked_review_reuses_the_prepared_diff_for_the_same_model_attempt(chunking_enabled):
+    reviewer = _make_reviewer()
+    reviewer._get_prediction = AsyncMock(side_effect=[CHUNK_A, CHUNK_B])
+    prepared = PreparedPRDiff(
+        diff="first compressed diff",
+        remaining_files_list=["b.py"],
+        file_dict={"a.py": {"patch": "chunk-a", "tokens": 10}},
+    )
+
+    with (
+        patch("pr_agent.tools.pr_reviewer.get_pr_diff", return_value=prepared) as get_pr_diff,
+        patch("pr_agent.tools.pr_reviewer.get_pr_multi_diffs",
+              return_value=(["chunk-a", "chunk-b"], ["still_left_out.py"])) as get_pr_multi_diffs,
+    ):
+        await reviewer._prepare_prediction("model")
+
+    assert get_pr_diff.call_args.kwargs["return_prepared"] is True
+    assert get_pr_multi_diffs.call_args.kwargs["prepared_diff"] is prepared
+    assert reviewer.review_chunk_count == 2
     assert reviewer.remaining_files_list == ["still_left_out.py"]
 
 


### PR DESCRIPTION
## Summary

Avoid duplicate diff preparation in the opt-in large-review chunking path.

`PRReviewer._prepare_prediction` now requests a request-scoped
`PreparedPRDiff`. When chunking is required, `get_pr_multi_diffs` reuses the
already converted and token-counted file patches instead of fetching and
preparing the same diff again.

The reuse is restricted to the same model, token handler, and line-number
format. Fallback attempts still prepare their own data.

Fixes #3290

## Benchmark

Docker test image, Python 3.12.14, 50 files, 38 changed lines per file,
8 output chunks, mock provider, 20 measured repetitions:

- wall p50: 59.169 ms -> 40.365 ms, 31.78% improvement
- wall p95: 60.104 ms -> 44.166 ms, 26.52% improvement
- token count calls: 226 -> 151
- Git provider diff/language calls: 2/2 -> 1/1
- chunk and remaining-file results unchanged

## Tests

- `pytest -q`: 4468 passed, 1 skipped, 1 xfailed
- focused chunking/diff tests: 32 passed
- `ruff check`: passed
- pre-commit: passed
- Docker test image build: passed
