### PR TITLE
chore: up dynaconf to 3.3.5 and fixes warns

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -3,6 +3,7 @@ import json
 import shlex
 from functools import partial
 
+import dynaconf
 from opentelemetry.trace import StatusCode
 
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
@@ -238,7 +239,7 @@ class PRAgent:
             get_logger().info(f'User has set the response language to: {response_language}')
             for key in get_settings():
                 setting = get_settings().get(key)
-                if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+                if isinstance(setting, dynaconf.DataDict):
                     if hasattr(setting, 'extra_instructions'):
                         current_extra_instructions = setting.extra_instructions
 

--- a/pr_agent/algo/artifacts.py
+++ b/pr_agent/algo/artifacts.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+import dynaconf
+
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
 
@@ -149,7 +151,7 @@ def inject_artifact_context() -> None:
         separator = "\n======\n\n"
         for key in get_settings():
             setting = get_settings().get(key)
-            if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+            if isinstance(setting, dynaconf.DataDict):
                 if key.lower() in target_tools and hasattr(setting, 'extra_instructions'):
                     extra_instructions = str(setting.extra_instructions or "")
                     if artifact_text not in extra_instructions:

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -12,7 +12,9 @@ current_dir = dirname(abspath(__file__))
 dynconf_kwargs = {'core_loaders': [], # DISABLE default loaders, otherwise will load toml files more than once.
                            'loaders': ['pr_agent.custom_merge_loader', 'dynaconf.loaders.env_loader'], # Use a custom loader to merge sections, but overwrite their overlapping values. Also support ENV variables to take precedence.
                            'root_path': join(current_dir, "settings"), #Used for Dynaconf.find_file() - So that root path points to settings folder, since we disabled all core loaders.
-                           'merge_enabled': True  # In case more than one file is sent, merge them. Must be set to True, otherwise, a .toml file with section [XYZ] overwrites the entire section of a previous .toml file's [XYZ] and we want it to only overwrite the overlapping fields under such section
+                           # Multi-file section-field merging is done by pr_agent.custom_merge_loader itself (it accumulates fields
+                           # across files and calls set() with a full section). Keeping dynaconf merge disabled makes settings.set()
+                           "merge_enabled": False
                            }
 global_settings = Dynaconf(
     envvar_prefix=False,

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -3,6 +3,8 @@ import json
 import os
 from typing import Union
 
+import dynaconf
+
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.algo.ai_handlers.litellm_helpers import (
     DEFAULT_CALLBACK_TIMEOUT_SECONDS,
@@ -190,7 +192,7 @@ async def run_action():
 
             for key in get_settings():
                 setting = get_settings().get(key)
-                if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+                if isinstance(setting, dynaconf.DataDict):
                     if key.lower() in ['pr_description', 'pr_code_suggestions', 'pr_reviewer']:
                         if hasattr(setting, 'extra_instructions'):
                             extra_instructions = setting.extra_instructions
@@ -328,8 +330,8 @@ async def run_action():
 
                 if url:
                     # handle_line_comments returns an argv list for /ask line
-                    # comments to bypass shell-style tokenisation; otherwise it
-                    # returns the raw comment string. Only normalise when the
+                    # comments to bypass shell-style tokenization; otherwise it
+                    # returns the raw comment string. Only normalize when the
                     # payload is a string, otherwise the argv list would be
                     # passed through .strip().lower() and raise AttributeError.
                     if isinstance(comment_body, str):
@@ -430,7 +432,7 @@ def _inject_ci_conclusion(conclusion):
     target_tools = {str(t).lower() for t in target_tools}
     for key in get_settings():
         setting = get_settings().get(key)
-        if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
+        if isinstance(setting, dynaconf.DataDict):
             if key.lower() in target_tools:
                 if hasattr(setting, "extra_instructions"):
                     extra_instructions = str(setting.extra_instructions or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "azure-identity==1.25.0",
   "boto3==1.43.78",
   "certifi>=2026.7.22",
-  "dynaconf>=3.2.13,<4",
+  "dynaconf>=3.3.5,<4",
   "fastapi>=0.141.1,<1",
   "GitPython>=3.1.59,<4",
   "starlette>=1.6.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -679,11 +679,11 @@ wheels = [
 
 [[package]]
 name = "dynaconf"
-version = "3.2.13"
+version = "3.3.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/0e/05927cf459e73f8bf9a9277cbea6f2d5b7db8a5cc9dc1e20e7a5fbac1b90/dynaconf-3.2.13.tar.gz", hash = "sha256:d79e0189d97b3f226b8ebb1717e2ce05d1a05cdf6ea05de66d24625fdb5a0cbd", size = 283507, upload-time = "2026-03-17T19:38:47.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/e4/723ba469856bb493c948985e5bd562c8a65f2b93e70c896e9764ab76de00/dynaconf-3.3.5.tar.gz", hash = "sha256:a08f6ab44025034ef3c9f86b32548ab01efd4039094a74bd9f028a43c63d016f", size = 333426, upload-time = "2026-08-05T19:50:25.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/43/11d6e5d2c00bf000b5329717c74563bf76a9193f4a41cb0c4ef277dde4fa/dynaconf-3.2.13-py2.py3-none-any.whl", hash = "sha256:4305527aef4834bdba3e39479b23c005186e83fb85f65bcaa4bcea58fa26759b", size = 238041, upload-time = "2026-03-17T19:38:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/95/41/b38501c34c40c3261868a2af8ed5fffe3e6d889c680638708de27eb57788/dynaconf-3.3.5-py3-none-any.whl", hash = "sha256:b3b4a753d5c866fc85466b65fc58d4954f6ed7dc8aa67f2b15bcbfd85d184687", size = 271426, upload-time = "2026-08-05T19:50:23.802Z" },
 ]
 
 [[package]]
@@ -2549,7 +2549,7 @@ requires-dist = [
     { name = "azure-identity", specifier = "==1.25.0" },
     { name = "boto3", specifier = "==1.43.78" },
     { name = "certifi", specifier = ">=2026.7.22" },
-    { name = "dynaconf", specifier = ">=3.2.13,<4" },
+    { name = "dynaconf", specifier = ">=3.3.5,<4" },
     { name = "fastapi", specifier = ">=0.141.1,<1" },
     { name = "giteapy", specifier = "==1.0.8" },
     { name = "gitpython", specifier = ">=3.1.59,<4" },


### PR DESCRIPTION
Hello

In PR:
1) up dynaconf from 3.2.13 to 3.3.5) https://github.com/dynaconf/dynaconf/compare/3.2.13...3.3.5 
2) fix warnings https://github.com/dynaconf/dynaconf/blob/master/dynaconf/utils/boxing.py#L16 
`class DynaBox(DataDict):
    def __init__(self, *args, **kwargs):
        warnings.warn(
            "DynaBox is deprecated and will be removed in 4.0.0,"
            " use dynaconf.DataDict instead.",
            DeprecationWarning,
            stacklevel=2,
        )
        super().__init__(*args, **kwargs)`
3) actualize behavior https://www.dynaconf.com/merging/