### PR TITLE
fix(improve): keep fallback suggestions in artifacts

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -1042,7 +1042,9 @@ class PRCodeSuggestions:
 
     async def push_inline_code_suggestions(self, data, include_coverage_footer: bool = True) -> None:
         code_suggestions = []
+        artifact_suggestions = []
         fallback_comments = []
+        artifact_batch_published = False
         coverage_footer = self._get_suggestions_coverage_footer() if include_coverage_footer else ""
         supports_suggestions_artifact = self.git_provider.supports_code_suggestions_artifact() is True
 
@@ -1113,20 +1115,26 @@ class PRCodeSuggestions:
                 elif requires_pr_fallback:
                     body += f"\n\nNot offered as a committable change because {fallback_reason}."
 
-            # Keep safety-rejected suggestions out of provider patch APIs while preserving standalone artifacts.
+            rendered_suggestion = {'body': body, 'relevant_file': relevant_file,
+                                   'relevant_lines_start': relevant_lines_start,
+                                   'relevant_lines_end': relevant_lines_end,
+                                   'original_suggestion': d}
+            if supports_suggestions_artifact:
+                artifact_suggestions.append(rendered_suggestion)
+
+            # Keep safety-rejected suggestions out of provider patch APIs and retain fallback recovery text.
             if not has_valid_anchor or (requires_pr_fallback and not supports_suggestions_artifact):
                 fallback_comments.append(f"{body}\n\nLocation: `{relevant_file}:"
                                          f"{relevant_lines_start}-{relevant_lines_end}`")
             else:
-                code_suggestions.append({'body': body, 'relevant_file': relevant_file,
-                                         'relevant_lines_start': relevant_lines_start,
-                                         'relevant_lines_end': relevant_lines_end,
-                                         'original_suggestion': d})
+                code_suggestions.append(rendered_suggestion)
 
-        if code_suggestions:
+        suggestions_to_publish = artifact_suggestions if supports_suggestions_artifact else code_suggestions
+        if suggestions_to_publish:
             if supports_suggestions_artifact:
                 is_successful = self.git_provider.publish_code_suggestions_artifact(
-                    code_suggestions, artifact_footer=coverage_footer)
+                    suggestions_to_publish, artifact_footer=coverage_footer)
+                artifact_batch_published = is_successful
             else:
                 is_successful = self.git_provider.publish_code_suggestions(code_suggestions)
             if is_successful:
@@ -1139,7 +1147,7 @@ class PRCodeSuggestions:
                         self._output_published = True
         if coverage_footer and not supports_suggestions_artifact:
             fallback_comments.append(coverage_footer.strip())
-        if fallback_comments:
+        if fallback_comments and not artifact_batch_published:
             self.git_provider.publish_comment("\n\n---\n\n".join(fallback_comments))
             self._output_published = True
         if code_suggestions and not is_successful:

--- a/tests/unittest/test_local_git_provider.py
+++ b/tests/unittest/test_local_git_provider.py
@@ -1,7 +1,7 @@
 import git
 import pytest
 
-from pr_agent.algo.types import EDIT_TYPE
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers.local_git_provider import LocalGitProvider
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
@@ -188,6 +188,44 @@ def test_publish_code_suggestions_artifact_includes_partial_coverage(tmp_path):
     content = improve_path.read_text()
     assert "No code suggestions found in the successfully analyzed chunks." in content
     assert "1 of 2 analysis chunks failed" in content
+
+
+@pytest.mark.asyncio
+async def test_mixed_suggestions_stay_in_improve_artifact(tmp_path):
+    improve_path = tmp_path / "improve.md"
+    review_path = tmp_path / "review.md"
+    provider = object.__new__(LocalGitProvider)
+    provider.improve_path = improve_path
+    provider.review_path = review_path
+    provider.diff_files = [FilePatchInfo(
+        base_file="old()\n",
+        head_file="old()\n",
+        patch="",
+        filename="app.py",
+    )]
+    tool = PRCodeSuggestions.__new__(PRCodeSuggestions)
+    tool.git_provider = provider
+    tool.progress_response = None
+
+    suggestion = {
+        "label": "maintainability",
+        "relevant_file": "app.py",
+        "suggestion_content": "Use the helper.",
+        "existing_code": "old()",
+        "improved_code": "new()",
+        "score": 8,
+    }
+    await tool.push_inline_code_suggestions({"code_suggestions": [
+        {**suggestion, "relevant_lines_start": 1, "relevant_lines_end": 1},
+        {**suggestion, "suggestion_content": "Keep this advice.",
+         "relevant_lines_start": 40, "relevant_lines_end": 40},
+    ]})
+
+    content = improve_path.read_text(encoding="utf-8")
+    assert content.index("Use the helper.") < content.index("Keep this advice.")
+    assert content.count("```suggestion") == 1
+    assert "because the anchored range is outside the file" in content
+    assert not review_path.exists()
 
 
 def test_publish_code_suggestions_uses_custom_heading_without_identity(tmp_path):


### PR DESCRIPTION
Follow-up to #3287.

## Summary

- publish anchorable and unanchorable suggestions together for standalone artifact providers
- preserve the existing hosted-provider and failed-publication fallback behavior
- cover the mixed case with an actual Local Git filesystem regression

## Result

For one anchorable and one unanchorable suggestion, `improve.md` now contains both entries in order and no separate `review.md` fallback file is created. The anchorable entry retains its suggestion fence; the unanchorable entry is rendered as noncommittable advice with its reason.

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_code_suggestions_core.py tests/unittest/test_pr_code_suggestions_lifecycle.py tests/unittest/test_local_git_provider.py -q` (160 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (7,520 passed, 33 skipped, 1 xfailed)
- `uv run pre-commit run --files pr_agent/tools/pr_code_suggestions.py tests/unittest/test_local_git_provider.py`
