### PR TITLE
fix(help): fit prompts for each attempted model

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3420,12 +3420,6 @@ class LiteLLMAIHandler(BaseAiHandler):
                 return value.strip().lower() in ("1", "true", "yes", "on")
             return default
 
-        def _as_int(value):
-            try:
-                return int(value)
-            except (TypeError, ValueError):
-                return 0
-
         provider_only = _as_list(openrouter_settings.get("provider_only", []))
         provider_order = _as_list(openrouter_settings.get("provider_order", []))
         if provider_only:
@@ -3439,7 +3433,7 @@ class LiteLLMAIHandler(BaseAiHandler):
         effective_reasoning_effort = str(
             openrouter_settings.get("reasoning_effort", "") or ""
         ).strip().lower()
-        reasoning_max_tokens = _as_int(openrouter_settings.get("reasoning_max_tokens", 0))
+        reasoning_max_tokens = self._coerce_token_value(openrouter_settings.get("reasoning_max_tokens", 0))
         if effective_reasoning_effort:
             try:
                 ReasoningEffort(effective_reasoning_effort)
@@ -3500,12 +3494,12 @@ class LiteLLMAIHandler(BaseAiHandler):
         if extra_body:
             kwargs["extra_body"] = extra_body
 
-        max_tokens = _as_int(openrouter_settings.get("max_tokens", 0))
+        max_tokens = self._coerce_token_value(openrouter_settings.get("max_tokens", 0))
         if max_tokens > 0:
-            existing = _as_int(kwargs.get("max_tokens", 0))
+            existing = self._coerce_token_value(kwargs.get("max_tokens", 0))
             kwargs["max_tokens"] = min(existing, max_tokens) if existing > 0 else max_tokens
-        effective_max_tokens = _as_int(kwargs.get("max_tokens", 0))
-        effective_reasoning_max_tokens = _as_int(reasoning.get("max_tokens", 0))
+        effective_max_tokens = self._coerce_token_value(kwargs.get("max_tokens", 0))
+        effective_reasoning_max_tokens = self._coerce_token_value(reasoning.get("max_tokens", 0))
         effective_reasoning_effort = reasoning.get("effort")
         if (
             model.startswith("openrouter/anthropic/")
@@ -3522,6 +3516,78 @@ class LiteLLMAIHandler(BaseAiHandler):
             )
         return kwargs
 
+    @staticmethod
+    def _coerce_token_value(value) -> int:
+        """Mirror the request's permissive integer coercion without conversion failures."""
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            return 0
+
+    def _claude_thinking_mode(self, model: str) -> str | None:
+        """Return the thinking mode selected by request construction for this model."""
+        adaptive_model = self._is_claude_adaptive_thinking_model(model)
+        if adaptive_model and self._claude_thinking_controls["enable_claude_adaptive_thinking"]:
+            return "adaptive"
+        if (
+            model in self.claude_extended_thinking_models
+            and self._claude_thinking_controls["enable_claude_extended_thinking"]
+        ):
+            return "unsupported_extended" if adaptive_model else "extended"
+        return None
+
+    def _get_claude_extended_thinking_limits(self) -> tuple[int, int]:
+        """Validate and return the snapshotted extended-thinking budget and output cap."""
+        extended_thinking_budget_tokens = self._claude_thinking_controls["extended_thinking_budget_tokens"]
+        extended_thinking_max_output_tokens = self._claude_thinking_controls["extended_thinking_max_output_tokens"]
+
+        if not isinstance(extended_thinking_budget_tokens, int) or extended_thinking_budget_tokens <= 0:
+            raise ValueError(
+                f"extended_thinking_budget_tokens must be a positive integer, "
+                f"got {extended_thinking_budget_tokens}"
+            )
+        if not isinstance(extended_thinking_max_output_tokens, int) or extended_thinking_max_output_tokens <= 0:
+            raise ValueError(
+                f"extended_thinking_max_output_tokens must be a positive integer, "
+                f"got {extended_thinking_max_output_tokens}"
+            )
+        if extended_thinking_max_output_tokens < extended_thinking_budget_tokens:
+            raise ValueError(
+                f"extended_thinking_max_output_tokens ({extended_thinking_max_output_tokens}) must be greater than "
+                f"or equal to extended_thinking_budget_tokens ({extended_thinking_budget_tokens})"
+            )
+        return extended_thinking_budget_tokens, extended_thinking_max_output_tokens
+
+    def _resolve_output_token_limit(self, model: str, openrouter_model: str | None) -> int:
+        """Return the final positive output cap selected by PR-Agent request controls."""
+        output_tokens = self._coerce_token_value(get_settings().config.get("max_output_tokens", 0))
+        if self._claude_thinking_mode(model) == "extended":
+            _, output_tokens = self._get_claude_extended_thinking_limits()
+
+        if openrouter_model:
+            openrouter_output_tokens = self._coerce_token_value(self._openrouter_controls.get("max_tokens", 0))
+            if openrouter_output_tokens > 0:
+                output_tokens = (
+                    min(output_tokens, openrouter_output_tokens)
+                    if output_tokens > 0
+                    else openrouter_output_tokens
+                )
+        return output_tokens if output_tokens > 0 else 0
+
+    def get_output_token_limit(self, model: str) -> int:
+        """Return the output cap that this handler will request for the supplied model."""
+        custom_llm_provider = self._custom_llm_provider
+        configured_deployment_id = self.deployment_id
+        routed_model = self._route_model_for_request(model, custom_llm_provider, configured_deployment_id)
+        completion_model = self._normalize_gpt5_model_for_request(routed_model, model, custom_llm_provider)
+        request_provider = (
+            PROVIDER_SETTING_ALIASES.get(custom_llm_provider, custom_llm_provider)
+            if custom_llm_provider
+            else self._resolve_request_provider(routed_model)
+        )
+        openrouter_model = self._canonical_openrouter_model(completion_model, request_provider)
+        return self._resolve_output_token_limit(completion_model, openrouter_model)
+
     def _configure_claude_extended_thinking(self, model: str, kwargs: dict) -> dict:
         """
         Configure Claude extended thinking parameters if applicable.
@@ -3533,16 +3599,9 @@ class LiteLLMAIHandler(BaseAiHandler):
         Returns:
             dict: Updated kwargs with extended thinking configuration
         """
-        extended_thinking_budget_tokens = self._claude_thinking_controls["extended_thinking_budget_tokens"]
-        extended_thinking_max_output_tokens = self._claude_thinking_controls["extended_thinking_max_output_tokens"]
-
-        # Validate extended thinking parameters
-        if not isinstance(extended_thinking_budget_tokens, int) or extended_thinking_budget_tokens <= 0:
-            raise ValueError(f"extended_thinking_budget_tokens must be a positive integer, got {extended_thinking_budget_tokens}")
-        if not isinstance(extended_thinking_max_output_tokens, int) or extended_thinking_max_output_tokens <= 0:
-            raise ValueError(f"extended_thinking_max_output_tokens must be a positive integer, got {extended_thinking_max_output_tokens}")
-        if extended_thinking_max_output_tokens < extended_thinking_budget_tokens:
-            raise ValueError(f"extended_thinking_max_output_tokens ({extended_thinking_max_output_tokens}) must be greater than or equal to extended_thinking_budget_tokens ({extended_thinking_budget_tokens})")
+        extended_thinking_budget_tokens, extended_thinking_max_output_tokens = (
+            self._get_claude_extended_thinking_limits()
+        )
 
         kwargs["thinking"] = {
             "type": "enabled",
@@ -3938,19 +3997,16 @@ class LiteLLMAIHandler(BaseAiHandler):
                 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
                 adaptive_thinking_enabled = self._claude_thinking_controls["enable_claude_adaptive_thinking"]
                 extended_thinking_enabled = self._claude_thinking_controls["enable_claude_extended_thinking"]
-                if self._is_claude_adaptive_thinking_model(model) and adaptive_thinking_enabled:
+                claude_thinking_mode = self._claude_thinking_mode(model)
+                if claude_thinking_mode == "adaptive":
                     kwargs = self._configure_claude_adaptive_thinking(model, kwargs)
-                elif (
-                    model in self.claude_extended_thinking_models
-                    and extended_thinking_enabled
-                ):
-                    if self._is_claude_adaptive_thinking_model(model):
-                        get_logger().warning(
-                            f"Skipping extended thinking for {model}: adaptive-only models reject "
-                            f"budget_tokens. Enable config.enable_claude_adaptive_thinking instead."
-                        )
-                    else:
-                        kwargs = self._configure_claude_extended_thinking(model, kwargs)
+                elif claude_thinking_mode == "extended":
+                    kwargs = self._configure_claude_extended_thinking(model, kwargs)
+                elif claude_thinking_mode == "unsupported_extended":
+                    get_logger().warning(
+                        f"Skipping extended thinking for {model}: adaptive-only models reject "
+                        f"budget_tokens. Enable config.enable_claude_adaptive_thinking instead."
+                    )
                 elif adaptive_thinking_enabled or extended_thinking_enabled:
                     message = (
                         f"No thinking configuration applied for model {model}: adaptive thinking "
@@ -3968,10 +4024,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 # providers apply a low service-side default (Bedrock Converse: 4096,
                 # which reasoning can fully consume, returning empty content).
                 # setdefault keeps the extended-thinking limit authoritative.
-                try:
-                    max_output_tokens = int(get_settings().config.get("max_output_tokens", 0))
-                except (TypeError, ValueError):
-                    max_output_tokens = 0
+                max_output_tokens = self._resolve_output_token_limit(model, openrouter_model)
                 if max_output_tokens > 0:
                     output_limit_param = "max_completion_tokens" if is_gpt6_astra else "max_tokens"
                     kwargs.setdefault(output_limit_param, max_output_tokens)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3588,6 +3588,13 @@ class LiteLLMAIHandler(BaseAiHandler):
         openrouter_model = self._canonical_openrouter_model(completion_model, request_provider)
         return self._resolve_output_token_limit(completion_model, openrouter_model)
 
+    @staticmethod
+    def normalize_request_prompts(model: str, system_prompt: str, user_prompt: str) -> tuple[str, str]:
+        """Return the prompt strings that request construction will send."""
+        if 'claude' in model and not system_prompt:
+            system_prompt = "No system prompt provided"
+        return system_prompt, user_prompt
+
     def _configure_claude_extended_thinking(self, model: str, kwargs: dict) -> dict:
         """
         Configure Claude extended thinking parameters if applicable.
@@ -3867,10 +3874,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                 # prefixes must remain intact in multi-provider configurations.
                 model = completion_model
                 openrouter_model = self._canonical_openrouter_model(model, request_provider)
-                if 'claude' in model and not system:
-                    system = "No system prompt provided"
+                normalized_system, user = self.normalize_request_prompts(model, system, user)
+                if normalized_system != system:
                     get_logger().warning(
                         "Empty system prompt for claude model. Adding a newline character to prevent OpenAI API error.")
+                system = normalized_system
                 messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
 
                 if img_path:

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3495,10 +3495,13 @@ class LiteLLMAIHandler(BaseAiHandler):
             kwargs["extra_body"] = extra_body
 
         max_tokens = self._coerce_token_value(openrouter_settings.get("max_tokens", 0))
+        output_limit_param = (
+            "max_completion_tokens" if "max_completion_tokens" in kwargs else "max_tokens"
+        )
         if max_tokens > 0:
-            existing = self._coerce_token_value(kwargs.get("max_tokens", 0))
-            kwargs["max_tokens"] = min(existing, max_tokens) if existing > 0 else max_tokens
-        effective_max_tokens = self._coerce_token_value(kwargs.get("max_tokens", 0))
+            existing = self._coerce_token_value(kwargs.get(output_limit_param, 0))
+            kwargs[output_limit_param] = min(existing, max_tokens) if existing > 0 else max_tokens
+        effective_max_tokens = self._coerce_token_value(kwargs.get(output_limit_param, 0))
         effective_reasoning_max_tokens = self._coerce_token_value(reasoning.get("max_tokens", 0))
         effective_reasoning_effort = reasoning.get("effort")
         if (
@@ -3587,6 +3590,39 @@ class LiteLLMAIHandler(BaseAiHandler):
         )
         openrouter_model = self._canonical_openrouter_model(completion_model, request_provider)
         return self._resolve_output_token_limit(completion_model, openrouter_model)
+
+    def get_output_token_reserve(self, model: str, default_output_tokens: int) -> int:
+        """Return completion headroom to reserve while fitting a request prompt."""
+        output_tokens = self.get_output_token_limit(model)
+        if output_tokens > 0:
+            return output_tokens
+
+        default_output_tokens = self._coerce_token_value(default_output_tokens)
+        custom_llm_provider = self._custom_llm_provider
+        routed_model = self._route_model_for_request(model, custom_llm_provider, self.deployment_id)
+        request_provider = (
+            PROVIDER_SETTING_ALIASES.get(custom_llm_provider, custom_llm_provider)
+            if custom_llm_provider
+            else self._resolve_request_provider(routed_model)
+        )
+        openrouter_model = self._canonical_openrouter_model(
+            routed_model, request_provider
+        )
+        if not openrouter_model:
+            return default_output_tokens
+
+        reasoning_effort = str(
+            self._openrouter_controls.get("reasoning_effort", "") or ""
+        ).strip().lower()
+        reasoning_effort = self._clamp_grok_reasoning_effort(
+            openrouter_model, reasoning_effort
+        )
+        reasoning_tokens = self._coerce_token_value(
+            self._openrouter_controls.get("reasoning_max_tokens", 0)
+        )
+        if reasoning_effort == "none" or reasoning_tokens <= 0:
+            return default_output_tokens
+        return default_output_tokens + reasoning_tokens
 
     @staticmethod
     def normalize_request_prompts(model: str, system_prompt: str, user_prompt: str) -> tuple[str, str]:

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -1,21 +1,27 @@
 import copy
 import re
 from functools import partial
+from math import ceil, isfinite
 from pathlib import Path
 
 from jinja2 import Environment, StrictUndefined, select_autoescape
+from litellm import token_counter
 
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
 from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
 from pr_agent.algo.pr_processing import retry_with_fallback_models
-from pr_agent.algo.token_handler import TokenHandler
-from pr_agent.algo.utils import ModelType, clip_tokens, get_max_tokens, load_yaml
+from pr_agent.algo.token_handler import TokenEncoder
+from pr_agent.algo.utils import ModelType, get_max_tokens, load_yaml
 from pr_agent.command_descriptions import COMMAND_DESCRIPTIONS
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider_with_context
 from pr_agent.log import get_logger
 
 DOCS_SITE_URL = "https://docs.pr-agent.ai"
+HELP_OUTPUT_TOKEN_RESERVE = 2_000
+MESSAGE_FRAMING_TOKEN_ALLOWANCE = 16
+REPLY_FRAMING_TOKEN_ALLOWANCE = 16
+TRUNCATION_MARKER = "\n...(truncated)\n"
 
 
 class PRHelpMessage:
@@ -29,13 +35,16 @@ class PRHelpMessage:
                 "question": self.question_str,
                 "snippets": "",
             }
-            self.token_handler = TokenHandler(None,
-                                              self.vars,
-                                              get_settings().pr_help_prompts.system,
-                                              get_settings().pr_help_prompts.user)
 
     async def _prepare_prediction(self, model: str):
         variables = copy.deepcopy(self.vars)
+        system_prompt, user_prompt = self._fit_prompts(variables, model)
+        response, finish_reason = await self.ai_handler.chat_completion(
+            model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
+        return response
+
+    @staticmethod
+    def _render_prompts(variables):
         # These string templates produce plain-text model prompts, not HTML.
         environment = Environment(
             autoescape=select_autoescape(default_for_string=False),
@@ -43,9 +52,88 @@ class PRHelpMessage:
         )
         system_prompt = environment.from_string(get_settings().pr_help_prompts.system).render(variables)
         user_prompt = environment.from_string(get_settings().pr_help_prompts.user).render(variables)
-        response, finish_reason = await self.ai_handler.chat_completion(
-            model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
-        return response
+        return system_prompt, user_prompt
+
+    @staticmethod
+    def _get_prompt_budget(model: str) -> int:
+        raw_output_tokens = get_settings().config.get("max_output_tokens", 0)
+        if isinstance(raw_output_tokens, int) and not isinstance(raw_output_tokens, bool):
+            output_tokens = raw_output_tokens
+        elif isinstance(raw_output_tokens, str) and re.fullmatch(r"[+-]?\d+", raw_output_tokens.strip()):
+            output_tokens = int(raw_output_tokens)
+        else:
+            output_tokens = 0
+        if output_tokens <= 0:
+            output_tokens = HELP_OUTPUT_TOKEN_RESERVE
+        return max(get_max_tokens(model, ignore_max_model_tokens=True) - output_tokens, 0)
+
+    @staticmethod
+    def _count_prompt_tokens(model: str, system_prompt: str, user_prompt: str) -> int:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        try:
+            model_token_count = token_counter(model=model, messages=messages)
+            if isinstance(model_token_count, int) and not isinstance(model_token_count, bool) and model_token_count > 0:
+                return model_token_count
+        except Exception as e:
+            get_logger().debug(f"Model-aware token counting failed for {model}: {e}")
+
+        get_logger().debug(f"Using a local token estimate for {model}")
+        encoder = TokenEncoder.get_token_encoder(model)
+        content_tokens = sum(
+            len(encoder.encode(message["content"], disallowed_special=())) for message in messages
+        )
+        framing_tokens = MESSAGE_FRAMING_TOKEN_ALLOWANCE * len(messages) + REPLY_FRAMING_TOKEN_ALLOWANCE
+        raw_factor = get_settings().get("config.model_token_count_estimate_factor", 0)
+        try:
+            extra_factor = float(raw_factor)
+        except (TypeError, ValueError, OverflowError):
+            extra_factor = 0
+        if isinstance(raw_factor, bool) or not isfinite(extra_factor):
+            extra_factor = 0
+        multiplier = max(1.0, 1.0 + extra_factor)
+        return ceil((content_tokens + framing_tokens) * multiplier)
+
+    def _fit_prompts(self, variables, model: str):
+        prompt_budget = self._get_prompt_budget(model)
+        raw_snippets = variables.get("snippets", "")
+
+        def render(snippets):
+            attempt_variables = copy.deepcopy(variables)
+            attempt_variables["snippets"] = snippets
+            return self._render_prompts(attempt_variables)
+
+        full_prompts = render(raw_snippets)
+        if self._count_prompt_tokens(model, *full_prompts) <= prompt_budget:
+            return full_prompts
+
+        empty_prompts = render("")
+        if self._count_prompt_tokens(model, *empty_prompts) > prompt_budget:
+            raise ValueError(f"The /help prompt exceeds the token limit for {model} without documentation")
+
+        marker_prompts = render(TRUNCATION_MARKER)
+        if self._count_prompt_tokens(model, *marker_prompts) > prompt_budget:
+            raise ValueError(f"The /help prompt exceeds the token limit for {model} with a truncation marker")
+
+        keep_chars = max(len(raw_snippets) - 1, 0)
+        while keep_chars > 0:
+            candidate = raw_snippets[:keep_chars].rstrip() + TRUNCATION_MARKER
+            candidate_prompts = render(candidate)
+            candidate_tokens = self._count_prompt_tokens(model, *candidate_prompts)
+            if candidate_tokens <= prompt_budget:
+                get_logger().warning(
+                    f"Documentation was clipped for /help to fit the {prompt_budget}-token input limit for {model}"
+                )
+                return candidate_prompts
+            next_keep_chars = max(1, int(keep_chars * prompt_budget / candidate_tokens))
+            keep_chars = min(keep_chars - 1, next_keep_chars)
+
+        get_logger().warning(
+            f"Documentation was clipped for /help to fit the {prompt_budget}-token input limit for {model}"
+        )
+        return marker_prompts
 
     def parse_args(self, args):
         if args and len(args) > 0:
@@ -125,16 +213,6 @@ class PRHelpMessage:
                             docs_prompt += f"\n==file name==\n\n{file_path}\n\n==file content==\n\n{f.read().strip()}\n=========\n\n"
                     except Exception as e:
                         get_logger().error(f"Error while reading the file {file}: {e}")
-                token_count = self.token_handler.count_tokens(docs_prompt)
-                get_logger().debug(f"Token count of full documentation website: {token_count}")
-
-                # take the actual max tokens, without any reductions. we do aim to get
-                # the full documentation website in the prompt
-                max_tokens_full = get_max_tokens(get_settings().config.model, ignore_max_model_tokens=True)
-                delta_output = 2000
-                if token_count > max_tokens_full - delta_output:
-                    get_logger().info(f"Token count {token_count} exceeds the limit {max_tokens_full - delta_output}. Skipping the PR Help message.")
-                    docs_prompt = clip_tokens(docs_prompt, max_tokens_full - delta_output)
                 self.vars['snippets'] = docs_prompt.strip()
 
                 # run the AI model

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -55,14 +55,31 @@ class PRHelpMessage:
         return system_prompt, user_prompt
 
     @staticmethod
-    def _get_prompt_budget(model: str) -> int:
-        raw_output_tokens = get_settings().config.get("max_output_tokens", 0)
-        if isinstance(raw_output_tokens, int) and not isinstance(raw_output_tokens, bool):
-            output_tokens = raw_output_tokens
-        elif isinstance(raw_output_tokens, str) and re.fullmatch(r"[+-]?\d+", raw_output_tokens.strip()):
-            output_tokens = int(raw_output_tokens)
-        else:
-            output_tokens = 0
+    def _coerce_output_token_limit(value) -> int:
+        try:
+            output_tokens = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return 0
+        return output_tokens if output_tokens > 0 else 0
+
+    def _get_prompt_budget(self, model: str) -> int:
+        output_tokens = 0
+        get_output_token_limit = getattr(self.ai_handler, "get_output_token_limit", None)
+        if callable(get_output_token_limit):
+            try:
+                handler_output_tokens = get_output_token_limit(model)
+            except Exception as e:
+                get_logger().debug(f"Failed to resolve the output token limit for {model}: {e}")
+            else:
+                if (
+                    isinstance(handler_output_tokens, int)
+                    and not isinstance(handler_output_tokens, bool)
+                    and handler_output_tokens > 0
+                ):
+                    output_tokens = handler_output_tokens
+        if output_tokens <= 0:
+            raw_output_tokens = get_settings().config.get("max_output_tokens", 0)
+            output_tokens = self._coerce_output_token_limit(raw_output_tokens)
         if output_tokens <= 0:
             output_tokens = HELP_OUTPUT_TOKEN_RESERVE
         return max(get_max_tokens(model, ignore_max_model_tokens=True) - output_tokens, 0)

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -111,7 +111,35 @@ class PRHelpMessage:
         if isinstance(raw_factor, bool) or not isfinite(extra_factor):
             extra_factor = 0
         multiplier = max(1.0, 1.0 + extra_factor)
-        return ceil((content_tokens + framing_tokens) * multiplier)
+        raw_estimate = content_tokens + framing_tokens
+        try:
+            estimated_tokens = raw_estimate * multiplier
+            if not isfinite(estimated_tokens):
+                raise ValueError("non-finite token estimate")
+            return ceil(estimated_tokens)
+        except (OverflowError, ValueError):
+            get_logger().warning(
+                f"model_token_count_estimate_factor is too large ({raw_factor!r}), using the estimate as is"
+            )
+            return raw_estimate
+
+    def _normalize_request_prompts(self, model: str, system_prompt: str, user_prompt: str) -> tuple[str, str]:
+        normalize_request_prompts = getattr(self.ai_handler, "normalize_request_prompts", None)
+        if not callable(normalize_request_prompts):
+            return system_prompt, user_prompt
+        try:
+            normalized_prompts = normalize_request_prompts(model, system_prompt, user_prompt)
+        except Exception as e:
+            get_logger().debug(f"Failed to normalize prompts for {model}: {e}")
+            return system_prompt, user_prompt
+        if (
+            isinstance(normalized_prompts, tuple)
+            and len(normalized_prompts) == 2
+            and all(isinstance(prompt, str) for prompt in normalized_prompts)
+        ):
+            return normalized_prompts
+        get_logger().debug(f"Ignoring unusable prompt normalization result for {model}")
+        return system_prompt, user_prompt
 
     def _fit_prompts(self, variables, model: str):
         prompt_budget = self._get_prompt_budget(model)
@@ -120,7 +148,8 @@ class PRHelpMessage:
         def render(snippets):
             attempt_variables = copy.deepcopy(variables)
             attempt_variables["snippets"] = snippets
-            return self._render_prompts(attempt_variables)
+            rendered_prompts = self._render_prompts(attempt_variables)
+            return self._normalize_request_prompts(model, *rendered_prompts)
 
         full_prompts = render(raw_snippets)
         if self._count_prompt_tokens(model, *full_prompts) <= prompt_budget:

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -64,8 +64,21 @@ class PRHelpMessage:
 
     def _get_prompt_budget(self, model: str) -> int:
         output_tokens = 0
+        get_output_token_reserve = getattr(self.ai_handler, "get_output_token_reserve", None)
+        if callable(get_output_token_reserve):
+            try:
+                handler_output_tokens = get_output_token_reserve(model, HELP_OUTPUT_TOKEN_RESERVE)
+            except Exception as e:
+                get_logger().debug(f"Failed to resolve the output token reserve for {model}: {e}")
+            else:
+                if (
+                    isinstance(handler_output_tokens, int)
+                    and not isinstance(handler_output_tokens, bool)
+                    and handler_output_tokens > 0
+                ):
+                    output_tokens = handler_output_tokens
         get_output_token_limit = getattr(self.ai_handler, "get_output_token_limit", None)
-        if callable(get_output_token_limit):
+        if output_tokens <= 0 and callable(get_output_token_limit):
             try:
                 handler_output_tokens = get_output_token_limit(model)
             except Exception as e:

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -86,6 +86,22 @@ async def test_chat_completion_passes_seed_when_temperature_is_zero(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_claude_empty_system_prompt_uses_public_request_normalization(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        expected_prompts = handler.normalize_request_prompts("claude-sonnet-4-5", "", "usr")
+
+        await handler.chat_completion(model="claude-sonnet-4-5", system="", user="usr")
+
+    messages = mock_call.call_args.kwargs["messages"]
+    assert expected_prompts == ("No system prompt provided", "usr")
+    assert (messages[0]["content"], messages[1]["content"]) == expected_prompts
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_probes_images_off_loop_with_timeout(monkeypatch):
     monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
     loop_thread = threading.get_ident()

--- a/tests/unittest/test_litellm_max_output_tokens.py
+++ b/tests/unittest/test_litellm_max_output_tokens.py
@@ -59,7 +59,7 @@ def test_fixture_clears_and_restores_ambient_litellm_key(monkeypatch):
     assert litellm.api_key == "test-ambient-key"
 
 
-def _make_settings(config_values=None):
+def _make_settings(config_values=None, openrouter=None, custom_llm_provider=""):
     """Minimal settings whose `config.get(key, ...)` serves the given dict."""
     config_values = config_values or {}
     settings_values = {
@@ -82,9 +82,12 @@ def _make_settings(config_values=None):
     return type("Settings", (), {
         "config": Config(),
         "litellm": type("LiteLLM", (), {
+            "custom_llm_provider": custom_llm_provider,
             "get": lambda self, key, default=None: default,
         })(),
-        "get": lambda self, key, default=None: settings_values.get(key, default),
+        "get": lambda self, key, default=None: (
+            (openrouter or {}) if key == "openrouter" else settings_values.get(key, default)
+        ),
     })()
 
 
@@ -96,22 +99,28 @@ def _mock_response():
     return mock
 
 
-async def _run(monkeypatch, model, config_values):
-    monkeypatch.setattr(litellm_handler, "get_settings", lambda: _make_settings(config_values))
+async def _run(monkeypatch, model, config_values, openrouter=None, custom_llm_provider=""):
+    monkeypatch.setattr(
+        litellm_handler,
+        "get_settings",
+        lambda: _make_settings(config_values, openrouter, custom_llm_provider),
+    )
     with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
                new_callable=AsyncMock) as mock_call:
         mock_call.return_value = _mock_response()
         handler = litellm_handler.LiteLLMAIHandler()
+        exposed_limit = handler.get_output_token_limit(model)
         await handler.chat_completion(model=model, system="sys", user="usr")
-    return mock_call.call_args[1]
+    return mock_call.call_args[1], exposed_limit
 
 
 class TestMaxOutputTokens:
 
     @pytest.mark.asyncio
     async def test_default_sends_no_max_tokens(self, monkeypatch):
-        kwargs = await _run(monkeypatch, "bedrock/anthropic.claude-sonnet-5-v1:0", {})
+        kwargs, exposed_limit = await _run(monkeypatch, "bedrock/anthropic.claude-sonnet-5-v1:0", {})
         assert "max_tokens" not in kwargs
+        assert exposed_limit == 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("model", [
@@ -119,28 +128,167 @@ class TestMaxOutputTokens:
         "gpt-4o",
     ])
     async def test_positive_value_sent_as_max_tokens(self, monkeypatch, model):
-        kwargs = await _run(monkeypatch, model, {"max_output_tokens": 16000})
+        kwargs, exposed_limit = await _run(monkeypatch, model, {"max_output_tokens": 16000})
         assert kwargs["max_tokens"] == 16000
+        assert exposed_limit == 16000
 
     @pytest.mark.asyncio
     async def test_extended_thinking_limit_stays_authoritative(self, monkeypatch):
-        kwargs = await _run(monkeypatch, "claude-3-7-sonnet-20250219", {
+        kwargs, exposed_limit = await _run(monkeypatch, "claude-3-7-sonnet-20250219", {
             "max_output_tokens": 16000,
             "enable_claude_extended_thinking": True,
             "extended_thinking_budget_tokens": 2048,
             "extended_thinking_max_output_tokens": 4096,
         })
         assert kwargs["max_tokens"] == 4096
+        assert exposed_limit == 4096
         assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 2048}
 
     @pytest.mark.asyncio
     async def test_string_override_is_coerced(self, monkeypatch):
         # Dynaconf/env overrides can arrive as strings.
-        kwargs = await _run(monkeypatch, "gpt-4o", {"max_output_tokens": "16000"})
+        kwargs, exposed_limit = await _run(monkeypatch, "gpt-4o", {"max_output_tokens": "16000"})
+        assert kwargs["max_tokens"] == 16000
+        assert exposed_limit == 16000
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["16k", None, 0, -1, float("nan"), float("inf"), "1" * 5_000])
+    async def test_unset_or_invalid_values_send_nothing(self, monkeypatch, value):
+        kwargs, exposed_limit = await _run(monkeypatch, "gpt-4o", {"max_output_tokens": value})
+        assert "max_tokens" not in kwargs
+        assert exposed_limit == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("value", "expected"), [(400.5, 400), (True, 1), (False, 0)])
+    async def test_existing_int_coercion_is_preserved(self, monkeypatch, value, expected):
+        kwargs, exposed_limit = await _run(monkeypatch, "gpt-4o", {"max_output_tokens": value})
+
+        assert exposed_limit == expected
+        if expected:
+            assert kwargs["max_tokens"] == expected
+        else:
+            assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "custom_llm_provider"),
+        [
+            ("openrouter/google/gemini-2.5-pro", ""),
+            ("google/gemini-2.5-pro", "openrouter"),
+        ],
+    )
+    async def test_openrouter_only_limit_is_exposed_and_sent(
+        self, monkeypatch, model, custom_llm_provider
+    ):
+        kwargs, exposed_limit = await _run(
+            monkeypatch,
+            model,
+            {},
+            openrouter={"max_tokens": 16000},
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        assert exposed_limit == 16000
         assert kwargs["max_tokens"] == 16000
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("value", ["16k", None, 0, -1])
-    async def test_unset_or_invalid_values_send_nothing(self, monkeypatch, value):
-        kwargs = await _run(monkeypatch, "gpt-4o", {"max_output_tokens": value})
-        assert "max_tokens" not in kwargs
+    async def test_openrouter_limit_caps_general_limit(self, monkeypatch):
+        kwargs, exposed_limit = await _run(
+            monkeypatch,
+            "openrouter/google/gemini-2.5-pro",
+            {"max_output_tokens": 16000},
+            openrouter={"max_tokens": 4096},
+        )
+
+        assert exposed_limit == 4096
+        assert kwargs["max_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_openrouter_limit_caps_extended_thinking_limit(self, monkeypatch):
+        model = "openrouter/anthropic/claude-3-7-sonnet-20250219"
+        kwargs, exposed_limit = await _run(
+            monkeypatch,
+            model,
+            {
+                "max_output_tokens": 16000,
+                "enable_claude_extended_thinking": True,
+                "extended_thinking_budget_tokens": 1024,
+                "extended_thinking_max_output_tokens": 4096,
+                "claude_extended_thinking_models_override": [model],
+            },
+            openrouter={"max_tokens": 2048},
+        )
+
+        assert exposed_limit == 2048
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+        assert kwargs["max_tokens"] == 2048
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("adaptive_enabled", [True, False])
+    async def test_adaptive_only_model_never_uses_legacy_extended_limit(
+        self, monkeypatch, adaptive_enabled
+    ):
+        model = "anthropic/claude-opus-5"
+        kwargs, exposed_limit = await _run(monkeypatch, model, {
+            "max_output_tokens": 16000,
+            "enable_claude_adaptive_thinking": adaptive_enabled,
+            "enable_claude_extended_thinking": True,
+            "extended_thinking_budget_tokens": 2048,
+            "extended_thinking_max_output_tokens": 4096,
+            "claude_extended_thinking_models_override": [model],
+        })
+
+        assert exposed_limit == 16000
+        assert kwargs["max_tokens"] == 16000
+        if adaptive_enabled:
+            assert kwargs["thinking"] == {"type": "adaptive"}
+        else:
+            assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_general_limit_is_live_while_handler_controls_are_snapshots(self, monkeypatch):
+        model = "openrouter/google/gemini-2.5-pro"
+        config_values = {"max_output_tokens": 16000}
+        openrouter = {"max_tokens": 4096}
+        active_settings = _make_settings(config_values, openrouter)
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: active_settings)
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        config_values["max_output_tokens"] = 2048
+        openrouter["max_tokens"] = 1024
+
+        with patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_call:
+            mock_call.return_value = _mock_response()
+            assert handler.get_output_token_limit(model) == 2048
+            await handler.chat_completion(model=model, system="sys", user="usr")
+
+        assert mock_call.call_args.kwargs["max_tokens"] == 2048
+
+    @pytest.mark.asyncio
+    async def test_extended_thinking_limit_is_snapshotted_for_accessor_and_request(self, monkeypatch):
+        model = "claude-3-7-sonnet-20250219"
+        config_values = {
+            "enable_claude_extended_thinking": True,
+            "extended_thinking_budget_tokens": 1024,
+            "extended_thinking_max_output_tokens": 4096,
+        }
+        active_settings = _make_settings(config_values)
+        monkeypatch.setattr(litellm_handler, "get_settings", lambda: active_settings)
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        config_values["extended_thinking_budget_tokens"] = 2048
+        config_values["extended_thinking_max_output_tokens"] = 8192
+
+        with patch(
+            "pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion",
+            new_callable=AsyncMock,
+        ) as mock_call:
+            mock_call.return_value = _mock_response()
+            assert handler.get_output_token_limit(model) == 4096
+            await handler.chat_completion(model=model, system="sys", user="usr")
+
+        assert mock_call.call_args.kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+        assert mock_call.call_args.kwargs["max_tokens"] == 4096

--- a/tests/unittest/test_litellm_max_output_tokens.py
+++ b/tests/unittest/test_litellm_max_output_tokens.py
@@ -99,7 +99,14 @@ def _mock_response():
     return mock
 
 
-async def _run(monkeypatch, model, config_values, openrouter=None, custom_llm_provider=""):
+async def _run(
+    monkeypatch,
+    model,
+    config_values,
+    openrouter=None,
+    custom_llm_provider="",
+    reserve_default=None,
+):
     monkeypatch.setattr(
         litellm_handler,
         "get_settings",
@@ -110,8 +117,14 @@ async def _run(monkeypatch, model, config_values, openrouter=None, custom_llm_pr
         mock_call.return_value = _mock_response()
         handler = litellm_handler.LiteLLMAIHandler()
         exposed_limit = handler.get_output_token_limit(model)
+        exposed_reserve = (
+            handler.get_output_token_reserve(model, reserve_default)
+            if reserve_default is not None
+            else None
+        )
         await handler.chat_completion(model=model, system="sys", user="usr")
-    return mock_call.call_args[1], exposed_limit
+    result = (mock_call.call_args[1], exposed_limit)
+    return (*result, exposed_reserve) if reserve_default is not None else result
 
 
 class TestMaxOutputTokens:
@@ -202,6 +215,66 @@ class TestMaxOutputTokens:
 
         assert exposed_limit == 4096
         assert kwargs["max_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("config_values", "openrouter", "expected_limit", "expected_reserve"),
+        [
+            ({}, {"reasoning_max_tokens": 4096}, 0, 6096),
+            ({"max_output_tokens": 8000}, {"reasoning_max_tokens": 4096}, 8000, 8000),
+            ({}, {"reasoning_max_tokens": 4096, "reasoning_effort": "none"}, 0, 2000),
+        ],
+    )
+    async def test_openrouter_reasoning_expands_only_the_default_reserve(
+        self,
+        monkeypatch,
+        config_values,
+        openrouter,
+        expected_limit,
+        expected_reserve,
+    ):
+        kwargs, exposed_limit, exposed_reserve = await _run(
+            monkeypatch,
+            "openrouter/google/gemini-2.5-pro",
+            config_values,
+            openrouter=openrouter,
+            reserve_default=2000,
+        )
+
+        assert exposed_limit == expected_limit
+        assert exposed_reserve == expected_reserve
+        if openrouter.get("reasoning_effort") == "none":
+            assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+        else:
+            assert kwargs["extra_body"]["reasoning"] == {"max_tokens": 4096}
+
+    @pytest.mark.asyncio
+    async def test_openrouter_grok_clamped_none_still_reserves_reasoning(self, monkeypatch):
+        kwargs, exposed_limit, exposed_reserve = await _run(
+            monkeypatch,
+            "openrouter/x-ai/grok-4.6",
+            {},
+            openrouter={"reasoning_max_tokens": 8000, "reasoning_effort": "none"},
+            reserve_default=2000,
+        )
+
+        assert exposed_limit == 0
+        assert exposed_reserve == 10000
+        assert kwargs["extra_body"]["reasoning"] == {"max_tokens": 8000}
+
+    @pytest.mark.asyncio
+    async def test_openrouter_astra_uses_one_capped_output_limit(self, monkeypatch):
+        kwargs, exposed_limit = await _run(
+            monkeypatch,
+            "gpt-6-astra",
+            {"max_output_tokens": 16000},
+            openrouter={"max_tokens": 4096},
+            custom_llm_provider="openrouter",
+        )
+
+        assert exposed_limit == 4096
+        assert kwargs["max_completion_tokens"] == 4096
+        assert "max_tokens" not in kwargs
 
     @pytest.mark.asyncio
     async def test_openrouter_limit_caps_extended_thinking_limit(self, monkeypatch):

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -156,12 +156,13 @@ async def test_each_attempt_fits_complete_prompt_for_its_model(help_tool, monkey
         (-1, 1_000),
         (None, 1_000),
         ("invalid", 1_000),
-        (400.0, 1_000),
-        (400.5, 1_000),
+        (400.0, 2_600),
+        (400.5, 2_600),
         (float("nan"), 1_000),
         (float("inf"), 1_000),
-        (True, 1_000),
+        (True, 2_999),
         (False, 1_000),
+        ("1" * 5_000, 1_000),
     ],
 )
 def test_prompt_budget_honors_positive_output_limit_or_help_default(
@@ -172,6 +173,38 @@ def test_prompt_budget_honors_positive_output_limit_or_help_default(
     monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
 
     assert tool._get_prompt_budget(PRIMARY) == expected_budget
+
+
+def test_prompt_budget_uses_handler_reported_output_limit(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+    get_settings().set("config.max_output_tokens", 400)
+    tool.ai_handler.get_output_token_limit = Mock(return_value=1_600)
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
+
+    assert tool._get_prompt_budget(PRIMARY) == 1_400
+    tool.ai_handler.get_output_token_limit.assert_called_once_with(PRIMARY)
+
+
+@pytest.mark.parametrize("reported_limit", [None, 0, -1, True, 1.5, "1600"])
+def test_unusable_handler_output_limit_falls_back_to_config(
+    help_tool, monkeypatch, reported_limit
+):
+    tool, _, _ = help_tool
+    get_settings().set("config.max_output_tokens", 400)
+    tool.ai_handler.get_output_token_limit = Mock(return_value=reported_limit)
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
+
+    assert tool._get_prompt_budget(PRIMARY) == 2_600
+
+
+def test_failing_handler_output_limit_falls_back_to_config(help_tool, monkeypatch):
+    tool, _, logger = help_tool
+    get_settings().set("config.max_output_tokens", 400)
+    tool.ai_handler.get_output_token_limit = Mock(side_effect=RuntimeError("unavailable"))
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
+
+    assert tool._get_prompt_budget(PRIMARY) == 2_600
+    assert any("output token limit" in call.args[0] for call in logger.debug.call_args_list)
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -239,7 +239,7 @@ def test_local_prompt_estimate_never_reduces_encoded_content(
     assert tool._count_prompt_tokens(PRIMARY, "abc", "de") == expected
 
 
-def test_local_prompt_estimate_fails_closed_on_overflow(help_tool, monkeypatch):
+def test_local_prompt_estimate_uses_raw_estimate_on_overflow(help_tool, monkeypatch):
     tool, _, _ = help_tool
 
     class CharacterEncoder:
@@ -251,8 +251,7 @@ def test_local_prompt_estimate_fails_closed_on_overflow(help_tool, monkeypatch):
     monkeypatch.setattr(pr_help_message, "token_counter", Mock(side_effect=RuntimeError("counter unavailable")))
     monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder())
 
-    with pytest.raises(OverflowError):
-        tool._count_prompt_tokens(PRIMARY, "abc", "de")
+    assert tool._count_prompt_tokens(PRIMARY, "abc", "de") == 53
 
 
 @pytest.mark.parametrize("counter_mode", ["error", "zero", "boolean", "non_integer"])
@@ -287,7 +286,7 @@ async def test_unusable_model_count_uses_local_estimate_before_provider_call(
     assert len(user_prompt) + 48 <= 70
 
 
-async def test_local_estimate_overflow_skips_provider_and_tries_fallback(help_tool, monkeypatch):
+async def test_local_estimate_overflow_still_tries_providers(help_tool, monkeypatch):
     tool, details, _ = help_tool
 
     class CharacterEncoder:
@@ -299,12 +298,40 @@ async def test_local_estimate_overflow_skips_provider_and_tries_fallback(help_to
     monkeypatch.setattr(pr_help_message, "token_counter", Mock(side_effect=RuntimeError("counter unavailable")))
     monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder())
     tool._prepare_prediction = AsyncMock(wraps=tool._prepare_prediction)
+    tool.ai_handler.chat_completion.side_effect = [RuntimeError("primary unavailable"), (ANSWER, "stop")]
 
-    assert await tool.run() == ""
+    await tool.run()
 
     assert [call.args[0] for call in tool._prepare_prediction.await_args_list] == [PRIMARY, BACKUP]
-    tool.ai_handler.chat_completion.assert_not_awaited()
-    assert details.model_used is None
+    assert attempted_models(tool) == [PRIMARY, BACKUP]
+    tool.git_provider.publish_comment.assert_called_once()
+    assert details.model_used == BACKUP
+
+
+async def test_empty_claude_system_prompt_is_normalized_before_fitting(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+    model = "anthropic/claude-sonnet-4-5"
+    tool.vars = {"question": "q", "snippets": "A" * 100}
+    get_settings().set("pr_help_prompts.system", "")
+    get_settings().set("pr_help_prompts.user", "{{ snippets }}")
+    monkeypatch.setattr(tool, "_get_prompt_budget", lambda _model: 80)
+    tool.ai_handler.normalize_request_prompts = pr_help_message.LiteLLMAIHandler.normalize_request_prompts
+    counted_system_prompts = []
+
+    def count_normalized_prompts(*, messages, **_kwargs):
+        counted_system_prompts.append(messages[0]["content"])
+        return count_message_characters(messages=messages)
+
+    monkeypatch.setattr(pr_help_message, "token_counter", count_normalized_prompts)
+    tool.ai_handler.chat_completion.return_value = ANSWER, "stop"
+
+    await tool._prepare_prediction(model)
+
+    assert counted_system_prompts
+    assert set(counted_system_prompts) == {"No system prompt provided"}
+    call = tool.ai_handler.chat_completion.await_args
+    assert call.kwargs["system"] == "No system prompt provided"
+    assert "...(truncated)" in call.kwargs["user"]
 
 
 def test_prompt_fitting_checks_smallest_nonempty_prefix(help_tool, monkeypatch):

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -1,6 +1,7 @@
 """Question-mode help delegates failed attempts to the shared fallback loop."""
 
 import asyncio
+from math import ceil
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -28,13 +29,15 @@ def help_tool(tmp_path, monkeypatch):
         "config.model": PRIMARY,
         "config.fallback_models": [BACKUP],
         "config.publish_output": True,
+        "config.max_output_tokens": 0,
+        "config.model_token_count_estimate_factor": 0,
         "model_routing.enable": False,
         # Keep this regression independent of the separate OpenAI-key gate fix.
         "openai.key": "test-only-key",
         "openai.deployment_id": "primary-deployment",
         "openai.fallback_deployments": ["backup-deployment"],
     }
-    snapshot = snapshot_settings([*overrides, "pr_help_prompts.user"])
+    snapshot = snapshot_settings([*overrides, "pr_help_prompts.system", "pr_help_prompts.user"])
     for key, value in overrides.items():
         get_settings().set(key, value)
 
@@ -53,7 +56,7 @@ def help_tool(tmp_path, monkeypatch):
     tool.question_str = "How do I configure automatic reviews?"
     tool.return_as_string = False
     tool.vars = {"question": tool.question_str, "snippets": ""}
-    tool.token_handler = SimpleNamespace(count_tokens=len)
+    tool._fixture_doc = doc
     try:
         yield tool, details, logger
     finally:
@@ -62,6 +65,10 @@ def help_tool(tmp_path, monkeypatch):
 
 def attempted_models(tool):
     return [call.kwargs["model"] for call in tool.ai_handler.chat_completion.await_args_list]
+
+
+def count_message_characters(*, messages, **_kwargs):
+    return sum(len(message["content"]) for message in messages)
 
 
 async def test_model_prompt_preserves_question_and_documentation_markup(help_tool):
@@ -96,6 +103,240 @@ async def test_primary_failure_uses_backup_answer(help_tool):
     assert details.model_used == BACKUP
     assert details.fallback_used is True
     assert get_settings().get("openai.deployment_id") == "primary-deployment"
+
+
+async def test_each_attempt_fits_complete_prompt_for_its_model(help_tool, monkeypatch):
+    tool, details, _ = help_tool
+    tool._fixture_doc.write_text("# Automatic review\n\n" + "A" * 600, encoding="utf-8")
+    get_settings().set("pr_help_prompts.system", "system")
+    get_settings().set("pr_help_prompts.user", "question={{ question }}\nsnippets={{ snippets }}")
+    get_settings().set("config.max_output_tokens", 20)
+    limits = {PRIMARY: 2_000, BACKUP: 260}
+    limit_calls = []
+    counted_models = []
+
+    def model_limit(model, ignore_max_model_tokens=False):
+        limit_calls.append((model, ignore_max_model_tokens))
+        return limits[model]
+
+    def model_token_count(*, model, messages):
+        counted_models.append(model)
+        character_count = count_message_characters(messages=messages)
+        return character_count if model == PRIMARY else character_count * 2
+
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", model_limit)
+    monkeypatch.setattr(pr_help_message, "token_counter", model_token_count)
+    tool.ai_handler.chat_completion.side_effect = [RuntimeError("primary unavailable"), (ANSWER, "stop")]
+
+    await tool.run()
+
+    assert attempted_models(tool) == [PRIMARY, BACKUP]
+    primary_prompt = tool.ai_handler.chat_completion.await_args_list[0].kwargs["user"]
+    backup_prompt = tool.ai_handler.chat_completion.await_args_list[1].kwargs["user"]
+    assert "A" * 600 in primary_prompt
+    assert "...(truncated)" not in primary_prompt
+    assert "A" * 600 not in backup_prompt
+    assert "...(truncated)" in backup_prompt
+    assert "==file name==" in backup_prompt
+    assert "/tools/review.md" in backup_prompt
+    assert 2 * (len(backup_prompt) + len("system")) <= limits[BACKUP] - 20
+    assert "A" * 600 in tool.vars["snippets"]
+    assert limit_calls == [(PRIMARY, True), (BACKUP, True)]
+    assert PRIMARY in counted_models
+    assert BACKUP in counted_models
+    assert details.model_used == BACKUP
+
+
+@pytest.mark.parametrize(
+    ("configured_output", "expected_budget"),
+    [
+        (400, 2_600),
+        ("400", 2_600),
+        (0, 1_000),
+        (-1, 1_000),
+        (None, 1_000),
+        ("invalid", 1_000),
+        (400.0, 1_000),
+        (400.5, 1_000),
+        (float("nan"), 1_000),
+        (float("inf"), 1_000),
+        (True, 1_000),
+        (False, 1_000),
+    ],
+)
+def test_prompt_budget_honors_positive_output_limit_or_help_default(
+    help_tool, monkeypatch, configured_output, expected_budget
+):
+    tool, _, _ = help_tool
+    get_settings().set("config.max_output_tokens", configured_output)
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
+
+    assert tool._get_prompt_budget(PRIMARY) == expected_budget
+
+
+@pytest.mark.parametrize(
+    ("estimate_factor", "expected"),
+    [
+        (-0.5, 53),
+        (0, 53),
+        (None, 53),
+        ("invalid", 53),
+        (float("nan"), 53),
+        (float("inf"), 53),
+        (True, 53),
+        (0.3, ceil(53 * 1.3)),
+    ],
+)
+def test_local_prompt_estimate_never_reduces_encoded_content(
+    help_tool, monkeypatch, estimate_factor, expected
+):
+    tool, _, _ = help_tool
+
+    class CharacterEncoder:
+        @staticmethod
+        def encode(text, disallowed_special=()):
+            return list(text)
+
+    get_settings().set("config.model_token_count_estimate_factor", estimate_factor)
+    monkeypatch.setattr(pr_help_message, "token_counter", Mock(side_effect=RuntimeError("counter unavailable")),
+                        raising=False)
+    monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder(),
+                        raising=False)
+
+    assert tool._count_prompt_tokens(PRIMARY, "abc", "de") == expected
+
+
+def test_local_prompt_estimate_fails_closed_on_overflow(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+
+    class CharacterEncoder:
+        @staticmethod
+        def encode(text, disallowed_special=()):
+            return list(text)
+
+    get_settings().set("config.model_token_count_estimate_factor", 1e308)
+    monkeypatch.setattr(pr_help_message, "token_counter", Mock(side_effect=RuntimeError("counter unavailable")))
+    monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder())
+
+    with pytest.raises(OverflowError):
+        tool._count_prompt_tokens(PRIMARY, "abc", "de")
+
+
+@pytest.mark.parametrize("counter_mode", ["error", "zero", "boolean", "non_integer"])
+async def test_unusable_model_count_uses_local_estimate_before_provider_call(
+    help_tool, monkeypatch, counter_mode
+):
+    tool, _, _ = help_tool
+    tool.vars = {"question": "q", "snippets": "A" * 100}
+    get_settings().set("pr_help_prompts.system", "")
+    get_settings().set("pr_help_prompts.user", "{{ snippets }}")
+    monkeypatch.setattr(tool, "_get_prompt_budget", lambda _model: 70)
+
+    class CharacterEncoder:
+        @staticmethod
+        def encode(text, disallowed_special=()):
+            return list(text)
+
+    def unusable_count(**_kwargs):
+        if counter_mode == "error":
+            raise RuntimeError("counter unavailable")
+        return {"zero": 0, "boolean": True, "non_integer": 1.5}[counter_mode]
+
+    monkeypatch.setattr(pr_help_message, "token_counter", unusable_count)
+    monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder())
+    tool.ai_handler.chat_completion.return_value = ANSWER, "stop"
+
+    await tool._prepare_prediction(PRIMARY)
+
+    tool.ai_handler.chat_completion.assert_awaited_once()
+    user_prompt = tool.ai_handler.chat_completion.await_args.kwargs["user"]
+    assert "...(truncated)" in user_prompt
+    assert len(user_prompt) + 48 <= 70
+
+
+async def test_local_estimate_overflow_skips_provider_and_tries_fallback(help_tool, monkeypatch):
+    tool, details, _ = help_tool
+
+    class CharacterEncoder:
+        @staticmethod
+        def encode(text, disallowed_special=()):
+            return list(text)
+
+    get_settings().set("config.model_token_count_estimate_factor", 1e308)
+    monkeypatch.setattr(pr_help_message, "token_counter", Mock(side_effect=RuntimeError("counter unavailable")))
+    monkeypatch.setattr(pr_help_message.TokenEncoder, "get_token_encoder", lambda _model: CharacterEncoder())
+    tool._prepare_prediction = AsyncMock(wraps=tool._prepare_prediction)
+
+    assert await tool.run() == ""
+
+    assert [call.args[0] for call in tool._prepare_prediction.await_args_list] == [PRIMARY, BACKUP]
+    tool.ai_handler.chat_completion.assert_not_awaited()
+    assert details.model_used is None
+
+
+def test_prompt_fitting_checks_smallest_nonempty_prefix(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+    get_settings().set("pr_help_prompts.system", "")
+    get_settings().set("pr_help_prompts.user", "{{ snippets }}")
+    monkeypatch.setattr(tool, "_get_prompt_budget", lambda _model: 10)
+
+    def discontinuous_count(*, messages, **_kwargs):
+        snippets = messages[1]["content"]
+        if snippets in ("", pr_help_message.TRUNCATION_MARKER):
+            return 1
+        if snippets == f"A{pr_help_message.TRUNCATION_MARKER}":
+            return 10
+        return 1_000
+
+    monkeypatch.setattr(pr_help_message, "token_counter", discontinuous_count)
+
+    _, user_prompt = tool._fit_prompts({"question": "q", "snippets": "ABC"}, PRIMARY)
+
+    assert user_prompt == f"A{pr_help_message.TRUNCATION_MARKER}"
+
+
+async def test_marker_only_prompt_is_sent_when_no_document_character_fits(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+    tool.vars = {"question": "q", "snippets": "ABC"}
+    get_settings().set("pr_help_prompts.system", "")
+    get_settings().set("pr_help_prompts.user", "{{ snippets }}")
+    monkeypatch.setattr(tool, "_get_prompt_budget", lambda _model: 10)
+
+    def marker_only_count(*, messages, **_kwargs):
+        snippets = messages[1]["content"]
+        if snippets == "":
+            return 1
+        if snippets == pr_help_message.TRUNCATION_MARKER:
+            return 5
+        return 1_000
+
+    monkeypatch.setattr(pr_help_message, "token_counter", marker_only_count)
+    tool.ai_handler.chat_completion.return_value = ANSWER, "stop"
+
+    await tool._prepare_prediction(PRIMARY)
+
+    tool.ai_handler.chat_completion.assert_awaited_once()
+    assert tool.ai_handler.chat_completion.await_args.kwargs["user"] == pr_help_message.TRUNCATION_MARKER
+
+
+async def test_fixed_prompt_overhead_skips_model_call_and_tries_larger_fallback(help_tool, monkeypatch):
+    tool, details, _ = help_tool
+    get_settings().set("pr_help_prompts.system", "S" * 300)
+    get_settings().set("pr_help_prompts.user", "question={{ question }}\nsnippets={{ snippets }}")
+    get_settings().set("config.max_output_tokens", 20)
+    limits = {PRIMARY: 250, BACKUP: 2_000}
+
+    monkeypatch.setattr(pr_help_message, "get_max_tokens",
+                        lambda model, ignore_max_model_tokens=False: limits[model])
+    monkeypatch.setattr(pr_help_message, "token_counter", count_message_characters, raising=False)
+    tool._prepare_prediction = AsyncMock(wraps=tool._prepare_prediction)
+    tool.ai_handler.chat_completion.return_value = ANSWER, "stop"
+
+    await tool.run()
+
+    assert [call.args[0] for call in tool._prepare_prediction.await_args_list] == [PRIMARY, BACKUP]
+    assert attempted_models(tool) == [BACKUP]
+    assert details.model_used == BACKUP
 
 
 async def test_all_models_fail_without_publishing_no_information(help_tool):

--- a/tests/unittest/test_pr_help_message_fallback.py
+++ b/tests/unittest/test_pr_help_message_fallback.py
@@ -185,6 +185,16 @@ def test_prompt_budget_uses_handler_reported_output_limit(help_tool, monkeypatch
     tool.ai_handler.get_output_token_limit.assert_called_once_with(PRIMARY)
 
 
+def test_prompt_budget_uses_handler_reported_output_reserve(help_tool, monkeypatch):
+    tool, _, _ = help_tool
+    get_settings().set("config.max_output_tokens", 400)
+    tool.ai_handler.get_output_token_reserve = Mock(return_value=1_600)
+    monkeypatch.setattr(pr_help_message, "get_max_tokens", lambda *_args, **_kwargs: 3_000)
+
+    assert tool._get_prompt_budget(PRIMARY) == 1_400
+    tool.ai_handler.get_output_token_reserve.assert_called_once_with(PRIMARY, 2_000)
+
+
 @pytest.mark.parametrize("reported_limit", [None, 0, -1, True, 1.5, "1600"])
 def test_unusable_handler_output_limit_falls_back_to_config(
     help_tool, monkeypatch, reported_limit


### PR DESCRIPTION
When question-mode `/help` falls back from a large-context model to a smaller model, it currently reuses the prompt prepared for the primary. The fallback can receive more input than its own limit and fail before answering.

## Summary

- Fit the complete `/help` prompt separately for every attempted model.
- Keep the full documentation when it fits; otherwise preserve the priority-ordered prefix and add a truncation marker.
- Reserve the completion headroom selected by the active handler, including Claude thinking and OpenRouter output/reasoning budgets.
- Send one capped output-limit field for OpenRouter-routed Astra requests.
- Normalize Claude's empty system prompt before both token counting and request construction.
- Keep fitted variables isolated per attempt and handle malformed, oversized, or overflowing numeric settings without blocking fallback.

## Result

Controlled fake-handler reproduction with the current documentation corpus:

```text
Primary forced to fail: gpt-4.1, 84,044 prompt tokens
Fallback: gpt-3.5-turbo, 13,816 prompt tokens / 14,000 prompt budget
```

The fallback provider attempt proceeds with a prompt fitted to its own input budget and the completion headroom used for that request.

## Testing

- Focused help, output-cap, Claude/OpenRouter, and model-limit tests: 607 passed
- Full unit suite: 7,806 passed, 33 skipped, 1 xfailed
- Ruff and pre-commit on all changed files: passed
