### PR TITLE
fix(algo): add Gemini 3.x models to SUPPORT_REASONING_EFFORT_MODELS

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -504,6 +504,13 @@ SUPPORT_REASONING_EFFORT_MODELS = [
     "grok-4.5-latest",
     "grok-build-latest",
     "grok-4.6",
+    # Gemini 3.x models support reasoning_effort the same way as 2.5.
+    # Bare names cover all provider-prefixed forms (gemini/, vertex_ai/, openrouter/)
+    # via the endswith("/" + m) check in litellm_ai_handler.py.
+    "gemini-3.1-flash",
+    "gemini-3.1-pro",
+    "gemini-3.5-pro",
+    "gemini-3.8-flash",
 ]
 
 # Clamp OpenAI-only levels for always-on Grok reasoning; allow xhigh on 4.6+.

--- a/tests/unittest/test_gemini3_reasoning_effort.py
+++ b/tests/unittest/test_gemini3_reasoning_effort.py
@@ -1,0 +1,51 @@
+"""
+Regression test for issue #3309:
+config.reasoning_effort must be forwarded for Gemini 3.x models.
+
+SUPPORT_REASONING_EFFORT_MODELS previously contained only gemini-2.5-pro and
+gemini-2.5-flash. Gemini 3.x models (gemini-3.1-flash, gemini-3.1-pro,
+gemini-3.5-pro, gemini-3.8-flash) were in MAX_TOKENS but absent from the
+allowlist, so any configured reasoning_effort was silently dropped.
+"""
+import pytest
+from pr_agent.algo import SUPPORT_REASONING_EFFORT_MODELS
+
+
+GEMINI_3X_MODELS = [
+    "gemini-3.1-flash",
+    "gemini-3.1-pro",
+    "gemini-3.5-pro",
+    "gemini-3.8-flash",
+]
+
+PROVIDER_PREFIXES = ["gemini/", "vertex_ai/", "openrouter/google/"]
+
+
+@pytest.mark.parametrize("model", GEMINI_3X_MODELS)
+def test_gemini3_bare_name_in_support_list(model):
+    """Bare Gemini 3.x model names must be in SUPPORT_REASONING_EFFORT_MODELS."""
+    assert model in SUPPORT_REASONING_EFFORT_MODELS, (
+        f"{model!r} is missing from SUPPORT_REASONING_EFFORT_MODELS; "
+        "reasoning_effort will be silently dropped for this model"
+    )
+
+
+@pytest.mark.parametrize("model", GEMINI_3X_MODELS)
+@pytest.mark.parametrize("prefix", PROVIDER_PREFIXES)
+def test_gemini3_prefixed_form_matches(model, prefix):
+    """Provider-prefixed forms must match via the endswith check used in the handler."""
+    prefixed = prefix + model
+    matched = any(
+        prefixed == m or prefixed.endswith("/" + m)
+        for m in SUPPORT_REASONING_EFFORT_MODELS
+    )
+    assert matched, (
+        f"{prefixed!r} does not match any entry in SUPPORT_REASONING_EFFORT_MODELS; "
+        "reasoning_effort will be silently dropped when the model is referenced with a provider prefix"
+    )
+
+
+def test_gemini25_still_present():
+    """Regression guard: gemini-2.5 entries must not be removed."""
+    assert "gemini-2.5-pro" in SUPPORT_REASONING_EFFORT_MODELS
+    assert "gemini-2.5-flash" in SUPPORT_REASONING_EFFORT_MODELS


### PR DESCRIPTION
## Root cause

`SUPPORT_REASONING_EFFORT_MODELS` in `pr_agent/algo/__init__.py` (lines 487-507) contained only `gemini-2.5-pro` and `gemini-2.5-flash`. Gemini 3.x models (`gemini-3.1-flash`, `gemini-3.1-pro`, `gemini-3.5-pro`, `gemini-3.8-flash`) were already in `MAX_TOKENS` (lines 355-370) so they are accepted as `config.model`, but any configured `reasoning_effort` was silently dropped.

The allowlist check in `litellm_ai_handler.py` at lines 3910-3912:

```python
if any(
    reasoning_model == m or reasoning_model.endswith("/" + m)
    for m in self.support_reasoning_models
):
```

never matched a Gemini 3.x model, so `kwargs["reasoning_effort"]` was never set and the thinking budget was never forwarded to the provider.

## Fix

Add the four Gemini 3.x bare model names to `SUPPORT_REASONING_EFFORT_MODELS`. The existing `endswith("/" + m)` check already covers all provider-prefixed forms (`gemini/`, `vertex_ai/`, `openrouter/google/`) without any additional changes.

## Tests

`tests/unittest/test_gemini3_reasoning_effort.py` adds 17 parametrized tests:
- 4 tests verify each bare model name is in the list (fail on unpatched code)
- 12 tests verify each model matches under `gemini/`, `vertex_ai/`, and `openrouter/google/` prefixes (fail on unpatched code)
- 1 regression guard confirms `gemini-2.5-pro` and `gemini-2.5-flash` are still present

All 17 pass with the fix. All 16 bare-name and prefix tests fail on the unpatched code.

Fixes #3309