### PR TITLE
fix(add_docs): align prompt example field

### DIFF
--- a/pr_agent/settings/pr_add_docs.toml
+++ b/pr_agent/settings/pr_add_docs.toml
@@ -56,7 +56,7 @@ Example output:
 Code Documentation:
 -   relevant file: |-
         src/file1.py
-    relevant lines: 12
+    relevant line: 12
     doc placement: after
     documentation: |-
         \"\"\"

--- a/tests/unittest/test_pr_add_docs_prompt_contract.py
+++ b/tests/unittest/test_pr_add_docs_prompt_contract.py
@@ -1,0 +1,14 @@
+import yaml
+
+from pr_agent.config_loader import get_settings
+
+
+def test_add_docs_example_uses_singular_relevant_line():
+    prompt = get_settings().pr_add_docs_prompt.system
+    example_section = prompt.partition("Example output:")[2]
+    example = example_section.partition("```yaml")[2].partition("```")[0]
+
+    documentation = yaml.safe_load(example)["Code Documentation"][0]
+
+    assert documentation["relevant line"] == 12
+    assert "relevant lines" not in documentation


### PR DESCRIPTION
Fixes #3319

## Summary

- Align the `/add_docs` YAML example with the existing `relevant line` schema and parser contract.
- Add a regression test that parses the example and checks the singular field.

## Result

The example now parses with `relevant line: 12`, and the existing parser accepts the entry instead of dropping it.

## Testing

- `PYTHONPATH=. uv run pytest tests/unittest/test_pr_add_docs_prompt_contract.py tests/unittest/test_prompt_fragments.py tests/unittest/test_add_docs_line_range_guard.py tests/unittest/test_add_docs_trigger.py -q` (26 passed)
- `PYTHONPATH=. uv run pytest tests/unittest -q` (7746 passed, 33 skipped, 1 xfailed)
- `uv run pre-commit run --files pr_agent/settings/pr_add_docs.toml tests/unittest/test_pr_add_docs_prompt_contract.py` (passed)