### PR TITLE
docs(review): correct ticket-compliance documentation

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -154,7 +154,11 @@ for the authoritative default values.
       </tr>
       <tr>
         <td><b>require_ticket_analysis_review</b></td>
-        <td>If set to true, and the PR contains a GitHub or Jira ticket link, the tool will add a section that checks if the PR in fact fulfilled the ticket requirements.</td>
+        <td>
+          If set to true and ticket context is available, the tool adds a ticket-compliance section to the review comment
+          that checks whether the PR fulfills the ticket requirements. Supported sources include GitHub and GitLab issues,
+          linked Azure DevOps work items, Jira Cloud tickets, and Asana tasks.
+        </td>
       </tr>
       <tr>
         <td><b>require_risk_assessment</b></td>
@@ -213,11 +217,15 @@ for the authoritative default values.
 
 !!! tip ""
 
-    The `review` can tool automatically add labels to your Pull Requests:
+    The `review` tool can automatically add labels to your Pull Requests:
 
     - **`possible security issue`**: This label is applied if the tool detects a potential [security vulnerability](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L134) in the PR's code. This feedback is controlled by the 'enable_review_labels_security' flag (default is true).
     - **`review effort [x/5]`**: This label estimates the [effort](https://github.com/the-pr-agent/pr-agent/blob/main/pr_agent/settings/pr_reviewer_prompts.toml#L118) required to review the PR on a relative scale of 1 to 5, where 'x' represents the assessed effort. This feedback is controlled by the 'enable_review_labels_effort' flag (default is true).
-    - **`ticket compliance`**: Adds a label indicating code compliance level ("Fully compliant" | "PR Code Verified" | "Partially compliant" | "Not compliant") to any GitHub/Jira/Linea ticket linked in the PR. Controlled by the 'require_ticket_labels' flag (default: false). If 'require_no_ticket_labels' is also enabled, PRs without ticket links will receive a "No ticket found" label.
+
+    Ticket compliance is reported in the review comment, not as a PR label. It is controlled by
+    `pr_reviewer.require_ticket_analysis_review` and requires available ticket context. The tool does not add
+    ticket-compliance labels or a "No ticket found" label. See
+    [Fetching ticket context](../core-abilities/fetching_ticket_context.md) for linking and authentication details.
 
 
 ### Auto-blocking PRs from being merged based on the generated labels
@@ -226,7 +234,7 @@ for the authoritative default values.
 
     You can configure a CI/CD Action to prevent merging PRs with specific labels. For example, implement a dedicated [GitHub Action](https://medium.com/sequra-tech/quick-tip-block-pull-request-merge-using-labels-6cc326936221).
 
-    This approach helps ensure PRs with potential security issues or ticket compliance problems will not be merged without further review.
+    This approach helps ensure PRs with potential security issues will not be merged without further review.
 
     Since AI may make mistakes or lack complete context, use this feature judiciously. For flexibility, users with appropriate permissions can remove generated labels when necessary. When a label is removed, this action will be automatically documented in the PR discussion, clearly indicating it was a deliberate override by an authorized user to allow the merge.
 


### PR DESCRIPTION
Fixes #3327.

## Summary

- Remove the unsupported ticket-compliance label, `require_ticket_labels`, `require_no_ticket_labels`, and `Linea` claims from the review guide.
- Explain that ticket compliance is included in the review comment under `pr_reviewer.require_ticket_analysis_review`, not published as PR labels.
- Align the supported-source wording with the current implementation, including linked Azure DevOps work items, and link to the ticket-context guide.
- Remove the implication that generated ticket-compliance labels can gate merging.

Only `docs/docs/tools/review.md` changes. No new settings or runtime behavior; #3328 is out of scope.

## Validation

- `PYTHONPATH=. uv run --frozen pytest -q tests/unittest/test_docs_nav_parity.py tests/unittest/test_markdown_ticket_output_core.py tests/unittest/test_ticket_compliance.py tests/unittest/test_ticket_pr_compliance_capabilities.py`: **152 passed, 1 xfailed**.
- `PYTHONPATH=. uv run --frozen pytest -q tests/unittest/test_pr_reviewer_core.py -k set_review_labels`: **2 passed, 79 deselected**.
- `mkdocs build -f docs/mkdocs.yml --site-dir <temporary-site-dir>` with the docs-CI packages: **passed**. Checked the generated HTML for the corrected text and link; both the review page and linked ticket-context page returned HTTP 200 when served locally.
- Markdown-applicable pre-commit hooks and `git diff --check`: **passed**. Used `SKIP=actionlint` because its local Go bootstrap hit an `operation not permitted` error; no workflow files changed.

Terminal capture:

```text
152 passed, 1 xfailed in 20.11s
2 passed, 79 deselected in 6.52s
INFO    -  Documentation built in 0.80 seconds
Review page: HTTP 200
Ticket-context link: HTTP 200
```

`mkdocs build --strict` aborts on the existing missing `site_url` warning. Repeated the strict build against unchanged upstream `ca725b1b`; the warning and link diagnostics are identical. No docs configuration changes are included.

Prepared with AI assistance.
