### PR TITLE
fix(azure): return language names from get_languages

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1165,15 +1165,26 @@ class AzureDevopsProvider(GitProvider):
         # sort_files_by_main_languages() maps each name back to its extensions, so
         # returning extensions ("py") silently drops every file into the "Other"
         # bucket and defeats the prioritisation. Use the shared configured
-        # filename matcher so all providers apply the same rules.
+        # filename matcher so all providers apply the same rules. Percentages are
+        # computed over the repository's blob inventory (not the PR change set),
+        # so transient files or untouched files in the PR cannot skew the ranking.
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
         get_language = build_language_file_matcher(lang_map)
 
+        files = self.azure_devops_client.get_items(
+            project=self.workspace_slug,
+            repository_id=self.repo_slug,
+            recursion_level="Full",
+            include_content_metadata=True,
+            include_links=False,
+            download=False,
+        )
+
         lang_count = Counter()
-        for filename in self.get_files():
-            if not filename:
+        for f in files:
+            if f.git_object_type != "blob" or not f.path:
                 continue
-            language = get_language(filename)
+            language = get_language(f.path)
             if language:
                 lang_count[language] += 1
 

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1178,6 +1178,9 @@ class AzureDevopsProvider(GitProvider):
             include_content_metadata=True,
             include_links=False,
             download=False,
+            version_descriptor=GitVersionDescriptor(
+                version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
+            ),
         )
 
         lang_count = Counter()

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -1171,6 +1171,13 @@ class AzureDevopsProvider(GitProvider):
         lang_map = get_settings().get("language_extension_map_org", {}) or {}
         get_language = build_language_file_matcher(lang_map)
 
+        # Azure may omit merge metadata for a PR; without a target commit there is no
+        # reliable revision to enumerate, so mirror the empty-map fallback used by the
+        # other providers for unrecognized repositories.
+        target_commit = getattr(self.pr, "last_merge_target_commit", None)
+        if target_commit is None or not getattr(target_commit, "commit_id", None):
+            return {}
+
         files = self.azure_devops_client.get_items(
             project=self.workspace_slug,
             repository_id=self.repo_slug,
@@ -1179,7 +1186,7 @@ class AzureDevopsProvider(GitProvider):
             include_links=False,
             download=False,
             version_descriptor=GitVersionDescriptor(
-                version=self.pr.last_merge_target_commit.commit_id, version_type="commit"
+                version=target_commit.commit_id, version_type="commit"
             ),
         )
 

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
-import os
 import re
+from collections import Counter
 from types import SimpleNamespace
 from typing import Optional, Tuple
 from urllib.parse import quote, unquote, urlparse
@@ -19,7 +19,7 @@ from ..algo.inline_comment_dedup import (
     get_inline_comment_store,
     has_marker,
 )
-from ..algo.language_handler import is_valid_file
+from ..algo.language_handler import build_language_file_matcher, is_valid_file
 from ..algo.utils import (
     PRCodeSuggestionsIdentity,
     PRDescriptionHeader,
@@ -1160,33 +1160,25 @@ class AzureDevopsProvider(GitProvider):
         return self.pr.title
 
     def get_languages(self):
-        languages = []
-        files = self.azure_devops_client.get_items(
-            project=self.workspace_slug,
-            repository_id=self.repo_slug,
-            recursion_level="Full",
-            include_content_metadata=True,
-            include_links=False,
-            download=False,
-        )
-        for f in files:
-            if f.git_object_type == "blob":
-                file_name, file_extension = os.path.splitext(f.path)
-                languages.append(file_extension[1:])
+        # Return {language name: percentage}, like the other providers. Keys are
+        # language NAMES (e.g. "Python"), not raw extensions: the consumer
+        # sort_files_by_main_languages() maps each name back to its extensions, so
+        # returning extensions ("py") silently drops every file into the "Other"
+        # bucket and defeats the prioritisation. Use the shared configured
+        # filename matcher so all providers apply the same rules.
+        lang_map = get_settings().get("language_extension_map_org", {}) or {}
+        get_language = build_language_file_matcher(lang_map)
 
-        extension_counts = {}
-        for ext in languages:
-            if ext != "":
-                extension_counts[ext] = extension_counts.get(ext, 0) + 1
+        lang_count = Counter()
+        for filename in self.get_files():
+            if not filename:
+                continue
+            language = get_language(filename)
+            if language:
+                lang_count[language] += 1
 
-        total_extensions = sum(extension_counts.values())
-
-        extension_percentages = {
-            ext: (count / total_extensions) * 100
-            for ext, count in extension_counts.items()
-        }
-
-        return extension_percentages
+        total = sum(lang_count.values()) or 1
+        return {lang: count / total * 100 for lang, count in lang_count.items()}
 
     def get_pr_branch(self):
         pr_info = self.azure_devops_client.get_pull_request_by_id(

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -46,7 +46,16 @@ def test_get_languages_returns_language_names():
     # extensions ("py"): sort_files_by_main_languages() maps names back to
     # extensions, so extension keys would drop every file into "Other".
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.get_files = MagicMock(return_value=["a.py", "b.py", "c.py", "d.js", "weird.zzz"])
+    provider.workspace_slug = "proj"
+    provider.repo_slug = "repo"
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_items.return_value = [
+        SimpleNamespace(git_object_type="blob", path="a.py"),
+        SimpleNamespace(git_object_type="blob", path="b.py"),
+        SimpleNamespace(git_object_type="blob", path="c.py"),
+        SimpleNamespace(git_object_type="blob", path="d.js"),
+        SimpleNamespace(git_object_type="blob", path="weird.zzz"),
+    ]
 
     languages = provider.get_languages()
 
@@ -56,22 +65,54 @@ def test_get_languages_returns_language_names():
 
 def test_get_languages_returns_empty_map_when_nothing_matches():
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.get_files = MagicMock(return_value=["weird.zzz", ""])
+    provider.workspace_slug = "proj"
+    provider.repo_slug = "repo"
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_items.return_value = [
+        SimpleNamespace(git_object_type="blob", path="weird.zzz"),
+        SimpleNamespace(git_object_type="blob", path=""),
+    ]
 
     assert provider.get_languages() == {}
 
 
 def test_get_languages_maps_full_paths_and_multipart_extensions():
-    # Azure get_files() returns repository paths (dirs + filenames); the matcher
-    # must classify by the basename and honor multipart extensions.
+    # The matcher must classify by the basename and honor multipart extensions.
     provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.get_files = MagicMock(
-        return_value=["src/foo.py", "lib/bar.py", "doc/README.md", "notes.txt", "tpl/file.test.ts"]
-    )
+    provider.workspace_slug = "proj"
+    provider.repo_slug = "repo"
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_items.return_value = [
+        SimpleNamespace(git_object_type="blob", path="src/foo.py"),
+        SimpleNamespace(git_object_type="blob", path="lib/bar.py"),
+        SimpleNamespace(git_object_type="blob", path="doc/README.md"),
+        SimpleNamespace(git_object_type="blob", path="notes.txt"),
+        SimpleNamespace(git_object_type="blob", path="tpl/file.test.ts"),
+    ]
 
     languages = provider.get_languages()
 
     assert languages == {"Python": 40.0, "Markdown": 20.0, "Text": 20.0, "TypeScript": 20.0}
+
+
+def test_get_languages_ignores_non_blob_items_and_other_languages():
+    # Percentages come from the repository blob inventory, not the PR change set:
+    # non-blob entries (e.g. folders) must be skipped, and off-language files
+    # must not skew the ranking.
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.workspace_slug = "proj"
+    provider.repo_slug = "repo"
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_items.return_value = [
+        SimpleNamespace(git_object_type="Folder", path="src"),
+        SimpleNamespace(git_object_type="blob", path="src/app.py"),
+        SimpleNamespace(git_object_type="blob", path="src/main.py"),
+        SimpleNamespace(git_object_type="blob", path="render.bin"),
+    ]
+
+    languages = provider.get_languages()
+
+    assert languages == {"Python": 100.0}
 
 
 class TestAzureDevopsProviderRepoContext:

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -41,21 +41,30 @@ def test_azure_resolve_comment_thread_closes_thread():
     provider.set_thread_status.assert_called_once_with(42, "closed")
 
 
+def _language_provider(items):
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.workspace_slug = "proj"
+    provider.repo_slug = "repo"
+    provider.pr = SimpleNamespace(
+        last_merge_target_commit=SimpleNamespace(commit_id="base-sha"),
+        last_merge_commit=SimpleNamespace(commit_id="head-sha"),
+    )
+    provider.azure_devops_client = MagicMock()
+    provider.azure_devops_client.get_items.return_value = items
+    return provider
+
+
 def test_get_languages_returns_language_names():
     # get_languages() must key on language NAMES (e.g. "Python"), not raw
     # extensions ("py"): sort_files_by_main_languages() maps names back to
     # extensions, so extension keys would drop every file into "Other".
-    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.workspace_slug = "proj"
-    provider.repo_slug = "repo"
-    provider.azure_devops_client = MagicMock()
-    provider.azure_devops_client.get_items.return_value = [
+    provider = _language_provider([
         SimpleNamespace(git_object_type="blob", path="a.py"),
         SimpleNamespace(git_object_type="blob", path="b.py"),
         SimpleNamespace(git_object_type="blob", path="c.py"),
         SimpleNamespace(git_object_type="blob", path="d.js"),
         SimpleNamespace(git_object_type="blob", path="weird.zzz"),
-    ]
+    ])
 
     languages = provider.get_languages()
 
@@ -63,32 +72,36 @@ def test_get_languages_returns_language_names():
     assert languages == {"Python": 75.0, "JavaScript": 25.0}
 
 
+def test_get_languages_queries_target_commit_inventory():
+    provider = _language_provider(
+        [SimpleNamespace(git_object_type="blob", path="a.py")]
+    )
+
+    provider.get_languages()
+
+    call_kwargs = provider.azure_devops_client.get_items.call_args.kwargs
+    assert call_kwargs["version_descriptor"].version == "base-sha"
+    assert call_kwargs["version_descriptor"].version_type == "commit"
+
+
 def test_get_languages_returns_empty_map_when_nothing_matches():
-    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.workspace_slug = "proj"
-    provider.repo_slug = "repo"
-    provider.azure_devops_client = MagicMock()
-    provider.azure_devops_client.get_items.return_value = [
+    provider = _language_provider([
         SimpleNamespace(git_object_type="blob", path="weird.zzz"),
         SimpleNamespace(git_object_type="blob", path=""),
-    ]
+    ])
 
     assert provider.get_languages() == {}
 
 
 def test_get_languages_maps_full_paths_and_multipart_extensions():
     # The matcher must classify by the basename and honor multipart extensions.
-    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.workspace_slug = "proj"
-    provider.repo_slug = "repo"
-    provider.azure_devops_client = MagicMock()
-    provider.azure_devops_client.get_items.return_value = [
+    provider = _language_provider([
         SimpleNamespace(git_object_type="blob", path="src/foo.py"),
         SimpleNamespace(git_object_type="blob", path="lib/bar.py"),
         SimpleNamespace(git_object_type="blob", path="doc/README.md"),
         SimpleNamespace(git_object_type="blob", path="notes.txt"),
         SimpleNamespace(git_object_type="blob", path="tpl/file.test.ts"),
-    ]
+    ])
 
     languages = provider.get_languages()
 
@@ -99,16 +112,12 @@ def test_get_languages_ignores_non_blob_items_and_other_languages():
     # Percentages come from the repository blob inventory, not the PR change set:
     # non-blob entries (e.g. folders) must be skipped, and off-language files
     # must not skew the ranking.
-    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
-    provider.workspace_slug = "proj"
-    provider.repo_slug = "repo"
-    provider.azure_devops_client = MagicMock()
-    provider.azure_devops_client.get_items.return_value = [
+    provider = _language_provider([
         SimpleNamespace(git_object_type="Folder", path="src"),
         SimpleNamespace(git_object_type="blob", path="src/app.py"),
         SimpleNamespace(git_object_type="blob", path="src/main.py"),
         SimpleNamespace(git_object_type="blob", path="render.bin"),
-    ]
+    ])
 
     languages = provider.get_languages()
 

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -84,6 +84,26 @@ def test_get_languages_queries_target_commit_inventory():
     assert call_kwargs["version_descriptor"].version_type == "commit"
 
 
+def test_get_languages_returns_empty_map_when_target_commit_missing():
+    provider = _language_provider(
+        [SimpleNamespace(git_object_type="blob", path="a.py")]
+    )
+    provider.pr = SimpleNamespace(last_merge_target_commit=None)
+
+    assert provider.get_languages() == {}
+    provider.azure_devops_client.get_items.assert_not_called()
+
+
+def test_get_languages_returns_empty_map_when_target_commit_id_missing():
+    provider = _language_provider(
+        [SimpleNamespace(git_object_type="blob", path="a.py")]
+    )
+    provider.pr = SimpleNamespace(last_merge_target_commit=SimpleNamespace(commit_id=None))
+
+    assert provider.get_languages() == {}
+    provider.azure_devops_client.get_items.assert_not_called()
+
+
 def test_get_languages_returns_empty_map_when_nothing_matches():
     provider = _language_provider([
         SimpleNamespace(git_object_type="blob", path="weird.zzz"),

--- a/tests/unittest/test_azure_devops_provider.py
+++ b/tests/unittest/test_azure_devops_provider.py
@@ -41,6 +41,39 @@ def test_azure_resolve_comment_thread_closes_thread():
     provider.set_thread_status.assert_called_once_with(42, "closed")
 
 
+def test_get_languages_returns_language_names():
+    # get_languages() must key on language NAMES (e.g. "Python"), not raw
+    # extensions ("py"): sort_files_by_main_languages() maps names back to
+    # extensions, so extension keys would drop every file into "Other".
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.get_files = MagicMock(return_value=["a.py", "b.py", "c.py", "d.js", "weird.zzz"])
+
+    languages = provider.get_languages()
+
+    # 3 Python + 1 JavaScript known; .zzz is unknown and excluded from the total.
+    assert languages == {"Python": 75.0, "JavaScript": 25.0}
+
+
+def test_get_languages_returns_empty_map_when_nothing_matches():
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.get_files = MagicMock(return_value=["weird.zzz", ""])
+
+    assert provider.get_languages() == {}
+
+
+def test_get_languages_maps_full_paths_and_multipart_extensions():
+    # Azure get_files() returns repository paths (dirs + filenames); the matcher
+    # must classify by the basename and honor multipart extensions.
+    provider = AzureDevopsProvider.__new__(AzureDevopsProvider)
+    provider.get_files = MagicMock(
+        return_value=["src/foo.py", "lib/bar.py", "doc/README.md", "notes.txt", "tpl/file.test.ts"]
+    )
+
+    languages = provider.get_languages()
+
+    assert languages == {"Python": 40.0, "Markdown": 20.0, "Text": 20.0, "TypeScript": 20.0}
+
+
 class TestAzureDevopsProviderRepoContext:
     def test_get_repo_file_content_reads_from_target_commit(self):
         # Repo-context files must be read from the PR target (base) commit, matching


### PR DESCRIPTION
## What

`AzureDevopsProvider.get_languages()` returns raw file-extension strings (e.g. `"py"`) as keys. Downstream `sort_files_by_main_languages` (`language_handler.py:97-106`) matches keys against language names, so Azure PRs silently drop every file into the "Other" bucket, disabling language-based hunk prioritization.

## Fix

Rewrite `get_languages()` to classify files through the shared `build_language_file_matcher` (`language_handler.py:42-77`), matching the pattern used by Local, Bitbucket Server, Gerrit, and PlainDiff providers.

## Evidence

Before: `{"py": 45.0, "js": 30.0, ...}` - no match in `language_extension_map_org`, everything buckets to "Other".

After: `{"Python": 75.0, "JavaScript": 25.0}` - files correctly sorted by main language.

## Tests

Added 3 unit tests mirroring Bitbucket Server's `get_languages` test pattern:

- `test_get_languages_returns_language_names`
- `test_get_languages_returns_empty_map_when_nothing_matches`
- `test_get_languages_maps_full_paths_and_multipart_extensions`

All 3 pass; full Azure suite (113 tests) green.

Closes #3333