### PR TITLE
fix(reviewer): normalize aware commit dates in incremental review

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -1229,6 +1229,11 @@ class PRReviewer:
         last_seen_commit_date = (
             self.incremental.last_seen_commit.commit.author.date if self.incremental.last_seen_commit else None
         )
+        # PyGithub returns timezone-aware UTC commit dates; the threshold below is a
+        # naive datetime. Normalize to naive UTC so the comparison cannot raise
+        # TypeError, matching how the GitLab and Azure providers emit commit dates.
+        if last_seen_commit_date is not None and last_seen_commit_date.tzinfo is not None:
+            last_seen_commit_date = last_seen_commit_date.astimezone(datetime.timezone.utc).replace(tzinfo=None)
         all_commits_too_recent = (
             last_seen_commit_date > recent_commits_threshold if self.incremental.last_seen_commit else False
         )

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -1223,7 +1223,7 @@ class PRReviewer:
         num_commits_threshold = get_settings().pr_reviewer.minimal_commits_for_incremental_review
         not_enough_commits = num_new_commits < num_commits_threshold
         # checking if the commits are not too recent to start the review
-        recent_commits_threshold = datetime.datetime.now() - datetime.timedelta(
+        recent_commits_threshold = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(
             minutes=get_settings().pr_reviewer.minimal_minutes_for_incremental_review
         )
         last_seen_commit_date = (

--- a/tests/unittest/test_github_incremental_default.py
+++ b/tests/unittest/test_github_incremental_default.py
@@ -86,3 +86,72 @@ def test_can_run_incremental_review_handles_aware_commit_dates():
         result = reviewer._can_run_incremental_review()
 
     assert result in (True, False)  # either outcome is valid; crash is the bug
+
+
+def _frozen_now(fixed_aware_utc):
+    class _FrozenDatetime:
+        timezone = datetime.timezone
+        timedelta = datetime.timedelta
+
+        class datetime:
+            @staticmethod
+            def now(*args, **kwargs):
+                return fixed_aware_utc.astimezone(datetime.timezone.utc)
+
+    return patch("pr_agent.tools.pr_reviewer.datetime", new=_FrozenDatetime)
+
+
+def test_incremental_review_runs_when_commit_is_older_than_utc_threshold():
+    """The threshold is naive UTC, so a host in a non-UTC zone must not shift
+    the minimum-age decision."""
+    from pr_agent.tools.pr_reviewer import PRReviewer
+
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.is_auto = False
+    reviewer.git_provider = MagicMock(spec=["get_incremental_commits"])
+    reviewer.pr_url = "https://github.com/test/repo/pull/1"
+
+    commit = SimpleNamespace(
+        commit=SimpleNamespace(author=SimpleNamespace(date=datetime.datetime(2026, 9, 10, 12, 0, tzinfo=datetime.timezone.utc)))
+    )
+    reviewer.incremental = IncrementalPR(True)
+    reviewer.incremental.commits_range = [commit]
+    reviewer.incremental.last_seen_commit = commit
+
+    with (
+        _frozen_now(datetime.datetime(2026, 9, 10, 13, 0, tzinfo=datetime.timezone.utc)),
+        patch("pr_agent.tools.pr_reviewer.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.git_provider = "github"
+        mock_settings.return_value.pr_reviewer.minimal_commits_for_incremental_review = 0
+        mock_settings.return_value.pr_reviewer.minimal_minutes_for_incremental_review = 30
+        mock_settings.return_value.pr_reviewer.require_all_thresholds_for_incremental_review = False
+
+        assert reviewer._can_run_incremental_review() is True
+
+
+def test_incremental_review_skipped_when_commit_is_newer_than_utc_threshold():
+    from pr_agent.tools.pr_reviewer import PRReviewer
+
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.is_auto = False
+    reviewer.git_provider = MagicMock(spec=["get_incremental_commits"])
+    reviewer.pr_url = "https://github.com/test/repo/pull/1"
+
+    commit = SimpleNamespace(
+        commit=SimpleNamespace(author=SimpleNamespace(date=datetime.datetime(2026, 9, 10, 13, 15, tzinfo=datetime.timezone.utc)))
+    )
+    reviewer.incremental = IncrementalPR(True)
+    reviewer.incremental.commits_range = [commit]
+    reviewer.incremental.last_seen_commit = commit
+
+    with (
+        _frozen_now(datetime.datetime(2026, 9, 10, 13, 0, tzinfo=datetime.timezone.utc)),
+        patch("pr_agent.tools.pr_reviewer.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.git_provider = "github"
+        mock_settings.return_value.pr_reviewer.minimal_commits_for_incremental_review = 0
+        mock_settings.return_value.pr_reviewer.minimal_minutes_for_incremental_review = 30
+        mock_settings.return_value.pr_reviewer.require_all_thresholds_for_incremental_review = True
+
+        assert reviewer._can_run_incremental_review() is False

--- a/tests/unittest/test_github_incremental_default.py
+++ b/tests/unittest/test_github_incremental_default.py
@@ -1,4 +1,6 @@
 """The default `IncrementalPR` is per call, not one object shared since import."""
+import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from pr_agent.git_providers.git_provider import IncrementalPR
@@ -55,3 +57,32 @@ def test_an_incremental_passed_in_is_the_one_used():
     provider.get_incremental_commits(given)
 
     assert provider.incremental is given
+
+
+def test_can_run_incremental_review_handles_aware_commit_dates():
+    """Regression: PyGithub 2.x returns timezone-aware commit timestamps,
+    but _can_run_incremental_review compared them against a naive
+    datetime.now(), raising TypeError on every second run."""
+    from pr_agent.tools.pr_reviewer import PRReviewer
+
+    reviewer = PRReviewer.__new__(PRReviewer)
+    reviewer.is_auto = False
+    reviewer.git_provider = MagicMock(spec=["get_incremental_commits"])
+    reviewer.pr_url = "https://github.com/test/repo/pull/1"
+
+    aware_date = datetime.datetime(2026, 9, 10, 12, 0, tzinfo=datetime.timezone.utc)
+    commit = SimpleNamespace(commit=SimpleNamespace(author=SimpleNamespace(date=aware_date)))
+
+    reviewer.incremental = IncrementalPR(True)
+    reviewer.incremental.commits_range = [commit]
+    reviewer.incremental.last_seen_commit = commit
+
+    with patch("pr_agent.tools.pr_reviewer.get_settings") as mock_settings:
+        mock_settings.return_value.git_provider = "github"
+        mock_settings.return_value.pr_reviewer.minimal_commits_for_incremental_review = 0
+        mock_settings.return_value.pr_reviewer.minimal_minutes_for_incremental_review = 0
+        mock_settings.return_value.pr_reviewer.require_all_thresholds_for_incremental_review = False
+        # Must not raise TypeError
+        result = reviewer._can_run_incremental_review()
+
+    assert result in (True, False)  # either outcome is valid; crash is the bug


### PR DESCRIPTION
## What

`/review -i` on GitHub raises `TypeError: can't compare offset-naive and offset-aware datetimes` on every re-run after a previous review exists, so the incremental review never runs (it falls into the generic failure handler and posts a "Failed to review PR" comment).

`pr_agent/tools/pr_reviewer.py:1226-1238` builds the threshold with `datetime.datetime.now()` (naive) but PyGithub 2.x returns timezone-aware UTC commit dates (`GithubObject._datetime_from_github_isoformat` normalizes to `datetime.timezone.utc`). GitLab and Azure avoid the crash only because they pre-normalize commit timestamps to naive UTC (`glab_provider.py:49-71`, `azuredevops_provider.py:100`); GitHub does not.

## Fix

Normalize `last_seen_commit_date` to naive UTC before the comparison, matching the GitLab/Azure convention:

```python
if last_seen_commit_date is not None and last_seen_commit_date.tzinfo is not None:
    last_seen_commit_date = last_seen_commit_date.astimezone(datetime.timezone.utc).replace(tzinfo=None)
```

The guard is idempotent for providers that already emit naive UTC datetimes, so GitLab and Azure remain unaffected.

## Tests

Added `test_can_run_incremental_review_handles_aware_commit_dates` to `tests/unittest/test_github_incremental_default.py`, driving `_can_run_incremental_review` with a PyGithub-style aware commit date. It passes with the fix and raises TypeError without it.

Local run: GitHub incremental + reviewer suites green (174 passed), ruff clean.

Closes #3335