### PR TITLE
docs: fix GitHub suggestion-count configuration examples

### DIFF
--- a/docs/docs/installation/github.md
+++ b/docs/docs/installation/github.md
@@ -49,7 +49,7 @@ When you open your next PR, you should see a comment from `github-actions` bot w
         # ... previous environment values
         OPENAI.ORG: "<Your organization name under your OpenAI account>"
         PR_REVIEWER.REQUIRE_TESTS_REVIEW: "false" # Disable tests review
-        PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS: 6 # Increase number of code suggestions
+        PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS_PER_CHUNK: 6 # Increase number of code suggestions
 ```
 
 See detailed usage instructions in the [USAGE GUIDE](../usage-guide/automations_and_usage.md#github-action)
@@ -380,7 +380,7 @@ Configure for specific programming languages:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Language-specific settings
         pr_reviewer.extra_instructions: "Focus on Python best practices, type hints, and docstrings."
-        pr_code_suggestions.num_code_suggestions: "8"
+        pr_code_suggestions.num_code_suggestions_per_chunk: "8"
         pr_code_suggestions.suggestions_score_threshold: "7"
         # Tool configuration
         github_action_config.auto_review: "true"
@@ -459,7 +459,7 @@ fallback_models = ["anthropic/claude-3-opus-20240229"]
 extra_instructions = "Focus on security issues and code quality."
 
 [pr_code_suggestions]
-num_code_suggestions = 6
+num_code_suggestions_per_chunk = 6
 suggestions_score_threshold = 7
 ```
 


### PR DESCRIPTION
Fixes #3331.

Use `num_code_suggestions_per_chunk` in the three GitHub installation examples. The previous keys left the actual setting at its default. Values and configuration mechanisms are unchanged; no runtime, default, dependency or workflow changes.

Validation (Windows, Python 3.12.13, frozen dependencies, uv 0.12.10):
- Loaded the two environment examples and parsed TOML override with the repository's Dynaconf settings: old examples read `3/3/3`; corrected examples read `6/8/6`.
- Configuration-reference and documentation-navigation tests: **6 passed**.
- Touched-file pre-commit hooks passed; independent Codex diff review found no issues.
- MkDocs build succeeded; checked all three keys in the generated GitHub page. Existing unrelated site/link warnings remain. Terminal capture:

```text
Environment PR_CODE_SUGGESTIONS.NUM_CODE_SUGGESTIONS_PER_CHUNK: expected 6, actual 6
Environment pr_code_suggestions.num_code_suggestions_per_chunk: expected 8, actual 8
TOML num_code_suggestions_per_chunk: expected 6, actual 6
Documentation built in 79.52 seconds
```

Broader Windows unit run: **7697 passed, 42 failed, 5 errors, 33 skipped, 1 xfailed, 1 deselected** (142.79s). Cleared proxy variables only in the test process to avoid the host's SOCKS/missing-socksio issue. All 47 failed/error test IDs also fail on the unmodified parent (exact failed-test rerun: 42 failed / 5 errors); categories include CRLF/GBK, unsupported Windows filesystem/POSIX operations and cleanup timing assertions. No unrelated runtime fixes included.

The deselected case is `test_skills_loader.py::TestPathExpansion::test_tilde_in_path_is_expanded`: it patches only `HOME`, while Windows `expanduser` uses `USERPROFILE`, causing discovery to traverse the actual user directory. Stopped the original run and isolated reproduction at that case, then explicitly deselected it for the broader run. It is **not** counted as passing. Restored the exact committed docs and reran the focused checks afterward.

No live provider/e2e run; no executable lines changed, so diff coverage is not applicable. Upstream Build-and-test, pre-commit and CodeQL all await workflow approval with zero jobs. Keeping Draft; local Windows results are not Linux-container CI validation.

Investigation, editing, validation and independent review are AI-assisted.
