### PR TITLE
fix(ask): keep image blocks for user-message-only models

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -3973,7 +3973,12 @@ class LiteLLMAIHandler(BaseAiHandler):
                     user = f"{system}\n\n\n{user}"
                     system = ""
                     get_logger().info(f"Using model {model}, combining system and user prompts")
-                    messages = [{"role": "user", "content": user}]
+                    if img_path:
+                        content = [{"type": "text", "text": user},
+                                   {"type": "image_url", "image_url": {"url": img_path}}]
+                    else:
+                        content = user
+                    messages = [{"role": "user", "content": content}]
 
                 # Build request kwargs after normalizing the model and messages so credentials and
                 # endpoints can be selected for the provider that will actually receive this call.

--- a/tests/unittest/test_litellm_chat_completion_core.py
+++ b/tests/unittest/test_litellm_chat_completion_core.py
@@ -464,6 +464,69 @@ async def test_chat_completion_combines_prompts_for_user_message_only_models(mon
     assert messages == [{"role": "user", "content": "sys\n\n\nusr"}]
 
 
+@pytest.mark.asyncio
+async def test_chat_completion_keeps_image_for_user_message_only_models(monkeypatch):
+    monkeypatch.setattr(litellm_handler, "get_settings", FakeSettings)
+    monkeypatch.setattr(
+        litellm_handler.requests,
+        "head",
+        lambda *args, **kwargs: SimpleNamespace(status_code=200),
+    )
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+        handler.user_message_only_models = ["user-only-model"]
+
+        await handler.chat_completion(
+            model="user-only-model",
+            system="sys",
+            user="usr",
+            img_path="https://example.test/image.png",
+        )
+
+    messages = mock_call.call_args.kwargs["messages"]
+    assert messages == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "sys\n\n\nusr"},
+                {"type": "image_url", "image_url": {"url": "https://example.test/image.png"}},
+            ],
+        }
+    ]
+    assert any(block.get("type") == "image_url" for block in messages[0]["content"])
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_keeps_image_for_custom_reasoning_models(monkeypatch):
+    settings = FakeSettings()
+    settings.config.custom_reasoning_model = True
+    monkeypatch.setattr(litellm_handler, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        litellm_handler.requests,
+        "head",
+        lambda *args, **kwargs: SimpleNamespace(status_code=200),
+    )
+
+    with patch("pr_agent.algo.ai_handlers.litellm_ai_handler.acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = _mock_response()
+        handler = litellm_handler.LiteLLMAIHandler()
+
+        await handler.chat_completion(
+            model="gpt-4o",
+            system="sys",
+            user="usr",
+            img_path="https://example.test/image.png",
+        )
+
+    messages = mock_call.call_args.kwargs["messages"]
+    assert messages[0]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.test/image.png"},
+    }
+
+
 # Wiring tests for the retry knobs: the helpers (_should_retry_same_model,
 # _configured_client_retries) are unit-tested in test_litellm_retry_config.py, but those
 # tests keep passing when the @retry predicate or the kwargs pass-through in


### PR DESCRIPTION
Fixes #3338

`/ask` with an image silently drops the image when the target model is in `user_message_only_models` (o1-preview, o1-mini, deepseek-reasoner) or when `custom_reasoning_model=true`.

## Why

`litellm_ai_handler.py` first attaches the image as a multimodal block on `messages[1]["content"]`. For user-message-only models it then rebuilds `messages` from the combined system+user string, discarding the `image_url` block with no warning.

## Change

Preserve the multimodal `image_url` block when collapsing to a single user message, mirroring the construction used for normal models. If the selected model cannot accept images, the provider now returns an explicit error instead of silently analyzing text only.

## Tests

- `test_chat_completion_keeps_image_for_user_message_only_models`
- `test_chat_completion_keeps_image_for_custom_reasoning_models`

Full unit suite passes (7831 passed, 33 skipped, 1 xfailed).